### PR TITLE
[MNG-6700] - Same compile source roots are added multiple times

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -304,6 +304,10 @@ public class MavenProject
                 {
                     path = file.getAbsolutePath();
                 }
+                else if ( ".".equals( path ) )
+                {
+                    path = getBasedir().getAbsolutePath();
+                }
                 else
                 {
                     path = new File( getBasedir(), path ).getAbsolutePath();

--- a/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
@@ -187,6 +187,19 @@ public class MavenProjectTest
         assertNoNulls( p.getTestClasspathElements() );
     }
 
+    public void testAddDotFile()
+    {
+        MavenProject project = new MavenProject();
+
+        File basedir = new File( System.getProperty( "java.io.tmpdir" ) );
+        project.setFile( new File( basedir, "file" ) );
+
+        project.addCompileSourceRoot( basedir.getAbsolutePath() );
+        project.addCompileSourceRoot( "." );
+
+        assertEquals( 1, project.getCompileSourceRoots().size() );
+    }
+
     private void assertNoNulls( List<String> elements )
     {
         assertFalse( elements.contains( null ) );


### PR DESCRIPTION
Maven 3.6.1 introduces a bug that basedir and "." can be added twice to `compileSourceRoots`,
which breaks some compiler plugin. This commit fixes this issue by correctly normailzing "."
when it's added to `compileSourceRoots`.

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
