### PR TITLE
MNG-3092: Add strategy based version range resolver.

### DIFF
--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -19,304 +19,34 @@ package org.apache.maven.repository.internal;
  * under the License.
  */
 
-import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import org.apache.maven.artifact.repository.metadata.Versioning;
-import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.util.IOUtil;
-import org.eclipse.aether.RepositoryEvent.EventType;
-import org.eclipse.aether.RepositoryEvent;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.RequestTrace;
-import org.eclipse.aether.SyncContext;
 import org.eclipse.aether.impl.MetadataResolver;
 import org.eclipse.aether.impl.RepositoryEventDispatcher;
 import org.eclipse.aether.impl.SyncContextFactory;
-import org.eclipse.aether.impl.VersionRangeResolver;
-import org.eclipse.aether.metadata.DefaultMetadata;
-import org.eclipse.aether.metadata.Metadata;
-import org.eclipse.aether.repository.ArtifactRepository;
-import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.repository.WorkspaceReader;
-import org.eclipse.aether.resolution.MetadataRequest;
-import org.eclipse.aether.resolution.MetadataResult;
-import org.eclipse.aether.resolution.VersionRangeRequest;
-import org.eclipse.aether.resolution.VersionRangeResolutionException;
-import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.spi.locator.Service;
-import org.eclipse.aether.spi.locator.ServiceLocator;
-import org.eclipse.aether.spi.log.Logger;
 import org.eclipse.aether.spi.log.LoggerFactory;
-import org.eclipse.aether.spi.log.NullLoggerFactory;
-import org.eclipse.aether.util.version.GenericVersionScheme;
-import org.eclipse.aether.version.InvalidVersionSpecificationException;
-import org.eclipse.aether.version.Version;
-import org.eclipse.aether.version.VersionConstraint;
-import org.eclipse.aether.version.VersionScheme;
 
 /**
+ * This class is for backward compatibility only. Don't use it anymore.
+ * <p>
+ * Formally this implementation was the default {@link VersionRangeResolver} implementation and was registered without a
+ * <i>hint</i> (means default) instead.
+ * </p>
+ * <p>
+ * The version range algorithm has moved to {@link MavenDefaultVersionRangeResolver} and now this implementation
+ * delegate all calls to {@link StrategyVersionRangeResolver}.
+ * </p>
+ *
  * @author Benjamin Bentmann
+ *
+ * @deprecated For backward compatibility only. Use {@link MavenDefaultVersionRangeResolver} instead.
  */
-@Named
-@Component( role = VersionRangeResolver.class )
-public class DefaultVersionRangeResolver
-    implements VersionRangeResolver, Service
+@Deprecated
+public class DefaultVersionRangeResolver extends StrategyVersionRangeResolver
 {
 
-    private static final String MAVEN_METADATA_XML = "maven-metadata.xml";
-
-    @SuppressWarnings( "unused" )
-    @Requirement( role = LoggerFactory.class )
-    private Logger logger = NullLoggerFactory.LOGGER;
-
-    @Requirement
-    private MetadataResolver metadataResolver;
-
-    @Requirement
-    private SyncContextFactory syncContextFactory;
-
-    @Requirement
-    private RepositoryEventDispatcher repositoryEventDispatcher;
-
-    public DefaultVersionRangeResolver()
-    {
-        // enable default constructor
-    }
-
-    @Inject
-    DefaultVersionRangeResolver( MetadataResolver metadataResolver, SyncContextFactory syncContextFactory,
-                                 RepositoryEventDispatcher repositoryEventDispatcher, LoggerFactory loggerFactory )
-    {
-        setMetadataResolver( metadataResolver );
-        setSyncContextFactory( syncContextFactory );
-        setLoggerFactory( loggerFactory );
-        setRepositoryEventDispatcher( repositoryEventDispatcher );
-    }
-
-    public void initService( ServiceLocator locator )
-    {
-        setLoggerFactory( locator.getService( LoggerFactory.class ) );
-        setMetadataResolver( locator.getService( MetadataResolver.class ) );
-        setSyncContextFactory( locator.getService( SyncContextFactory.class ) );
-        setRepositoryEventDispatcher( locator.getService( RepositoryEventDispatcher.class ) );
-    }
-
-    public DefaultVersionRangeResolver setLoggerFactory( LoggerFactory loggerFactory )
-    {
-        this.logger = NullLoggerFactory.getSafeLogger( loggerFactory, getClass() );
-        return this;
-    }
-
-    void setLogger( LoggerFactory loggerFactory )
-    {
-        // plexus support
-        setLoggerFactory( loggerFactory );
-    }
-
-    public DefaultVersionRangeResolver setMetadataResolver( MetadataResolver metadataResolver )
-    {
-        if ( metadataResolver == null )
-        {
-            throw new IllegalArgumentException( "metadata resolver has not been specified" );
-        }
-        this.metadataResolver = metadataResolver;
-        return this;
-    }
-
-    public DefaultVersionRangeResolver setSyncContextFactory( SyncContextFactory syncContextFactory )
-    {
-        if ( syncContextFactory == null )
-        {
-            throw new IllegalArgumentException( "sync context factory has not been specified" );
-        }
-        this.syncContextFactory = syncContextFactory;
-        return this;
-    }
-
-    public DefaultVersionRangeResolver setRepositoryEventDispatcher( RepositoryEventDispatcher red )
-    {
-        if ( red == null )
-        {
-            throw new IllegalArgumentException( "repository event dispatcher has not been specified" );
-        }
-        this.repositoryEventDispatcher = red;
-        return this;
-    }
-
-    public VersionRangeResult resolveVersionRange( RepositorySystemSession session, VersionRangeRequest request )
-        throws VersionRangeResolutionException
-    {
-        VersionRangeResult result = new VersionRangeResult( request );
-
-        VersionScheme versionScheme = new GenericVersionScheme();
-
-        VersionConstraint versionConstraint;
-        try
-        {
-            versionConstraint = versionScheme.parseVersionConstraint( request.getArtifact().getVersion() );
-        }
-        catch ( InvalidVersionSpecificationException e )
-        {
-            result.addException( e );
-            throw new VersionRangeResolutionException( result );
-        }
-
-        result.setVersionConstraint( versionConstraint );
-
-        if ( versionConstraint.getRange() == null )
-        {
-            result.addVersion( versionConstraint.getVersion() );
-        }
-        else
-        {
-            Map<String, ArtifactRepository> versionIndex = getVersions( session, result, request );
-
-            List<Version> versions = new ArrayList<Version>();
-            for ( Map.Entry<String, ArtifactRepository> v : versionIndex.entrySet() )
-            {
-                try
-                {
-                    Version ver = versionScheme.parseVersion( v.getKey() );
-                    if ( versionConstraint.containsVersion( ver ) )
-                    {
-                        versions.add( ver );
-                        result.setRepository( ver, v.getValue() );
-                    }
-                }
-                catch ( InvalidVersionSpecificationException e )
-                {
-                    result.addException( e );
-                }
-            }
-
-            Collections.sort( versions );
-            result.setVersions( versions );
-        }
-
-        return result;
-    }
-
-    private Map<String, ArtifactRepository> getVersions( RepositorySystemSession session, VersionRangeResult result,
-                                                         VersionRangeRequest request )
-    {
-        RequestTrace trace = RequestTrace.newChild( request.getTrace(), request );
-
-        Map<String, ArtifactRepository> versionIndex = new HashMap<String, ArtifactRepository>();
-
-        Metadata metadata =
-            new DefaultMetadata( request.getArtifact().getGroupId(), request.getArtifact().getArtifactId(),
-                                 MAVEN_METADATA_XML, Metadata.Nature.RELEASE_OR_SNAPSHOT );
-
-        List<MetadataRequest> metadataRequests = new ArrayList<MetadataRequest>( request.getRepositories().size() );
-
-        metadataRequests.add( new MetadataRequest( metadata, null, request.getRequestContext() ) );
-
-        for ( RemoteRepository repository : request.getRepositories() )
-        {
-            MetadataRequest metadataRequest = new MetadataRequest( metadata, repository, request.getRequestContext() );
-            metadataRequest.setDeleteLocalCopyIfMissing( true );
-            metadataRequest.setTrace( trace );
-            metadataRequests.add( metadataRequest );
-        }
-
-        List<MetadataResult> metadataResults = metadataResolver.resolveMetadata( session, metadataRequests );
-
-        WorkspaceReader workspace = session.getWorkspaceReader();
-        if ( workspace != null )
-        {
-            List<String> versions = workspace.findVersions( request.getArtifact() );
-            for ( String version : versions )
-            {
-                versionIndex.put( version, workspace.getRepository() );
-            }
-        }
-
-        for ( MetadataResult metadataResult : metadataResults )
-        {
-            result.addException( metadataResult.getException() );
-
-            ArtifactRepository repository = metadataResult.getRequest().getRepository();
-            if ( repository == null )
-            {
-                repository = session.getLocalRepository();
-            }
-
-            Versioning versioning = readVersions( session, trace, metadataResult.getMetadata(), repository, result );
-            for ( String version : versioning.getVersions() )
-            {
-                if ( !versionIndex.containsKey( version ) )
-                {
-                    versionIndex.put( version, repository );
-                }
-            }
-        }
-
-        return versionIndex;
-    }
-
-    private Versioning readVersions( RepositorySystemSession session, RequestTrace trace, Metadata metadata,
-                                     ArtifactRepository repository, VersionRangeResult result )
-    {
-        Versioning versioning = null;
-
-        FileInputStream fis = null;
-        try
-        {
-            if ( metadata != null )
-            {
-                SyncContext syncContext = syncContextFactory.newInstance( session, true );
-
-                try
-                {
-                    syncContext.acquire( null, Collections.singleton( metadata ) );
-
-                    if ( metadata.getFile() != null && metadata.getFile().exists() )
-                    {
-                        fis = new FileInputStream( metadata.getFile() );
-                        org.apache.maven.artifact.repository.metadata.Metadata m =
-                            new MetadataXpp3Reader().read( fis, false );
-                        versioning = m.getVersioning();
-                    }
-                }
-                finally
-                {
-                    syncContext.close();
-                }
-            }
-        }
-        catch ( Exception e )
-        {
-            invalidMetadata( session, trace, metadata, repository, e );
-            result.addException( e );
-        }
-        finally
-        {
-            IOUtil.close( fis );
-        }
-
-        return ( versioning != null ) ? versioning : new Versioning();
-    }
-
-    private void invalidMetadata( RepositorySystemSession session, RequestTrace trace, Metadata metadata,
-                                  ArtifactRepository repository, Exception exception )
-    {
-        RepositoryEvent.Builder event = new RepositoryEvent.Builder( session, EventType.METADATA_INVALID );
-        event.setTrace( trace );
-        event.setMetadata( metadata );
-        event.setException( exception );
-        event.setRepository( repository );
-
-        repositoryEventDispatcher.dispatch( event.build() );
-    }
+  DefaultVersionRangeResolver( MetadataResolver metadataResolver, SyncContextFactory syncContextFactory,
+          RepositoryEventDispatcher repositoryEventDispatcher, LoggerFactory loggerFactory )
+  {
+    // do nothing
+  }
 
 }

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/MavenAetherModule.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/MavenAetherModule.java
@@ -19,13 +19,14 @@ package org.apache.maven.repository.internal;
  * under the License.
  */
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.name.Names;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
-
 import org.apache.maven.model.building.DefaultModelBuilderFactory;
 import org.apache.maven.model.building.ModelBuilder;
 import org.eclipse.aether.impl.AetherModule;
