### PR TITLE
Fix snapshot regular expression

### DIFF
--- a/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
@@ -46,7 +46,7 @@ public interface Artifact
 
     String SNAPSHOT_VERSION = "SNAPSHOT";
 
-    Pattern VERSION_FILE_PATTERN = Pattern.compile( "^(.*)-([0-9]{8}.[0-9]{6})-([0-9]+)$" );
+    Pattern VERSION_FILE_PATTERN = Pattern.compile( "^(.*)-([0-9]{8}\.[0-9]{6})-([0-9]+)$" );
 
     // TODO into artifactScope handler
 


### PR DESCRIPTION
The snapshot regular expression should only match an explicit period.