### PR TITLE
[MNG-5613] Avoid NPE when dependency graph creation fails

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -267,6 +267,11 @@ public class DefaultMaven
         //
         ProjectDependencyGraph projectDependencyGraph = createProjectDependencyGraph( projects, request, result, true );
 
+        if ( result.hasExceptions() )
+        {
+            return result;
+        }
+
         session.setProjects( projectDependencyGraph.getSortedProjects() );
         
         if ( result.hasExceptions() )


### PR DESCRIPTION
As described in MNG-5613 a NPE occurs if the dependency graph creation fails. Errors where properly catched and added to the result. However, after the call to createProjectDependencyGraph, the resulting projectDependencyGraph was null and as result was not checked for exceptions the call to projectDependencyGraph.getSortedProjects() resulted in a NPE.
