### PR TITLE
Fix links to Apache/CDDL/MIT licenses

### DIFF
--- a/apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
+++ b/apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
@@ -21,19 +21,23 @@ Apache Maven includes a number of components and libraries with separate
 copyright notices and license terms. Your use of those components are 
 subject to the terms and conditions of the following licenses. 
 
-#set ( $apacheTxt = "The Apache Software License, Version 2.0" )
-
+#set ( $apacheLicTexts = [ "Apache License, Version 2.0", "The Apache Software License, Version 2.0",
+    "ASLv2", "Apache Public License 2.0" ] )
 #foreach ( $project in $projects )
 #foreach ( $license in $project.licenses)
-#if ( ! ($apacheTxt == $license.name) ) 
+#if ( !($apacheLicTexts.contains( $license.name)) )
 #set ( $artId = $project.artifact.artifactId)
 #set ( $lf = $locator )
 #set ( $url = $license.url )
 ## glass fish URL is now invalid, use a fixed one
 #if ($url == "https://glassfish.dev.java.net/public/CDDLv1.0.html")
-#set ( $url = 'https://glassfish.java.net/public/CDDLv1.0.html' )
+#set ( $url = 'https://spdx.org/licenses/CDDL-1.0.txt' )
 #end
-#if ($url) 
+## jcl-over-slf4j - redirect
+#if ($url == "http://www.opensource.org/licenses/mit-license.php")
+#set ( $url = 'https://spdx.org/licenses/MIT.txt' )
+#end
+#if ($url)
 #set ( $licFile = 'lib/' + $artId + '.license' )
 #set ( $downloaded = $lf.getResourceAsFile($url, "licenses/${licFile}") )
 #end


### PR DESCRIPTION
- skip download of Apache License files
- correct address to Oracle CDDL and MIT licenses