### PR TITLE
[MNG-5947] dependencyManagement import section does not resolve dependencies using "nearest" definition

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -1122,8 +1122,12 @@ public class DefaultModelBuilder
         {
             Dependency dependency = it.next();
 
-            if ( !"pom".equals( dependency.getType() ) || !"import".equals( dependency.getScope() ) )
+            boolean declaredDependency = !"pom".equals( dependency.getType() ) 
+                                                    || !"import".equals( dependency.getScope() );
+            
+            if ( declaredDependency )
             {
+                depMngt.addDeclaredDependency( dependency );
                 continue;
             }
 
@@ -1271,6 +1275,7 @@ public class DefaultModelBuilder
             }
 
             importMngts.add( importMngt );
+            depMngt.addImportedDependencyManagement( importMngt );
         }
 
         importIds.remove( importing );

--- a/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultDependencyManagementImporter.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultDependencyManagementImporter.java
@@ -20,16 +20,23 @@ package org.apache.maven.model.composition;
  */
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelProblemCollector;
+import org.apache.maven.model.building.ModelProblemCollectorRequest;
+import org.apache.maven.model.building.ModelProblem.Severity;
+import org.apache.maven.model.building.ModelProblem.Version;
 import org.codehaus.plexus.component.annotations.Component;
+
+import com.google.common.base.Optional;
 
 /**
  * Handles the import of dependency management from other models into the target model.
@@ -40,6 +47,7 @@ import org.codehaus.plexus.component.annotations.Component;
 public class DefaultDependencyManagementImporter
     implements DependencyManagementImporter
 {
+    private static final Optional<Integer> DIRECT_DEPENDENCY = Optional.of( 0 );
 
     @Override
     public void importManagement( Model target, List<? extends DependencyManagement> sources,
@@ -48,6 +56,8 @@ public class DefaultDependencyManagementImporter
         if ( sources != null && !sources.isEmpty() )
         {
             Map<String, Dependency> dependencies = new LinkedHashMap<>();
+            Set<String> directDependencies = new HashSet<>();
+            Map<String, DependencyManagement> dependencySources = new LinkedHashMap<>();
 
             DependencyManagement depMngt = target.getDependencyManagement();
 
@@ -56,6 +66,7 @@ public class DefaultDependencyManagementImporter
                 for ( Dependency dependency : depMngt.getDependencies() )
                 {
                     dependencies.put( dependency.getManagementKey(), dependency );
+                    directDependencies.add( dependency.getManagementKey() );
                 }
             }
             else
@@ -71,13 +82,106 @@ public class DefaultDependencyManagementImporter
                     String key = dependency.getManagementKey();
                     if ( !dependencies.containsKey( key ) )
                     {
-                        dependencies.put( key, dependency );
+                        storeDependency( dependencies, dependencySources, source, dependency, key );
                     }
+                    else if ( ! directDependencies.contains( key ) )
+                    {
+                        //non-direct dependency - check source depths to determine distance
+                        DependencyManagement sourceDepMngt = dependencySources.get( key );
+                        Dependency sourceDependency = dependencies.get( key );
+                        
+                        Optional<Integer> previousSourceDepth = 
+                                findDeclaredDependencyDepth( sourceDepMngt, sourceDependency );
+                        if ( previousSourceDepth.isPresent() )
+                        {
+                            Optional<Integer> currentDepth = findDeclaredDependencyDepth( source, dependency );
+                            if ( currentDepth.isPresent() )
+                            {
+                                boolean currentDependencyNearest = currentDepth.get() < previousSourceDepth.get();
+                                
+                                if ( currentDependencyNearest )
+                                {
+                                    storeDependency( dependencies, dependencySources, source, dependency, key );
+                                }
+                            }
+                            else
+                            {
+                                String message = "Invalid state - current source depth not found for " 
+                                        + dependency.getManagementKey() + " in " + describeTarget( target );
+                                addProblem( problems, dependency, message );
+                            }
+                        }
+                        else
+                        {
+                            String msg = "Invalid state - previous source depth not found for " 
+                                    + dependency.getManagementKey() + " in " + describeTarget( target );
+                            addProblem( problems, dependency, msg );
+                        }
+                    }  
                 }
             }
 
-            depMngt.setDependencies( new ArrayList<>( dependencies.values() ) );
+            depMngt.setDependencies( new ArrayList<Dependency>( dependencies.values() ) );
         }
     }
 
+    void storeDependency( Map<String, Dependency> dependencies, Map<String, DependencyManagement> dependencySources,
+                          DependencyManagement source, Dependency dependency, String key )
+    {
+        dependencies.put( key, dependency );
+        dependencySources.put( key, source );
+    }
+
+    /**
+     * Finds depth of a particular dependency inside dependency management hierarchy.
+     * 
+     * @param dependencyManagement
+     * @param dependency
+     * @since 3.4.0
+     * @return Optional<Integer> - absent if dependency not found, depth value otherwise
+     */
+    Optional<Integer> findDeclaredDependencyDepth( DependencyManagement dependencyManagement, Dependency dependency )
+    {
+        List<Dependency> declaredDependencies = dependencyManagement.getDeclaredDependencies();
+
+        if ( declaredDependencies.contains( dependency ) )
+        {
+            return DIRECT_DEPENDENCY;
+        }
+        else
+        {
+            int depth = Integer.MAX_VALUE;
+            List<DependencyManagement> importedDependencyManagements = 
+                    dependencyManagement.getImportedDependencyManagements();
+
+            for ( DependencyManagement importedDependencyManagement : importedDependencyManagements )
+            {
+                Optional<Integer> nodeDepth = findDeclaredDependencyDepth( importedDependencyManagement, dependency );
+                if ( nodeDepth.isPresent() )
+                {
+                    depth = Math.min( nodeDepth.get(), depth );
+                }
+            }
+
+            boolean dependencyFound = depth != Integer.MAX_VALUE;
+            if ( dependencyFound )
+            {
+                return Optional.of( 1 + depth );
+            }
+        }
+
+        return Optional.absent();
+    }
+
+    private void addProblem( ModelProblemCollector problems, Dependency dependency, String message )
+    {
+        problems.add( new ModelProblemCollectorRequest( Severity.WARNING, Version.BASE )
+            .setMessage( message )
+            .setLocation( dependency.getLocation( "" ) ) );
+    }
+
+    private String describeTarget( Model target )
+    {
+        return target.getGroupId() + ":" + target.getArtifactId() + ":" + target.getVersion();
+    }
 }

