### PR TITLE
Support directories with spaces in mvn

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -197,10 +197,10 @@ fi
 # traverses directory structure from process work directory to filesystem root
 # first directory with .mvn subdirectory is considered project base directory
 find_maven_basedir() {
-  local basedir=$(pwd)
-  local wdir=$(pwd)
+  local basedir="$(pwd)"
+  local wdir="$(pwd)"
   while [ "$wdir" != '/' ] ; do
-    wdir=$(cd "$wdir/.."; pwd)
+    wdir="$(cd "$wdir/.."; pwd)"
     if [ -d "$wdir"/.mvn ] ; then
       basedir=$wdir
       break
@@ -216,7 +216,7 @@ concat_lines() {
   fi
 }
 
-MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-$(find_maven_basedir)}
+MAVEN_PROJECTBASEDIR="${MAVEN_BASEDIR:-$(find_maven_basedir)}"
 MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
 
 # For Cygwin, switch project base directory path to Windows format before


### PR DESCRIPTION
find_maven_basedir() doesn't handle a current working directory containing spaces; this patch fixes this behaviour.