### PR TITLE
[MNG-6558] - ToolchainsBuildingResult event is not sent on EventSpy

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -596,7 +596,7 @@ public class MavenCli
         populateProperties( cliRequest.commandLine, cliRequest.systemProperties, cliRequest.userProperties );
     }
 
-    private PlexusContainer container( CliRequest cliRequest )
+    PlexusContainer container( CliRequest cliRequest )
         throws Exception
     {
         if ( cliRequest.classWorld == null )
@@ -1201,7 +1201,7 @@ public class MavenCli
         }
     }
 
-    private void toolchains( CliRequest cliRequest )
+    void toolchains( CliRequest cliRequest )
         throws Exception
     {
         File userToolchainsFile;
@@ -1265,7 +1265,7 @@ public class MavenCli
 
         ToolchainsBuildingResult toolchainsResult = toolchainsBuilder.build( toolchainsRequest );
 
-        eventSpyDispatcher.onEvent( toolchainsRequest );
+        eventSpyDispatcher.onEvent( toolchainsResult );
 
         executionRequestPopulator.populateFromToolchains( cliRequest.request,
                                                           toolchainsResult.getEffectiveToolchains() );


### PR DESCRIPTION
Emit the `ToolchainsBuildingResult` event to the `EventSpy` instead the `ToolchainsBuildingRequest` event two times.

Corresponding IT test: https://github.com/apache/maven-integration-testing/pull/42

---
To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)