### PR TITLE
MNG-6173 MavenSession.getAllProjects() should return all projects in the reactor

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -520,15 +520,6 @@ public class DefaultMaven
                 logger.error( problem.toString() );
             }
         }
-
-        if ( !graphResult.hasErrors() )
-        {
-            ProjectDependencyGraph projectDependencyGraph = graphResult.get();
-            session.setProjects( projectDependencyGraph.getSortedProjects() );
-            session.setAllProjects( projectDependencyGraph.getSortedProjects() );
-            session.setProjectDependencyGraph( projectDependencyGraph );
-        }
-
         return graphResult;
     }
 

--- a/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -81,6 +81,7 @@ public class DefaultGraphBuilder
             try
             {
                 projects = getProjectsForMavenReactor( session );
+                session.setAllProjects( projects );
             }
             catch ( ProjectBuildingException e )
             {


### PR DESCRIPTION
This commit moves the initialisation of the allProjects field in
MavenSession into the DefaultGraphBuilder as the full list of projects
in the reactor is only available there.

Since MavenSessions's projects and projectDependencyGraph fields were
already initialised in DefaultGraphBuilder, the code that sets them
again in DefaultMaven is removed.