### PR TITLE
MNG-3092: Filter Version Range Result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ out/
 /bootstrap
 /dependencies.xml
 .java-version
+nb-configuration.xml
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Maven is available under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- [Maven Issue Tracker](http://jira.codehaus.org/browse/MNG)
+- [Maven Issue Tracker](https://issues.apache.org/jira/browse/MNG)
 - [Maven Wiki](https://cwiki.apache.org/confluence/display/MAVEN/Index)
 - [Building Maven](http://maven.apache.org/guides/development/guide-building-m2.html)
 - [Running Core ITs](http://maven.apache.org/core-its/core-it-suite/)

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>apache-maven</artifactId>
@@ -37,7 +37,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>apache-maven</artifactId>
@@ -37,7 +37,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>apache-maven</artifactId>
@@ -37,7 +37,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>apache-maven</artifactId>
@@ -37,7 +37,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>apache-maven</artifactId>
@@ -37,7 +37,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>apache-maven</artifactId>
@@ -37,7 +37,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-aether-provider</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-aether-provider</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-aether-provider</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-aether-provider</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-aether-provider</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-aether-provider</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -19,6 +19,14 @@ package org.apache.maven.repository.internal;
  * under the License.
  */
 
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.codehaus.plexus.component.annotations.Component;
@@ -54,15 +62,6 @@ import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionConstraint;
 import org.eclipse.aether.version.VersionScheme;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * @author Benjamin Bentmann
  */
@@ -86,6 +85,9 @@ public class DefaultVersionRangeResolver
 
     @Requirement
     private RepositoryEventDispatcher repositoryEventDispatcher;
+
+    @Requirement( optional = true )
+    private VersionRangeResultFilter versionRangeResultFilter = new DefaultVersionRangeResultFilter();
 
     public DefaultVersionRangeResolver()
     {
@@ -152,6 +154,16 @@ public class DefaultVersionRangeResolver
         return this;
     }
 
+    public DefaultVersionRangeResolver setVersionRageResultFilter( VersionRangeResultFilter versionRangeResultFilter )
+    {
+        if ( versionRangeResultFilter == null )
+        {
+            throw new IllegalArgumentException( "version range result filter has not been specified" );
+        }
+        this.versionRangeResultFilter = versionRangeResultFilter;
+        return this;
+    }
+
     public VersionRangeResult resolveVersionRange( RepositorySystemSession session, VersionRangeRequest request )
         throws VersionRangeResolutionException
     {
@@ -202,7 +214,7 @@ public class DefaultVersionRangeResolver
             result.setVersions( versions );
         }
 
-        return result;
+      return versionRangeResultFilter.filterVersionRangeResult( result );
     }
 
     private Map<String, ArtifactRepository> getVersions( RepositorySystemSession session, VersionRangeResult result,

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResultFilter.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResultFilter.java
@@ -1,0 +1,44 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+
+/**
+ * Non filtering implementation of {@link VersionRangeResultFilter}.
+ *
+ * <p>
+ * This implementation reflects the Apache Maven default version range handling and don't filter anything out of
+ * {@link VersionRangeResult}.
+ *
+ * @since 3.3.7
+ */
+public class DefaultVersionRangeResultFilter implements VersionRangeResultFilter
+{
+
+  @Override
+    public VersionRangeResult filterVersionRangeResult( VersionRangeResult versionRangeResult )
+        throws VersionRangeResolutionException
+  {
+    return versionRangeResult;
+  }
+
+}

--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/VersionRangeResultFilter.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/VersionRangeResultFilter.java
@@ -1,0 +1,42 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+
+/**
+ * Filters the resolved versions provided by {@link VersionRangeResult#getVersions()}.
+ */
+public interface VersionRangeResultFilter
+{
+
+  /**
+   *
+   * @param versionRangeResult The version range result, must not be {@code null}
+   * @return A filtered version range result, never {@code null}
+   * @throws VersionRangeResolutionException If the requested range could not be parsed. Note that an empty range does
+   *                                         not raise an exception.
+   * @see VersionRangeResult#getVersions()
+   */
+  VersionRangeResult filterVersionRangeResult( VersionRangeResult versionRangeResult )
+          throws VersionRangeResolutionException;
+
+}

--- a/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
+++ b/maven-aether-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
@@ -1,0 +1,455 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Iterator;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionScheme;
+
+/**
+ * Tests the {@link DefaultVersionRangeResolver} based on 'virtual' repository data stored at
+ * {@literal /maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml}
+ * <p>
+ * Note: Information about the version scheme: {@link org.eclipse.aether.util.version.GenericVersionScheme}.<br/>
+ * Design document for dependency version ranges: <a
+ * href="http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution"
+ * >http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution</a>
+ * </p>
+ */
+public class DefaultVersionRangeResolverTest
+    extends AbstractRepositoryTestCase
+{
+    private final VersionScheme versionScheme = new GenericVersionScheme();
+
+    private DefaultVersionRangeResolver sut;
+
+    private VersionRangeRequest request;
+
+    @Override
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+        // be sure we're testing the right class, i.e. DefaultVersionRangeResolver.class
+        sut = (DefaultVersionRangeResolver) lookup( VersionRangeResolver.class, "default" );
+        request = new VersionRangeRequest();
+        request.addRepository( newTestRepository() );
+    }
+
+    @Override
+    protected void tearDown()
+        throws Exception
+    {
+        sut = null;
+        super.tearDown();
+    }
+
+    /**
+     * Test resolves version range {@code (,2.0.0]} (x &lt;= 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0-SNAPSHOT} and ends with the highest
+     * inclusive version {@code 2.0.0}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftOpenRightInclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.0" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.2.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(,2.0.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 34, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code 1.2.0}.
+     * <p>
+     * The passed value is a 'soft' requirement on {@code 1.2.0} and <b>not</b> a real version range pattern. The
+     * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testSoft()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.0" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code 1.2.4} for a <b>unknown</b> version.
+     * <p>
+     * The passed value is a 'soft' requirement on {@code 1.2.4} and <b>not</b> a real version range pattern. The
+     * resolver does nothing but insert the passed value into {@link VersionRangeResult}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testSoft_unknown()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.4" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "1.2.4" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2.0]}.
+     * <p>
+     * The passed value is a 'hard' requirement on {@code 1.2.0}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testHard()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2.4]} for a <b>unknown</b> version.
+     * <p>
+     * The passed value is a 'hard' requirement on the unknown version {@code 1.2.4}. The resolver does nothing but
+     * insert the passed value into {@link VersionRangeResult}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testHard_unknown()
+        throws Exception
+    {
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.4]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertNull( result.getLowestVersion() );
+        assertNull( result.getHighestVersion() );
+        assertTrue( result.getVersions().isEmpty() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2]}.
+     * <p>
+     * Based on javadoc of {@link GenericVersionScheme}:<br>
+     * <blockquote> An empty segment/string is equivalent to 0. </blockquote>
+     * </p>
+     * 
+     * @see GenericVersionScheme
+     * @throws Exception
+     */
+    public void testHard_short()
+        throws Exception
+    {
+        final Version expectedVersion = versionScheme.parseVersion( "1.2.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedVersion, result.getLowestVersion() );
+        assertEquals( expectedVersion, result.getHighestVersion() );
+        assertEquals( 1, result.getVersions().size() );
+    }
+
+    /**
+     * Test resolves version range {@code [1.2.*]}.
+     * <p>
+     * Based on javadoc of {@link GenericVersionScheme}:<br>
+     * <blockquote> In addition to the above mentioned qualifiers, the tokens "min" and "max" may be used as final
+     * version segment to denote the smallest/greatest version having a given prefix. For example, "1.2.min" denotes the
+     * smallest version in the 1.2 line, "1.2.max" denotes the greatest version in the 1.2 line. A version range of the
+     * form "[M.N.*]" is short for "[M.N.min, M.N.max]". </blockquote>
+     * </p>
+     * 
+     * @see GenericVersionScheme
+     * @throws Exception
+     */
+    public void testHard_wildcard()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.2.0-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "1.2.3" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.2.2-SNAPSHOT" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "1.2.1" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.2.*]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 8, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code [1.0.0,2.0.0]} (1.0.0 &lt;= x &lt;= 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+     * version {@code 2.0.0}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftInclusiveRightInclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "1.3.1" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 33, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code [1.0.0,2.0.0)} (1.0.0 &lt;= x &lt; 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+     * version {@code 2.0.0-SNAPSHOT}.
+     * </p>
+     * <p>
+     * Note: {@code 2.0.0-SNAPSHOT} is 'lower' than {@code 2.0.0} and will be part of this version range.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftInclusiveRightExclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0-SNAPSHOT" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,2.0.0)" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( 32, result.getVersions().size() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code (1.0.0,2.0.0]} (1.0.0 &lt; x &lt;= 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+     * inclusive version {@code 2.0.0}.
+     * </p>
+     * <p>
+     * Note: The version {@code 1.0.0} will be excluded by pattern and {@code 1.0.1-SNAPSHOT} is the lowest version
+     * instead.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftExclusiveRightInclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0]" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 32, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code (1.0.0,2.0.0)} (1.0.0 &lt; x &lt; 2.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.1-SNAPSHOT} and ends with the highest
+     * inclusive version {@code 2.0.0-SNAPSHOT}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftExclusiveRightExclusive()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.1-SNAPSHOT" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0-SNAPSHOT" );
+        final Version expectedSnapshotVersion = versionScheme.parseVersion( "1.3.1-SNAPSHOT" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(1.0.0,2.0.0)" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 31, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedSnapshotVersion ) );
+    }
+
+    /**
+     * Test resolves version range {@code [1.0.0,)} (x &lt; 1.0.0).
+     * <p>
+     * The expected version range starts with the lowest version {@code 1.0.0} and ends with the highest inclusive
+     * version {@code 3.1.0-SNAPSHOT}.
+     * </p>
+     * 
+     * @throws Exception
+     */
+    public void testLeftInclusiveRightOpen()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "3.1.0-SNAPSHOT" );
+        final Version expectedReleaseVersion = versionScheme.parseVersion( "2.0.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "[1.0.0,)" ) );
+
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 69, result.getVersions().size() );
+        assertTrue( result.getVersions().contains( expectedReleaseVersion ) );
+    }
+
+    /**
+     * Test filter of resolved version range {@code (,2.0.0]} (x &lt;= 2.0.0).
+     * <p>
+     * The expected versions are only non {@code SNAPSHOT}. The version range starts with the lowest version
+     * {@code 1.0.0} and ends with the highest inclusive version {@code 2.0.0}.
+     * </p>
+     *
+     * @throws Exception
+     */
+    public void testVersionRangeResultFilter()
+        throws Exception
+    {
+        final Version expectedLowestVersion = versionScheme.parseVersion( "1.0.0" );
+        final Version expectedHighestVersion = versionScheme.parseVersion( "2.0.0" );
+
+        request.setArtifact( new DefaultArtifact( "org.apache.maven.its", "mng-3092", "jar", "(,2.0.0]" ) );
+
+        sut.setVersionRageResultFilter( new TestOnlyVersionRangeResultFilter() );
+        final VersionRangeResult result = sut.resolveVersionRange( session, request );
+
+        assertNotNull( result );
+        assertEquals( expectedLowestVersion, result.getLowestVersion() );
+        assertEquals( expectedHighestVersion, result.getHighestVersion() );
+        assertEquals( 17, result.getVersions().size() );
+        for ( Iterator<Version> it = result.getVersions().iterator(); it.hasNext(); )
+        {
+            // XXX: better way to identify a SNAPSHOT version
+            if ( String.valueOf( it.next() ).endsWith( "SNAPSHOT" ) )
+            {
+                fail( "Non filtered SNAPSHOT version in version range result." );
+            }
+        }
+    }
+
+    /**
+     * Test error handling if invalid {@link VersionRangeResultFilter} will be set.
+     *
+     * @throws Exception
+     */
+    public void testInvalidVersionRangeResultFilter()
+        throws Exception
+    {
+        try
+        {
+            sut.setVersionRageResultFilter( null );
+            fail( "Exception expected by set invalid version range result filter." );
+        }
+        catch ( IllegalArgumentException iae )
+        {
+            assertEquals( "version range result filter has not been specified", iae.getMessage() );
+        }
+    }
+
+    private final class TestOnlyVersionRangeResultFilter implements VersionRangeResultFilter
+    {
+
+        @Override
+        public VersionRangeResult filterVersionRangeResult( VersionRangeResult versionRangeResult )
+            throws VersionRangeResolutionException
+        {
+            for ( Iterator<Version> it = versionRangeResult.getVersions().iterator(); it.hasNext(); )
+            {
+                // XXX: better way to identify a SNAPSHOT version
+                if ( String.valueOf( it.next() ).endsWith( "SNAPSHOT" ) )
+                {
+                    it.remove();
+                }
+            }
+            return versionRangeResult;
+        }
+
+    }
+}

--- a/maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml
+++ b/maven-aether-provider/src/test/resources/repo/org/apache/maven/its/mng-3092/maven-metadata.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata xmlns="http://maven.apache.org/METADATA/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/METADATA/1.1.0 http://maven.apache.org/xsd/metadata-1.1.0.xsd">
+  <groupId>ut.simple</groupId>
+  <artifactId>parent</artifactId>
+  <versioning>
+    <latest>3.1.0-SNAPSHOT</latest>
+    <release>3.0.1</release>
+    <versions>
+      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0</version>
+      <version>1.0.1-SNAPSHOT</version>
+      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
+      <version>1.0.2</version>
+      <version>1.0.3-SNAPSHOT</version>
+      <version>1.0.3</version>
+      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
+      <version>1.1.1</version>
+      <version>1.1.2-SNAPSHOT</version>
+      <version>1.1.2</version>
+      <version>1.1.3-SNAPSHOT</version>
+      <version>1.1.3</version>
+      <version>1.2.0-SNAPSHOT</version>
+      <version>1.2.0</version>
+      <version>1.2.1-SNAPSHOT</version>
+      <version>1.2.1</version>
+      <version>1.2.2-SNAPSHOT</version>
+      <version>1.2.2</version>
+      <version>1.2.3-SNAPSHOT</version>
+      <version>1.2.3</version>
+      <version>1.3.0-SNAPSHOT</version>
+      <version>1.3.0</version>
+      <version>1.3.1-SNAPSHOT</version>
+      <version>1.3.1</version>
+      <version>1.3.2-SNAPSHOT</version>
+      <version>1.3.2</version>
+      <version>1.3.3-SNAPSHOT</version>
+      <version>1.3.3</version>
+      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0</version>
+      <version>2.0.1-SNAPSHOT</version>
+      <version>2.0.1</version>
+      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.2</version>
+      <version>2.0.3-SNAPSHOT</version>
+      <version>2.0.3</version>
+      <version>2.1.0-SNAPSHOT</version>
+      <version>2.1.0</version>
+      <version>2.1.1-SNAPSHOT</version>
+      <version>2.1.1</version>
+      <version>2.1.2-SNAPSHOT</version>
+      <version>2.1.2</version>
+      <version>2.1.3-SNAPSHOT</version>
+      <version>2.1.3</version>
+      <version>2.2.0-SNAPSHOT</version>
+      <version>2.2.0</version>
+      <version>2.2.1-SNAPSHOT</version>
+      <version>2.2.1</version>
+      <version>2.2.2-SNAPSHOT</version>
+      <version>2.2.2</version>
+      <version>2.2.3-SNAPSHOT</version>
+      <version>2.2.3</version>
+      <version>2.3.0-SNAPSHOT</version>
+      <version>2.3.0</version>
+      <version>2.3.1-SNAPSHOT</version>
+      <version>2.3.1</version>
+      <version>2.3.2-SNAPSHOT</version>
+      <version>2.3.2</version>
+      <version>2.3.3-SNAPSHOT</version>
+      <version>2.3.3</version>
+      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0</version>
+      <version>3.0.1-SNAPSHOT</version>
+      <version>3.0.1</version>
+      <version>3.0.2-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
+    </versions>
+    <lastUpdated>20150401000001</lastUpdated>
+  </versioning>
+</metadata>
+

--- a/maven-artifact/pom.xml
+++ b/maven-artifact/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-artifact</artifactId>
@@ -26,7 +26,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-artifact/pom.xml
+++ b/maven-artifact/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-artifact</artifactId>
@@ -26,7 +26,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-artifact/pom.xml
+++ b/maven-artifact/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-artifact</artifactId>
@@ -26,7 +26,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-artifact/pom.xml
+++ b/maven-artifact/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-artifact</artifactId>
@@ -26,7 +26,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/maven-artifact/pom.xml
+++ b/maven-artifact/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-artifact</artifactId>
@@ -26,7 +26,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-artifact/pom.xml
+++ b/maven-artifact/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-artifact</artifactId>
@@ -26,7 +26,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -184,7 +184,7 @@ public class ComparableVersionTest
     }
 
     /**
-     * Test <a href="https://jira.codehaus.org/browse/MNG-5568">MNG-5568</a> edge case
+     * Test <a href="https://issues.apache.org/jira/browse/MNG-5568">MNG-5568</a> edge case
      * which was showing transitive inconsistency: since A > B and B > C then we should have A > C
      * otherwise sorting a list of ComparableVersions() will in some cases throw runtime exception;
      * see Netbeans issues <a href="https://netbeans.org/bugzilla/show_bug.cgi?id=240845">240845</a> and

--- a/maven-builder-support/pom.xml
+++ b/maven-builder-support/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-builder-support</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-builder-support/pom.xml
+++ b/maven-builder-support/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-builder-support</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-builder-support/pom.xml
+++ b/maven-builder-support/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-builder-support</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-builder-support/pom.xml
+++ b/maven-builder-support/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-builder-support</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/maven-builder-support/pom.xml
+++ b/maven-builder-support/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-builder-support</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-builder-support/pom.xml
+++ b/maven-builder-support/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-builder-support</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-compat</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <properties>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-compat</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <properties>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-compat</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-compat</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <properties>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-compat</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-compat</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
@@ -28,7 +28,7 @@ import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
  * Verifies scope of root project is preserved regardless of parent depenedency management.
  *
  * @author <a href="mailto:pschneider@gmail.com">Patrick Schneider</a>
- * @see <a href="http://jira.codehaus.org/browse/MNG-2919">MNG-2919</a>
+ * @see <a href="https://issues.apache.org/jira/browse/MNG-2919">MNG-2919</a>
  */
 public class ProjectInheritanceTest
     extends AbstractProjectInheritanceTestCase

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-core</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <properties>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-core</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-core</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-core</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-core</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <properties>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-core</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <properties>

--- a/maven-core/src/main/java/org/apache/maven/AbstractMavenLifecycleParticipant.java
+++ b/maven-core/src/main/java/org/apache/maven/AbstractMavenLifecycleParticipant.java
@@ -28,7 +28,7 @@ import org.apache.maven.execution.MavenSession;
  * indicate at what lifecycle point it is being called.
  *
  * @see <a href="http://maven.apache.org/examples/maven-3-lifecycle-extensions.html">example</a>
- * @see <a href="http://jira.codehaus.org/browse/MNG-4224">MNG-4224</a>
+ * @see <a href="https://issues.apache.org/jira/browse/MNG-4224">MNG-4224</a>
  * @since 3.0-alpha-3
  */
 public abstract class AbstractMavenLifecycleParticipant

--- a/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
+++ b/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
@@ -64,7 +64,7 @@ public class DefaultClassRealmManager
 
     /**
      * During normal command line build, ClassWorld is loaded by jvm system classloader, which only includes
-     * plexus-classworlds jar and possibly javaagent classes, see http://jira.codehaus.org/browse/MNG-4747.
+     * plexus-classworlds jar and possibly javaagent classes, see https://issues.apache.org/jira/browse/MNG-4747.
      * <p>
      * Using ClassWorld to determine plugin/extensions realm parent classloaders gives m2e and integration test harness
      * flexibility to load multiple version of maven into dedicated classloaders without assuming state of jvm system

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/Lifecycle.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/Lifecycle.java
@@ -68,9 +68,15 @@ public class Lifecycle
         return this.phases;
     }
 
-    public Map<String, LifecyclePhase> getDefaultPhases()
+    public Map<String, LifecyclePhase> getDefaultLifecyclePhases()
     {
         return defaultPhases;
+    }
+    
+    @Deprecated
+    public Map<String, String> getDefaultPhases()
+    {
+        return LifecyclePhase.toLegacyMap( getDefaultLifecyclePhases() );
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
@@ -104,11 +104,11 @@ public class DefaultLifecyclePluginAnalyzer
 
             if ( lifecycleConfiguration != null )
             {
-                phaseToGoalMapping = lifecycleConfiguration.getPhases();
+                phaseToGoalMapping = lifecycleConfiguration.getLifecyclePhases();
             }
-            else if ( lifecycle.getDefaultPhases() != null )
+            else if ( lifecycle.getDefaultLifecyclePhases() != null )
             {
-                phaseToGoalMapping = lifecycle.getDefaultPhases();
+                phaseToGoalMapping = lifecycle.getDefaultLifecyclePhases();
             }
 
             if ( phaseToGoalMapping != null )

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/DefaultLifecycleMapping.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/DefaultLifecycleMapping.java
@@ -61,13 +61,13 @@ public class DefaultLifecycleMapping
 
                 for ( String lifecycleId : lifecycleIds )
                 {
-                    Map<String, LifecyclePhase> phases = getPhases( lifecycleId );
+                    Map<String, LifecyclePhase> phases = getLifecyclePhases( lifecycleId );
                     if ( phases != null )
                     {
                         Lifecycle lifecycle = new Lifecycle();
 
                         lifecycle.setId( lifecycleId );
-                        lifecycle.setPhases( phases );
+                        lifecycle.setLifecyclePhases( phases );
 
                         lifecycleMap.put( lifecycleId, lifecycle );
                     }
@@ -88,7 +88,7 @@ public class DefaultLifecycleMapping
         return null;
     }
 
-    public Map<String, LifecyclePhase> getPhases( String lifecycle )
+    private Map<String, LifecyclePhase> getLifecyclePhases( String lifecycle )
     {
         initLifecycleMap();
 
@@ -96,7 +96,7 @@ public class DefaultLifecycleMapping
 
         if ( lifecycleMapping != null )
         {
-            return lifecycleMapping.getPhases();
+            return lifecycleMapping.getLifecyclePhases();
         }
         else if ( "default".equals( lifecycle ) )
         {
@@ -106,6 +106,12 @@ public class DefaultLifecycleMapping
         {
             return null;
         }
+    }
+    
+    @Deprecated
+    public Map<String, String> getPhases( String lifecycle )
+    {
+        return LifecyclePhase.toLegacyMap( getLifecyclePhases( lifecycle ) );
     }
 
 }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/Lifecycle.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/Lifecycle.java
@@ -19,8 +19,11 @@ package org.apache.maven.lifecycle.mapping;
  * under the License.
  */
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
 
 /**
  * Class Lifecycle.
@@ -35,7 +38,7 @@ public class Lifecycle
     /**
      * Field phases
      */
-    private Map<String, LifecyclePhase> phases;
+    private Map<String, LifecyclePhase> lifecyclePhases;
 
     /*
      * NOTE: This exists merely for backward-compat with legacy-style lifecycle definitions and allows configuration
@@ -53,13 +56,13 @@ public class Lifecycle
     }
 
     /**
-     * Method getPhases
+     * Method getLifecyclePhases
      */
-    public Map<String, LifecyclePhase> getPhases()
+    public Map<String, LifecyclePhase> getLifecyclePhases()
     {
-        return this.phases;
+        return this.lifecyclePhases;
     }
-
+    
     /**
      * Method setId
      *
@@ -71,13 +74,40 @@ public class Lifecycle
     }
 
     /**
-     * Method setPhases
+     * Method setLifecyclePhases
      *
      * @param phases
      */
+    public void setLifecyclePhases( Map<String, LifecyclePhase> lifecyclePhases )
+    {
+        this.lifecyclePhases = lifecyclePhases;
+    }
+
+    @Deprecated
+    public Map<String, String> getPhases()
+    {
+        Map<String, LifecyclePhase> lphases = getLifecyclePhases();
+        if ( lphases == null )
+        {
+            return null;
+        }
+        
+        if ( lphases.isEmpty() )
+        {
+            return Collections.emptyMap();
+        }
+        
+        Map<String, String> phases = new LinkedHashMap<>();
+        for ( Map.Entry<String, LifecyclePhase> e: lphases.entrySet() )
+        {
+            phases.put( e.getKey(), e.getValue().toString() );
+        }
+        return phases;
+    }
+
+    @Deprecated
     public void setPhases( Map<String, LifecyclePhase> phases )
     {
-        this.phases = phases;
-    } //-- void setPhases(java.util.List)
-
+        setLifecyclePhases( phases );
+    }
 }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecycleMapping.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecycleMapping.java
