### PR TITLE
[MNG-6255] Fix concat_lines in mvn to deal with CRLF

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -167,7 +167,7 @@ find_file_argument_basedir() {
 # concatenates all lines of a file
 concat_lines() {
   if [ -f "$1" ]; then
-    echo "`tr -s '\n' ' ' < "$1"`"
+    echo "`tr -s '\r\n' '  ' < "$1"`"
   fi
 }
 


### PR DESCRIPTION
Change `tr` command to deal with CRLF line endings properly.

This was triggered by running the `mvn` shell script on a Windows machine (with the Git bash shell and utilities) against a GitHub repository generated on a Mac, which contained a `.mvn/jvm.config` file with CRLF line endings.

See https://issues.apache.org/jira/browse/MNG-6255 for further details.