### PR TITLE
Version ranges with non-snapshot bounds can contain snapshot versions

### DIFF
--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -74,7 +74,9 @@ public class DefaultVersionRangeResolver
 {
 
     private static final String MAVEN_METADATA_XML = "maven-metadata.xml";
-
+	
+	private static final String SNAPSHOT = "SNAPSHOT";
+	
     @SuppressWarnings( "unused" )
     @Requirement( role = LoggerFactory.class )
     private Logger logger = NullLoggerFactory.LOGGER;
@@ -254,10 +256,20 @@ public class DefaultVersionRangeResolver
             Versioning versioning = readVersions( session, trace, metadataResult.getMetadata(), repository, result );
             for ( String version : versioning.getVersions() )
             {
-                if ( !versionIndex.containsKey( version ) )
-                {
-                    versionIndex.put( version, repository );
-                }
+                if(request.getArtifact().getVersion().toUpperCase().contains(SNAPSHOT)){            		
+            		if ( !versionIndex.containsKey( version ) )
+	                {
+	                    versionIndex.put( version, repository );
+	                }
+            	}
+            	else{
+            		if(!version.toUpperCase().contains(SNAPSHOT)){
+            			if ( !versionIndex.containsKey( version ) )
+    	                {
+    	                    versionIndex.put( version, repository );
+    	                }
+            		}
+            	}
             }
         }
 


### PR DESCRIPTION
Issue : MNG-3092 

Disallow snapshots in ranges when they are not an explicit boundary. If User keeps SNAPSHOT at any boundary we will allow SNAPSHOT in range.