@@ -34,6 +34,6 @@ public interface LifecycleMapping
     List<String> getOptionalMojos( String lifecycle );
 
     @Deprecated
-    Map<String, LifecyclePhase> getPhases( String lifecycle );
+    Map<String, String> getPhases( String lifecycle );
 
 }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
@@ -20,7 +20,10 @@ package org.apache.maven.lifecycle.mapping;
  */
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.codehaus.plexus.util.StringUtils;
 
@@ -61,4 +64,46 @@ public class LifecyclePhase
             mojos.add( lifecycleMojo );
         }
     }
+    
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for ( LifecycleMojo mojo: getMojos() )
+        {
+            if ( first )
+            {
+                first = false;
+            }
+            else
+            {
+                sb.append( "," );
+            }
+            sb.append( mojo.getGoal() );
+        }
+        return sb.toString();
+    }
+    
+    @Deprecated
+    public static Map<String, String> toLegacyMap( Map<String, LifecyclePhase> lifecyclePhases )
+    {
+        if ( lifecyclePhases == null )
+        {
+            return null;
+        }
+        
+        if ( lifecyclePhases.isEmpty() )
+        {
+            return Collections.emptyMap();
+        }
+        
+        Map<String, String> phases = new LinkedHashMap<>();
+        for ( Map.Entry<String, LifecyclePhase> e: lifecyclePhases.entrySet() )
+        {
+            phases.put( e.getKey(), e.getValue().toString() );
+        }
+        return phases;
+    }
+    
 }

