### PR TITLE
Add org.slf4j.event to exported packages

### DIFF
--- a/maven-core/src/main/resources/META-INF/maven/extension.xml
+++ b/maven-core/src/main/resources/META-INF/maven/extension.xml
@@ -119,6 +119,7 @@ under the License.
     <exportedPackage>org.slf4j.*</exportedPackage>
     <exportedPackage>org.slf4j.spi.*</exportedPackage>
     <exportedPackage>org.slf4j.helpers.*</exportedPackage>
+    <exportedPackage>org.slf4j.event.*</exportedPackage>
 
     <!-- JAnsi -->
     <exportedPackage>org.fusesource.jansi.*</exportedPackage>


### PR DESCRIPTION
maven-core should export org.slf4j.event.* from slf4j-api 1.7.15 or later.
For example, this package is where the `Level` class is located.

Otherwise, issues similar to MNG-5842 and MNG-5845 will arise with plugins that use Slf4j themselves (or more likely plugins that use libraries that use Slf4j).

Discovered while working on in-house Maven plugin that failed with `java.lang.NoClassDefFoundError: org/slf4j/event/Level`.