### PR TITLE
[MNG-6772] - Prevent Super POM central entry from overriding

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
@@ -110,7 +110,7 @@ public class ProjectModelResolver
         this.externalRepositories = original.externalRepositories;
         this.repositories = new ArrayList<>( original.repositories );
         this.repositoryMerging = original.repositoryMerging;
-        this.repositoryIds = new HashSet<>( original.repositoryIds );
+        this.repositoryIds = new HashSet<>();
         this.modelPool = original.modelPool;
     }
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -104,7 +104,7 @@ class DefaultModelResolver
         this.remoteRepositoryManager = original.remoteRepositoryManager;
         this.repositories = new ArrayList<>( original.repositories );
         this.externalRepositories = original.externalRepositories;
-        this.repositoryIds = new HashSet<>( original.repositoryIds );
+        this.repositoryIds = new HashSet<>();
     }
 
     @Override


### PR DESCRIPTION
This change resets the `repositoryIds` that have been added to `ModelResolver`s when a new copy is created, which at least within the Maven project is only used while importing dependencyManagement.

The issue is that after interpolation, the ModelResolver is reconfigured, which adds the `central` repository ID from the Super POM if there isn't an override present in that direct POM lineage (but overwrites any `central` override in the request). The Super POM's entry should be a last-resort fallback and should only be applied when no other `central` repository is present.

This largely comes into play when working in an environment where the true Maven Central repository is unreachable, or when using JFrog Artifactory. Artifactory removes all repository definitions from the POMs it serves from its virtual repositories, meaning even if every project has a direct `central` override in its POM, when pulled in as a dependency/import, the repository will be absent and this issue will be encountered.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
