### PR TITLE
- logging configuration now no longer overwrites the default log level

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -318,11 +318,8 @@ public class MavenCli
             cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_ERROR );
             slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.ERROR );
         }
-        else
-        {
-            cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_INFO );
-            slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.INFO );
-        }
+        // else fall back to default log level specified in conf
+        // see http://jira.codehaus.org/browse/MNG-2570
 
         if ( cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
         {


### PR DESCRIPTION
- logging configuration now no longer overwrites the default log level as specified in conf/logging/simplelogger.properties (see [MNG-2570](http://jira.codehaus.org/browse/MNG-2570) (related)); the default log level was always set to "info" unless either option "debug" or "quiet" were used; this made it effectively impossible to change the default log level to something other than "debug", "error" or "info"
