### PR TITLE
[MNG-6207] display build WARNING if deprecated 'system' scope is used

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -467,6 +467,12 @@ public class DefaultModelValidator
             }
             else if ( "system".equals( dependency.getScope() ) )
             {
+
+                if ( request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1 ) {
+                    addViolation( problems, Severity.WARNING, Version.V31, prefix + ".scope", key,
+                            "declares usage of deprecated 'system' scope ", dependency );
+                }
+
                 String sysPath = dependency.getSystemPath();
                 if ( StringUtils.isNotEmpty( sysPath ) )
                 {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -418,7 +418,20 @@ public class DefaultModelValidatorTest
 
         assertViolations( result, 0, 0, 1 );
 
-        assertTrue( result.getWarnings().get( 0 ).contains( "test:a:jar" ) );
+        assertContains( result.getWarnings().get( 0 ),
+                "'dependencies.dependency.systemPath' for test:a:jar should use a variable instead of a hard-coded path" );
+
+        SimpleProblemCollector result_31 = validateRaw( "hard-coded-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1 );
+
+        assertViolations( result_31, 0, 0, 3 );
+
+        assertContains( result_31.getWarnings().get( 0 ),
+                "'dependencies.dependency.scope' for test:a:jar declares usage of deprecated 'system' scope" );
+        assertContains( result_31.getWarnings().get( 1 ),
+                "'dependencies.dependency.systemPath' for test:a:jar should use a variable instead of a hard-coded path" );
+        assertContains( result_31.getWarnings().get( 2 ),
+                "'dependencies.dependency.scope' for test:b:jar declares usage of deprecated 'system' scope" );
+
     }
 
     public void testEmptyModule()
@@ -611,10 +624,23 @@ public class DefaultModelValidatorTest
 
         assertViolations( result, 0, 0, 2 );
 
-        assertContains( result.getWarnings().get( 0 ), "'dependencies.dependency.systemPath' for test:a:jar "
-            + "should not point at files within the project directory" );
-        assertContains( result.getWarnings().get( 1 ), "'dependencies.dependency.systemPath' for test:b:jar "
-            + "should not point at files within the project directory" );
+        assertContains( result.getWarnings().get( 0 ),
+                "'dependencies.dependency.systemPath' for test:a:jar should not point at files within the project directory" );
+        assertContains( result.getWarnings().get( 1 ),
+                "'dependencies.dependency.systemPath' for test:b:jar should not point at files within the project directory" );
+
+        SimpleProblemCollector result_31 = validateRaw( "basedir-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1 );
+
+        assertViolations( result_31, 0, 0, 4 );
+
+        assertContains( result_31.getWarnings().get( 0 ),
+                "'dependencies.dependency.scope' for test:a:jar declares usage of deprecated 'system' scope" );
+        assertContains( result_31.getWarnings().get( 1 ),
+                "'dependencies.dependency.systemPath' for test:a:jar should not point at files within the project directory" );
+        assertContains( result_31.getWarnings().get( 2 ),
+                "'dependencies.dependency.scope' for test:b:jar declares usage of deprecated 'system' scope" );
+        assertContains( result_31.getWarnings().get( 3 ),
+                "'dependencies.dependency.systemPath' for test:b:jar should not point at files within the project directory" );
     }
 
     public void testInvalidVersionInPluginManagement()


### PR DESCRIPTION
JIRA ticket: [MNG-6207: Create WARNINGs in case of using system scope](https://issues.apache.org/jira/browse/MNG-6207)

Note: since **_system_** scope requires _**systemPath**_ I decided to expand  and rename existing systemPath tests; if that kind of change is not acceptable please suggest different approach. 
