### PR TITLE
[MNG-6206] display deprecation build warning in case when dependencies use metaversions (LATEST or RELEASE)

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -487,7 +487,7 @@ public class DefaultModelValidator
 
             if ( equals("LATEST", dependency.getVersion()) || equals("RELEASE", dependency.getVersion()))
             {
-                addViolation( problems, Severity.WARNING, Version.V20, prefix + ".version", key,
+                addViolation( problems, Severity.WARNING, Version.V31, prefix + ".version", key,
                         "is either LATEST or RELEASE (both of them are being deprecated)", dependency );
             }
 

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -485,6 +485,12 @@ public class DefaultModelValidator
                 }
             }
 
+            if ( equals("LATEST", dependency.getVersion()) || equals("RELEASE", dependency.getVersion()))
+            {
+                addViolation( problems, Severity.WARNING, Version.V20, prefix + ".version", key,
+                        "is either LATEST or RELEASE (both of them are being deprecated)", dependency );
+            }
+
             Dependency existing = index.get( key );
 
             if ( existing != null )

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -485,7 +485,8 @@ public class DefaultModelValidator
                 }
             }
 
-            if ( equals("LATEST", dependency.getVersion()) || equals("RELEASE", dependency.getVersion()))
+            if ( request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1
+                    && ( equals( "LATEST", dependency.getVersion() ) || equals( "RELEASE", dependency.getVersion() ) ) )
             {
                 addViolation( problems, Severity.WARNING, Version.V31, prefix + ".version", key,
                         "is either LATEST or RELEASE (both of them are being deprecated)", dependency );

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -676,4 +676,16 @@ public class DefaultModelValidatorTest
         assertViolations( result, 0, 0, 0 );
     }
 
+    public void testDeprecatedDependencyMetaversionsLatestAndRelease()
+            throws Exception
+    {
+        SimpleProblemCollector result = validateRaw( "deprecated-dependency-metaversions-latest-and-release.xml" );
+
+        assertViolations( result, 0, 0, 2 );
+
+        assertContains( result.getWarnings().get( 0 ),
+               "'dependencies.dependency.version' for test:a:jar is either LATEST or RELEASE (both of them are being deprecated)" );
+        assertContains( result.getWarnings().get( 1 ),
+                "'dependencies.dependency.version' for test:b:jar is either LATEST or RELEASE (both of them are being deprecated)" );
+    }
 }

--- a/maven-model-builder/src/test/resources/poms/validation/deprecated-dependency-metaversions-latest-and-release.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/deprecated-dependency-metaversions-latest-and-release.xml
@@ -1,0 +1,38 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>gid</groupId>
+  <artifactId>aid</artifactId>
+  <version>0.1</version>
+
+    <dependencies>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>a</artifactId>
+        <version>LATEST</version>
+      </dependency>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>b</artifactId>
+        <version>RELEASE</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
JIRA ticket: [MNG-6206: We should produce a WARNING by using RELEASE, LATEST as versions](https://issues.apache.org/jira/browse/MNG-6206)

