### PR TITLE
[MNG-6053] prevent NPE when copying System Properties in MavenRepositorySystemUtils

### DIFF
--- a/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/MavenRepositorySystemUtils.java
+++ b/maven-aether-provider/src/main/java/org/apache/maven/repository/internal/MavenRepositorySystemUtils.java
@@ -131,7 +131,12 @@ public final class MavenRepositorySystemUtils
         Properties sysProps = new Properties();
         for ( String key : System.getProperties().stringPropertyNames() )
         {
-            sysProps.put( key, System.getProperty( key ) );
+            Object value = System.getProperty( key );
+            // MNG-6053 guard against key without value
+            if ( value != null )
+            {
+                sysProps.put( key, value );
+            }
         }
         session.setSystemProperties( sysProps );
         session.setConfigProperties( sysProps );


### PR DESCRIPTION
Added a Null check when copying System Properties in MavenRepositorySystemUtils.newSession().
Many NPEs were reported when using Maven in Eclipse[1]. The error is most probably caused by some concurrency issue.

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=493871

Signed-off-by: Fred Bricon <fbricon@gmail.com>