### PR TITLE
Fix call to SimpleLoggerFactory.reset method

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/Slf4jSimpleConfiguration.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/Slf4jSimpleConfiguration.java
@@ -58,20 +58,5 @@ public class Slf4jSimpleConfiguration
         // property for root logger level or System.out redirection need to be taken into account
         MavenSlf4jFriend.reset();
         MavenSlf4jSimpleFriend.init();
-        
-        try
-        {
-             org.slf4j.ILoggerFactory loggerFactory = org.slf4j.LoggerFactory.getILoggerFactory();
-             synchronized ( loggerFactory )
-             {
-                 java.lang.reflect.Field loggerMap = loggerFactory.getClass().getDeclaredField( "loggerMap" );
-                 loggerMap.setAccessible( true );
-                 ( (java.util.Map) loggerMap.get( loggerFactory ) ).clear();
-             }
-        }
-        catch ( Exception e )
-        {
-            // ignore for now...
-        }        
     }
 }

--- a/maven-embedder/src/main/java/org/slf4j/impl/MavenSlf4jSimpleFriend.java
+++ b/maven-embedder/src/main/java/org/slf4j/impl/MavenSlf4jSimpleFriend.java
@@ -19,6 +19,9 @@ package org.slf4j.impl;
  * under the License.
  */
 
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
 /**
  * Utility for Maven to access Slf4j-Simple internals through package access.
  * Use with precaution, since this is not normally intended for production use.
@@ -28,6 +31,10 @@ public class MavenSlf4jSimpleFriend
     public static void init()
     {
         SimpleLogger.init();
-        SimpleLoggerFactory.INSTANCE.reset();
+        ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+        if ( loggerFactory instanceof SimpleLoggerFactory )
+        {
+            ( (SimpleLoggerFactory) loggerFactory ).reset();
+        }
     }
 }


### PR DESCRIPTION
Use LoggerFactory to make sure we get the right instance to reset, as SimpleLoggerFactory.INSTANCE is not actually used by slf4j-simple's StaticLoggerBinder (instead it has its own SINGLETON field to hold the logger factory).

Can now remove temporary reflection workaround.