--- a/maven-core/src/main/java/org/apache/maven/properties/internal/SystemProperties.java
+++ b/maven-core/src/main/java/org/apache/maven/properties/internal/SystemProperties.java
@@ -29,7 +29,7 @@ public class SystemProperties
     /**
      * Thread-safe System.properties copy implementation.
      *
-     * @see http://jira.codehaus.org/browse/MNG-5670
+     * @see https://issues.apache.org/jira/browse/MNG-5670
      */
     public static void addSystemProperties( Properties props )
     {

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-embedder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-embedder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-embedder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-embedder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-embedder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-embedder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -377,7 +377,10 @@ public class MavenCli
             {
                 for ( String arg : Files.toString( configFile, Charsets.UTF_8 ).split( "\\s+" ) )
                 {
-                    args.add( arg );
+                    if ( !arg.isEmpty() )
+                    {
+                        args.add( arg );
+                    }
                 }
 
                 CommandLine config = cliManager.parse( args.toArray( new String[args.size()] ) );

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -446,7 +446,7 @@ public class MavenCli
             slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.ERROR );
         }
         // else fall back to default log level specified in conf
-        // see http://jira.codehaus.org/browse/MNG-2570
+        // see https://issues.apache.org/jira/browse/MNG-2570
 
         if ( cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
         {

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-model-builder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-model-builder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-model-builder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-model-builder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-model-builder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-model-builder</artifactId>
@@ -27,7 +27,7 @@
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-builder-support</artifactId>
     </dependency>
     <dependency>

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -513,7 +513,7 @@ public class DefaultModelBuilder
             }
         }
 
