### PR TITLE
Fixing misspellings in test names (Progessed to Progressed)

### DIFF
--- a/maven-embedder/src/test/java/org/apache/maven/cli/transfer/FileSizeFormatTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/transfer/FileSizeFormatTest.java
@@ -221,16 +221,16 @@ public class FileSizeFormatTest {
     }
 
     @Test( expected = IllegalArgumentException.class )
-    public void testNegativeProgessedSize()
+    public void testNegativeProgressedSize()
     {
         FileSizeFormat format = new FileSizeFormat( Locale.ENGLISH );
 
-        long negativeProgessedSize = -100L;
-        format.formatProgress( negativeProgessedSize, 10L );
+        long negativeProgressedSize = -100L;
+        format.formatProgress( negativeProgressedSize, 10L );
     }
 
     @Test( expected = IllegalArgumentException.class )
-    public void testNegativeProgessedSizeBiggerThanSize()
+    public void testNegativeProgressedSizeBiggerThanSize()
     {
         FileSizeFormat format = new FileSizeFormat( Locale.ENGLISH );
 


### PR DESCRIPTION
I noticed that there seem to be some misspellings in the test names in this test class (along with some similar misspellings in local variable names), and so this pull request simply addresses those misspellings.