### PR TITLE
Removing redundant test

### DIFF
--- a/maven-embedder/src/test/java/org/apache/maven/cli/transfer/FileSizeFormatTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/transfer/FileSizeFormatTest.java
@@ -257,15 +257,6 @@ public class FileSizeFormatTest {
     }
 
     @Test
-    public void testProgressedSizeWithZeroSize()
-    {
-         FileSizeFormat format = new FileSizeFormat( Locale.ENGLISH );
-
-         long _0_bytes = 0L;
-         assertEquals( "0 B", format.formatProgress( _0_bytes, _0_bytes ) );
-    }
-
-    @Test
     public void testProgressedSizeZeroAndSizeZero()
     {
          FileSizeFormat format = new FileSizeFormat( Locale.ENGLISH );


### PR DESCRIPTION
In FileSizeFormatTest, the two tests testProgressedSizeWithZeroSize and testProgressedSizeZeroAndSizeZero are exactly the same, so one of them should be deleted. This pull request deletes testProgressedSizeWithZeroSize.

From looking at the test names, it seems testProgressedSizeWithZeroSize is supposed to be testing formatProgress with the first parameter being non-zero. However, having the first parameter being non-zero while the second parameter being zero results in an IllegalArgumentException, similar to what is being tested in testNegativeProgressedSizeBiggerThanSize.

If deleting this test is no good, then perhaps it should be changed to testing the first parameter being non-zero and second parameter being zero, and then expecting an IllegalArgumentException. This might still overlap with testNegativeProgressedSizeBiggerThanSize.