### PR TITLE
MNG-5909 : Add combined expression evaluator to file activation property

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
@@ -22,6 +22,8 @@ package org.apache.maven.model.building;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.composition.DefaultDependencyManagementImporter;
 import org.apache.maven.model.composition.DependencyManagementImporter;
+import org.apache.maven.model.condition.CombinedValueEvaluator;
+import org.apache.maven.model.condition.DefaultCombinedValueEvaluator;
 import org.apache.maven.model.inheritance.DefaultInheritanceAssembler;
 import org.apache.maven.model.inheritance.InheritanceAssembler;
 import org.apache.maven.model.interpolation.ModelInterpolator;
@@ -108,8 +110,13 @@ public class DefaultModelBuilderFactory
 
     protected ProfileActivator[] newProfileActivators()
     {
-        return new ProfileActivator[] { new JdkVersionProfileActivator(), new OperatingSystemProfileActivator(),
-            new PropertyProfileActivator(), new FileProfileActivator().setPathTranslator( newPathTranslator() ) };
+        return new ProfileActivator[]
+        {
+            new JdkVersionProfileActivator(), new OperatingSystemProfileActivator(),
+            new PropertyProfileActivator(),
+            new FileProfileActivator().setPathTranslator( newPathTranslator() )
+                                      .setCombinedValueEvaluator( newCombinedValueEvaluator() )
+        };
     }
 
     protected UrlNormalizer newUrlNormalizer()
@@ -120,6 +127,11 @@ public class DefaultModelBuilderFactory
     protected PathTranslator newPathTranslator()
     {
         return new DefaultPathTranslator();
+    }
+
+    protected CombinedValueEvaluator newCombinedValueEvaluator()
+    {
+        return new DefaultCombinedValueEvaluator();
     }
 
     protected ModelInterpolator newModelInterpolator()
