### PR TITLE
[MNG-6298] 3.5.2: ClassNotFoundException

### DIFF
--- a/maven-core/src/main/resources/META-INF/maven/extension.xml
+++ b/maven-core/src/main/resources/META-INF/maven/extension.xml
@@ -100,6 +100,7 @@ under the License.
 
     <!-- javax.annotation (JSR-250) -->
     <exportedPackage>javax.annotation.*</exportedPackage>
+    <exportedPackage>javax.annotation.security.*</exportedPackage>
 
     <!-- 
       | We may potentially want to export these, but right now I'm not sure that anything Guice specific needs


### PR DESCRIPTION
Adding exportedPackage to find class:
javax.annotation.security.RolesAllowed

First maven commit :) Works but might be deeper issue