### PR TITLE
[MNG-5816] Empy maven.config cause Maven to exit with failure

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -376,7 +376,10 @@ public class MavenCli
             {
                 for ( String arg : Files.toString( configFile, Charsets.UTF_8 ).split( "\\s+" ) )
                 {
-                    args.add( arg );
+                    if ( !arg.isEmpty() )
+                    {
+                        args.add( arg );
+                    }
                 }
 
                 CommandLine config = cliManager.parse( args.toArray( new String[args.size()] ) );


### PR DESCRIPTION
Avoided adding a non empty configuration argument that causes exception.