### PR TITLE
[MNG-5961] Fix the SLF4J logger factory implementation used for LOG4J2

### DIFF
--- a/maven-embedder/src/main/resources/META-INF/maven/slf4j-configuration.properties
+++ b/maven-embedder/src/main/resources/META-INF/maven/slf4j-configuration.properties
@@ -19,5 +19,5 @@
 # value = corresponding o.a.m.cli.logging.Slf4jConfiguration class
 org.slf4j.impl.SimpleLoggerFactory org.apache.maven.cli.logging.impl.Slf4jSimpleConfiguration
 org.slf4j.impl.MavenSimpleLoggerFactory org.apache.maven.cli.logging.impl.Slf4jSimpleConfiguration
-org.slf4j.helpers.Log4jLoggerFactory org.apache.maven.cli.logging.impl.Log4j2Configuration
+org.apache.logging.slf4j.Log4jLoggerFactory org.apache.maven.cli.logging.impl.Log4j2Configuration
 ch.qos.logback.classic.LoggerContext org.apache.maven.cli.logging.impl.LogbackConfiguration


### PR DESCRIPTION
This is the fix I did in https://git-wip-us.apache.org/repos/asf?p=maven.git;a=blobdiff;f=maven-embedder/src/main/resources/META-INF/maven/slf4j-configuration.properties;h=cd01f9e6bb29cf31371e0e6df04d095430d3ea9b;hp=87418363b1812e85d6a41a63df4486d07227e1d5;hb=202f757af3aba6e1b96631de025e0ba692098009;hpb=5a3332ca347628605bec7d3e9f9309081aaba46c