@@ -33,10 +34,6 @@ import org.eclipse.aether.impl.ArtifactDescriptorReader;
 import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.VersionRangeResolver;
 import org.eclipse.aether.impl.VersionResolver;
-
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import com.google.inject.name.Names;
 
 public final class MavenAetherModule
     extends AbstractModule
@@ -51,7 +48,7 @@ public final class MavenAetherModule
         bind( VersionResolver.class ) //
         .to( DefaultVersionResolver.class ).in( Singleton.class );
         bind( VersionRangeResolver.class ) //
-        .to( DefaultVersionRangeResolver.class ).in( Singleton.class );
+        .to( StrategyVersionRangeResolver.class ).in( Singleton.class );
         bind( MetadataGeneratorFactory.class ).annotatedWith( Names.named( "snapshot" ) ) //
         .to( SnapshotMetadataGeneratorFactory.class ).in( Singleton.class );
         bind( MetadataGeneratorFactory.class ).annotatedWith( Names.named( "versions" ) ) //

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/MavenDefaultVersionRangeResolver.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/MavenDefaultVersionRangeResolver.java
@@ -1,0 +1,339 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.IOUtil;
+import org.eclipse.aether.RepositoryEvent;
+import org.eclipse.aether.RepositoryEvent.EventType;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.RequestTrace;
+import org.eclipse.aether.SyncContext;
+import org.eclipse.aether.impl.MetadataResolver;
+import org.eclipse.aether.impl.RepositoryEventDispatcher;
+import org.eclipse.aether.impl.SyncContextFactory;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.ArtifactRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.WorkspaceReader;
+import org.eclipse.aether.resolution.MetadataRequest;
+import org.eclipse.aether.resolution.MetadataResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.spi.locator.Service;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.spi.log.Logger;
+import org.eclipse.aether.spi.log.LoggerFactory;
+import org.eclipse.aether.spi.log.NullLoggerFactory;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionConstraint;
+import org.eclipse.aether.version.VersionScheme;
+
+/**
+ * This implementation ({@value #VERSION_RANGE_RESOLVER_STRATEGY}) resolve all artifact versions in a version range.
+ * <p>
+ * version range: (,3.0.0]<br/>
+ * found versions: 1.0.0-SNAPSHOT,1.0.0, 1.0.1-SNAPSHOT, 2.0.0-SNAPSHOT, 2.0.0, 2.1.0-SNAPSHOT, 3.0.0-SNAPSHOT<br/>
+ * returned versions: 1.0.0-SNAPSHOT,1.0.0, 1.0.1-SNAPSHOT, 2.0.0-SNAPSHOT, 2.0.0, 2.1.0-SNAPSHOT, 3.0.0-SNAPSHOT
+ * </p>
+ *
+ * <p>
+ * Note: This implementation is the default version range resolve behavior of Maven.</p>
+ * <p>
+ * Note: This class was formally known as <code>DefaultVersionRangeResolver</code>.</p>
+ *
+ * @author Benjamin Bentmann
+ */
+
+@Named
+@Component( role = VersionRangeResolver.class, hint = MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY )
+public class MavenDefaultVersionRangeResolver
+        implements VersionRangeResolver, Service
+{
+
+  public static final String VERSION_RANGE_RESOLVER_STRATEGY = "mavenDefault";
+
+  private static final String MAVEN_METADATA_XML = "maven-metadata.xml";
+
+  @SuppressWarnings( "unused" )
+  @Requirement( role = LoggerFactory.class )
+  private Logger logger = NullLoggerFactory.LOGGER;
+
+  @Requirement
+  private MetadataResolver metadataResolver;
+
+  @Requirement
+  private SyncContextFactory syncContextFactory;
+
+  @Requirement
+  private RepositoryEventDispatcher repositoryEventDispatcher;
+
+  public MavenDefaultVersionRangeResolver()
+  {
+    // enable default constructor
+  }
+
+  @Inject
+  MavenDefaultVersionRangeResolver( final MetadataResolver metadataResolver,
+          final SyncContextFactory syncContextFactory, final RepositoryEventDispatcher repositoryEventDispatcher,
+          final LoggerFactory loggerFactory )
+  {
+    setMetadataResolver( metadataResolver );
+    setSyncContextFactory( syncContextFactory );
+    setLoggerFactory( loggerFactory );
+    setRepositoryEventDispatcher( repositoryEventDispatcher );
+  }
+
+  @Override
+  public void initService( final ServiceLocator locator )
+  {
+    setLoggerFactory( locator.getService( LoggerFactory.class ) );
+    setMetadataResolver( locator.getService( MetadataResolver.class ) );
+    setSyncContextFactory( locator.getService( SyncContextFactory.class ) );
+    setRepositoryEventDispatcher( locator.getService( RepositoryEventDispatcher.class ) );
+  }
+
+  public final MavenDefaultVersionRangeResolver setLoggerFactory( final LoggerFactory loggerFactory )
+  {
+    this.logger = NullLoggerFactory.getSafeLogger( loggerFactory, getClass() );
+    return this;
+  }
+
+  void setLogger( final LoggerFactory loggerFactory )
+  {
+    // plexus support
+    setLoggerFactory( loggerFactory );
+  }
+
+  public final MavenDefaultVersionRangeResolver setMetadataResolver( final MetadataResolver metadataResolver )
+  {
+    if ( metadataResolver == null )
+    {
+      throw new IllegalArgumentException( "metadata resolver has not been specified" );
+    }
+    this.metadataResolver = metadataResolver;
+    return this;
+  }
+
+  public final MavenDefaultVersionRangeResolver setSyncContextFactory( final SyncContextFactory syncContextFactory )
+  {
+    if ( syncContextFactory == null )
+    {
+      throw new IllegalArgumentException( "sync context factory has not been specified" );
+    }
+    this.syncContextFactory = syncContextFactory;
+    return this;
+  }
+
+  public final MavenDefaultVersionRangeResolver setRepositoryEventDispatcher( final RepositoryEventDispatcher red )
+  {
+    if ( red == null )
+    {
+      throw new IllegalArgumentException( "repository event dispatcher has not been specified" );
+    }
+    this.repositoryEventDispatcher = red;
+    return this;
+  }
+
+  @Override
+  public VersionRangeResult resolveVersionRange( final RepositorySystemSession session,
+          final VersionRangeRequest request )
+          throws VersionRangeResolutionException
+  {
+    final VersionRangeResult result = new VersionRangeResult( request );
+
+    final VersionScheme versionScheme = new GenericVersionScheme();
+
+    final VersionConstraint versionConstraint;
+    try
+    {
+      versionConstraint = versionScheme.parseVersionConstraint( request.getArtifact().getVersion() );
+    }
+    catch ( InvalidVersionSpecificationException e )
+    {
+      result.addException( e );
+      throw new VersionRangeResolutionException( result );
+    }
+
+    result.setVersionConstraint( versionConstraint );
+
+    if ( versionConstraint.getRange() == null )
+    {
+      result.addVersion( versionConstraint.getVersion() );
+    }
+    else
+    {
+      final Map<String, ArtifactRepository> versionIndex = getVersions( session, result, request );
+
+      final List<Version> versions = new ArrayList<Version>();
+      for ( Map.Entry<String, ArtifactRepository> v : versionIndex.entrySet() )
+      {
+        try
+        {
+          final Version ver = versionScheme.parseVersion( v.getKey() );
+          if ( versionConstraint.containsVersion( ver ) )
+          {
+            versions.add( ver );
+            result.setRepository( ver, v.getValue() );
+          }
+        }
+        catch ( InvalidVersionSpecificationException e )
+        {
+          result.addException( e );
+        }
+      }
+
+      Collections.sort( versions );
+      result.setVersions( versions );
+    }
+
+    return result;
+  }
+
+  private Map<String, ArtifactRepository> getVersions( final RepositorySystemSession session,
+          final VersionRangeResult result, final VersionRangeRequest request )
+  {
+    final RequestTrace trace = RequestTrace.newChild( request.getTrace(), request );
+
+    final Map<String, ArtifactRepository> versionIndex = new HashMap<String, ArtifactRepository>();
+
+    final Metadata metadata
+            = new DefaultMetadata( request.getArtifact().getGroupId(), request.getArtifact().getArtifactId(),
+                    MAVEN_METADATA_XML, Metadata.Nature.RELEASE_OR_SNAPSHOT );
+
+    final List<MetadataRequest> metadataRequests = new ArrayList<MetadataRequest>( request.getRepositories().size() );
+
+    metadataRequests.add( new MetadataRequest( metadata, null, request.getRequestContext() ) );
+
+    for ( final RemoteRepository repository : request.getRepositories() )
+    {
+      final MetadataRequest metadataRequest = new MetadataRequest( metadata, repository, request.getRequestContext() );
+      metadataRequest.setDeleteLocalCopyIfMissing( true );
+      metadataRequest.setTrace( trace );
+      metadataRequests.add( metadataRequest );
+    }
+
+    final List<MetadataResult> metadataResults = metadataResolver.resolveMetadata( session, metadataRequests );
+
+    final WorkspaceReader workspace = session.getWorkspaceReader();
+    if ( workspace != null )
+    {
+      final List<String> versions = workspace.findVersions( request.getArtifact() );
+      for ( final String version : versions )
+      {
+        versionIndex.put( version, workspace.getRepository() );
+      }
+    }
+
+    for ( final MetadataResult metadataResult : metadataResults )
+    {
+      result.addException( metadataResult.getException() );
+
+      ArtifactRepository repository = metadataResult.getRequest().getRepository();
+      if ( repository == null )
+      {
+        repository = session.getLocalRepository();
+      }
+
+      final Versioning versioning = readVersions( session, trace, metadataResult.getMetadata(), repository, result );
+      for ( final String version : versioning.getVersions() )
+      {
+        if ( !versionIndex.containsKey( version ) )
+        {
+          versionIndex.put( version, repository );
+        }
+      }
+    }
+
+    return versionIndex;
+  }
+
+  private Versioning readVersions( final RepositorySystemSession session, final RequestTrace trace,
+          final Metadata metadata, final ArtifactRepository repository, final VersionRangeResult result )
+  {
+    Versioning versioning = null;
+
+    FileInputStream fis = null;
+    try
+    {
+      if ( metadata != null )
+      {
+        final SyncContext syncContext = syncContextFactory.newInstance( session, true );
+
+        try
+        {
+          syncContext.acquire( null, Collections.singleton( metadata ) );
+
+          if ( metadata.getFile() != null && metadata.getFile().exists() )
+          {
+            fis = new FileInputStream( metadata.getFile() );
+            org.apache.maven.artifact.repository.metadata.Metadata m
+                    = new MetadataXpp3Reader().read( fis, false );
+            versioning = m.getVersioning();
+          }
+        }
+        finally
+        {
+          syncContext.close();
+        }
+      }
+    }
+    catch ( Exception e )
+    {
+      invalidMetadata( session, trace, metadata, repository, e );
+      result.addException( e );
+    }
+    finally
+    {
+      IOUtil.close( fis );
+    }
+
+    return ( versioning != null ) ? versioning : new Versioning();
+  }
+
+  private void invalidMetadata( final RepositorySystemSession session, final RequestTrace trace,
+          final Metadata metadata, final ArtifactRepository repository, final Exception exception )
+  {
+    final RepositoryEvent.Builder event = new RepositoryEvent.Builder( session, EventType.METADATA_INVALID );
+    event.setTrace( trace );
+    event.setMetadata( metadata );
+    event.setException( exception );
+    event.setRepository( repository );
+
+    repositoryEventDispatcher.dispatch( event.build() );
+  }
+
+}

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/OnlyReleaseVersionRangeResolver.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/OnlyReleaseVersionRangeResolver.java
@@ -1,0 +1,136 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Iterator;
+import javax.inject.Named;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.spi.locator.Service;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.spi.log.Logger;
+import org.eclipse.aether.spi.log.LoggerFactory;
+import org.eclipse.aether.spi.log.NullLoggerFactory;
+import org.eclipse.aether.version.Version;
+
+/**
+ * This implementation ({@value #VERSION_RANGE_RESOLVER_STRATEGY}) resolve all artifact versions in a version range and
+ * removes all "SNAPSHOT" versions.
+ * <p>
+ * Use the delegate {@link VersionRangeResolver} to resolve all versions within the version range and remove all
+ * "SNAPSHOT" version.
+ * </p>
+ * <p>
+ * version range: (,3.0.0]<br/>
+ * found versions: 1.0.0-SNAPSHOT,1.0.0, 1.0.1-SNAPSHOT, 2.0.0-SNAPSHOT, 2.0.0, 2.1.0-SNAPSHOT, 3.0.0-SNAPSHOT<br/>
+ * returned versions: 1.0.0, 2.0.0
+ * </p>
+ */
+
+@Named
+@Component( role = VersionRangeResolver.class, hint = OnlyReleaseVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY )
+public class OnlyReleaseVersionRangeResolver
+        implements VersionRangeResolver, Service
+{
+
+  public static final String VERSION_RANGE_RESOLVER_STRATEGY = "onlyReleases";
+
+  @SuppressWarnings( "unused" )
+  @Requirement( role = LoggerFactory.class )
+  private Logger logger = NullLoggerFactory.LOGGER;
+
+  @Requirement( hint = MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY )
+  private VersionRangeResolver delegateVersionRangeResolver;
+
+  public OnlyReleaseVersionRangeResolver()
+  {
+    // enable default constructor
+  }
+
+  @Override
+  public void initService( final ServiceLocator locator )
+  {
+    setLoggerFactory( locator.getService( LoggerFactory.class ) );
+    if ( null == delegateVersionRangeResolver )
+    {
+      MavenDefaultVersionRangeResolver mavenDefaultVersionRangeResolver = new MavenDefaultVersionRangeResolver();
+      mavenDefaultVersionRangeResolver.initService( locator );
+      setDelegateVersionRangeResolver( mavenDefaultVersionRangeResolver );
+    }
+  }
+
+  public final OnlyReleaseVersionRangeResolver setLoggerFactory( final LoggerFactory loggerFactory )
+  {
+    this.logger = NullLoggerFactory.getSafeLogger( loggerFactory, getClass() );
+    return this;
+  }
+
+  void setLogger( final LoggerFactory loggerFactory )
+  {
+    // plexus support
+    setLoggerFactory( loggerFactory );
+  }
+
+  /**
+   * Set the {@link VersionRangeResolver} who resolves all versions within the version range.
+   *
+   * @param delegateVersionRangeResolver must not be {@code null}
+   *
+   * @return this instance for fluent API
+   *
+   * @throws IllegalArgumentException if passed {@link VersionRangeResolver} is {@code null}
+   */
+  public final OnlyReleaseVersionRangeResolver setDelegateVersionRangeResolver(
+          final VersionRangeResolver delegateVersionRangeResolver )
+  {
+    if ( null == delegateVersionRangeResolver )
+    {
+      throw new IllegalArgumentException( "all version range resolver has not been specified" );
+    }
+    this.delegateVersionRangeResolver = delegateVersionRangeResolver;
+    return this;
+  }
+
+  @Override
+  public VersionRangeResult resolveVersionRange( final RepositorySystemSession session,
+          final VersionRangeRequest request ) throws VersionRangeResolutionException
+  {
+    if ( null == delegateVersionRangeResolver )
+    {
+      throw new VersionRangeResolutionException( null, "No internal version range resolver available." );
+    }
+    final VersionRangeResult resolveVersionRange = delegateVersionRangeResolver.resolveVersionRange( session, request );
+    for ( Iterator<Version> it = resolveVersionRange.getVersions().iterator(); it.hasNext(); )
+    {
+      // XXX: better way to identify a SNAPSHOT version
+      if ( String.valueOf( it.next() ).endsWith( "SNAPSHOT" ) )
+      {
+        it.remove();
+      }
+    }
+    return resolveVersionRange;
+  }
+
+}

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/ReleaseOnBoundariesVersionRangeResolver.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/ReleaseOnBoundariesVersionRangeResolver.java
@@ -1,0 +1,160 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Iterator;
+import javax.inject.Named;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.spi.locator.Service;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.spi.log.Logger;
+import org.eclipse.aether.spi.log.LoggerFactory;
+import org.eclipse.aether.spi.log.NullLoggerFactory;
+import org.eclipse.aether.version.Version;
+
+/**
+ * This implementation ({@value #VERSION_RANGE_RESOLVER_STRATEGY}) resolve all artifact versions in a version range but
+ * <b>only released</b> at the version range boundaries.
+ * <p>
+ * Use the delegate {@link VersionRangeResolver} to resolve all versions within the version range and remove every
+ * "SNAPSHOT" version at the begin and the end of the version range.
+ * </p>
+ * <p>
+ * version range: (,3.0.0]<br/>
+ * found versions: 1.0.0-SNAPSHOT,1.0.0, 1.0.1-SNAPSHOT, 2.0.0-SNAPSHOT, 2.0.0, 2.1.0-SNAPSHOT, 3.0.0-SNAPSHOT<br/>
+ * returned versions: 1.0.0, 1.0.1-SNAPSHOT, 2.0.0-SNAPSHOT, 2.0.0
+ * </p>
+ */
+
+@Named
+@Component( role = VersionRangeResolver.class,
+        hint = ReleaseOnBoundariesVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY )
+public class ReleaseOnBoundariesVersionRangeResolver
+        implements VersionRangeResolver, Service
+{
+
+  public static final String VERSION_RANGE_RESOLVER_STRATEGY = "releaseOnBoundaries";
+
+  @SuppressWarnings( "unused" )
+  @Requirement( role = LoggerFactory.class )
+  private Logger logger = NullLoggerFactory.LOGGER;
+
+  @Requirement( hint = MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY )
+  private VersionRangeResolver delegateVersionRangeResolver;
+
+  public ReleaseOnBoundariesVersionRangeResolver()
+  {
+    // enable default constructor
+  }
+
+  @Override
+  public void initService( final ServiceLocator locator )
+  {
+    setLoggerFactory( locator.getService( LoggerFactory.class ) );
+    if ( null == delegateVersionRangeResolver )
+    {
+      final MavenDefaultVersionRangeResolver mavenDefaultVersionRangeResolver = new MavenDefaultVersionRangeResolver();
+      mavenDefaultVersionRangeResolver.initService( locator );
+      setDelegateVersionRangeResolver( mavenDefaultVersionRangeResolver );
+    }
+  }
+
+  public final ReleaseOnBoundariesVersionRangeResolver setLoggerFactory( final LoggerFactory loggerFactory )
+  {
+    this.logger = NullLoggerFactory.getSafeLogger( loggerFactory, getClass() );
+    return this;
+  }
+
+  void setLogger( final LoggerFactory loggerFactory )
+  {
+    // plexus support
+    setLoggerFactory( loggerFactory );
+  }
+
+  /**
+   * Set the {@link VersionRangeResolver} who resolves all versions within the version range.
+   *
+   * @param delegateVersionRangeResolver must not be {@code null}
+   *
+   * @return this instance for fluent API
+   *
+   * @throws IllegalArgumentException if passed {@link VersionRangeResolver} is {@code null}
+   */
+  public final ReleaseOnBoundariesVersionRangeResolver setDelegateVersionRangeResolver(
+          final VersionRangeResolver delegateVersionRangeResolver )
+  {
+    if ( null == delegateVersionRangeResolver )
+    {
+      throw new IllegalArgumentException( "all version range resolver has not been specified" );
+    }
+    this.delegateVersionRangeResolver = delegateVersionRangeResolver;
+    return this;
+  }
+
+  @Override
+  public VersionRangeResult resolveVersionRange( final RepositorySystemSession session,
+          final VersionRangeRequest request )
+          throws VersionRangeResolutionException
+  {
+    if ( null == delegateVersionRangeResolver )
+    {
+      throw new VersionRangeResolutionException( null, "No internal version range resolver available." );
+    }
+    final VersionRangeResult resolveVersionRange = delegateVersionRangeResolver.resolveVersionRange( session, request );
+    // remove all SNAPSHOT versions on top of the list
+    for ( Iterator<Version> it = resolveVersionRange.getVersions().iterator(); it.hasNext(); )
+    {
+      if ( removeSNAPSHOTVersion( it ) )
+      {
+        break;
+      }
+    }
+
+    // remove all SNAPSHOT versions at the end of the list
+    for ( Iterator<Version> it = resolveVersionRange.getVersions().listIterator( resolveVersionRange.getVersions().
+            size() ); it.hasNext(); )
+    {
+      if ( removeSNAPSHOTVersion( it ) )
+      {
+        break;
+      }
+    }
+
+    return resolveVersionRange;
+  }
+
+  private boolean removeSNAPSHOTVersion( final Iterator<Version> iterator )
+  {
+    // XXX: better way to identify a SNAPSHOT version
+    if ( ! ! !String.valueOf( iterator.next() ).endsWith( "SNAPSHOT" ) )
+    {
+      return true;
+    }
+    iterator.remove();
+    return false;
+  }
+
+}

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/StrategyVersionRangeResolver.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/StrategyVersionRangeResolver.java
@@ -1,0 +1,224 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.spi.locator.Service;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.spi.log.Logger;
+import org.eclipse.aether.spi.log.LoggerFactory;
+import org.eclipse.aether.spi.log.NullLoggerFactory;
+
+/**
+ * This {@link VersionRangeResolver} implementation choose a named {@link VersionRangeResolver} based on system property
+ * {@value StrategyVersionRangeResolver#STRATEGY_PROPERTY_KEY}.
+ *
+ * <p>
+ * This implementation is the default implementation of {@link VersionRangeResolver}.
+ * It choose the concrete strategy out of all registered {@link VersionRangeResolver} instances.
+ * <br/>
+ * If the strategy is unknown the {@link MavenDefaultVersionRangeResolver}
+ * ({@value MavenDefaultVersionRangeResolver#VERSION_RANGE_RESOLVER_STRATEGY}) is used.
+ * </p>
+ */
+
+@Named
+@Component( role = VersionRangeResolver.class )
+public class StrategyVersionRangeResolver
+        implements VersionRangeResolver, Service
+{
+
+  /**
+   * system property key providing the {@link VersionRangeResolver} strategy.
+   */
+  public static final String STRATEGY_PROPERTY_KEY = "maven.versionRangeResolver.strategy";
+
+  @SuppressWarnings( "unused" )
+  @Requirement( role = LoggerFactory.class )
+  private Logger logger = NullLoggerFactory.LOGGER;
+
+  @Requirement( role = VersionRangeResolver.class,
+          hint = MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY )
+  private VersionRangeResolver defaultMavenVersionRangeResolver;
+
+  private VersionRangeResolver actualVersionRangeResolver;
+
+  // the key of the entry is the component`s hint.
+  @Requirement( role = VersionRangeResolver.class )
+  private final Map<String, VersionRangeResolver> versionrangeResolverStrategies
+          = new HashMap<String, VersionRangeResolver>();
+
+  public StrategyVersionRangeResolver()
+  {
+    // enable default constructor
+  }
+
+  @Inject
+  StrategyVersionRangeResolver( final LoggerFactory loggerFactory,
+          Map<String, VersionRangeResolver> versionRangeResolverStrategies )
+  {
+    setLoggerFactory( loggerFactory );
+    setVersionRangeResolverStrategies( versionRangeResolverStrategies );
+  }
+
+  @Override
+  public void initService( final ServiceLocator locator )
+  {
+    setLoggerFactory( locator.getService( LoggerFactory.class ) );
+    setVersionRangeResolverStrategies( locator.getServices( VersionRangeResolver.class ) );
+  }
+
+  public final StrategyVersionRangeResolver setLoggerFactory( final LoggerFactory loggerFactory )
+  {
+    this.logger = NullLoggerFactory.getSafeLogger( loggerFactory, getClass() );
+    return this;
+  }
+
+  void setLogger( final LoggerFactory loggerFactory )
+  {
+    // plexus support
+    setLoggerFactory( loggerFactory );
+  }
+
+  /**
+   * Replace all {@link VersionRangeResolver} strategies with the passed list.
+   *
+   * @param versionRangeResolverStrategies must not be {@code null}
+   *
+   * @return this instance for fluent API
+   *
+   * @throws IllegalArgumentException if the passed list is {@code null}
+   */
+  public final StrategyVersionRangeResolver setVersionRangeResolverStrategies(
+          final List<VersionRangeResolver> versionRangeResolverStrategies )
+  {
+    if ( null == versionRangeResolverStrategies )
+    {
+      throw new IllegalArgumentException( "version range resolver strategy not been specified" );
+    }
+    this.versionrangeResolverStrategies.clear();
+    for ( final VersionRangeResolver versionRangeResolverStrategy : versionRangeResolverStrategies )
+    {
+      if ( null == versionRangeResolverStrategy )
+      {
+        continue;
+      }
+      final Component component = versionRangeResolverStrategy.getClass().getAnnotation( Component.class );
+      if ( component != null && ! ! !versionrangeResolverStrategies.containsKey( component.hint() ) )
+      {
+        versionrangeResolverStrategies.put( component.hint(), versionRangeResolverStrategy );
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Replace all {@link VersionRangeResolver} strategies with the passed map.
+   *
+   * @param versionRangeResolverStrategies must not be {@code null}
+   *
+   * @return this instance for fluent API
+   *
+   * @throws IllegalArgumentException if the passed map is {@code null}
+   */
+  public final StrategyVersionRangeResolver setVersionRangeResolverStrategies(
+          final Map<String, VersionRangeResolver> versionRangeResolverStrategies )
+  {
+    if ( null == versionRangeResolverStrategies )
+    {
+      throw new IllegalArgumentException( "version range resolver strategy map not been specified" );
+    }
+    this.versionrangeResolverStrategies.clear();
+    this.versionrangeResolverStrategies.putAll( versionRangeResolverStrategies );
+    return this;
+  }
+
+  /**
+   *
+   * @return unmodifiable map of {@link VersionRangeResolver} strategies.
+   */
+  Map<String, VersionRangeResolver> getVersionrangeResolverStrategies()
+  {
+    return Collections.unmodifiableMap( versionrangeResolverStrategies );
+  }
+
+  @Override
+  public VersionRangeResult resolveVersionRange( final RepositorySystemSession session,
+          final VersionRangeRequest request ) throws VersionRangeResolutionException
+  {
+    return getVersionRangeResolverStrategy( getStrategyName( session.getSystemProperties() ) ).resolveVersionRange(
+            session, request );
+  }
+
+  /**
+   *
+   * @return version range resolver strategy never {@code null}
+   *
+   * @throws VersionRangeResolutionException if default version range strategy is unavailable.
+   */
+  VersionRangeResolver getVersionRangeResolverStrategy( final String strategyName )
+          throws VersionRangeResolutionException
+  {
+    if ( actualVersionRangeResolver != null )
+    {
+      return actualVersionRangeResolver;
+    }
+    final VersionRangeResolver versionRangeResolver = null == getVersionrangeResolverStrategies() ? null
+            : getVersionrangeResolverStrategies().get( strategyName );
+    if ( null == versionRangeResolver )
+    {
+      logger.debug( String.format( "Could not find a version range resolver strategy for name: %1$s", strategyName ) );
+      if ( defaultMavenVersionRangeResolver != null )
+      {
+        return actualVersionRangeResolver = defaultMavenVersionRangeResolver;
+      }
+      throw new VersionRangeResolutionException( null, "Invalid version range resolver strategy." );
+    }
+    logger.debug( String.format( "Using version range resolver strategy: %1$s [%2$s]", versionRangeResolver.getClass().
+            getName(), strategyName ) );
+    return actualVersionRangeResolver = versionRangeResolver;
+  }
+
+  /**
+   *
+   * @return strategy name never {@code null}
+   */
+  String getStrategyName( final Map<String, String> properties )
+  {
+    final String strategyName = StringUtils.defaultString( StringUtils.trim( properties.get( STRATEGY_PROPERTY_KEY ) ),
+            MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY );
+    return StringUtils.isBlank( strategyName )
+            ? MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY : strategyName;
+  }
+
+}

--- a/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/AbstractVersionRangeTestCase.java
+++ b/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/AbstractVersionRangeTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.maven.repository.internal;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionScheme;
+
+import static org.apache.maven.repository.internal.AbstractRepositoryTestCase.newTestRepository;
+
+/**
+ *
+ *
+ */
+public abstract class AbstractVersionRangeTestCase extends AbstractRepositoryTestCase
+{
+
+  protected final VersionRangeRequest request = new VersionRangeRequest();
+  protected final VersionScheme versionScheme = new GenericVersionScheme();
+
+  @Override
+  protected void setUp()
+          throws Exception
+  {
+    super.setUp();
+    request.addRepository( newTestRepository() );
+  }
+
+  @Override
+  protected void tearDown()
+          throws Exception
+  {
+    super.tearDown();
+  }
+
+  protected static boolean contains_SNAPSHOT_Versions( final List<Version> versions )
+  {
+    if ( null == versions || versions.isEmpty() )
+    {
+      return false;
+    }
+    return Arrays.deepToString( versions.toArray() ).contains( "SNAPSHOT" );
+  }
+
+}

--- a/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
+++ b/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
@@ -1,0 +1,381 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionScheme;
+
+/**
+ * Tests the {@link DefaultVersionRangeResolver} based on 'virtual' repository data stored at
+ * {@literal /maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml}
+ * <p>
+ * Note: Information about the version scheme: {@link org.eclipse.aether.util.version.GenericVersionScheme}.<br/>
+ * Design document for dependency version ranges: <a
+ * href="http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution"
+ * >http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution</a>
+ * </p>
+ */
+public class DefaultVersionRangeResolverTest
+    extends AbstractRepositoryTestCase
+{
+    private final VersionScheme versionScheme = new GenericVersionScheme();
+
+    private DefaultVersionRangeResolver sut;
+
+    private VersionRangeRequest request;
+
+    @Override
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+        // be sure we're testing the right class, i.e. DefaultVersionRangeResolver.class
+        sut = (DefaultVersionRangeResolver) lookup( VersionRangeResolver.class, "default" );
+        request = new VersionRangeRequest();
+        request.addRepository( newTestRepository() );
+    }
+
+    @Override
+    protected void tearDown()
+        throws Exception
+    {
+        sut = null;
+        super.tearDown();
+    }
+
+    /**
+     * Test resolves version range {@code (,2.0.0]} (x &lt;= 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0-SNAPSHOT} and ends with the highest
+     * inclusive version {@code 2.0.0}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftOpenRightInclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.0" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.2.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(,2.0.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 34, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code 1.2.0}.
+     * <p>
+     * The passed value is a 'soft' requirement on {@code 1.2.0} and <b>not</b> a real version range pattern. The
+     * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testSoft()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.0" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code 1.2.4} for a <b>unknown</b> version.
+     * <p>
+     * The passed value is a 'soft' requirement on {@code 1.2.4} and <b>not</b> a real version range pattern. The
+     * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testSoft_unknown()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.4" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.4" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2.0]}.
+     * <p>
+     * The passed value is a 'hard' requirement on {@code 1.2.0}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testHard()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2.4]} for a <b>unknown</b> version.
+     * <p>
+     * The passed value is a 'hard' requirement on the unknown version {@code 1.2.4}. The resolver does nothing but
+     * insert the passed value into {@link VersionRangeResult}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testHard_unknown()
+        throws Exception
+    {
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.4]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertNull( result.getLowestVersion() );
+        assertNull( result.getHighestVersion() );
+        assertTrue( result.getVersions().isEmpty() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2]}.
+     * <p>
+     * Based on javadoc of {@link GenericVersionScheme}:<br>
+     * <blockquote> An empty segment/string is equivalent to 0. </blockquote>
+     * </p>
+     * 
+     * @see GenericVersionScheme
+     * @throws Exception
+     */
+    public void testHard_short()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2.*]}.
+     * <p>
+     * Based on javadoc of {@link GenericVersionScheme}:<br>
+     * <blockquote> In addition to the above mentioned qualifiers, the tokens "min" and "max" may be used as final
+     * version segment to denote the smallest/greatest version having a given prefix. For example, "1.2.min" denotes the
+     * smallest version in the 1.2 line, "1.2.max" denotes the greatest version in the 1.2 line. A version range of the
+     * form "[M.N.*]" is short for "[M.N.min, M.N.max]". </blockquote>
+     * </p>
+     * 
+     * @see GenericVersionScheme
+     * @throws Exception
+     */
+    public void testHard_wildcard()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.2.0-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "1.2.3" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.2.2-SNAPSHOT" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "1.2.1" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.*]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 8, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code [1.0.0,2.0.0]} (1.0.0 &lt;= x &lt;= 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+     * version {@code 2.0.0}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftInclusiveRightInclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.1" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 33, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code [1.0.0,2.0.0)} (1.0.0 &lt;= x &lt; 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+     * version {@code 2.0.0-SNAPSHOT}.
+     * </p>
+     * <p>
+     * Note: {@code 2.0.0-SNAPSHOT} is 'lower' than {@code 2.0.0} and will be part of this version range.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftInclusiveRightExclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0-SNAPSHOT" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0)" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( 32, result.getVersions().size() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code (1.0.0,2.0.0]} (1.0.0 &lt; x &lt;= 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+     * inclusive version {@code 2.0.0}.
+     * </p>
+     * <p>
+     * Note: The version {@code 1.0.0} will be excluded by pattern and {@code 1.0.1-SNAPSHOT} is the lowest version
+     * instead.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftExclusiveRightInclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 32, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code (1.0.0,2.0.0)} (1.0.0 &lt; x &lt; 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+     * inclusive version {@code 2.0.0-SNAPSHOT}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftExclusiveRightExclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0-SNAPSHOT" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0)" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 31, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code [1.0.0,)} (x &lt; 1.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+     * version {@code 3.1.0-SNAPSHOT}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftInclusiveRightOpen()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "3.1.0-SNAPSHOT" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "2.0.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,)" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 69, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+    }
+
+}

