### PR TITLE
[MNG-5965] Parallel build multiplies work if multiple goals are given

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ConcurrencyDependencyGraph.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ConcurrencyDependencyGraph.java
@@ -61,12 +61,12 @@ public class ConcurrencyDependencyGraph
     /**
      * Gets all the builds that have no reactor-dependencies
      *
-     * @return A list of all the initial builds
+     * @return A set of all the initial builds
      */
 
-    public List<MavenProject> getRootSchedulableBuilds()
+    public Set<MavenProject> getRootSchedulableBuilds()
     {
-        List<MavenProject> result = new ArrayList<>();
+        Set<MavenProject> result = new HashSet<>();
         for ( ProjectSegment projectBuild : projectBuilds )
         {
             if ( projectDependencyGraph.getUpstreamProjects( projectBuild.getProject(), false ).size() == 0 )

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/multithreaded/MultiThreadedBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/multithreaded/MultiThreadedBuilder.java
@@ -87,17 +87,18 @@ public class MultiThreadedBuilder
         }
         ExecutorService executor = Executors.newFixedThreadPool( nThreads, new BuildThreadFactory() );
         CompletionService<ProjectSegment> service = new ExecutorCompletionService<>( executor );
-        ConcurrencyDependencyGraph analyzer =
-            new ConcurrencyDependencyGraph( projectBuilds, session.getProjectDependencyGraph() );
 
         // Currently disabled
         ThreadOutputMuxer muxer = null; // new ThreadOutputMuxer( analyzer.getProjectBuilds(), System.out );
 
         for ( TaskSegment taskSegment : taskSegments )
         {
+          ProjectBuildList segmentProjectBuilds = projectBuilds.getByTaskSegment( taskSegment );
             Map<MavenProject, ProjectSegment> projectBuildMap = projectBuilds.selectSegment( taskSegment );
             try
             {
+                ConcurrencyDependencyGraph analyzer = new ConcurrencyDependencyGraph( segmentProjectBuilds, 
+                                                                                      session.getProjectDependencyGraph() );
                 multiThreadedProjectTaskSegmentBuild( analyzer, reactorContext, session, service, taskSegment,
                                                       projectBuildMap, muxer );
                 if ( reactorContext.getReactorBuildStatus().isHalted() )

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ConcurrencyDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ConcurrencyDependencyGraphTest.java
@@ -31,6 +31,7 @@ import org.apache.maven.plugin.version.PluginVersionResolutionException;
 import org.apache.maven.project.MavenProject;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.*;
 
@@ -51,9 +52,9 @@ public class ConcurrencyDependencyGraphTest
         ConcurrencyDependencyGraph graph =
             new ConcurrencyDependencyGraph( getProjectBuildList( session ), dependencyGraph );
 
-        final List<MavenProject> projectBuilds = graph.getRootSchedulableBuilds();
+        final Set<MavenProject> projectBuilds = graph.getRootSchedulableBuilds();
         assertEquals( 1, projectBuilds.size() );
-        assertEquals( A, projectBuilds.get( 0 ) );
+        assertEquals( A, projectBuilds.iterator().next() );
 
         final List<MavenProject> subsequent = graph.markAsFinished( A );
         assertEquals( 2, subsequent.size() );


### PR DESCRIPTION

[mng-5965.zip](https://github.com/apache/maven/files/1124059/mng-5965.zip)
This p/r should also fix MNG-5705.

### Problem
When multiple tasks are given so that they are grouped in different task segments, the MultiThreadedBuilder fails. 
The reason is that it creates project segments, which is a set of unique pairs of (module, task).
It then handles each task separately, and it will schedules the build of the task for **all** root module in those pairs, instead of scheduling only the root modules which are associated with that particular task.

### Example
For example, given the project with the following hierarchy of modules:
```
root
-- module1
```

If we run `mvn task1 task2`, being task2 an aggregating task, we get the following project segments:
   (task1, root), (task1, module1), (task2, root).

The MultiThreadedBuilder will first handle task1, and will schedule the build of: (task1, root), (task1, root).
Each of these builds will then recursively build its children, meaning that _task1 will be executed twice for every module in the project_.

### Fix
This fix changes the builder so that it considers the project segments of each task segment separately, by creating a ConcurrencyDependencyGraph for each task segment.


### Related
I believe that MNG-5705 is a consequence of the same problem, because the builder will not count correctly the number of projects that are built because of the shared ConcurrencyDependencyGraph, resulting in a NPE.

### Test
I opened a separate P/R to add an IT for this issue: https://github.com/apache/maven-integration-testing/pull/22

It uses a very simple multi module project, which is attached here too.

To reproduce:
```
mvn clean install:help install -T10
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] module-1
[INFO] module-2
[INFO] base-project
[INFO] 
[INFO] Using the MultiThreadedBuilder implementation with a thread count of 10
[INFO] 
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building module-2 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building base-project 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ module-2 ---
[INFO] ------------------------------------------------------------------------
[INFO] Building module-1 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ base-project ---
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ module-1 ---
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building base-project 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ base-project ---
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building module-1 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ module-1 ---
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building module-2 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ module-2 ---
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building base-project 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ base-project ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] module-1 ........................................... SUCCESS [  0.069 s]
[INFO] module-2 ........................................... SUCCESS [  0.069 s]
[INFO] base-project ....................................... SUCCESS [  0.001 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.197 s (Wall Clock)
[INFO] Finished at: 2017-07-05T11:06:42+02:00
[INFO] Final Memory: 8M/240M
[INFO] ------------------------------------------------------------------------
[ERROR] NullPointerException
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```

Note the clean goal being executed twice for each module, and the NPE (as described by MNG-5705).

Expected result, after the fix:
```
/tmp/apache-maven-3.5.1-SNAPSHOT/bin/mvn clean install:help install -T10
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] module-1
[INFO] module-2
[INFO] base-project
[INFO] 
[INFO] Using the MultiThreadedBuilder implementation with a thread count of 10
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building module-2 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ module-2 ---
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building base-project 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building module-1 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ module-1 ---
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ base-project ---
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building base-project 0.1
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-install-plugin:2.4:help (default-cli) @ base-project ---
[INFO] Maven Install Plugin 2.4
  Copies the project artifacts to the user's local repository.

This plugin has 3 goals:

install:help
  Display help information on maven-install-plugin.
  Call mvn install:help -Ddetail=true -Dgoal=<goal-name> to display parameter
  details.

install:install
  Installs the project's main artifact, and any other artifacts attached by
  other plugins in the lifecycle, to the local repository.

install:install-file
  Installs a file in the local repository.
```
