### PR TITLE
[MNG-6110] updated Aether to Maven Resolver 1.2.0-SNAPSHOT

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -84,12 +84,12 @@ under the License.
       <artifactId>wagon-file</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-wagon</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-wagon</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/maven-aether-provider/pom.xml
+++ b/maven-aether-provider/pom.xml
@@ -31,7 +31,7 @@ under the License.
   <artifactId>maven-aether-provider</artifactId>
 
   <name>Maven Aether Provider</name>
-  <description>Extensions to Aether for utilizing Maven POM and repository metadata.</description>
+  <description>Extensions to Maven Resolver for utilizing Maven POM and repository metadata.</description>
 
   <dependencies>
     <dependency>
@@ -47,20 +47,20 @@ under the License.
       <artifactId>maven-repository-metadata</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -104,13 +104,13 @@ under the License.
     </dependency>
     <!-- Testing -->
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-wagon</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-wagon</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -71,16 +71,16 @@ under the License.
       <artifactId>maven-aether-provider</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -109,13 +109,13 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-wagon</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-wagon</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -77,20 +77,20 @@ under the License.
       <artifactId>maven-aether-provider</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -63,12 +63,12 @@ under the License.
       <artifactId>maven-model-builder</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ under the License.
     <cipherVersion>1.7</cipherVersion>
     <modelloVersion>1.8.3</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <aetherVersion>1.0.2.v20150114</aetherVersion>
+    <resolverVersion>1.2.0-SNAPSHOT</resolverVersion>
     <!-- Upgrade of SLF4J blocked by SLF4J-370 (MNG-6023). -->
     <!--   https://issues.apache.org/jira/browse/MNG-6023  -->
     <!--   http://jira.qos.ch/browse/SLF4J-370             -->
@@ -362,34 +362,34 @@ under the License.
       </dependency>
       <!--  Repository -->
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-api</artifactId>
-        <version>${aetherVersion}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-api</artifactId>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-spi</artifactId>
-        <version>${aetherVersion}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-spi</artifactId>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-impl</artifactId>
-        <version>${aetherVersion}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-impl</artifactId>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-util</artifactId>
-        <version>${aetherVersion}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-util</artifactId>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-connector-basic</artifactId>
-        <version>${aetherVersion}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-connector-basic</artifactId>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-transport-wagon</artifactId>
-        <version>${aetherVersion}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-wagon</artifactId>
+        <version>${resolverVersion}</version>
       </dependency>
       <!--  Commons -->
       <dependency>
@@ -678,6 +678,7 @@ under the License.
               <notimestamp>true</notimestamp>
               <quiet>true</quiet>
               <links combine.children="append">
+                <!-- TODO link to Maven Resolver Javadoc -->
                 <link>http://download.eclipse.org/aether/aether-core/${aetherVersion}/apidocs/</link>
                 <link>https://codehaus-plexus.github.io/plexus-containers/plexus-container-default/apidocs/</link>
               </links>


### PR DESCRIPTION
TODO:

* Upgrade to 1.2.0 once it's released.
* Should `maven-aether-provider` be renamed?
* Update Javadoc link for Maven Resolver in reactor POM.