--- a/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/MavenDefaultVersionRangeResolverTest.java
+++ b/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/MavenDefaultVersionRangeResolverTest.java
@@ -21,40 +21,34 @@ package org.apache.maven.repository.internal;
 
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.VersionRangeResolver;
-import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.Version;
-import org.eclipse.aether.version.VersionScheme;
 
 /**
- * Tests the {@link DefaultVersionRangeResolver} based on 'virtual' repository data stored at
+ * Tests the {@link MavenDefaultVersionRangeResolver} based on 'virtual' repository data stored at
  * {@literal /maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml}
  * <p>
  * Note: Information about the version scheme: {@link org.eclipse.aether.util.version.GenericVersionScheme}.<br/>
  * Design document for dependency version ranges: <a
  * href="http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution"
  * >http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution</a>
- * </p>
  */
-public class DefaultVersionRangeResolverTest
-    extends AbstractRepositoryTestCase
+public class MavenDefaultVersionRangeResolverTest
+        extends AbstractVersionRangeTestCase
 {
-    private final VersionScheme versionScheme = new GenericVersionScheme();
-
-    private DefaultVersionRangeResolver sut;
-
-    private VersionRangeRequest request;
+  private MavenDefaultVersionRangeResolver sut;
 
     @Override
     protected void setUp()
         throws Exception
     {
         super.setUp();
-        // be sure we're testing the right class, i.e. DefaultVersionRangeResolver.class
-        sut = (DefaultVersionRangeResolver) lookup( VersionRangeResolver.class, "default" );
-        request = new VersionRangeRequest();
-        request.addRepository( newTestRepository() );
+      // be sure we're testing the right class, i.e. DefaultVersionRangeResolver.class
+      final VersionRangeResolver resolver = lookup(VersionRangeResolver.class,
+              MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY );
+      assertTrue( MavenDefaultVersionRangeResolver.class.isInstance( resolver ) );
+      sut = (MavenDefaultVersionRangeResolver) resolver;
     }
 
     @Override

--- a/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/OnlyReleaseVersionRangeResolverTest.java
+++ b/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/OnlyReleaseVersionRangeResolverTest.java
@@ -1,0 +1,377 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.Version;
+
+/**
+ * Tests the {@link DefaultVersionRangeResolver} based on 'virtual' repository data stored at
+ * {@literal /maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml}
+ * <p>
+ * Note: Information about the version scheme: {@link org.eclipse.aether.util.version.GenericVersionScheme}.<br/>
+ * Design document for dependency version ranges: <a
+ * href="http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution"
+ * >http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution</a>
+ */
+public class OnlyReleaseVersionRangeResolverTest
+        extends AbstractVersionRangeTestCase
+{
+
+  private OnlyReleaseVersionRangeResolver sut;
+
+  @Override
+  protected void setUp()
+          throws Exception
+  {
+    super.setUp();
+    // be sure we're testing the right class, i.e. DefaultVersionRangeResolver.class
+    final VersionRangeResolver resolver = lookup( VersionRangeResolver.class,
+            OnlyReleaseVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY );
+    assertTrue( OnlyReleaseVersionRangeResolver.class.isInstance( resolver ) );
+    sut = (OnlyReleaseVersionRangeResolver) resolver;
+  }
+
+  @Override
+  protected void tearDown()
+          throws Exception
+  {
+    sut = null;
+    super.tearDown();
+  }
+
+  /**
+   * Test resolves version range {@code (,2.0.0]} (x &lt;= 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest
+   * inclusive version {@code 2.0.0}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftOpenRightInclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(,2.0.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 17, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+
+    assertFalse( contains_SNAPSHOT_Versions( result.getVersions() ) );
+  }
+
+  /**
+   * Test resolves version range {@code 1.2.0}.
+   * <p>
+   * The passed value is a 'soft' requirement on {@code 1.2.0} and <b>not</b> a real version range pattern. The
+   * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testSoft()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.0" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code 1.2.4} for a <b>unknown</b> version.
+   * <p>
+   * The passed value is a 'soft' requirement on {@code 1.2.4} and <b>not</b> a real version range pattern. The
+   * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testSoft_unknown()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.4" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.4" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2.0]}.
+   * <p>
+   * The passed value is a 'hard' requirement on {@code 1.2.0}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testHard()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2.4]} for a <b>unknown</b> version.
+   * <p>
+   * The passed value is a 'hard' requirement on the unknown version {@code 1.2.4}. The resolver does nothing but
+   * insert the passed value into {@link VersionRangeResult}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testHard_unknown()
+          throws Exception
+  {
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.4]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertNull( result.getLowestVersion() );
+    assertNull( result.getHighestVersion() );
+    assertTrue( result.getVersions().isEmpty() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2]}.
+   * <p>
+   * Based on javadoc of {@link GenericVersionScheme}:<br>
+   * <blockquote> An empty segment/string is equivalent to 0. </blockquote>
+   * </p>
+   *
+   * @see GenericVersionScheme
+   * @throws Exception
+   */
+  public void testHard_short()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2.*]}.
+   * <p>
+   * Based on javadoc of {@link GenericVersionScheme}:<br>
+   * <blockquote> In addition to the above mentioned qualifiers, the tokens "min" and "max" may be used as final
+   * version segment to denote the smallest/greatest version having a given prefix. For example, "1.2.min" denotes the
+   * smallest version in the 1.2 line, "1.2.max" denotes the greatest version in the 1.2 line. A version range of the
+   * form "[M.N.*]" is short for "[M.N.min, M.N.max]". </blockquote>
+   * </p>
+   *
+   * @see GenericVersionScheme
+   * @throws Exception
+   */
+  public void testHard_wildcard()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.2.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "1.2.3" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "1.2.1" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.*]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 4, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+
+    assertFalse( contains_SNAPSHOT_Versions( result.getVersions() ) );
+  }
+
+  /**
+   * Test resolves version range {@code [1.0.0,2.0.0]} (1.0.0 &lt;= x &lt;= 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+   * version {@code 2.0.0}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftInclusiveRightInclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.1" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 17, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+
+    assertFalse( contains_SNAPSHOT_Versions( result.getVersions() ) );
+  }
+
+  /**
+   * Test resolves version range {@code [1.0.0,2.0.0)} (1.0.0 &lt;= x &lt; 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+   * version {@code 2.0.0-SNAPSHOT}.
+   * </p>
+   * <p>
+   * Note: {@code 2.0.0-SNAPSHOT} is 'lower' than {@code 2.0.0} and will be part of this version range.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftInclusiveRightExclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "1.3.3" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0)" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( 16, result.getVersions().size() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+
+    assertFalse( contains_SNAPSHOT_Versions( result.getVersions() ) );
+  }
+
+  /**
+   * Test resolves version range {@code (1.0.0,2.0.0]} (1.0.0 &lt; x &lt;= 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+   * inclusive version {@code 2.0.0}.
+   * </p>
+   * <p>
+   * Note: The version {@code 1.0.0} will be excluded by pattern and {@code 1.0.1-SNAPSHOT} is the lowest version
+   * instead.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftExclusiveRightInclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 16, result.getVersions().size() );
+
+    assertFalse( contains_SNAPSHOT_Versions( result.getVersions() ) );
+  }
+
+  /**
+   * Test resolves version range {@code (1.0.0,2.0.0)} (1.0.0 &lt; x &lt; 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+   * inclusive version {@code 2.0.0-SNAPSHOT}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftExclusiveRightExclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "1.3.3" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0)" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 15, result.getVersions().size() );
+
+    assertFalse( contains_SNAPSHOT_Versions( result.getVersions() ) );
+  }
+
+  /**
+   * Test resolves version range {@code [1.0.0,)} (x &lt; 1.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+   * version {@code 3.1.0-SNAPSHOT}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftInclusiveRightOpen()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "3.0.1" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "2.0.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,)" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 34, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+
+    assertFalse( contains_SNAPSHOT_Versions( result.getVersions() ) );
+  }
+
+}

--- a/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/ReleaseOnBoundariesVersionRangeResolverTest.java
+++ b/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/ReleaseOnBoundariesVersionRangeResolverTest.java
@@ -1,0 +1,375 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.Version;
+
+/**
+ * Tests the {@link ReleaseOnBoundariesVersionRangeResolver} based on 'virtual' repository data stored at
+ * {@literal /maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml}
+ * <p>
+ * Note: Information about the version scheme: {@link org.eclipse.aether.util.version.GenericVersionScheme}.<br/>
+ * Design document for dependency version ranges: <a
+ * href="http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution"
+ * >http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution</a>
+ */
+public class ReleaseOnBoundariesVersionRangeResolverTest
+        extends AbstractVersionRangeTestCase
+{
+
+  private ReleaseOnBoundariesVersionRangeResolver sut;
+
+  @Override
+  protected void setUp()
+          throws Exception
+  {
+    super.setUp();
+    // be sure we're testing the right class, i.e. ReleaseOnBoundariesVersionRangeResolver class
+    final VersionRangeResolver resolver = lookup( VersionRangeResolver.class,
+            ReleaseOnBoundariesVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY );
+    assertTrue( ReleaseOnBoundariesVersionRangeResolver.class.isInstance( resolver ) );
+    sut = (ReleaseOnBoundariesVersionRangeResolver) resolver;
+  }
+
+  @Override
+  protected void tearDown()
+          throws Exception
+  {
+    sut = null;
+    super.tearDown();
+  }
+
+  /**
+   * Test resolves version range {@code (,2.0.0]} (x &lt;= 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0-SNAPSHOT} and ends with the highest
+   * inclusive version {@code 2.0.0}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftOpenRightInclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.0" );
+    final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.2.1-SNAPSHOT" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(,2.0.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 33, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+    assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+  }
+
+  /**
+   * Test resolves version range {@code 1.2.0}.
+   * <p>
+   * The passed value is a 'soft' requirement on {@code 1.2.0} and <b>not</b> a real version range pattern. The
+   * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testSoft()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.0" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code 1.2.4} for a <b>unknown</b> version.
+   * <p>
+   * The passed value is a 'soft' requirement on {@code 1.2.4} and <b>not</b> a real version range pattern. The
+   * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testSoft_unknown()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.4" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.4" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2.0]}.
+   * <p>
+   * The passed value is a 'hard' requirement on {@code 1.2.0}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testHard()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2.4]} for a <b>unknown</b> version.
+   * <p>
+   * The passed value is a 'hard' requirement on the unknown version {@code 1.2.4}. The resolver does nothing but
+   * insert the passed value into {@link VersionRangeResult}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testHard_unknown()
+          throws Exception
+  {
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.4]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertNull( result.getLowestVersion() );
+    assertNull( result.getHighestVersion() );
+    assertTrue( result.getVersions().isEmpty() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2]}.
+   * <p>
+   * Based on javadoc of {@link GenericVersionScheme}:<br>
+   * <blockquote> An empty segment/string is equivalent to 0. </blockquote>
+   * </p>
+   *
+   * @see GenericVersionScheme
+   * @throws Exception
+   */
+  public void testHard_short()
+          throws Exception
+  {
+    final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedVersion, result.getLowestVersion() );
+    assertEquals( expectedVersion, result.getHighestVersion() );
+    assertEquals( 1, result.getVersions().size() );
+  }
+
+  /**
+   * Test resolves version range {@code [1.2.*]}.
+   * <p>
+   * Based on javadoc of {@link GenericVersionScheme}:<br>
+   * <blockquote> In addition to the above mentioned qualifiers, the tokens "min" and "max" may be used as final
+   * version segment to denote the smallest/greatest version having a given prefix. For example, "1.2.min" denotes the
+   * smallest version in the 1.2 line, "1.2.max" denotes the greatest version in the 1.2 line. A version range of the
+   * form "[M.N.*]" is short for "[M.N.min, M.N.max]". </blockquote>
+   * </p>
+   *
+   * @see GenericVersionScheme
+   * @throws Exception
+   */
+  public void testHard_wildcard()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.2.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "1.2.3" );
+    final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.2.2-SNAPSHOT" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "1.2.1" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.*]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 7, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+  }
+
+  /**
+   * Test resolves version range {@code [1.0.0,2.0.0]} (1.0.0 &lt;= x &lt;= 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+   * version {@code 2.0.0}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftInclusiveRightInclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+    final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.1" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 33, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+  }
+
+  /**
+   * Test resolves version range {@code [1.0.0,2.0.0)} (1.0.0 &lt;= x &lt; 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+   * version {@code 2.0.0-SNAPSHOT}.
+   * </p>
+   * <p>
+   * Note: {@code 2.0.0-SNAPSHOT} is 'lower' than {@code 2.0.0} and will be part of this version range.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftInclusiveRightExclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0-SNAPSHOT" );
+    final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0)" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( 32, result.getVersions().size() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+  }
+
+  /**
+   * Test resolves version range {@code (1.0.0,2.0.0]} (1.0.0 &lt; x &lt;= 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+   * inclusive version {@code 2.0.0}.
+   * </p>
+   * <p>
+   * Note: The version {@code 1.0.0} will be excluded by pattern and {@code 1.0.1-SNAPSHOT} is the lowest version
+   * instead.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftExclusiveRightInclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+    final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0]" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 31, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+  }
+
+  /**
+   * Test resolves version range {@code (1.0.0,2.0.0)} (1.0.0 &lt; x &lt; 2.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+   * inclusive version {@code 2.0.0-SNAPSHOT}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftExclusiveRightExclusive()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0-SNAPSHOT" );
+    final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0)" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 30, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+  }
+
+  /**
+   * Test resolves version range {@code [1.0.0,)} (x &lt; 1.0.0).
+   * <p>
+   * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+   * version {@code 3.1.0-SNAPSHOT}.
+   * </p>
+   *
+   * @throws Exception
+   */
+  public void testLeftInclusiveRightOpen()
+          throws Exception
+  {
+    final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+    final Version expectedHighestVersion = versionScheme.parseVersion( "3.1.0-SNAPSHOT" );
+    final Version expectedReleaseVersion = versionScheme.parseVersion( "2.0.0" );
+
+    request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,)" ) );
+
+    final VersionRangeResult result = sut.resolveVersionRange( session, request );
+    assertNotNull( result );
+    assertEquals( expectedLowestVersion, result.getLowestVersion() );
+    assertEquals( expectedHighestVersion, result.getHighestVersion() );
+    assertEquals( 69, result.getVersions().size() );
+    assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+  }
+
+}

