### PR TITLE
[MNG-6203] Minor cleanup in MavenCli.java

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1462,17 +1462,6 @@ public class MavenCli
             alternatePomFile = commandLine.getOptionValue( CLIManager.ALTERNATE_POM_FILE );
         }
 
-        File userToolchainsFile;
-        if ( commandLine.hasOption( CLIManager.ALTERNATE_USER_TOOLCHAINS ) )
-        {
-            userToolchainsFile = new File( commandLine.getOptionValue( CLIManager.ALTERNATE_USER_TOOLCHAINS ) );
-            userToolchainsFile = resolveFile( userToolchainsFile, workingDirectory );
-        }
-        else
-        {
-            userToolchainsFile = MavenCli.DEFAULT_USER_TOOLCHAINS_FILE;
-        }
-
         request.setBaseDirectory( baseDirectory ).setGoals( goals ).setSystemProperties(
             cliRequest.systemProperties ).setUserProperties( cliRequest.userProperties ).setReactorFailureBehavior(
             reactorFailureBehaviour ) // default: fail fast


### PR DESCRIPTION
There is some unnecessary code in the MavenCli.java from line #1465 to #1474.
The functionality has been moved to line #1215.

Signed-off-by: Stefan Eicher <stefan.eicher@gmail.com>