### PR TITLE
Fixed typo in error output

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/DefaultBuildPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/DefaultBuildPluginManager.java
@@ -189,7 +189,7 @@ public class DefaultBuildPluginManager
 
             ByteArrayOutputStream os = new ByteArrayOutputStream( 1024 );
             PrintStream ps = new PrintStream( os );
-            ps.println( "A type incompatibility occured while executing " + mojoDescriptor.getId() + ": "
+            ps.println( "A type incompatibility occurred while executing " + mojoDescriptor.getId() + ": "
                 + e.getMessage() );
             pluginRealm.display( ps );
 


### PR DESCRIPTION
Noticed a typo in an error log message:
"occured" should be "occurred".