### PR TITLE
Simplify the bootstrapping instructions to remove use of M2_HOME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@ If you want to bootstrap Maven, you'll need:
 - Java 1.6+
 - Ant 1.8 or later
 
-First, give Ant a location into which the completed Maven distro should be installed:
+Run Ant, specifying a location into which the completed Maven distro should be installed:
 
 ```
-export M2_HOME=$HOME/apps/maven/apache-maven-3.2.x-SNAPSHOT
+ant -Dmaven.home="$HOME/apps/maven/apache-maven-3.2.x-SNAPSHOT"
 ```
 
-Then, run Ant:
-
-```
-ant
-```
-
-Once the build completes, you should have a new Maven distro ready to roll in your $M2_HOME directory!
+Once the build completes, you should have a new Maven distro ready to roll in that directory!


### PR DESCRIPTION
General consensus on maven-dev ([Remove M2_HOME setup from download page instructions](http://mail-archives.apache.org/mod_mbox/maven-dev/201501.mbox/%3CCAPCjjnG_SUEbKTV9DW-tPN54WA-FgDm4wUpsjnVW01sjxb2POA@mail.gmail.com%3E)) was to deprecate M2_HOME from public documentation and eventually remove it from the source.

As part of doing that, avoid using it in the bootstrapping instructions in the README and use the equivalent `maven.home` property instead.
