### PR TITLE
[MNG-4921] Add a qualityManagement element to the Project Object Model

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/project/inheritance/DefaultModelInheritanceAssembler.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/inheritance/DefaultModelInheritanceAssembler.java
@@ -261,6 +261,12 @@ public class DefaultModelInheritanceAssembler
             child.setCiManagement( parent.getCiManagement() );
         }
 
+        // qualityManagement
+        if ( child.getQualityManagement() == null )
+        {
+            child.setQualityManagement( parent.getQualityManagement() );
+        }
+
         // developers
         if ( child.getDevelopers().size() == 0 )
         {

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -42,6 +42,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.CiManagement;
+import org.apache.maven.model.QualityManagement;
 import org.apache.maven.model.Contributor;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
@@ -546,6 +547,16 @@ public class MavenProject
     public void setCiManagement( CiManagement ciManagement )
     {
         getModel().setCiManagement( ciManagement );
+    }
+
+    public QualityManagement getQualityManagement()
+    {
+        return getModel().getQualityManagement();
+    }
+
+    public void setQualityManagement( QualityManagement qualityManagement )
+    {
+        getModel().setQualityManagement( qualityManagement );
     }
 
     public IssueManagement getIssueManagement()

--- a/maven-model-builder/src/main/java/org/apache/maven/model/merge/MavenModelMerger.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/merge/MavenModelMerger.java
@@ -173,7 +173,7 @@ public class MavenModelMerger
 
     @Override
     protected void mergeModel_QualityManagement( Model target, Model source, boolean sourceDominant,
-                                            Map<Object, Object> context )
+                                                 Map<Object, Object> context )
     {
         QualityManagement src = source.getQualityManagement();
         if ( src != null )

--- a/maven-model-builder/src/main/java/org/apache/maven/model/merge/MavenModelMerger.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/merge/MavenModelMerger.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.CiManagement;
+import org.apache.maven.model.QualityManagement;
 import org.apache.maven.model.Contributor;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DeploymentRepository;
@@ -166,6 +167,24 @@ public class MavenModelMerger
                 tgt.setLocation( "", src.getLocation( "" ) );
                 target.setCiManagement( tgt );
                 mergeCiManagement( tgt, src, sourceDominant, context );
+            }
+        }
+    }
+
+    @Override
+    protected void mergeModel_QualityManagement( Model target, Model source, boolean sourceDominant,
+                                            Map<Object, Object> context )
+    {
+        QualityManagement src = source.getQualityManagement();
+        if ( src != null )
+        {
+            QualityManagement tgt = target.getQualityManagement();
+            if ( tgt == null )
+            {
+                tgt = new QualityManagement();
+                tgt.setLocation( "", src.getLocation( "" ) );
+                target.setQualityManagement( tgt );
+                mergeQualityManagement( tgt, src, sourceDominant, context );
             }
         }
     }

--- a/maven-model/src/main/java/org/apache/maven/model/merge/ModelMerger.java
+++ b/maven-model/src/main/java/org/apache/maven/model/merge/ModelMerger.java
@@ -469,7 +469,7 @@ public class ModelMerger
     }
 
     protected void mergeModel_QualityManagement( Model target, Model source, boolean sourceDominant,
-        Map<Object, Object> context )
+                                                 Map<Object, Object> context )
     {
         QualityManagement src = source.getQualityManagement();
         if ( src != null )
@@ -2160,14 +2160,14 @@ public class ModelMerger
     }
 
     protected void mergeQualityManagement( QualityManagement target, QualityManagement source, boolean sourceDominant,
-                                            Map<Object, Object> context )
+                                           Map<Object, Object> context )
     {
         mergeQualityManagement_System( target, source, sourceDominant, context );
         mergeQualityManagement_Url( target, source, sourceDominant, context );
     }
 
     protected void mergeQualityManagement_System( QualityManagement target, QualityManagement source,
-                                                    boolean sourceDominant, Map<Object, Object> context )
+                                                  boolean sourceDominant, Map<Object, Object> context )
     {
         String src = source.getSystem();
         if ( src != null )
@@ -2181,7 +2181,7 @@ public class ModelMerger
     }
 
     protected void mergeQualityManagement_Url( QualityManagement target, QualityManagement source,
-                                                boolean sourceDominant, Map<Object, Object> context )
+                                               boolean sourceDominant, Map<Object, Object> context )
     {
         String src = source.getUrl();
         if ( src != null )

--- a/maven-model/src/main/java/org/apache/maven/model/merge/ModelMerger.java
+++ b/maven-model/src/main/java/org/apache/maven/model/merge/ModelMerger.java
@@ -30,6 +30,7 @@ import org.apache.maven.model.Activation;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.CiManagement;
+import org.apache.maven.model.QualityManagement;
 import org.apache.maven.model.ConfigurationContainer;
 import org.apache.maven.model.Contributor;
 import org.apache.maven.model.Dependency;
@@ -145,6 +146,7 @@ public class ModelMerger
         mergeModel_IssueManagement( target, source, sourceDominant, context );
         mergeModel_Scm( target, source, sourceDominant, context );
         mergeModel_CiManagement( target, source, sourceDominant, context );
+        mergeModel_QualityManagement( target, source, sourceDominant, context );
         mergeModel_Prerequisites( target, source, sourceDominant, context );
         mergeModel_Build( target, source, sourceDominant, context );
         mergeModel_Profiles( target, source, sourceDominant, context );
@@ -463,6 +465,22 @@ public class ModelMerger
                 target.setCiManagement( tgt );
             }
             mergeCiManagement( tgt, src, sourceDominant, context );