--- a/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/StrategyVersionRangeResolverTest.java
+++ b/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/StrategyVersionRangeResolverTest.java
@@ -1,0 +1,118 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.VersionScheme;
+
+/**
+ */
+public class StrategyVersionRangeResolverTest
+        extends AbstractRepositoryTestCase
+{
+
+  private final VersionScheme versionScheme = new GenericVersionScheme();
+
+  private StrategyVersionRangeResolver sut;
+
+  private VersionRangeRequest request;
+
+  @Override
+  protected void setUp()
+          throws Exception
+  {
+    super.setUp();
+    // be sure we're testing the right class, i.e. DefaultVersionRangeResolver.class
+    final VersionRangeResolver resolver = lookup( VersionRangeResolver.class );
+    assertTrue( StrategyVersionRangeResolver.class.isInstance( resolver ) );
+    sut = (StrategyVersionRangeResolver) resolver;
+    request = new VersionRangeRequest();
+    request.addRepository( newTestRepository() );
+  }
+
+  @Override
+  protected void tearDown()
+          throws Exception
+  {
+    sut = null;
+    super.tearDown();
+  }
+
+  public void testVersionRangeStrategies()
+  {
+    assertNotNull( sut.getVersionrangeResolverStrategies() );
+    assertFalse( sut.getVersionrangeResolverStrategies().isEmpty() );
+  }
+
+  public void testVersionRangeStrategies_mavenDefault()
+  {
+    assertNotNull( sut.getVersionrangeResolverStrategies().get(
+            MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY ) );
+  }
+
+  public void testVersionRangeStrategies_onlyReleases()
+  {
+    assertNotNull( sut.getVersionrangeResolverStrategies().get(
+            OnlyReleaseVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY ) );
+  }
+
+  public void testVersionRangeStrategies_releaseOnBoundaries()
+  {
+    assertNotNull( sut.getVersionrangeResolverStrategies().get(
+            ReleaseOnBoundariesVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY ) );
+  }
+
+  public void testGetStrategyName_notSet()
+  {
+    assertEquals( MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY, sut.getStrategyName( session.
+            getSystemProperties() ) );
+  }
+
+  public void testGetStrategyName_empty()
+  {
+    final Map<String, String> systemProperties = new HashMap<String, String>();
+    systemProperties.putAll( session.getSystemProperties() );
+    systemProperties.put( StrategyVersionRangeResolver.STRATEGY_PROPERTY_KEY, "" );
+    assertEquals( MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY, sut.getStrategyName(
+            systemProperties ) );
+  }
+
+  public void testGetStrategyName_blank()
+  {
+    final Map<String, String> systemProperties = new HashMap<String, String>();
+    systemProperties.putAll( session.getSystemProperties() );
+    systemProperties.put( StrategyVersionRangeResolver.STRATEGY_PROPERTY_KEY, "      " );
+    assertEquals( MavenDefaultVersionRangeResolver.VERSION_RANGE_RESOLVER_STRATEGY, sut.getStrategyName(
+            systemProperties ) );
+  }
+
+  public void testGetStrategyName()
+  {
+    final Map<String, String> systemProperties = new HashMap<String, String>();
+    systemProperties.putAll( session.getSystemProperties() );
+    systemProperties.put( StrategyVersionRangeResolver.STRATEGY_PROPERTY_KEY, "expectedStrategy" );
+    assertEquals( "expectedStrategy", sut.getStrategyName(
+            systemProperties ) );
+  }
+
+}

