### PR TITLE
[MNG-6405] Fix basedir in MavenProject.deepCopy

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1207,7 +1207,8 @@ public class MavenProject
         // disown the parent
 
         // copy fields
-        setFile( project.getFile() );
+        file = project.file;
+        basedir = project.basedir;
 
         // don't need a deep copy, they don't get modified or added/removed to/from - but make them unmodifiable to be
         // sure!

--- a/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
@@ -185,7 +185,7 @@ public class MavenProjectTest
         projectToClone.setPomFile( new File( new File( f.getParentFile(), "target" ), "flattened.xml" ) );
         MavenProject clonedProject = projectToClone.clone();
         assertEquals( "POM file is preserved across clone", projectToClone.getFile(), clonedProject.getFile() );
-        assertEquals( "Base directory is preserved across clone", projectToClone.getBasedir(), clonedProject.getBasedir());
+        assertEquals( "Base directory is preserved across clone", projectToClone.getBasedir(), clonedProject.getBasedir() );
     }
 
     public void testUndefinedOutputDirectory()

--- a/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
@@ -177,6 +177,17 @@ public class MavenProjectTest
                        activeProfilesClone );
     }
 
+    public void testCloneWithBaseDir()
+        throws Exception
+    {
+        File f = getFileForClasspathResource( "canonical-pom.xml" );
+        MavenProject projectToClone = getProject( f );
+        projectToClone.setPomFile( new File( new File( f.getParentFile(), "target" ), "flattened.xml" ) );
+        MavenProject clonedProject = projectToClone.clone();
+        assertEquals( "POM file is preserved across clone", projectToClone.getFile(), clonedProject.getFile() );
+        assertEquals( "Base directory is preserved across clone", projectToClone.getBasedir(), clonedProject.getBasedir());
+    }
+
     public void testUndefinedOutputDirectory()
         throws Exception
     {


### PR DESCRIPTION
[MNG-6405](https://issues.apache.org/jira/browse/MNG-6405) since https://github.com/mojohaus/flatten-maven-plugin/issues/53#issuecomment-447826001 brought this up again. I have not received any hints on the proper approach to test this.

-----

By the way

 - [ ] You have run the Core IT successfully.

Is this not already done by the `Jenkinsfile`? Maybe an obsolete PR template.