+        }
+    }
+
+    protected void mergeModel_QualityManagement( Model target, Model source, boolean sourceDominant,
+        Map<Object, Object> context )
+    {
+        QualityManagement src = source.getQualityManagement();
+        if ( src != null )
+        {
+            QualityManagement tgt = target.getQualityManagement();
+            if ( tgt == null )
+            {
+                tgt = new QualityManagement();
+                target.setQualityManagement( tgt );
+            }
+            mergeQualityManagement( tgt, src, sourceDominant, context );
         }
     }
 
@@ -2138,6 +2156,41 @@ public class ModelMerger
         if ( sourceDominant )
         {
             target.setSendOnWarning( source.isSendOnWarning() );
+        }
+    }
+
+    protected void mergeQualityManagement( QualityManagement target, QualityManagement source, boolean sourceDominant,
+                                            Map<Object, Object> context )
+    {
+        mergeQualityManagement_System( target, source, sourceDominant, context );
+        mergeQualityManagement_Url( target, source, sourceDominant, context );
+    }
+
+    protected void mergeQualityManagement_System( QualityManagement target, QualityManagement source,
+                                                    boolean sourceDominant, Map<Object, Object> context )
+    {
+        String src = source.getSystem();
+        if ( src != null )
+        {
+            if ( sourceDominant || target.getSystem() == null )
+            {
+                target.setSystem( src );
+                target.setLocation( "system", source.getLocation( "system" ) );
+            }
+        }
+    }
+
+    protected void mergeQualityManagement_Url( QualityManagement target, QualityManagement source,
+                                                boolean sourceDominant, Map<Object, Object> context )
+    {
+        String src = source.getUrl();
+        if ( src != null )
+        {
+            if ( sourceDominant || target.getUrl() == null )
+            {
+                target.setUrl( src );
+                target.setLocation( "url", source.getLocation( "url" ) );
+            }
         }
     }
 

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -430,6 +430,19 @@
         </field>
 
         <!-- ====================================================================== -->
+        <!-- Quality Management                                                          -->
+        <!-- ====================================================================== -->
+
+        <field>
+          <name>qualityManagement</name>
+          <version>4.0.0+</version>
+          <description>The project's quality management information.</description>
+          <association>
+            <type>QualityManagement</type>
+          </association>
+        </field>
+
+        <!-- ====================================================================== -->
         <!-- Distribution Management                                                -->
         <!-- ====================================================================== -->
 
@@ -1075,6 +1088,35 @@
             <multiplicity>*</multiplicity>
             <type>Notifier</type>
           </association>
+        </field>
+      </fields>
+    </class>
+    <class java.clone="deep">
+      <name>QualityManagement</name>
+      <version>4.0.0+</version>
+      <description>
+        <![CDATA[
+        The <code>&lt;QualityManagement&gt;</code> element contains informations required to the
+        quality management system of the project.
+        ]]>
+      </description>
+      <fields>
+        <field>
+          <name>system</name>
+          <version>4.0.0+</version>
+          <description>
+            <![CDATA[
+            The name of the quality management system, e.g. <code>SonarQube</code>.
+            ]]>
+          </description>
+          <type>String</type>
+        </field>
+        <field>
+          <name>url</name>
+          <version>4.0.0+</version>
+          <description>URL for the quality management system used by the project if it has a web
+            interface.</description>
+          <type>String</type>
         </field>
       </fields>
     </class>

--- a/maven-model/src/test/java/org/apache/maven/model/QualityManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/QualityManagementTest.java
@@ -1,0 +1,56 @@
+package org.apache.maven.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.TestCase;
+
+/**
+ * Tests {@code QualityManagement}.
+ *
+ * @author Xavier Chatelain
+ */
+public class QualityManagementTest
+    extends TestCase
+{
+
+    public void testHashCodeNullSafe()
+    {
+        new QualityManagement().hashCode();
+    }
+
+    public void testEqualsNullSafe()
+    {
+        assertFalse( new QualityManagement().equals( null ) );
+
+        new QualityManagement().equals( new QualityManagement() );
+    }
+
+    public void testEqualsIdentity()
+    {
+        QualityManagement thing = new QualityManagement();
+        assertTrue( thing.equals( thing ) );
+    }
+
+    public void testToStringNullSafe()
+    {
+        assertNotNull( new QualityManagement().toString() );
+    }
+
+}


### PR DESCRIPTION
Cf. https://jira.codehaus.org/browse/MPIR-149
Need first this new qualityManagement element into the Project Object Model
Then another patch will be possible to add a new Quality Management report into the maven-project-info-reports-plugin
