### PR TITLE
Duplicate conditional and body in MetadataResolutionResult.java

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/repository/metadata/MetadataResolutionResult.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/metadata/MetadataResolutionResult.java
@@ -115,11 +115,7 @@ public class MetadataResolutionResult
         {
             return conflictResolver.resolveConflicts( getGraph(), ArtifactScopeEnum.runtime );
         }
-        else if ( requestType.equals( MetadataResolutionRequestTypeEnum.classpathRuntime ) )
-        {
-            return conflictResolver.resolveConflicts( getGraph(), ArtifactScopeEnum.test );
-        }
-        else if ( requestType.equals( MetadataResolutionRequestTypeEnum.classpathRuntime ) )
+        else if ( requestType.equals( MetadataResolutionRequestTypeEnum.classpathTest ) )
         {
             return conflictResolver.resolveConflicts( getGraph(), ArtifactScopeEnum.test );
         }


### PR DESCRIPTION
The `requestType.equals( MetadataResolutionRequestTypeEnum.classpathRuntime` case is repeated three times. One should be removed, and the other looks like it should be `requestType.equals( MetadataResolutionRequestTypeEnum.classpathTest`