### PR TITLE
[MNG-5738] Addition of command line flag '--legacy-reactor-resolution'.

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -234,25 +234,30 @@ public class DefaultMaven
             return addExceptionToResult( result, e );
         }
 
-        WorkspaceReader reactorWorkspace;
-        try
+        // As of Maven 3.3.0, workspace resolution can be disabled. See MNG-5738.
+        if ( !request.isUseLegacyReactorResolution() )
         {
-            reactorWorkspace = container.lookup( WorkspaceReader.class, ReactorReader.HINT );
-        }
-        catch ( ComponentLookupException e )
-        {
-            return addExceptionToResult( result, e );
-        }
+            WorkspaceReader reactorWorkspace;
+            try
+            {
+                reactorWorkspace = container.lookup( WorkspaceReader.class, ReactorReader.HINT );
+            }
+            catch ( ComponentLookupException e )
+            {
+                return addExceptionToResult( result, e );
+            }
 
-        //
-        // Desired order of precedence for local artifact repositories
-        //
-        // Reactor
-        // Workspace
-        // User Local Repository
-        //
-        repoSession.setWorkspaceReader( ChainedWorkspaceReader.newInstance( reactorWorkspace,
-                                                                            repoSession.getWorkspaceReader() ) );
+            //
+            // Desired order of precedence for local artifact repositories
+            //
+            // Reactor
+            // Workspace
+            // User Local Repository
+            //
+            repoSession.setWorkspaceReader( ChainedWorkspaceReader.newInstance( reactorWorkspace,
+                                                                                repoSession.getWorkspaceReader() ) );
+
+        }
 
         repoSession.setReadOnly();
 

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -163,6 +163,9 @@ public class DefaultMavenExecutionRequest
 
     private Map<String, Object> data;
     
+    /** @since 3.3.0 */
+    private boolean useLegacyReactorResolution = false;
+
     public DefaultMavenExecutionRequest()
     {
     }
@@ -207,6 +210,7 @@ public class DefaultMavenExecutionRequest
         copy.setNoSnapshotUpdates( original.isNoSnapshotUpdates() );
         copy.setExecutionListener( original.getExecutionListener() );
         copy.setUseLegacyLocalRepository( original.isUseLegacyLocalRepository() );
+        copy.setUseLegacyReactorResolution( original.isUseLegacyReactorResolution() );
         copy.setBuilderId( original.getBuilderId() );
         return copy;
     }
@@ -1232,6 +1236,19 @@ public class DefaultMavenExecutionRequest
     }
 
     @Override
+    /** @since 3.3.0 */
+    public boolean isUseLegacyReactorResolution()
+    {
+        return this.useLegacyReactorResolution;
+    }
+
+    /** @since 3.3.0 */
+    public MavenExecutionRequest setUseLegacyReactorResolution( boolean value )
+    {
+        this.useLegacyReactorResolution = value;
+        return this;
+    }
+
     public MavenExecutionRequest setBuilderId( String builderId )
     {
         this.builderId = builderId;

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -388,6 +388,16 @@ public interface MavenExecutionRequest
     MavenExecutionRequest setUseLegacyLocalRepository( boolean useLegacyLocalRepository );
 
     /**
+     * @since 3.3.0
+     */
+    boolean isUseLegacyReactorResolution();
+
+    /**
+     * @since 3.3.0
+     */
+    MavenExecutionRequest setUseLegacyReactorResolution( boolean value );
+
+    /**
      * Controls the {@link Builder} used by Maven by specification of the builder's id.
      *
      * @since 3.2.0

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -148,7 +148,12 @@ public class DefaultRepositorySystemSessionFactory
             session.setLocalRepositoryManager( repoSystem.newLocalRepositoryManager( session, localRepo ) );
         }
 
-        if ( request.getWorkspaceReader() != null )
+        // As of Maven 3.3.0, workspace resolution can be disabled. See MNG-5738.
+        if ( request.isUseLegacyReactorResolution() )
+        {
+            session.setWorkspaceReader( null );
+        }
+        else if ( request.getWorkspaceReader() != null )
         {
             session.setWorkspaceReader( request.getWorkspaceReader() );
         }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -101,6 +101,8 @@ public class CLIManager
 
     public static final String LEGACY_LOCAL_REPOSITORY = "llr";
 
+    public static final String LEGACY_REACTOR_RESOLUTION = "lrr";
+
     public static final String BUILDER = "b";
 
     protected Options options;
@@ -141,6 +143,7 @@ public class CLIManager
         options.addOption( OptionBuilder.withLongOpt( "encrypt-password" ).hasOptionalArg().withDescription( "Encrypt server password" ).create( ENCRYPT_PASSWORD ) );
         options.addOption( OptionBuilder.withLongOpt( "threads" ).hasArg().withDescription( "Thread count, for instance 2.0C where C is core multiplied" ).create( THREADS ) );
         options.addOption( OptionBuilder.withLongOpt( "legacy-local-repository" ).withDescription( "Use Maven 2 Legacy Local Repository behaviour, ie no use of _remote.repositories. Can also be activated by using -Dmaven.legacyLocalRepo=true" ).create( LEGACY_LOCAL_REPOSITORY ) );
+        options.addOption( OptionBuilder.withLongOpt( "legacy-reactor-resolution" ).withDescription( "Use Maven 2 legacy reactor resolution behaviour, ie disable workspace resolution. Can also be activated by using -Dmaven.legacyReactorResolution=true" ).create( LEGACY_REACTOR_RESOLUTION ) );
         options.addOption( OptionBuilder.withLongOpt( "builder" ).hasArg().withDescription( "The id of the build strategy to use." ).create( BUILDER ) );
 
         // Adding this back in for compatibility with the verifier that hard codes this option.

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -272,6 +272,7 @@ public class MavenCli
             populateRequest( cliRequest );
             encryption( cliRequest );
             repository( cliRequest );
+            resolution( cliRequest );
             return execute( cliRequest );
         }
         catch ( ExitException e )
@@ -839,6 +840,16 @@ public class MavenCli
             || Boolean.getBoolean( "maven.legacyLocalRepo" ) )
         {
            cliRequest.request.setUseLegacyLocalRepository( true );
+        }
+    }
+
+    private void resolution( CliRequest cliRequest )
+        throws Exception
+    {
+        if ( cliRequest.commandLine.hasOption( CLIManager.LEGACY_REACTOR_RESOLUTION )
+                 || Boolean.getBoolean( "maven.legacyReactorResolution" ) )
+        {
+            cliRequest.request.setUseLegacyReactorResolution( true );
         }
     }
 


### PR DESCRIPTION
See http://jira.codehaus.org/browse/MNG-5738

This pull request will add a new command line flag '--legacy-reactor-resolution' to Maven to allow disabling workspace resolution. The name was choosen to be consistent with '--legacy-local-repositoy'.
