### PR TITLE
MNG-4226 Detect JAVA_HOME on newer Mac OS X

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -78,6 +78,13 @@ case "`uname`" in
              #
              export JAVA_HOME=/Library/Java/JavaVirtualMachines/CurrentJDK/Contents/Home
            fi           
+
+           if [[ -z "$JAVA_HOME" && -x /usr/libexec/java_home ]] ; then
+             #
+             # Apple JDKs
+             #
+             export JAVA_HOME=$(/usr/libexec/java_home)
+           fi
            ;;
 esac
 


### PR DESCRIPTION
  This patch falls back on the system configured JVM for the current
  user, only when no prior methods for detecting JAVA_HOME succeed.
  If one of the prior methods was successful, then that prior behavior
  is preserved.
