### PR TITLE
Make resolver debug log messages for projects and plugins consistent.

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -19,6 +19,7 @@ package org.apache.maven.plugin.internal;
  * under the License.
  */
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.apache.maven.plugin.PluginResolutionException;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -54,6 +56,7 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.filter.AndDependencyFilter;
 import org.eclipse.aether.util.filter.ScopeDependencyFilter;
+import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
@@ -221,6 +224,7 @@ public class DefaultPluginDependenciesResolver
         return node;
     }
 
+    // Keep this class in sync with org.apache.maven.project.DefaultProjectDependenciesResolver.GraphLogger
     class GraphLogger
         implements DependencyVisitor
     {
@@ -234,10 +238,60 @@ public class DefaultPluginDependenciesResolver
             org.eclipse.aether.graph.Dependency dep = node.getDependency();
             if ( dep != null )
             {
-                Artifact art = dep.getArtifact();
+                org.eclipse.aether.artifact.Artifact art = dep.getArtifact();
 
                 buffer.append( art );
                 buffer.append( ':' ).append( dep.getScope() );
+                buffer.append( ':' ).append( dep.isOptional() ? "optional" : "not optional" );
+
+                // TODO We currently cannot tell which <dependencyManagement> section contained the management
+                //      information. When the resolver provides this information, these log messages should be updated
+                //      to contain it.
+                if ( ( node.getManagedBits() & DependencyNode.MANAGED_SCOPE ) == DependencyNode.MANAGED_SCOPE )
+                {
+                    final String premanagedScope = DependencyManagerUtils.getPremanagedScope( node );
+                    buffer.append( " (scope managed from " );
+                    buffer.append( StringUtils.defaultString( premanagedScope, "default" ) );
+                    buffer.append( ')' );
+                }
+
+                if ( ( node.getManagedBits() & DependencyNode.MANAGED_VERSION ) == DependencyNode.MANAGED_VERSION )
+                {
+                    final String premanagedVersion = DependencyManagerUtils.getPremanagedVersion( node );
+                    buffer.append( " (version managed from " );
+                    buffer.append( StringUtils.defaultString( premanagedVersion, "default" ) );
+                    buffer.append( ')' );
+                }
+
+                if ( ( node.getManagedBits() & DependencyNode.MANAGED_OPTIONAL ) == DependencyNode.MANAGED_OPTIONAL )
+                {
+                    final Boolean premanagedOptional = DependencyManagerUtils.getPremanagedOptional( node );
+                    buffer.append( " (optionality managed from " );
+                    buffer.append( StringUtils.defaultString( premanagedOptional, "default" ) );
+                    buffer.append( ')' );
+                }
+
+                if ( ( node.getManagedBits() & DependencyNode.MANAGED_EXCLUSIONS )
+                         == DependencyNode.MANAGED_EXCLUSIONS )
+                {
+                    final Collection<org.eclipse.aether.graph.Exclusion> premanagedExclusions =
+                        DependencyManagerUtils.getPremanagedExclusions( node );
+
+                    buffer.append( " (exclusions managed from " );
+                    buffer.append( StringUtils.defaultString( premanagedExclusions, "default" ) );
+                    buffer.append( ')' );
+                }
+
+                if ( ( node.getManagedBits() & DependencyNode.MANAGED_PROPERTIES )
+                         == DependencyNode.MANAGED_PROPERTIES )
+                {
+                    final Map<String, String> premanagedProperties =
+                        DependencyManagerUtils.getPremanagedProperties( node );
+
+                    buffer.append( " (properties managed from " );
+                    buffer.append( StringUtils.defaultString( premanagedProperties, "default" ) );
+                    buffer.append( ')' );
+                }
             }
 
             logger.debug( buffer.toString() );

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -228,6 +228,7 @@ public class DefaultProjectDependenciesResolver
         }
     }
 
+    // Keep this class in sync with org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver.GraphLogger
     class GraphLogger
         implements DependencyVisitor
     {
@@ -252,9 +253,10 @@ public class DefaultProjectDependenciesResolver
 
                 buffer.append( art );
                 buffer.append( ':' ).append( dep.getScope() );
+                buffer.append( ':' ).append( dep.isOptional() ? "optional" : "not optional" );
 
                 // TODO We currently cannot tell which <dependencyManagement> section contained the management
-                //      information. When resolver 1.1 provides this information, these log messages should be updated
+                //      information. When the resolver provides this information, these log messages should be updated
                 //      to contain it.
                 if ( ( node.getManagedBits() & DependencyNode.MANAGED_SCOPE ) == DependencyNode.MANAGED_SCOPE )
                 {
@@ -281,24 +283,25 @@ public class DefaultProjectDependenciesResolver
                 }
 
                 if ( ( node.getManagedBits() & DependencyNode.MANAGED_EXCLUSIONS )
-                        == DependencyNode.MANAGED_EXCLUSIONS )
+                         == DependencyNode.MANAGED_EXCLUSIONS )
                 {
-                    // TODO As of resolver 1.1, use DependencyManagerUtils.getPremanagedExclusions( node ).
-                    //      The resolver 1.0.x releases do not record premanaged state of exclusions.
-                    buffer.append( " (exclusions managed)" );
+                    final Collection<org.eclipse.aether.graph.Exclusion> premanagedExclusions =
+                        DependencyManagerUtils.getPremanagedExclusions( node );
+
+                    buffer.append( " (exclusions managed from " );
+                    buffer.append( StringUtils.defaultString( premanagedExclusions, "default" ) );
+                    buffer.append( ')' );
                 }
 
                 if ( ( node.getManagedBits() & DependencyNode.MANAGED_PROPERTIES )
-                        == DependencyNode.MANAGED_PROPERTIES )
+                         == DependencyNode.MANAGED_PROPERTIES )
                 {
-                    // TODO As of resolver 1.1, use DependencyManagerUtils.getPremanagedProperties( node ).
-                    //      The resolver 1.0.x releases do not record premanaged state of properties.
-                    buffer.append( " (properties managed)" );
-                }
+                    final Map<String, String> premanagedProperties =
+                        DependencyManagerUtils.getPremanagedProperties( node );
 
-                if ( dep.isOptional() )
-                {
-                    buffer.append( " (optional)" );
+                    buffer.append( " (properties managed from " );
+                    buffer.append( StringUtils.defaultString( premanagedProperties, "default" ) );
+                    buffer.append( ')' );
                 }
             }
             else

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ under the License.
     <cipherVersion>1.7</cipherVersion>
     <modelloVersion>1.9.1</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.0.3</resolverVersion>
+    <resolverVersion>1.1.0-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.22</slf4jVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <!-- Control the name of the distribution and information output by mvn -->


### PR DESCRIPTION
The graph returned by the resolver after resolution is logged at debug level. This pull request only updates those debug log messages to be consistent across project and plugin resolution and to provide as much information as possible to make users aware of what is going on.