### PR TITLE
[MNG-4347] Set the profiles on reecursive dependencyManagement imports

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -1270,6 +1270,9 @@ public class DefaultModelBuilder
                         importRequest.setSystemProperties( request.getSystemProperties() );
                         importRequest.setUserProperties( request.getUserProperties() );
                         importRequest.setLocationTracking( request.isLocationTracking() );
+                        importRequest.setProfiles( request.getProfiles() );
+                        importRequest.setActiveProfileIds( request.getActiveProfileIds() );
+                        importRequest.setInactiveProfileIds( request.getInactiveProfileIds() );
                     }
 
                     importRequest.setModelSource( importSource );


### PR DESCRIPTION
When a set of default repositories are specified via a profile in the global settings.xml, recursive dependencyManagement imports cannot be resolved from repositories in the profiles, since the profiles are not currently passed along to the ModelBuildingRequest used for resolving recursive imports.  This adds the profile to that ModelBuildingRequest.
