### PR TITLE
fix release profile to use source:jar-no-fork instead of source:jar

### DIFF
--- a/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -117,7 +117,7 @@ under the License.
               <execution>
                 <id>attach-sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>jar-no-fork</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
This fixes `release-profile` in Maven's default pom so that it invokes `source:jar-no-fork` instead of `source:jar`, because the forked build can sometimes make troubles.

More details are in jira: [MNG-5863](https://issues.apache.org/jira/browse/MNG-5863).