### PR TITLE
spelling: excident

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/repository/MetadataGraphNode.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/MetadataGraphNode.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * MetadataGraph node - as it's a directed graph - holds adjacency lists for incident and exident nodes
+ * MetadataGraph node - as it's a directed graph - holds adjacency lists for incident and excident nodes
  *
  * @author Oleg Gusakov
  *
@@ -36,7 +36,7 @@ public class MetadataGraphNode
     /** nodes, incident to this (depend on me) */
     List<MetadataGraphNode> inNodes;
 
-    /** nodes, exident to this (I depend on) */
+    /** nodes, excident to this (I depend on) */
     List<MetadataGraphNode> exNodes;
 
     public MetadataGraphNode()
@@ -57,7 +57,7 @@ public class MetadataGraphNode
         return this;
     }
 
-    public MetadataGraphNode addExident( MetadataGraphNode node )
+    public MetadataGraphNode addExcident( MetadataGraphNode node )
     {
         exNodes.add( node );
         return this;


### PR DESCRIPTION
split from #100 

This is for consistency. I know it's a public API. But, I don't know if this is the word you want. If it is, we can add the @Deprecated annotation. If it isn't, then we should figure out the right word and fix the others too.