### PR TITLE
[MNG-5756] Java home output in mvn -v is misleading

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
@@ -68,7 +68,10 @@ public final class CLIReportingUtils
         version.append( "Java version: " ).append(
             System.getProperty( "java.version", "<unknown Java version>" ) ).append( ", vendor: " ).append(
             System.getProperty( "java.vendor", "<unknown vendor>" ) ).append( ls );
-        version.append( "Java home: " ).append( System.getProperty( "java.home", "<unknown Java home>" ) ).append( ls );
+        String javaHome = System.getenv( "JAVA_HOME" );
+        javaHome = ( javaHome == null ? "<unknown Java home>" : javaHome );
+        version.append( "Java home: " ).append( javaHome ).append( ls );
+        version.append( "JRE used: " ).append( System.getProperty( "java.home", "<unknown JRE>" ) ).append( ls );
         version.append( "Default locale: " ).append( Locale.getDefault() ).append( ", platform encoding: " ).append(
             System.getProperty( "file.encoding", "<unknown encoding>" ) ).append( ls );
         version.append( "OS name: \"" ).append( Os.OS_NAME ).append( "\", version: \"" ).append( Os.OS_VERSION ).append(


### PR DESCRIPTION
Renamed previous printing of JRE to "JRE used" and provided
separate mechanism to actually tell value of JAVA_HOME