### PR TITLE
Repair Jenkins job - add a full path to workspace when run on Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ for (String os in runITsOses) {
                     // on Windows, need a short path or we hit 256 character limit for paths
                     // using EXECUTOR_NUMBER guarantees that concurrent builds on same agent
                     // will not trample each other
-                    dir(isUnix() ? 'test' : "/mvn-it-${EXECUTOR_NUMBER}.tmp") {
+                    dir(isUnix() ? 'test' : "c:\\mvn-it-${EXECUTOR_NUMBER}.tmp") {
                         def WORK_DIR=pwd()
                         checkout tests
                         if (isUnix()) {


### PR DESCRIPTION
Fixes errors like: Cannot relativize 'c:\mvn-it-0.tmp\core-it-support\..' relatively to '/mvn-it-0.tmp'

Reference JENKINS-52657