### PR TITLE
fix apple jdk detection

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -83,7 +83,7 @@ case "`uname`" in
              #
              # Apple JDKs
              #
-             export JAVA_HOME=/usr/libexec/java_home
+             export JAVA_HOME=`/usr/libexec/java_home`
            fi
            ;;
 esac


### PR DESCRIPTION
This fixes JAVA_HOME being falsely set, resulting in the following error:
```
Error: JAVA_HOME is not defined correctly.
  We cannot execute /usr/libexec/java_home/bin/java
```