### PR TITLE
Update Guava dependency to 18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,7 @@
     <plexusVersion>1.5.5</plexusVersion>
     <plexusInterpolationVersion>1.21</plexusInterpolationVersion>
     <plexusUtilsVersion>3.0.20</plexusUtilsVersion>
-    <!-- Latest version of Guava that works with Sisu -->
-    <guavaVersion>14.0.1</guavaVersion>
+    <guavaVersion>18.0</guavaVersion>
     <guiceVersion>3.2.3</guiceVersion>
     <sisuInjectVersion>0.3.0.M1</sisuInjectVersion>
     <wagonVersion>2.6</wagonVersion>


### PR DESCRIPTION
With the update of Guice to 3.2.3, the limitation on the Guava dependency no longer applies.
