### PR TITLE
.travis and SonarQube.com support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ install:
 before_script:
   - mvn clean
 script:
-  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" org.jacoco:jacoco-maven-plugin:prepare-agent package
-  - mvn org.jacoco:jacoco-maven-plugin:report-aggregate site
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Djacoco.destFile="${maven.multiModuleProjectDirectory}/target/jacoco.exec" org.jacoco:jacoco-maven-plugin:prepare-agent package
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ install:
 before_script:
   - mvn clean
 script:
-  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" org.jacoco:jacoco-maven-plugin:prepare-agent package org.jacoco:jacoco-maven-plugin:report-aggregate
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" org.jacoco:jacoco-maven-plugin:prepare-agent package
+  - mvn org.jacoco:jacoco-maven-plugin:report-aggregate
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 before_script:
   - mvn clean
 script:
-  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Djacoco.destFile="${PWD}/target/jacoco.exec" org.jacoco:jacoco-maven-plugin:prepare-agent package
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Dsonar.dynamicAnalysis=reuseReports -Djacoco.destFile="${PWD}/target/jacoco.exec" org.jacoco:jacoco-maven-plugin:prepare-agent package
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 before_script:
   - mvn clean
 script:
-  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Dsonar.dynamicAnalysis=reuseReports -Djacoco.destFile="${PWD}/target/jacoco.exec" org.jacoco:jacoco-maven-plugin:prepare-agent package
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Dsonar.dynamicAnalysis=reuseReports -Dsonar.jacoco.reportPath="${PWD}/target/jacoco.exec" -Djacoco.destFile="${PWD}/target/jacoco.exec" org.jacoco:jacoco-maven-plugin:prepare-agent package
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 before_script:
   - mvn clean
 script:
-  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Djacoco.destFile='${maven.multiModuleProjectDirectory}/target/jacoco.exec' org.jacoco:jacoco-maven-plugin:prepare-agent package
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Djacoco.destFile="${PWD}/target/jacoco.exec" org.jacoco:jacoco-maven-plugin:prepare-agent package
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 before_script:
   - mvn clean
 script:
-  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Djacoco.destFile="${maven.multiModuleProjectDirectory}/target/jacoco.exec" org.jacoco:jacoco-maven-plugin:prepare-agent package
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" -Djacoco.destFile='${maven.multiModuleProjectDirectory}/target/jacoco.exec' org.jacoco:jacoco-maven-plugin:prepare-agent package
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+language: java
+jdk:
+  - openjdk7
+sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+  sonarqube: true
+cache:
+  directories:
+    - "$HOME/.m2"
+    - "$HOME/.sonar/cache"
+env:
+  global:
+    - JAVA_TOOL_OPTIONS: "-Xmx512m"
+    - MAVEN_OPTS: "-Xmx512m"
+    - secure: fTuQG00/LoV6nPKinPr41wBmSblaNpFoEvLD2mG0FIokwBS3m+AUrfHnyvQkVbvkSGFzvTfXFca9ucobzuMV9z8SCBWBZv0ZzOm6D1wCBqbbjhvpNjLog0A3546MZ0Fzn7V6/6ZfK2qtERC6eF8uRSKSkiTmlUFR3bTZXE+m0fCiv53bGeNh0M6nj+pApC6wVkOfWvre/di8GvnKQc1RqN/EZCCxTAEyQfGkJKFNfqJfBwahUjAhm5jiAsFtqbyWmUCjHeigWYvHC1zj1knZ7v4F+du2NpUra6pOIwFdxFXp5eJGa8ano35DG2lEb/fIyeEYnfBw8bf63Wte8GSOLWg+qOxHgeIg9W1h9o8ywoyNvs1UOz3gTXj/lIQiGFmrW3g8YAzsfHac6Owyl6+QH6sft4xcVqbflclOpCJ3m5WJPX6km0N0tqkaAgT4mu7NSalWEKYNrTv1aPUU84C/Wj+lfP0dNzaYQpqK8zE1c1gzjsyoOm9dXxqZNJIk1/1axmr8xGC94ODMw2DJ//ibld74BVK0ybCQdgDepmbJgtE1SZCxpvOZPdCLMni4vG7uSKk116x5vKBdOnyXTaVKSqY94hiafh8QNdUSkObaWTr9M8rgIWkYJfpnvkT97dSS8SuA+CZQBGgYWkgq6QWLtdN482NxRD/AdVU+0MpuZDc=
+install:
+  - mvn dependency:go-offline
+before_script:
+  - mvn clean
+script:
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" org.jacoco:jacoco-maven-plugin:prepare-agent package
+after_success:
+  - jdk_switcher use oraclejdk8
+  - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
   - mvn clean
 script:
   - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" org.jacoco:jacoco-maven-plugin:prepare-agent package
-  - mvn org.jacoco:jacoco-maven-plugin:report-aggregate
+  - mvn org.jacoco:jacoco-maven-plugin:report-aggregate site
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 before_script:
   - mvn clean
 script:
-  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" org.jacoco:jacoco-maven-plugin:prepare-agent package
+  - mvn -DdistributionTargetFolder="$HOME/app/maven/apache-maven-3.4.x-SNAPSHOT" org.jacoco:jacoco-maven-plugin:prepare-agent package org.jacoco:jacoco-maven-plugin:report-aggregate
 after_success:
   - jdk_switcher use oraclejdk8
   - mvn sonar:sonar

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Maven is available under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+[![Build Status](https://travis-ci.org/apache/maven.svg?branch=master)](https://travis-ci.org/apache/maven)
+[![Quality Gate](https://sonarqube.com/api/badges/gate?key=org.apache.maven:maven)](https://sonarqube.com/dashboard/index/org.apache.maven:maven)
+
 - [Maven Issue Tracker](https://issues.apache.org/jira/browse/MNG)
 - [Maven Wiki](https://cwiki.apache.org/confluence/display/MAVEN/Index)
 - [Building Maven](https://maven.apache.org/guides/development/guide-building-maven.html)


### PR DESCRIPTION
This PR provides two commits, the first one adds Travis build support.  https://travis-ci.org/trajano/maven the README is coded to point to apache/maven though.

The second adds SonarQube support.  For the SonarQube support to work, the token needs to change to something that is owned by apache/maven repository rather than something associated with my ID.

https://sonarqube.com/dashboard/index?id=org.apache.maven%3Amaven

@apache Please create tokens for GITHUB and SonarQube, I had documented the instructions here https://www.trajano.net/2016/11/integrating-travis-sonarqube/

<pre>
travis encrypt SONAR_TOKEN=[token from sonarqube.com]
travis encrypt SONAR_GITHUB_TOKEN=[token from github.com]
</pre>

This will also enable pull request analyisis in the future as well.