-        problems.setSource( modelSource.getLocation() );
+        problems.setSource(modelSource.getLocation());
         try
         {
             boolean strict = request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0;
@@ -594,10 +594,10 @@ public class DefaultModelBuilder
             throw problems.newModelBuildingException();
         }
 
-        model.setPomFile( pomFile );
+        model.setPomFile(pomFile);
 
-        problems.setSource( model );
-        modelValidator.validateRawModel( model, request, problems );
+        problems.setSource(model);
+        modelValidator.validateRawModel(model, request, problems);
 
         if ( hasFatalErrors( problems ) )
         {
@@ -615,7 +615,7 @@ public class DefaultModelBuilder
         context.setInactiveProfileIds( request.getInactiveProfileIds() );
         context.setSystemProperties( request.getSystemProperties() );
         context.setUserProperties( request.getUserProperties() );
-        context.setProjectDirectory( ( request.getPomFile() != null ) ? request.getPomFile().getParentFile() : null );
+        context.setProjectDirectory((request.getPomFile() != null) ? request.getPomFile().getParentFile() : null);
 
         return context;
     }
@@ -735,7 +735,7 @@ public class DefaultModelBuilder
                 activation = activation.clone();
             }
 
-            activations.put( profile.getId(), activation );
+            activations.put(profile.getId(), activation);
         }
 
         return activations;
