### PR TITLE
[MNG-4347] import-scoped dependencies of direct dependencies are not resolved using profile modifications from settings.xml

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
@@ -71,6 +71,8 @@ public class ProjectModelResolver
 
     private final List<RemoteRepository> externalRepositories;
 
+    private final Set<String> externalRepositoryIds;
+
     private final RepositorySystem resolver;
 
     private final RemoteRepositoryManager remoteRepositoryManager;
@@ -98,6 +100,12 @@ public class ProjectModelResolver
         this.repositories.addAll( externalRepositories );
         this.repositoryMerging = repositoryMerging;
         this.repositoryIds = new HashSet<>();
+        this.externalRepositoryIds = new HashSet<>();
+        for ( final RemoteRepository repository : this.repositories )
+        {
+            this.repositoryIds.add( repository.getId() );
+            this.externalRepositoryIds.add( repository.getId() );
+        }
         this.modelPool = modelPool;
     }
 
@@ -112,6 +120,7 @@ public class ProjectModelResolver
         this.repositories = new ArrayList<>( original.repositories );
         this.repositoryMerging = original.repositoryMerging;
         this.repositoryIds = new HashSet<>( original.repositoryIds );
+        this.externalRepositoryIds = new HashSet<>( original.externalRepositoryIds );
         this.modelPool = original.modelPool;
     }
 
@@ -127,7 +136,7 @@ public class ProjectModelResolver
     {
         if ( !repositoryIds.add( repository.getId() ) )
         {
-            if ( !replace )
+            if ( !replace || this.externalRepositoryIds.contains( repository.getId() ) )
             {
                 return;
             }

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -70,6 +70,8 @@ class DefaultModelResolver
 
     private final List<RemoteRepository> externalRepositories;
 
+    private final Set<String> externalRepositoryIds;
+
     private final ArtifactResolver resolver;
 
     private final VersionRangeResolver versionRangeResolver;
@@ -92,8 +94,13 @@ class DefaultModelResolver
         List<RemoteRepository> externalRepositories = new ArrayList<>();
         externalRepositories.addAll( repositories );
         this.externalRepositories = Collections.unmodifiableList( externalRepositories );
-
         this.repositoryIds = new HashSet<>();
+        this.externalRepositoryIds = new HashSet<>();
+        for ( final RemoteRepository repository : this.repositories )
+        {
+            this.repositoryIds.add( repository.getId() );
+            this.externalRepositoryIds.add( repository.getId() );
+        }
     }
 
     private DefaultModelResolver( DefaultModelResolver original )
@@ -107,6 +114,7 @@ class DefaultModelResolver
         this.repositories = new ArrayList<>( original.repositories );
         this.externalRepositories = original.externalRepositories;
         this.repositoryIds = new HashSet<>( original.repositoryIds );
+        this.externalRepositoryIds = new HashSet<>( original.externalRepositoryIds );
     }
 
     @Override
@@ -127,7 +135,7 @@ class DefaultModelResolver
 
         if ( !repositoryIds.add( repository.getId() ) )
         {
-            if ( !replace )
+            if ( !replace || this.externalRepositoryIds.contains( repository.getId() ) )
             {
                 return;
             }


### PR DESCRIPTION
o Updated the 'DefaultModelResolver' to handle replacing repositories the same way the
  'DefaultDependencyCollector' does. When the 'DefaultDependencyCollector' finds
  a repository in a child node with an id matching a repository already in use,
  it will only merge any mirror definitions but never change the repository already
  in use. The 'DefaultModelResolver' needs to follow the same logic. What has been
  provided must not change for consistency.

Cherry-picked from @ChristianSchulte's fork, per comment on the MNG-4347 ticket.  I made the same changes to the ProjectModelResolver, since it seems that's the implementation that's getting used by the dependencyManagement import resolution rather than the DefaultModelResolver.