### PR TITLE
Modifying test in DefaultWagonManagerTest

### DIFF
--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
@@ -138,7 +138,7 @@ public class DefaultWagonManagerTest
 
         try
         {
-            wagonManager.getArtifact( artifact, repo, null, false );
+            wagonManager.getArtifact( artifact, repo, null, true );
 
             fail();
         }


### PR DESCRIPTION
The two tests testGetMissingJar and testGetMissingJarForced have exactly the same test bodies. From their names, it seems testGetMissingJarForced should be invoking the method getArtifact with the argument for forced being true. This pull request updates testGetMissingJarForced to invoke getArtifact with true for the forced argument.