### PR TITLE
Upgrade to Eclipse/Sisu 0.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- Latest version of Guava that works with Sisu -->
     <guavaVersion>18.0</guavaVersion>
     <guiceVersion>4.0</guiceVersion>
-    <sisuInjectVersion>0.3.1</sisuInjectVersion>
+    <sisuInjectVersion>0.3.2</sisuInjectVersion>
     <wagonVersion>2.9</wagonVersion> <!-- Verify SNAPSHOT for MNG-5605 -->
     <securityDispatcherVersion>1.3</securityDispatcherVersion>
     <cipherVersion>1.7</cipherVersion>


### PR DESCRIPTION
http://wiki.eclipse.org/Sisu/Changelog

Includes the following fixes of interest to Maven:

[470780](https://bugs.eclipse.org/bugs/show_bug.cgi?id=470780) - Date AM/PM parsing should use explicit locale
[470781](https://bugs.eclipse.org/bugs/show_bug.cgi?id=470781) - Only fall back to default-value if Plexus configuration has no value and no children
[475588](https://bugs.eclipse.org/bugs/show_bug.cgi?id=475588) - Make conversion of comma-separated strings to arrays/collections more consistent

If you spot anything odd/unexpected after upgrading please report it at https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Sisu&format=guided