### PR TITLE
[MNG-5075] MavenProject.getParent throws undocumented ISE

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -102,6 +102,8 @@ public class MavenProject
 
     public static final String EMPTY_PROJECT_VERSION = "0";
 
+    private static final MavenProject ERROR_BUILDING_PARENT = new MavenProject();
+
     private Model model;
 
     private MavenProject parent;
@@ -344,6 +346,10 @@ public class MavenProject
         return model;
     }
 
+    /**
+     * Returns the project corresponding to a declared parent.
+     * @return the parent, or null if no parent is declared or there was an error building it
+     */
     public MavenProject getParent()
     {
         if ( parent == null )
@@ -364,7 +370,11 @@ public class MavenProject
                 }
                 catch ( ProjectBuildingException e )
                 {
-                    throw new IllegalStateException( "Failed to build parent project for " + getId(), e );
+                    if ( logger != null )
+                    {
+                        logger.error( "Failed to build parent project for " + getId(), e );
+                    }
+                    parent = ERROR_BUILDING_PARENT;
                 }
             }
             else if ( model.getParent() != null )
@@ -379,11 +389,15 @@ public class MavenProject
                 }
                 catch ( ProjectBuildingException e )
                 {
-                    throw new IllegalStateException( "Failed to build parent project for " + getId(), e );
+                    if ( logger != null )
+                    {
+                        logger.error( "Failed to build parent project for " + getId(), e );
+                    }
+                    parent = ERROR_BUILDING_PARENT;
                 }
             }
         }
-        return parent;
+        return parent == ERROR_BUILDING_PARENT ? null : parent;
     }
 
     public void setParent( MavenProject parent )


### PR DESCRIPTION
Fix for [MNG-5075](http://jira.codehaus.org/browse/MNG-5075): `MavenProject.getParent` throws `IllegalStateException` when there is a model building error. Patch (updated version of JIRA original) just sends any problems to the logger and returns `null`, which is not great but is at least now documented and will prevent innocent clients from being fatally broken by an unchecked exception.

I am `jglick@apache.org` and intend this patch to be submitted to the ASF under the ASL 2.0.
