### PR TITLE
[MNG-5958] restore binary compatibility of Lifecycle.setPhases

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/Lifecycle.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/Lifecycle.java
@@ -106,8 +106,13 @@ public class Lifecycle
     }
 
     @Deprecated
-    public void setPhases( Map<String, LifecyclePhase> phases )
+    public void setPhases( Map<String, String> phases )
     {
-        setLifecyclePhases( phases );
+        Map<String, LifecyclePhase> lphases = new LinkedHashMap<>();
+        for ( Map.Entry<String, String> e: phases.entrySet() )
+        {
+            lphases.put( e.getKey(), new LifecyclePhase( e.getValue() ) );
+        }
+        setLifecyclePhases( lphases );
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MNG-5958

While MNG-5805 restored binary compatibility of Lifecycle.getPhases it didn't do the same for Lifecycle.setPhases. This breaks plugins like flexmojos-maven-plugin which have their own lifecycle mapping implementations.

The following pom.xml demonstrates the issue:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>

  <groupId>org.example</groupId>
  <artifactId>mng-5958</artifactId>
  <version>1.0</version>

  <packaging>swf</packaging>

  <build>
    <plugins>
      <plugin>
        <groupId>org.sonatype.flexmojos</groupId>
        <artifactId>flexmojos-maven-plugin</artifactId>
        <version>4.0-RC2</version>
        <extensions>true</extensions>
      </plugin>
    </plugins>
  </build>

</project>
```
Using "mvn validate" with Maven 3.3.9 you get the following exception:
```
[INFO] Scanning for projects...
[ERROR] Internal error: java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.maven.lifecycle.mapping.LifecyclePhase -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.maven.lifecycle.mapping.LifecyclePhase
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:121)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.maven.lifecycle.mapping.LifecyclePhase
	at org.apache.maven.lifecycle.internal.DefaultLifecyclePluginAnalyzer.getPluginsBoundByDefaultToAllLifecycles(DefaultLifecyclePluginAnalyzer.java:119)
	at org.apache.maven.model.plugin.DefaultLifecycleBindingsInjector.injectLifecycleBindings(DefaultLifecycleBindingsInjector.java:64)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:451)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:421)
	at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:620)
	at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:411)
	at org.apache.maven.graph.DefaultGraphBuilder.collectProjects(DefaultGraphBuilder.java:419)
	at org.apache.maven.graph.DefaultGraphBuilder.getProjectsForMavenReactor(DefaultGraphBuilder.java:410)
	at org.apache.maven.graph.DefaultGraphBuilder.build(DefaultGraphBuilder.java:83)
	at org.apache.maven.DefaultMaven.buildGraph(DefaultMaven.java:491)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:219)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	... 11 more
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/InternalErrorException
```
With Maven 3.3.3 this exception doesn't occur.