### PR TITLE
FIX: MAVEN_OPTS env variable with mvnDebug

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -34,7 +34,11 @@
 #   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
 # ----------------------------------------------------------------------------
 
+
+
 if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  MAVEN_OPTS_TEMP="$MAVEN_OPTS"
 
   if [ -f /etc/mavenrc ] ; then
     . /etc/mavenrc
@@ -43,6 +47,8 @@ if [ -z "$MAVEN_SKIP_RC" ] ; then
   if [ -f "$HOME/.mavenrc" ] ; then
     . "$HOME/.mavenrc"
   fi
+
+  MAVEN_OPTS="$MAVEN_OPTS $MAVEN_OPTS_TEMP"
 
 fi
 


### PR DESCRIPTION
+ Add a temp env variable for save the MAVEN_OPTS before load .mavenrc.

Signed-off-by: Francisco Collao Garate <pcollaog@gmail.com>