### PR TITLE
[MNG-6549] Remove unused transitive dependencies of Guava

### DIFF
--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -78,6 +78,33 @@ under the License.
        <groupId>com.google.inject</groupId>
        <artifactId>guice</artifactId>
        <classifier>no_aop</classifier>
+       <exclusions>
+         <exclusion>
+           <groupId>aopalliance</groupId>
+           <artifactId>aopalliance</artifactId>
+         </exclusion>
+         <!-- MNG-6549 remove unused transitive dependencies of Guava, that is a dependency of Guice -->
+         <exclusion>
+           <groupId>com.google.code.findbugs</groupId>
+           <artifactId>jsr305</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>org.checkerframework</groupId>
+           <artifactId>checker-compat-qual</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.google.errorprone</groupId>
+           <artifactId>error_prone_annotations</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.google.j2objc</groupId>
+           <artifactId>j2objc-annotations</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>org.codehaus.mojo</groupId>
+           <artifactId>animal-sniffer-annotations</artifactId>
+         </exclusion>
+       </exclusions>
      </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -240,11 +240,6 @@ under the License.
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guiceVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject</groupId>
-        <artifactId>guice</artifactId>
-        <version>${guiceVersion}</version>
         <classifier>no_aop</classifier>
       </dependency>
       <dependency>


### PR DESCRIPTION
while at it, did a little bit of cleanup:
- removed aopalliance (like done in maven-resolver-provider)
- removed guice dependency management that should be part of MNG-6475

see https://issues.apache.org/jira/browse/MNG-6549