### PR TITLE
Fix to prevent warning due to CI-friendly version in the parent pom

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -669,6 +669,9 @@ public class DefaultProjectBuilder
                 else
                 {
                     Artifact parentArtifact = project.getParentArtifact();
+                    if (parentArtifact.getVersion().matches("\\$\\{(revision|sha1|changelist)}")) {
+                        parentArtifact.setVersion(project.getModel().getParent().getVersion());
+                    }
                     try
                     {
                         parent = build( parentArtifact, projectBuildingRequest ).getProject();


### PR DESCRIPTION
This PR fixes the following issue:
https://issues.apache.org/jira/browse/MNG-6455
