### PR TITLE
MNG-5734: Fail, rather than just warning, on empty '<module>' entries.

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -312,7 +312,7 @@ public class DefaultModelValidator
                 String module = m.getModules().get( i );
                 if ( StringUtils.isBlank( module ) )
                 {
-                    addViolation( problems, Severity.WARNING, Version.BASE, "modules.module[" + i + "]", null,
+                    addViolation( problems, Severity.ERROR, Version.BASE, "modules.module[" + i + "]", null,
                                   "has been specified without a path to the project directory.",
                                   m.getLocation( "modules" ) );
                 }

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -430,9 +430,9 @@ public class DefaultModelValidatorTest
     {
         SimpleProblemCollector result = validate( "empty-module.xml" );
 
-        assertViolations( result, 0, 0, 1 );
+        assertViolations( result, 0, 1, 0 );
 
-        assertTrue( result.getWarnings().get( 0 ).contains( "'modules.module[0]' has been specified without a path" ) );
+        assertTrue( result.getErrors().get( 0 ).contains( "'modules.module[0]' has been specified without a path" ) );
     }
 
     public void testDuplicatePlugin()


### PR DESCRIPTION
An incorrect non-blank module is currently treated as an error. Behave
the same way for a blank module, rather than simply warning about
the mistake.