### PR TITLE
Fixes MNG-5663 - a regression introduced in 3.2.2 by MNG-5639 that preve...

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -580,7 +580,7 @@ public class DefaultModelBuilder
         configureResolver( modelResolver, model, problems, false );
     }
 
-    private void configureResolver( ModelResolver modelResolver, Model model, DefaultModelProblemCollector problems, boolean resetRepositories )
+    private void configureResolver( ModelResolver modelResolver, Model model, DefaultModelProblemCollector problems, boolean replaceRepositories )
     {
         if ( modelResolver == null )
         {
@@ -591,16 +591,11 @@ public class DefaultModelBuilder
 
         List<Repository> repositories = model.getRepositories();
 
-        if ( resetRepositories )
-        {
-            modelResolver.resetRepositories();
-        }
-
         for ( Repository repository : repositories )
         {
             try
             {
-                modelResolver.addRepository( repository );
+                modelResolver.addRepository( repository, replaceRepositories );
             }
             catch ( InvalidRepositoryException e )
             {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/resolution/ModelResolver.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/resolution/ModelResolver.java
@@ -68,10 +68,18 @@ public interface ModelResolver
         throws InvalidRepositoryException;
 
     /**
-     * Resets repositories, has the effect of clearing any repositories previously added by the
-     * {link #addRepository(Repository) method
+     * Adds a repository to use for subsequent resolution requests. The order in which repositories are added matters,
+     * repositories that were added first should also be searched first. When multiple repositories with the same
+     * identifier are added, then the value of the replace argument is determines the behaviour.
+     *
+     * If replace is false than any existing repository with the same Id will remain in use. If replace
+     * is true the new repository replaces the original.
+     *
+     * @param repository The repository to add to the internal search chain, must not be {@code null}.
+     * @throws InvalidRepositoryException If the repository could not be added (e.g. due to invalid URL or layout).
      */
-    void resetRepositories();
+    void addRepository( Repository repository, boolean replace )
+            throws InvalidRepositoryException;
 
     /**
      * Clones this resolver for usage in a forked resolution process. In general, implementors need not provide a deep


### PR DESCRIPTION
...nts

nested import POMs from resolving their dependencies.

The cuplrit was the resetRepositories method in tandem with the repository
list instances being shared between ModelResolvers.
- The copy constructor for the ModelResolvers now creates new lists.
- The resetRepositories method has been removed. Instead there is a
  'replace' parameter on the addRepository method that allows the
  desired parameter replacement of MNG-5639 to take place.
