### PR TITLE
MNG-6414 Add more Apache license headers to skip downloading license …

### DIFF
--- a/apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
+++ b/apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
@@ -21,11 +21,11 @@ Apache Maven includes a number of components and libraries with separate
 copyright notices and license terms. Your use of those components are 
 subject to the terms and conditions of the following licenses. 
 
-#set ( $apacheTxt = "The Apache Software License, Version 2.0" )
-
+#set ( $apacheLicTexts = [ "Apache License, Version 2.0", "The Apache Software License, Version 2.0",
+    "ASLv2", "Apache Public License 2.0", "Apache 2.0" ] )
 #foreach ( $project in $projects )
 #foreach ( $license in $project.licenses)
-#if ( ! ($apacheTxt == $license.name) ) 
+#if ( ! ($apacheLicTexts.contains( $license.name) ) )
 #set ( $artId = $project.artifact.artifactId)
 #set ( $lf = $locator )
 #set ( $url = $license.url )
@@ -33,7 +33,7 @@ subject to the terms and conditions of the following licenses.
 #if ($url == "https://glassfish.dev.java.net/public/CDDLv1.0.html")
 #set ( $url = 'https://glassfish.java.net/public/CDDLv1.0.html' )
 #end
-#if ($url) 
+#if ($url)
 #set ( $licFile = 'lib/' + $artId + '.license' )
 #set ( $downloaded = $lf.getResourceAsFile($url, "licenses/${licFile}") )
 #end


### PR DESCRIPTION
…text

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)