@@ -921,8 +921,17 @@ public class DefaultModelBuilder
         }
         if ( version != null && parent.getVersion() != null && !version.equals( parent.getVersion() ) )
         {
-            // version skew drop back to resolution from the repository
-            return null;
+            //
+            // If the parent version is a range we will let it through here as we do not have the classes
+            // for determining if the parent is within the range in scope. This may lead to MNG-5840 style
+            // regressions in the range, but without this the parent version range will not work at all.
+            //
+            
+            if ( !parent.getVersion().startsWith("[") && !parent.getVersion().startsWith("(") ) 
+            {
+                // version skew drop back to resolution from the repository
+                return null;
+            }
         }
 
         //

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -513,7 +513,7 @@ public class DefaultModelBuilder
             }
         }
 
-        problems.setSource(modelSource.getLocation());
+        problems.setSource( modelSource.getLocation() );
         try
         {
             boolean strict = request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0;
@@ -594,10 +594,10 @@ public class DefaultModelBuilder
             throw problems.newModelBuildingException();
         }
 
-        model.setPomFile(pomFile);
+        model.setPomFile( pomFile );
 
-        problems.setSource(model);
-        modelValidator.validateRawModel(model, request, problems);
+        problems.setSource( model );
+        modelValidator.validateRawModel( model, request, problems );
 
         if ( hasFatalErrors( problems ) )
         {
@@ -615,7 +615,7 @@ public class DefaultModelBuilder
         context.setInactiveProfileIds( request.getInactiveProfileIds() );
         context.setSystemProperties( request.getSystemProperties() );
         context.setUserProperties( request.getUserProperties() );
-        context.setProjectDirectory((request.getPomFile() != null) ? request.getPomFile().getParentFile() : null);
+        context.setProjectDirectory( ( request.getPomFile() != null ) ? request.getPomFile().getParentFile() : null );
 
         return context;
     }
