### PR TITLE
Avoid mixing two flavours of Guice on the classpath.

### DIFF
--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -88,9 +88,8 @@ under the License.
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>3.0</version>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-guice</artifactId>
       <classifier>no_aop</classifier>
       <optional>true</optional>
       <exclusions>


### PR DESCRIPTION
Note: the main blocker to using Google-Guice for Maven3 is the lack of a release with the new ProvisionListener API, which is needed to support Plexus lifecycles. While there are other fixes/features in Sisu-Guice that are nice-to-have (such as removal of the big global singleton lock) they aren't strictly required for Maven3.