@@ -234,7 +246,9 @@ public class DefaultModelBuilderFactory
     {
 
         @Override
-        public void injectLifecycleBindings( Model model, ModelBuildingRequest request, ModelProblemCollector problems )
+        public void injectLifecycleBindings( Model model,
+                                             ModelBuildingRequest request,
+                                             ModelProblemCollector problems )
         {
         }
 

--- a/maven-model-builder/src/main/java/org/apache/maven/model/condition/CombinedValueEvaluator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/condition/CombinedValueEvaluator.java
@@ -1,0 +1,43 @@
+package org.apache.maven.model.condition;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @author Loïc B.
+ */
+public interface CombinedValueEvaluator
+{
+
+    /**
+     * Parses a string representing a condition, and evaluates its result using simple boolean logic.
+     * 
+     * @param expression Boolean expression to be evaluated. Format : <br/>
+     *            all(condition1,condition2,...) or and(condition1,condition2,...) : will be true if all conditions are
+     *            true<br/>
+     *            any(condition1,condition2,...) or or(condition1,condition2,...) : will be true if at least one of the
+     *            conditions is true Nested operators are not supported.<br/>
+     *            If there is no condition expressed, the string is simply passed to the evaluator as-is.
+     * @param evaluator Actual evaluator for a single condition. Will be called once for each condition found in the
+     *            expression
+     * @return result of evaluation, depending on expression contents
+     */
+    boolean evaluate( String expression, SingleValueEvaluator evaluator );
+
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/condition/DefaultCombinedValueEvaluator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/condition/DefaultCombinedValueEvaluator.java
@@ -1,0 +1,69 @@
+package org.apache.maven.model.condition;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.codehaus.plexus.component.annotations.Component;
+
+/**
+ * @author Loïc B.
+ */
+@Component( role = CombinedValueEvaluator.class )
+public class DefaultCombinedValueEvaluator
+    implements CombinedValueEvaluator
+{
+    private static final Pattern PATTERN_AND = Pattern.compile( "^(?:all|and)\\((?:([^,]*),)*([^,]*)\\)$" );
+
+    private static final Pattern PATTERN_OR = Pattern.compile( "^(?:any|or)\\((?:([^,]*),)*([^,]*)\\)$" );
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.maven.model.profile.activation.CombinedValueEvaluator#evaluate(java.lang.String,
+     * org.apache.maven.model.profile.activation.SingleValueEvaluator)
+     */
+    @Override
+    public boolean evaluate( String expression, SingleValueEvaluator evaluator )
+    {
+        Matcher andMatcher = PATTERN_AND.matcher( expression );
+        if ( andMatcher.matches() )
+        {
+            boolean result = true;
+            for ( int i = 1; i <= andMatcher.groupCount(); i++ )
+            {
+                result &= evaluator.evaluate( andMatcher.group( i ) );
+            }
+            return result;
+        }
+        Matcher orMatcher = PATTERN_OR.matcher( expression );
+        if ( orMatcher.matches() )
+        {
+            boolean result = false;
+            for ( int i = 1; i <= andMatcher.groupCount(); i++ )
+            {
+                result |= evaluator.evaluate( orMatcher.group( i ) );
+            }
+            return result;
+        }
+        // Default
+        return evaluator.evaluate( expression );
+    }
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/condition/SingleValueEvaluator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/condition/SingleValueEvaluator.java
@@ -1,0 +1,32 @@
+package org.apache.maven.model.condition;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @author Loïc B.
+ */
+public interface SingleValueEvaluator
+{
+    /**
+     * Evaluiates the expression and returns a boolean result. Expression evaluation and intended result is
+     * implementation-dependent.
+     */
+    boolean evaluate( String expression );
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileExistenceEvaluator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileExistenceEvaluator.java
@@ -1,0 +1,78 @@
+package org.apache.maven.model.profile.activation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+import org.apache.maven.model.condition.SingleValueEvaluator;
+import org.apache.maven.model.path.PathTranslator;
+
+/**
+ * @author Loïc B.
+ */
+public class FileExistenceEvaluator
+    implements SingleValueEvaluator
+{
+
+    private final boolean missing;
+
+    private final PathTranslator pathTranslator;
+
+    private final File basedir;
+
+    /**
+     * Creates the FileExistenceEvaluator for missing or existing files.
+     * 
+     * @param missing true if the file should be missing, false if it should be existing
+     * @param pathTranslator path translator implementation to be used
+     */
+    public FileExistenceEvaluator( boolean missing, PathTranslator pathTranslator, File basedir )
+    {
+        this.missing = missing;
+        this.pathTranslator = pathTranslator;
+        this.basedir = basedir;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.maven.model.profile.activation.SingleValueEvaluator#evaluate(java.lang.String)
+     */
+    @Override
+    public boolean evaluate( String path )
+    {
+        boolean reversed = false;
+        if ( path.startsWith( "!" ) )
+        {
+            reversed = true;
+            path = path.substring( 1 );
+        }
+        path = pathTranslator.alignToBaseDirectory( path, basedir );
+        File f = new File( path );
+
+        if ( !f.isAbsolute() )
+        {
+            return false;
+        }
+
+        boolean fileExists = f.exists();
+
+        return missing ^ reversed ? !fileExists : fileExists;
+    }
+
+}

--- a/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/FileProfileActivatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/FileProfileActivatorTest.java
@@ -1,0 +1,149 @@
+package org.apache.maven.model.profile.activation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.Properties;
+
+import org.apache.maven.model.Activation;
+import org.apache.maven.model.ActivationFile;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.profile.DefaultProfileActivationContext;
+import org.apache.maven.model.profile.ProfileActivationContext;
+
+/**
+ * Tests {@link JdkVersionProfileActivator}.
+ *
+ * @author Loïc B.
+ */
+public class FileProfileActivatorTest
+    extends AbstractProfileActivatorTest<FileProfileActivator>
+{
+
+    public FileProfileActivatorTest()
+    {
+        super( FileProfileActivator.class );
+    }
+
+    private Profile newProfile( String exists, String missing )
+    {
+        ActivationFile file = new ActivationFile();
+        file.setExists( exists );
+        file.setMissing( missing );
+
+        Activation a = new Activation();
+        a.setFile( file );
+
+        Profile p = new Profile();
+        p.setActivation( a );
+
+        return p;
+    }
+
+    @Override
+    protected ProfileActivationContext newContext( Properties userProperties, Properties systemProperties )
+    {
+        DefaultProfileActivationContext context =
+            (DefaultProfileActivationContext) super.newContext( userProperties, systemProperties );
+        context.setProjectDirectory( new File( "." ) );
+        return context;
+    }
+    public void testNullSafe()
+        throws Exception
+    {
+        Profile p = new Profile();
+
+        assertActivation( false, p, newContext( null, null ) );
+
+        p.setActivation( new Activation() );
+
+        assertActivation( false, p, newContext( null, null ) );
+    }
+
+    public void testSingleFile()
+        throws Exception
+    {
+        checkActivation( true, "${basedir}/pom.xml", null );
+        checkActivation( false, "!${basedir}/pom.xml", null );
+        checkActivation( false, null, "${basedir}/pom.xml" );
+        checkActivation( true, null, "!${basedir}/pom.xml" );
+
+        checkActivation( false, "${basedir}/non-existent-file.xml", null );
+        checkActivation( true, "!${basedir}/non-existent-file.xml", null );
+        checkActivation( true, null, "${basedir}/non-existent-file.xml" );
+        checkActivation( false, null, "!${basedir}/non-existent-file.xml" );
+
+    }
+
+    public void testAnd()
+        throws Exception
+    {
+        checkActivation( true, "and(${basedir}/pom.xml,${basedir}/src)", null );
+        checkActivation( false, "and(${basedir}/pom.xml,${basedir}/non-existent-file.xml)", null );
+
+        checkActivation( true, "all(${basedir}/pom.xml,${basedir}/src)", null );
+        checkActivation( false, "all(${basedir}/pom.xml,${basedir}/non-existent-file.xml)", null );
+
+        checkActivation( false, null, "and(${basedir}/pom.xml,${basedir}/src)" );
+        checkActivation( false, null, "and(${basedir}/pom.xml,${basedir}/non-existent-file.xml)" );
+        checkActivation( true, null, "and(${basedir}/missing-file.xml,${basedir}/non-existent-file.xml)" );
+
+        checkActivation( false, null, "all(${basedir}/pom.xml,${basedir}/src)" );
+        checkActivation( false, null, "all(${basedir}/pom.xml,${basedir}/non-existent-file.xml)" );
+        checkActivation( true, null, "all(${basedir}/missing-file.xml,${basedir}/non-existent-file.xml)" );
+    }
+
+    public void testOr()
+        throws Exception
+    {
+        checkActivation( true, "or(${basedir}/pom.xml,${basedir}/src)", null );
+        checkActivation( true, "or(${basedir}/pom.xml,${basedir}/non-existent-file.xml)", null );
+        checkActivation( false, "or(${basedir}/missing-file.xml,${basedir}/non-existent-file.xml)", null );
+
+        checkActivation( true, "any(${basedir}/pom.xml,${basedir}/src)", null );
+        checkActivation( true, "any(${basedir}/pom.xml,${basedir}/non-existent-file.xml)", null );
+        checkActivation( false, "any(${basedir}/missing-file.xml,${basedir}/non-existent-file.xml)", null );
+
+        checkActivation( false, null, "or(${basedir}/pom.xml,${basedir}/src)" );
+        checkActivation( true, null, "or(${basedir}/pom.xml,${basedir}/non-existent-file.xml)" );
+        checkActivation( true, null, "or(${basedir}/missing-file.xml,${basedir}/non-existent-file.xml)" );
+
+        checkActivation( false, null, "any(${basedir}/pom.xml,${basedir}/src)" );
+        checkActivation( true, null, "any(${basedir}/pom.xml,${basedir}/non-existent-file.xml)" );
+        checkActivation( true, null, "any(${basedir}/missing-file.xml,${basedir}/non-existent-file.xml)" );
+
+    }
+
+    public void testNegated()
+        throws Exception
+    {
+        checkActivation( true, "all(${basedir}/pom.xml,!${basedir}/non-existent-file.xml)", null );
+        checkActivation( true, "any(!${basedir}/pom.xml,!${basedir}/non-existent-file.xml)", null );
+        checkActivation( false, "any(!${basedir}/pom.xml,${basedir}/non-existent-file.xml)", null );
+        checkActivation( true, null, "all(!${basedir}/pom.xml,${basedir}/non-existent-file.xml)" );
+        checkActivation( false, null, "any(${basedir}/pom.xml,!${basedir}/non-existent-file.xml)" );
+    }
+
+    private void checkActivation( boolean expected, String existing, String missing )
+    {
+        Profile profile = newProfile( existing, missing );
+        assertActivation( expected, profile, newContext( null, null ) );
+    }
+}

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -2616,6 +2616,9 @@
         is the location of a file that needs to exist, and if it doesn't, the profile will be
         activated. On the other hand, <code>exists</code> will test for the existence of the file and if it is
         there, the profile will be activated.<br>
+        To test for (non-)existence of multiple files, combine them with expressions : operator(file1,file2,...)
+        where operator can be : and, all, or, any. Nested expressions are not supported, but the operator can be
+        negated for each file by prepending its path with a !. Example : and(batch.mark,!test.mark)<br>
         Variable interpolation for these file specifications is limited to <code>${basedir}</code>,
         System properties and request properties.]]></description>
       <fields>
@@ -2624,13 +2627,20 @@
           <version>4.0.0+</version>
           <type>String</type>
           <description>The name of the file that must be missing to activate the
-          profile.</description>
+          profile, or an expression. If the operator used is 'and' or 'all',
+            then all files must be missing to activate the profile. If the operator
+            is 'any' or 'or', then at least one of the files must be missing to activate
+            the profile.</description>
         </field>
         <field>
           <name>exists</name>
           <version>4.0.0+</version>
           <type>String</type>
-          <description>The name of the file that must exist to activate the profile.</description>
+          <description>The name of the file that must exist to activate the profile,
+            or an expression. If the operator used is 'and' or 'all',
+            then all files must exist to activate the profile. If the operator
+            is 'any' or 'or', then at least one of the files must exist to activate
+            the profile.</description>
         </field>
       </fields>
     </class>

--- a/maven-settings/src/main/mdo/settings.mdo
+++ b/maven-settings/src/main/mdo/settings.mdo
@@ -1046,6 +1046,9 @@
         This is the file specification used to activate a profile. The missing value will be a the location
         of a file that needs to exist, and if it doesn't the profile must run.  On the other hand exists will test
         for the existence of the file and if it is there will run the profile.
+        To test for (non-)existence of multiple files, combine them with expressions : operator(file1,file2,...)
+        where operator can be : and, all, or, any. Nested expressions are not supported, but the operator can be
+        negated for each file by prepending its path with a !. Example : and(batch.mark,!test.mark)
         ]]>
       </description>
       <fields>
@@ -1055,7 +1058,10 @@
           <type>String</type>
           <description>
             The name of the file that should be missing to activate a
-            profile.
+            profile, or an expression. If the operator used is 'and' or 'all',
+            then all files must be missing to activate the profile. If the operator
+            is 'any' or 'or', then at least one of the files must be missing to activate
+            the profile.
           </description>
         </field>
         <field>
@@ -1063,7 +1069,11 @@
           <version>1.0.0+</version>
           <type>String</type>
           <description>
-            The name of the file that should exist to activate a profile.
+            The name of the file that should exist to activate a profile,
+            or an expression. If the operator used is 'and' or 'all',
+            then all files must exist to activate the profile. If the operator
+            is 'any' or 'or', then at least one of the files must exist to activate
+            the profile.
           </description>
         </field>
       </fields>


### PR DESCRIPTION
Suggested solution for MNG-5909 : the file activation element will understand basic boolean expressions such as and(file1,file2) or(file3,!file4) etc... Please see added unit test for expression examples.
If you think this could benefit to other activators (property, os, ...) please say so and I will happily modify them too.
I will also post a message on maven dev mailing list.
