### PR TITLE
[MNG-5686] Use /usr/libexec/java_home to find JAVA_HOME

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -83,7 +83,7 @@ case "`uname`" in
              #
              # Apple JDKs
              #
-             export JAVA_HOME=/usr/libexec/java_home
+             export JAVA_HOME=`/usr/libexec/java_home`
            fi
            ;;
 esac

--- a/apache-maven/src/bin/mvnDebug
+++ b/apache-maven/src/bin/mvnDebug
@@ -82,6 +82,13 @@ case "`uname`" in
              #
              export JAVA_HOME=/Library/Java/JavaVirtualMachines/CurrentJDK/Contents/Home
            fi           
+
+           if [ -z "$JAVA_HOME" ] && [ -x "/usr/libexec/java_home" ]; then
+             #
+             # Apple JDKs
+             #
+             export JAVA_HOME=`/usr/libexec/java_home`
+           fi
            ;;
 esac
 

--- a/apache-maven/src/bin/mvnyjp
+++ b/apache-maven/src/bin/mvnyjp
@@ -86,6 +86,13 @@ case "`uname`" in
              #
              export JAVA_HOME=/Library/Java/JavaVirtualMachines/CurrentJDK/Contents/Home
            fi           
+
+           if [ -z "$JAVA_HOME" ] && [ -x "/usr/libexec/java_home" ]; then
+             #
+             # Apple JDKs
+             #
+             export JAVA_HOME=`/usr/libexec/java_home`
+           fi
            ;;
 esac
 


### PR DESCRIPTION
This fixes the /usr/libexec/java_home choser (OSX) for the main script and adds the missing section to the other tows (ASF Commiter Signoff: ecki)