--- a/maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml
+++ b/maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata xmlns="http://maven.apache.org/METADATA/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/METADATA/1.1.0 http://maven.apache.org/xsd/metadata-1.1.0.xsd">
+  <groupId>ut.simple</groupId>
+  <artifactId>parent</artifactId>
+  <versioning>
+    <latest>3.1.0-SNAPSHOT</latest>
+    <release>3.0.1</release>
+    <versions>
+      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0</version>
+      <version>1.0.1-SNAPSHOT</version>
+      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
+      <version>1.0.2</version>
+      <version>1.0.3-SNAPSHOT</version>
+      <version>1.0.3</version>
+      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
+      <version>1.1.1</version>
+      <version>1.1.2-SNAPSHOT</version>
+      <version>1.1.2</version>
+      <version>1.1.3-SNAPSHOT</version>
+      <version>1.1.3</version>
+      <version>1.2.0-SNAPSHOT</version>
+      <version>1.2.0</version>
+      <version>1.2.1-SNAPSHOT</version>
+      <version>1.2.1</version>
+      <version>1.2.2-SNAPSHOT</version>
+      <version>1.2.2</version>
+      <version>1.2.3-SNAPSHOT</version>
+      <version>1.2.3</version>
+      <version>1.3.0-SNAPSHOT</version>
+      <version>1.3.0</version>
+      <version>1.3.1-SNAPSHOT</version>
+      <version>1.3.1</version>
+      <version>1.3.2-SNAPSHOT</version>
+      <version>1.3.2</version>
+      <version>1.3.3-SNAPSHOT</version>
+      <version>1.3.3</version>
+      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0</version>
+      <version>2.0.1-SNAPSHOT</version>
+      <version>2.0.1</version>
+      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.2</version>
+      <version>2.0.3-SNAPSHOT</version>
+      <version>2.0.3</version>
+      <version>2.1.0-SNAPSHOT</version>
+      <version>2.1.0</version>
+      <version>2.1.1-SNAPSHOT</version>
+      <version>2.1.1</version>
+      <version>2.1.2-SNAPSHOT</version>
+      <version>2.1.2</version>
+      <version>2.1.3-SNAPSHOT</version>
+      <version>2.1.3</version>
+      <version>2.2.0-SNAPSHOT</version>
+      <version>2.2.0</version>
+      <version>2.2.1-SNAPSHOT</version>
+      <version>2.2.1</version>
+      <version>2.2.2-SNAPSHOT</version>
+      <version>2.2.2</version>
+      <version>2.2.3-SNAPSHOT</version>
+      <version>2.2.3</version>
+      <version>2.3.0-SNAPSHOT</version>
+      <version>2.3.0</version>
+      <version>2.3.1-SNAPSHOT</version>
+      <version>2.3.1</version>
+      <version>2.3.2-SNAPSHOT</version>
+      <version>2.3.2</version>
+      <version>2.3.3-SNAPSHOT</version>
+      <version>2.3.3</version>
+      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0</version>
+      <version>3.0.1-SNAPSHOT</version>
+      <version>3.0.1</version>
+      <version>3.0.2-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
+    </versions>
+    <lastUpdated>20150401000001</lastUpdated>
+  </versioning>
+</metadata>
+


