### PR TITLE
MNG-4463: Version ranges cannot be used for artifacts with 'import' scope

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -1185,7 +1185,13 @@ public class DefaultModelBuilder
                     final ModelSource importSource;
                     try
                     {
-                        importSource = modelResolver.resolveModel( groupId, artifactId, version );
+                        //https://issues.apache.org/jira/browse/MNG-4463 allow pom import via version range
+                        Parent parent = new Parent();
+                        parent.setGroupId( groupId );
+                        parent.setArtifactId( artifactId );
+                        parent.setVersion( version );
+                        
+                        importSource = modelResolver.resolveModel( parent );
                     }
                     catch ( UnresolvableModelException e )
                     {


### PR DESCRIPTION
MNG-4463:  Version ranges cannot be used for artifacts with 'import' scope
This is a quick patch to support version range resolution for artifacts with pom import.