### PR TITLE
[MNG-5840] Parent version is a range hack

### DIFF
--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-builder-support</artifactId>
     </dependency>
     <dependency>

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -20,20 +20,9 @@ package org.apache.maven.model.building;
  */
 
 
-import static org.apache.maven.model.building.Result.error;
-import static org.apache.maven.model.building.Result.newResult;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
@@ -72,6 +61,20 @@ import org.apache.maven.model.superpom.SuperPomProvider;
 import org.apache.maven.model.validation.ModelValidator;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.maven.model.building.Result.error;
+import static org.apache.maven.model.building.Result.newResult;
 
 /**
  * @author Benjamin Bentmann
@@ -921,15 +924,18 @@ public class DefaultModelBuilder
         }
         if ( version != null && parent.getVersion() != null && !version.equals( parent.getVersion() ) )
         {
-            //
-            // If the parent version is a range we will let it through here as we do not have the classes
-            // for determining if the parent is within the range in scope. This may lead to MNG-5840 style
-            // regressions in the range, but without this the parent version range will not work at all.
-            //
-
-            if ( !parent.getVersion().startsWith( "[" ) && !parent.getVersion().startsWith( "(" ) )
+            try
             {
-                // version skew drop back to resolution from the repository
+                VersionRange parentRange = VersionRange.createFromVersionSpec( parent.getVersion() );
+                if ( !parentRange.containsVersion( new DefaultArtifactVersion( version ) ) )
+                {
+                    // version skew drop back to resolution from the repository
+                    return null;
+                }
+            }
+            catch ( InvalidVersionSpecificationException e )
+            {
+                // invalid version range, so drop back to resolution from the repository
                 return null;
             }
         }


### PR DESCRIPTION
- I don't like this, but it does let all the integration tests pass:

```
Running org.apache.maven.it.MavenITmng2199ParentVersionRangeTest
mng2199ParentVersionRange(ValidParentVersionRangeWithInclusiveUpperBound)OK (3.7 s)
mng2199ParentVersionRange(ValidParentVersionRangeWithExclusiveUpperBound)OK (1.7 s)
mng2199ParentVersionRange(InvalidParentVersionRange)........OK (0.7 s)
mng2199ParentVersionRange(ValidParentVersionRangeInvalidVersionExpression)OK (0.5 s)
mng2199ParentVersionRange(ValidParentVersionRangeInvalidVersionInheritance)OK (0.4 s)
mng2199ParentVersionRange(ValidLocalParentVersionRange).....OK (0.4 s)
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.509 sec - in org.apache.maven.it.MavenITmng2199ParentVersionRangeTest
Running org.apache.maven.it.MavenITmng5840ParentVersionRanges
mng5840ParentVersionRanges(ParentRangeRelativePathPointsToWrongVersion)OK (0.4 s)
mng5840ParentVersionRanges(ParentRangeRelativePathPointsToCorrectVersion)OK (0.4 s)
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.784 sec - in org.apache.maven.it.MavenITmng5840ParentVersionRanges
Running org.apache.maven.it.MavenITmng5840RelativePathReactorMatching
mng5840RelativePathReactorMatching(RelativePathPointsToWrongVersion)OK (0.4 s)
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.374 sec - in org.apache.maven.it.MavenITmng5840RelativePathReactorMatching
```

I have created this as a pull request because I do not like the dependency change it requires.