### PR DESCRIPTION
The discussion on issue [MNG-3092](https://issues.apache.org/jira/browse/MNG-3092) shows the seriously needs of different kinds of version range resolving in Maven.

I know about the risk on changing the resolving mechanism in Maven.
I always had the backward compatibility in mind, if I have something changed.
I added some basic tests for the default version range resolver (strategy) before I've started with the refactoring.

This pull request contains a solution based on the strategy pattern.

The actual version range resolving algorithm **wasn't change** but moved into a strategy.
The provided other strategies are, more or less, only result filter around the result of the default version range strategy.

These changes are only placed in _maven-aether-provider_.

----

The original ```DefaultVersionRangeResolver``` will be replaced by the
new strategy pattern based version range resolver.

The actual version range resolving algorithm, formerly located in
```DefaultVersionRangeResolver```, is moved into a new strategy class
```MavenDefaultVersionRangeResolver``` with the name/hint ```"mavenDefault"```.
The resolving algorithm **WAS NOT CHANGED**.

The new ```StrategyVersionRangeResolver``` will be registered as new
default version range resolver (without name/hint).
Additional strategies are registered as ```VersionRangeResolver``` with a
unique name/hint.

The used strategy will be configured in ```StrategyVersionRangeResolver```
via the Maven system parameter ```-Dmaven.versionRangeResolver.strategy=...```.

If no strategy is configured or the strategy is unknown, the Maven
default version range resolver ```"mavenDefault"``` will be used.
Otherwise the named strategy will be used.

The following strategies are available:
* ```MavenDefaultVersionRangeResolver``` ```"mavenDefault"```
 * the actual UNTOUCHED default
 * resolves all versions including all _SNAPSHOT_ versions.
* ```ReleaseOnBoundariesVersionRangeResolver``` ```"releaseOnBoundaries"```
 * Used the ```MavenDefaultVersionRangeResolver``` internally and filters
the result. Removes all SNAPSHOT versions at the begin and the end of
the resolved versions list until to a released version.
* ```OnlyReleaseVersionRangeResolver``` ```"onlyReleases"```
 * Used the ```MavenDefaultVersionRangeResolver``` internally and filters
the result. Removes all SNAPSHOT versions at the resolved versions list.