--- a/maven-model-builder/src/site/apt/index.apt
+++ b/maven-model-builder/src/site/apt/index.apt
@@ -86,7 +86,7 @@ Maven Model Builder
    with its <<<DefaultLifecycleBindingsInjector>>> implementation
    ({{{./xref/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.html}source}})
 
-   ** dependency management import (for dependencies of type <<<pom>>> in the <<<\<dependencyManagement\>>>> section)
+   ** dependency management import (for dependencies of type <<<pom>>> in the <<<\<dependencyManagement\>>>> section) with dependency mediation using "nearest distance" definition
 
    ** dependency management injection: <<<DependencyManagementInjector>>> ({{{./apidocs/org/apache/maven/model/management/DependencyManagementInjector.html}javadoc}}),
    with its <<<DefaultDependencyManagementInjector>>> implementation

--- a/maven-model-builder/src/test/java/org/apache/maven/model/composition/DefaultDependencyManagementImporterTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/composition/DefaultDependencyManagementImporterTest.java
@@ -1,0 +1,174 @@
+package org.apache.maven.model.composition;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelProblemCollector;
+import org.apache.maven.model.building.SimpleProblemCollector;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Test case for {@link DefaultDependencyManagementImporter}
+ * 
+ * @author Michal Kowalcze
+ * @since 3.4.0
+ */
+public class DefaultDependencyManagementImporterTest
+{
+
+    private DependencyManagement depMgmt_1_1;
+
+    private DependencyManagement depMgmt_1_0;
+
+    private DependencyManagement import_1_0;
+
+    private Dependency dependency_1_1;
+
+    private Dependency dependency_1_0;
+
+    private DefaultDependencyManagementImporter defaultDependencyManagementImporter;
+
+    @Before
+    public void prepare()
+    {
+        dependency_1_0 = createDependency( "DefaultDependencyManagementImporterTest", "dep", "1.0" );
+        dependency_1_1 = createDependency( "DefaultDependencyManagementImporterTest", "dep", "1.1" );
+
+        depMgmt_1_0 = new DependencyManagement();
+        depMgmt_1_0.addDependency( dependency_1_0 );
+        depMgmt_1_0.addDeclaredDependency( dependency_1_0 );
+
+        depMgmt_1_1 = new DependencyManagement();
+        depMgmt_1_1.addDependency( dependency_1_1 );
+        depMgmt_1_1.addDeclaredDependency( dependency_1_1 );
+
+        import_1_0 = new DependencyManagement();
+        import_1_0.addImportedDependencyManagement( depMgmt_1_0 );
+        import_1_0.addDependency( dependency_1_0 );
+
+        defaultDependencyManagementImporter = new DefaultDependencyManagementImporter();
+    }
+
+    @Test
+    public void testDependencyManagementFromCloserImport()
+    {
+        Model target = new Model();
+        ModelBuildingRequest request = null;
+        List<DependencyManagement> sources = ImmutableList.of( import_1_0, depMgmt_1_1 );
+        SimpleProblemCollector problems = new SimpleProblemCollector();
+
+        defaultDependencyManagementImporter.importManagement( target, sources, request, problems );
+
+        List<Dependency> dependencies = target.getDependencyManagement().getDependencies();
+        assertEquals( 1, dependencies.size() );
+        assertEquals( dependency_1_1, dependencies.get( 0 ) );
+        assertEquals( 0, problems.getWarnings().size() );
+        assertEquals( 0, problems.getFatals().size() );
+        assertEquals( 0, problems.getErrors().size() );
+    }
+
+    @Test
+    public void testDependencyManagementFromCloserImportWithoutDepthCheck()
+    {
+        Model target = new Model();
+        ModelBuildingRequest request = null;
+        List<DependencyManagement> sources = ImmutableList.of( depMgmt_1_1, import_1_0 );
+        SimpleProblemCollector problems = new SimpleProblemCollector();
+
+        defaultDependencyManagementImporter.importManagement( target, sources, request, problems );
+
+        List<Dependency> dependencies = target.getDependencyManagement().getDependencies();
+        assertEquals( 1, dependencies.size() );
+        assertEquals( dependency_1_1, dependencies.get( 0 ) );
+        assertEquals( 0, problems.getWarnings().size() );
+        assertEquals( 0, problems.getFatals().size() );
+        assertEquals( 0, problems.getErrors().size() );
+    }
+
+    @Test
+    public void testDirectDependencyManagement()
+    {
+        DependencyManagement dependencyManagement = new DependencyManagement();
+        dependencyManagement.addDependency( dependency_1_0 );
+        Model target = new Model();
+        target.setDependencyManagement( dependencyManagement );
+        ModelBuildingRequest request = null;
+        List<DependencyManagement> sources = ImmutableList.of( import_1_0, depMgmt_1_1 );
+        SimpleProblemCollector problems = new SimpleProblemCollector();
+
+        defaultDependencyManagementImporter.importManagement( target, sources, request, problems );
+
+        List<Dependency> dependencies = target.getDependencyManagement().getDependencies();
+        assertEquals( 1, dependencies.size() );
+        assertEquals( dependency_1_0, dependencies.get( 0 ) );
+        assertEquals( 0, problems.getWarnings().size() );
+        assertEquals( 0, problems.getFatals().size() );
+        assertEquals( 0, problems.getErrors().size() );
+    }
+
+    @Test
+    public void testDepthOfADirectDependency()
+    {
+        Optional<Integer> depth =
+            defaultDependencyManagementImporter.findDeclaredDependencyDepth( depMgmt_1_1, dependency_1_1 );
+        assertTrue( depth.isPresent() );
+        assertEquals( 0, (int) depth.get() );
+    }
+
+    @Test
+    public void testDepthOfAIndirectDependency()
+    {
+        Optional<Integer> depth =
+            defaultDependencyManagementImporter.findDeclaredDependencyDepth( import_1_0, dependency_1_0 );
+        assertTrue( depth.isPresent() );
+        assertEquals( 1, (int) depth.get() );
+    }
+
+    @Test
+    public void testDepthOfAMissingDependency()
+    {
+        Optional<Integer> depth =
+            defaultDependencyManagementImporter.findDeclaredDependencyDepth( import_1_0, dependency_1_1 );
+        assertFalse( depth.isPresent() );
+    }
+
+    private Dependency createDependency( String groupId, String artifactId, String version )
+    {
+        Dependency dependency = new Dependency();
+
+        dependency.setGroupId( groupId );
+        dependency.setArtifactId( artifactId );
+        dependency.setVersion( version );
+
+        return dependency;
+    }
+}

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -2969,6 +2969,29 @@
             <multiplicity>*</multiplicity>
           </association>
         </field>
+        <field>
+          <name>declaredDependencies</name>
+          <version>4.0.0+</version>
+          <description>The dependencies specified here are specified directly in the 
+            dependency management section of a POM and are not imported.
+            This allows finding "distance" using standard maven metric while
+            resolving conflicts.</description>
+          <association>
+            <type>Dependency</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
+        <field>
+          <name>importedDependencyManagements</name>
+          <version>4.0.0+</version>
+          <description>The dependency managements specified here reflect imported POMs.
+          This allows find "distance" using standard maven metric while
+          resolving conflicts.</description>
+          <association>
+            <type>DependencyManagement</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
       </fields>
     </class>
     <class>


### PR DESCRIPTION
dependencies using "nearest" definition

o DepenencyManagement model updated to contain declared dependencies 
  and imported dependency managements
o DefaultModelBuilder responsible for filling updated
  DependencyManagement model
o DefaultDepenendcyManagementImporter uses graph of dependencyManagement
  imports to properly find depth of a dependency in a tree and use
  "nearest" version (instead of first match)