### PR TITLE
MNG-5786: Fix edge case in determining maven.multiModuleProjectDirectory.

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -199,12 +199,14 @@ fi
 find_maven_basedir() {
   local basedir=$(pwd)
   local wdir=$(pwd)
-  while [ "$wdir" != '/' ] ; do
-    wdir=$(cd "$wdir/.."; pwd)
+  while true ; do
     if [ -d "$wdir"/.mvn ] ; then
       basedir=$wdir
       break
+    elif [ "$wdir" = '/' ] ; then
+      break;
     fi
+    wdir=$(cd "$wdir/.."; pwd)
   done
   echo "${basedir}"
 }


### PR DESCRIPTION
See [MNG-5786](https://jira.codehaus.org/browse/MNG-5786) for details. The commit message explains the issue in different words:

    MNG-5786: Fix maven.multiModuleProjectDirectory.
    
    Fixes an edge case where maven.multiModuleProjectDirectory is set incorrectly.
    Consider the following scenario:
    
      /some/path/to/the/workspace/.mvn
      /some/path/to/the/workspace/project/.mvn
      /some/path/to/the/workspace/project/pom.xml
    
    Prior to the fix, running Maven inside the *project* directory will cause
    maven.multiModuleProjectDirectory to be set to the *workspace* directory. The
    fix entails testing for the presence of .mvn before traversing one directory
    up, rather than afterwards.
    
    The loop termination condition was moved inside the loop, so as to ensure that
    .mvn can also be placed in the file system root.
