### PR TITLE
spelling: vertices

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
@@ -105,7 +105,7 @@ public class ProjectSorter
             vertices.put( project.getVersion(), dag.addVertex( projectId ) );
         }
 
-        for ( Vertex projectVertex : dag.getVerticies() )
+        for ( Vertex projectVertex : dag.getVertices() )
         {
             String projectId = projectVertex.getLabel();
 


### PR DESCRIPTION
split from #100 

I think this is a bug fix. I can't figure out how it could work otherwise.