@@ -735,7 +735,7 @@ public class DefaultModelBuilder
                 activation = activation.clone();
             }
 
-            activations.put(profile.getId(), activation);
+            activations.put( profile.getId(), activation );
         }
 
         return activations;
@@ -926,8 +926,8 @@ public class DefaultModelBuilder
             // for determining if the parent is within the range in scope. This may lead to MNG-5840 style
             // regressions in the range, but without this the parent version range will not work at all.
             //
-            
-            if ( !parent.getVersion().startsWith("[") && !parent.getVersion().startsWith("(") ) 
+
+            if ( !parent.getVersion().startsWith( "[" ) && !parent.getVersion().startsWith( "(" ) )
             {
                 // version skew drop back to resolution from the repository
                 return null;

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -20,20 +20,9 @@ package org.apache.maven.model.building;
  */
 
 
-import static org.apache.maven.model.building.Result.error;
-import static org.apache.maven.model.building.Result.newResult;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
@@ -72,6 +61,20 @@ import org.apache.maven.model.superpom.SuperPomProvider;
 import org.apache.maven.model.validation.ModelValidator;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.maven.model.building.Result.error;
+import static org.apache.maven.model.building.Result.newResult;
 
 /**
  * @author Benjamin Bentmann
@@ -921,15 +924,18 @@ public class DefaultModelBuilder
         }
         if ( version != null && parent.getVersion() != null && !version.equals( parent.getVersion() ) )
         {
-            //
-            // If the parent version is a range we will let it through here as we do not have the classes
-            // for determining if the parent is within the range in scope. This may lead to MNG-5840 style
-            // regressions in the range, but without this the parent version range will not work at all.
-            //
-
-            if ( !parent.getVersion().startsWith( "[" ) && !parent.getVersion().startsWith( "(" ) )
+            try
             {
-                // version skew drop back to resolution from the repository
+                VersionRange parentRange = VersionRange.createFromVersionSpec( parent.getVersion() );
+                if ( !parentRange.containsVersion( new DefaultArtifactVersion( version ) ) )
+                {
+                    // version skew drop back to resolution from the repository
+                    return null;
+                }
+            }
+            catch ( InvalidVersionSpecificationException e )
+            {
+                // invalid version range, so drop back to resolution from the repository
                 return null;
             }
         }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileProfileActivator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileProfileActivator.java
@@ -40,7 +40,7 @@ import org.codehaus.plexus.util.StringUtils;
 /**
  * Determines profile activation based on the existence/absence of some file.
  * File name interpolation support is limited to <code>${basedir}</code> (since Maven 3,
- * see <a href="http://jira.codehaus.org/browse/MNG-2363">MNG-2363</a>),
+ * see <a href="https://issues.apache.org/jira/browse/MNG-2363">MNG-2363</a>),
  * System properties and request properties.
  * <code>${project.basedir}</code> is intentionally not supported as this form would suggest that other
  * <code>${project.*}</code> expressions can be used, which is however beyond the design.

--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/ProfileActivator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/ProfileActivator.java
@@ -46,7 +46,7 @@ public interface ProfileActivator
     /**
      * Determines whether specified activation method is present in configuration or not. It should help to have AND
      * between activation conditions
-     * Need for solving http://jira.codehaus.org/browse/MNG-4565
+     * Need for solving https://issues.apache.org/jira/browse/MNG-4565
      * @param profile The profile whose activation status should be determined, must not be {@code null}.
      * @param context The environmental context used to determine the activation status of the profile, must not be
      *            {@code null}.

--- a/maven-model-builder/src/site/apt/index.apt
+++ b/maven-model-builder/src/site/apt/index.apt
@@ -175,7 +175,7 @@ Maven Model Builder
   compatibility with previous Maven versions:
 
     * <<<$\{project.build.sourceEncoding\}>>> for
-    {{{http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding}source files encoding}}
+    {{{https://cwiki.apache.org/confluence/display/MAVEN/POM+Element+for+Source+File+Encoding}source files encoding}}
     (defaults to platform encoding)
 
     * <<<$\{project.reporting.outputEncoding\}>>> for

--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-model</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-model</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-model</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <properties>

--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-model</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-model</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <properties>

--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-model</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <properties>

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-plugin-api</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-plugin-api</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-api</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-api</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-plugin-api</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-api</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-repository-metadata/pom.xml
+++ b/maven-repository-metadata/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-repository-metadata</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-repository-metadata/pom.xml
+++ b/maven-repository-metadata/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-repository-metadata</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/maven-repository-metadata/pom.xml
+++ b/maven-repository-metadata/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-repository-metadata</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-repository-metadata/pom.xml
+++ b/maven-repository-metadata/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-repository-metadata</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-repository-metadata/pom.xml
+++ b/maven-repository-metadata/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-repository-metadata</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-repository-metadata/pom.xml
+++ b/maven-repository-metadata/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-repository-metadata</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-settings-builder</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <contributors>

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-settings-builder</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <contributors>

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-settings-builder</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <contributors>

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-settings-builder</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <contributors>

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-settings-builder</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <contributors>

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-settings-builder</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <contributors>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-settings</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.3.5</version>
   </parent>
 
   <artifactId>maven-settings</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
 
   <dependencies>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6</version>
+    <version>3.3.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-settings</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4</version>
   </parent>
 
   <artifactId>maven-settings</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
 
   <dependencies>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-settings</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>maven-3.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.3.6-SNAPSHOT</version>
+    <version>3.3.6</version>
   </parent>
 
   <artifactId>maven-settings</artifactId>
@@ -36,7 +36,7 @@ under the License.
   <scm><!-- remove when git scm url format can accept artifact-id at the end, as automatically inherited -->
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>maven</artifactId>
-  <version>3.3.4-SNAPSHOT</version>
+  <version>3.3.4</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven</name>
@@ -91,7 +91,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
     <url>https://github.com/apache/maven/tree/${project.scm.tag}</url>
-    <tag>master</tag>
+    <tag>maven-3.3.4</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>maven</artifactId>
-  <version>3.3.5</version>
+  <version>3.3.6-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven</name>
@@ -91,7 +91,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
     <url>https://github.com/apache/maven/tree/${project.scm.tag}</url>
-    <tag>maven-3.3.5</tag>
+    <tag>master</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>maven</artifactId>
-  <version>3.3.6</version>
+  <version>3.3.7-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven</name>
@@ -91,7 +91,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
     <url>https://github.com/apache/maven/tree/${project.scm.tag}</url>
-    <tag>maven-3.3.6</tag>
+    <tag>master</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>maven</artifactId>
-  <version>3.3.6-SNAPSHOT</version>
+  <version>3.3.6</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven</name>
@@ -91,7 +91,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
     <url>https://github.com/apache/maven/tree/${project.scm.tag}</url>
-    <tag>master</tag>
+    <tag>maven-3.3.6</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>maven</artifactId>
-  <version>3.3.4</version>
+  <version>3.3.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven</name>
@@ -91,7 +91,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
     <url>https://github.com/apache/maven/tree/${project.scm.tag}</url>
-    <tag>maven-3.3.4</tag>
+    <tag>master</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>maven</artifactId>
-  <version>3.3.5-SNAPSHOT</version>
+  <version>3.3.5</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven</name>
@@ -91,7 +91,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven.git</developerConnection>
     <url>https://github.com/apache/maven/tree/${project.scm.tag}</url>
-    <tag>master</tag>
+    <tag>maven-3.3.5</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -57,13 +57,13 @@
           <area shape="rect" coords="409,342,500,378" alt="maven-model" href="maven-model/" />
           <area shape="rect" coords="551,58,707,94"   alt="commons-cli" href="http://commons.apache.org/cli/" />
           <area shape="rect" coords="551,116,739,152" alt="wagon-provider-api" href="http://maven.apache.org/wagon/wagon-provider-api/" />
-          <area shape="rect" coords="550,175,690,211" alt="plexus-sec-dispatcher" href="http://plexus.codehaus.org/plexus-components/plexus-sec-dispatcher/project-reports.html" />
-          <area shape="rect" coords="581,230,660,265" alt="plexus-cipher" href="http://plexus.codehaus.org/plexus-components/plexus-cipher/project-reports.html" />
-          <area shape="rect" coords="551,284,707,320" alt="plexus-interpolation" href="http://plexus.codehaus.org/plexus-components/plexus-interpolation/" />
-          <area shape="rect" coords="551,359,776,395" alt="plexus-component-annotations" href="http://plexus.codehaus.org/plexus-containers/plexus-component-annotations/" />
-          <area shape="rect" coords="550,401,682,437" alt="plexus-classworlds" href="http://plexus.codehaus.org/plexus-classworlds/" />
-          <area shape="rect" coords="685,455,775,491" alt="plexus-utils" href="http://plexus.codehaus.org/plexus-utils/" />
-          <area shape="rect" coords="542,167,783,502" alt="plexus" href="http://plexus.codehaus.org/" />
+          <area shape="rect" coords="550,175,690,211" alt="plexus-sec-dispatcher" href="https://github.com/codehaus-plexus/plexus-sec-dispatcher" />
+          <area shape="rect" coords="581,230,660,265" alt="plexus-cipher" href="hhttps://github.com/codehaus-plexus/plexus-cipher" />
+          <area shape="rect" coords="551,284,707,320" alt="plexus-interpolation" href="https://github.com/codehaus-plexus/plexus-interpolation" />
+          <area shape="rect" coords="551,359,776,395" alt="plexus-component-annotations" href="https://github.com/codehaus-plexus/plexus-containers" />
+          <area shape="rect" coords="550,401,682,437" alt="plexus-classworlds" href="https://github.com/codehaus-plexus/plexus-classworlds" />
+          <area shape="rect" coords="685,455,775,491" alt="plexus-utils" href="https://github.com/codehaus-plexus/plexus-utils" />
+          <area shape="rect" coords="542,167,783,502" alt="plexus" href="https://github.com/codehaus-plexus" />
           <area shape="rect" coords="68,338,240,482"  alt="aether" href="http://www.eclipse.org/projects/project_summary.php?projectid=technology.aether" />
           <area shape="rect" coords="388,393,520,594" alt="sisu" href="http://www.eclipse.org/projects/project_summary.php?projectid=technology.sisu" />
           <area shape="rect" coords="519,518,621,554" alt="guice" href="http://code.google.com/p/google-guice/" />


### PR DESCRIPTION
The discussion on issue [MNG-3092](https://issues.apache.org/jira/browse/MNG-3092) shows the seriously needs of different kinds of version range resolving in Maven.

I know about the risk on changing the resolving mechanism in Maven.
I always had the backward compatibility in mind, if I have something changed.
I added some basic tests for the default version range resolver before I've started with the refactoring.

This pull request contains the basic tests and a less invasive solution based on a filter works with resolved version range results.

The actual version range resolving algorithm **wasn't changed** and the internal used default filter implementation don't filter anything.

The goal:
Provide a hook for Maven extensions/plugins to change the list of resolved version range results as required.

These changes are only placed in _maven-aether-provider_.