### PR TITLE
Use Eclipse/Sisu 0.0.0.M2 milestone

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -48,8 +48,8 @@
       <artifactId>maven-compat</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
     <!-- CLI -->
     <dependency>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -76,8 +76,8 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -54,8 +54,8 @@
       <artifactId>plexus-interpolation</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -72,8 +72,8 @@
     </dependency>
     <!-- Plexus -->
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-core/src/main/java/org/apache/maven/DefaultArtifactFilterManager.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultArtifactFilterManager.java
@@ -58,6 +58,7 @@ public class DefaultArtifactFilterManager
         artifacts.add( "plexus:plexus-container-default" );
         artifacts.add( "org.sonatype.spice:spice-inject-plexus" );
         artifacts.add( "org.sonatype.sisu:sisu-inject-plexus" );
+        artifacts.add( "org.eclipse.sisu:org.eclipse.sisu.plexus" );
         artifacts.add( "org.apache.maven:maven-artifact" );
         artifacts.add( "org.apache.maven:maven-aether-provider" );
         artifacts.add( "org.apache.maven:maven-artifact-manager" );

--- a/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
+++ b/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
@@ -199,11 +199,10 @@ public class DefaultClassRealmManager
         imports.put( "org.codehaus.plexus.logging", coreRealm );
         imports.put( "org.codehaus.plexus.personality", coreRealm );
 
-        // javax.inject, sisu-inject (JSR-330)
+        // javax.inject (JSR-330)
         imports.put( "javax.inject.*", coreRealm );
         imports.put( "javax.enterprise.inject.*", coreRealm );
-        imports.put( "org.sonatype.inject.*", coreRealm );
-        
+
         // com.google
         //
         // We may potentially want to export these, but right now I'm not sure that anything Guice specific needs

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -55,8 +55,8 @@
       <artifactId>plexus-classworlds</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -43,8 +43,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -49,8 +49,8 @@ under the License.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,10 @@
     <plexusVersion>1.5.5</plexusVersion>
     <plexusInterpolationVersion>1.16</plexusInterpolationVersion>
     <plexusUtilsVersion>3.0.10</plexusUtilsVersion>
-    <sisuInjectVersion>2.3.0</sisuInjectVersion>
+    <!-- last Java5 release of Guava -->
+    <guavaVersion>11.0.2</guavaVersion>
+    <guiceVersion>3.1.3</guiceVersion>
+    <sisuInjectVersion>0.0.0.M2</sisuInjectVersion>
     <wagonVersion>2.4</wagonVersion>
     <securityDispatcherVersion>1.3</securityDispatcherVersion>
     <cipherVersion>1.7</cipherVersion>
@@ -176,16 +179,25 @@
         <version>${plexusUtilsVersion}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guavaVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>org.sonatype.sisu</groupId>
-        <artifactId>sisu-inject-plexus</artifactId>
+        <artifactId>sisu-guice</artifactId>
+        <version>${guiceVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-guice</artifactId>
+        <version>${guiceVersion}</version>
+        <classifier>no_aop</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.plexus</artifactId>
         <version>${sisuInjectVersion}</version>
-        <exclusions>
-          <exclusion>
-            <!-- Decouple build from MNG-3443 and ensure optional/unused dependency from sisu-guice stays out -->
-            <groupId>org.sonatype.sisu.inject</groupId>
-            <artifactId>cglib</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -277,6 +289,10 @@
           <exclusion>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-container-default</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.sonatype.sisu</groupId>
+            <artifactId>sisu-inject-plexus</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
See https://jira.codehaus.org/browse/MNG-5453

The major differences between the new Eclipse/Sisu artifacts and the old bundles are:
- brand new Plexus configurator code
- no shading/jarjar of any dependencies

From a Plexus API perspective the artifacts are "drop-in" compatible. Local testing has not revealed any issues with the new Plexus configurators, but as this code was developed indirectly from the behaviour of the old configurators further real-world testing may reveal differences that could either be beneficial or unwanted...

PS. Any Eclipse/Sisu issues can be logged at https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Sisu&format=guided or discussed at https://dev.eclipse.org/mailman/listinfo/sisu-users
