### PR TITLE
(doc) - correct plural form of 'child'

### DIFF
--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -195,7 +195,7 @@
           <version>4.0.0+</version>
           <description>
             <![CDATA[
-            When childs inherit from project's url, append path or not? Note: While the type
+            When children inherit from project's url, append path or not? Note: While the type
             of this field is <code>String</code> for technical reasons, the semantic type is actually
             <code>Boolean</code>
             <br><b>Default value is</b>: <code>true</code>
@@ -1659,7 +1659,7 @@
           <version>4.0.0+</version>
           <description>
             <![CDATA[
-            When childs inherit from scm connection, append path or not? Note: While the type
+            When children inherit from scm connection, append path or not? Note: While the type
             of this field is <code>String</code> for technical reasons, the semantic type is actually
             <code>Boolean</code>
             <br><b>Default value is</b>: <code>true</code>
@@ -1673,7 +1673,7 @@
           <version>4.0.0+</version>
           <description>
             <![CDATA[
-            When childs inherit from scm developer connection, append path or not? Note: While the type
+            When children inherit from scm developer connection, append path or not? Note: While the type
             of this field is <code>String</code> for technical reasons, the semantic type is actually
             <code>Boolean</code>
             <br><b>Default value is</b>: <code>true</code>
@@ -1687,7 +1687,7 @@
           <version>4.0.0+</version>
           <description>
             <![CDATA[
-            When childs inherit from scm url, append path or not? Note: While the type
+            When children inherit from scm url, append path or not? Note: While the type
             of this field is <code>String</code> for technical reasons, the semantic type is actually
             <code>Boolean</code>
             <br><b>Default value is</b>: <code>true</code>
@@ -2067,7 +2067,7 @@
           <version>4.0.0+</version>
           <description>
             <![CDATA[
-            When childs inherit from distribution management site url, append path or not? Note: While the type
+            When children inherit from distribution management site url, append path or not? Note: While the type
             of this field is <code>String</code> for technical reasons, the semantic type is actually
             <code>Boolean</code>
             <br><b>Default value is</b>: <code>true</code>


### PR DESCRIPTION
To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)