### PR TITLE
[MNG-6762] - Multimodule project with .mvn/settings.xml not working properly

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -32,7 +32,27 @@ import org.apache.commons.cli.ParseException;
  */
 public class CLIManager
 {
-    public static final char ALTERNATE_POM_FILE = 'f';
+    public enum FileOption
+    {
+        ALTERNATE_POM_FILE( "f" ),
+        ALTERNATE_USER_SETTINGS( "s" ),
+        ALTERNATE_GLOBAL_SETTINGS( "gs" ),
+        ALTERNATE_USER_TOOLCHAINS( "t" ),
+        ALTERNATE_GLOBAL_TOOLCHAINS( "gt" ),
+        LOG_FILE( "l" );
+
+        private final String opt;
+
+        FileOption( String opt )
+        {
+            this.opt = opt;
+        }
+
+        String getOpt()
+        {
+            return opt;
+        }
+    }
 
     public static final char BATCH_MODE = 'B';
 
@@ -64,14 +84,6 @@ public class CLIManager
 
     public static final char CHECKSUM_WARNING_POLICY = 'c';
 
-    public static final char ALTERNATE_USER_SETTINGS = 's';
-
-    public static final String ALTERNATE_GLOBAL_SETTINGS = "gs";
-
-    public static final char ALTERNATE_USER_TOOLCHAINS = 't';
-
-    public static final String ALTERNATE_GLOBAL_TOOLCHAINS = "gt";
-
     public static final String FAIL_FAST = "ff";
 
     public static final String FAIL_AT_END = "fae";
@@ -85,8 +97,6 @@ public class CLIManager
     public static final String ALSO_MAKE = "am";
 
     public static final String ALSO_MAKE_DEPENDENTS = "amd";
-
-    public static final String LOG_FILE = "l";
 
     public static final String ENCRYPT_MASTER_PASSWORD = "emp";
 
@@ -107,7 +117,7 @@ public class CLIManager
     {
         options = new Options();
         options.addOption( Option.builder( Character.toString( HELP ) ).longOpt( "help" ).desc( "Display help information" ).build() );
-        options.addOption( Option.builder( Character.toString( ALTERNATE_POM_FILE ) ).longOpt( "file" ).hasArg().desc( "Force the use of an alternate POM file (or directory with pom.xml)" ).build() );
+        options.addOption( Option.builder( FileOption.ALTERNATE_POM_FILE.getOpt() ).longOpt( "file" ).hasArg().desc( "Force the use of an alternate POM file (or directory with pom.xml)" ).build() );
         options.addOption( Option.builder( Character.toString( SET_SYSTEM_PROPERTY ) ).longOpt( "define" ).hasArg().desc( "Define a system property" ).build() );
         options.addOption( Option.builder( Character.toString( OFFLINE ) ).longOpt( "offline" ).desc( "Work offline" ).build() );
         options.addOption( Option.builder( Character.toString( VERSION ) ).longOpt( "version" ).desc( "Display version information" ).build() );
@@ -121,10 +131,10 @@ public class CLIManager
         options.addOption( Option.builder( SUPRESS_SNAPSHOT_UPDATES ).longOpt( "no-snapshot-updates" ).desc( "Suppress SNAPSHOT updates" ).build() );
         options.addOption( Option.builder( Character.toString( CHECKSUM_FAILURE_POLICY ) ).longOpt( "strict-checksums" ).desc( "Fail the build if checksums don't match" ).build() );
         options.addOption( Option.builder( Character.toString( CHECKSUM_WARNING_POLICY ) ).longOpt( "lax-checksums" ).desc( "Warn if checksums don't match" ).build() );
-        options.addOption( Option.builder( Character.toString( ALTERNATE_USER_SETTINGS ) ).longOpt( "settings" ).desc( "Alternate path for the user settings file" ).hasArg().build() );
-        options.addOption( Option.builder( ALTERNATE_GLOBAL_SETTINGS ).longOpt( "global-settings" ).desc( "Alternate path for the global settings file" ).hasArg().build() );
-        options.addOption( Option.builder( Character.toString( ALTERNATE_USER_TOOLCHAINS ) ).longOpt( "toolchains" ).desc( "Alternate path for the user toolchains file" ).hasArg().build() );
-        options.addOption( Option.builder( ALTERNATE_GLOBAL_TOOLCHAINS ).longOpt( "global-toolchains" ).desc( "Alternate path for the global toolchains file" ).hasArg().build() );
+        options.addOption( Option.builder( FileOption.ALTERNATE_USER_SETTINGS.getOpt() ).longOpt( "settings" ).desc( "Alternate path for the user settings file" ).hasArg().build() );
+        options.addOption( Option.builder( FileOption.ALTERNATE_GLOBAL_SETTINGS.getOpt() ).longOpt( "global-settings" ).desc( "Alternate path for the global settings file" ).hasArg().build() );
+        options.addOption( Option.builder( FileOption.ALTERNATE_USER_TOOLCHAINS.getOpt() ).longOpt( "toolchains" ).desc( "Alternate path for the user toolchains file" ).hasArg().build() );
+        options.addOption( Option.builder( FileOption.ALTERNATE_GLOBAL_TOOLCHAINS.getOpt() ).longOpt( "global-toolchains" ).desc( "Alternate path for the global toolchains file" ).hasArg().build() );
         options.addOption( Option.builder( FAIL_FAST ).longOpt( "fail-fast" ).desc( "Stop at first failure in reactorized builds" ).build() );
         options.addOption( Option.builder( FAIL_AT_END ).longOpt( "fail-at-end" ).desc( "Only fail the build afterwards; allow all non-impacted builds to continue" ).build() );
         options.addOption( Option.builder( FAIL_NEVER ).longOpt( "fail-never" ).desc( "NEVER fail the build, regardless of project result" ).build() );
@@ -132,7 +142,7 @@ public class CLIManager
         options.addOption( Option.builder( PROJECT_LIST ).longOpt( "projects" ).desc( "Comma-delimited list of specified reactor projects to build instead of all projects. A project can be specified by [groupId]:artifactId or by its relative path" ).hasArg().build() );
         options.addOption( Option.builder( ALSO_MAKE ).longOpt( "also-make" ).desc( "If project list is specified, also build projects required by the list" ).build() );
         options.addOption( Option.builder( ALSO_MAKE_DEPENDENTS ).longOpt( "also-make-dependents" ).desc( "If project list is specified, also build projects that depend on projects on the list" ).build() );
-        options.addOption( Option.builder( LOG_FILE ).longOpt( "log-file" ).hasArg().desc( "Log file where all build output will go (disables output color)" ).build() );
+        options.addOption( Option.builder( FileOption.LOG_FILE.getOpt() ).longOpt( "log-file" ).hasArg().desc( "Log file where all build output will go (disables output color)" ).build() );
         options.addOption( Option.builder( Character.toString( SHOW_VERSION ) ).longOpt( "show-version" ).desc( "Display version information WITHOUT stopping build" ).build() );
         options.addOption( Option.builder( ENCRYPT_MASTER_PASSWORD ).longOpt( "encrypt-master-password" ).hasArg().optionalArg( true ).desc( "Encrypt master security password" ).build() );
         options.addOption( Option.builder( ENCRYPT_PASSWORD ).longOpt( "encrypt-password" ).hasArg().optionalArg( true ).desc( "Encrypt server password" ).build() );
@@ -148,10 +158,10 @@ public class CLIManager
         options.addOption( Option.builder( "npu" ).longOpt( "no-plugin-updates" ).desc( "Ineffective, only kept for backward compatibility" ).build() );
     }
 
-    public CommandLineWrapper parse( String[] args )
+    public CommandLineWrapper parse( String baseDirectory, String[] args )
         throws ParseException
     {
-        return CommandLineWrapper.parse( options, args );
+        return CommandLineWrapper.parse( options, baseDirectory, args );
     }
 
     public void displayHelp( PrintStream stdout )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -32,6 +32,10 @@ import org.apache.commons.cli.ParseException;
  */
 public class CLIManager
 {
+    /**
+     * All command-line options with file paths
+     * as arguments
+     */
     public enum FileOption
     {
         ALTERNATE_POM_FILE( "f" ),

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -22,7 +22,6 @@ package org.apache.maven.cli;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -151,7 +150,7 @@ public class CLIManager
         options.addOption( Option.builder( "npu" ).longOpt( "no-plugin-updates" ).desc( "Ineffective, only kept for backward compatibility" ).build() );
     }
 
-    public CommandLine parse( String[] args )
+    public CommandLineWrapper parse( String[] args )
         throws ParseException
     {
         // We need to eat any quotes surrounding arguments...
@@ -159,7 +158,7 @@ public class CLIManager
 
         CommandLineParser parser = new GnuParser();
 
-        return parser.parse( options, cleanArgs );
+        return new CommandLineWrapper( parser.parse( options, cleanArgs ) );
     }
 
     public void displayHelp( PrintStream stdout )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -22,8 +22,6 @@ package org.apache.maven.cli;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -153,12 +151,7 @@ public class CLIManager
     public CommandLineWrapper parse( String[] args )
         throws ParseException
     {
-        // We need to eat any quotes surrounding arguments...
-        String[] cleanArgs = CleanArgument.cleanArgs( args );
-
-        CommandLineParser parser = new GnuParser();
-
-        return new CommandLineWrapper( parser.parse( options, cleanArgs ) );
+        return CommandLineWrapper.parse( options, args );
     }
 
     public void displayHelp( PrintStream stdout )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
@@ -22,7 +22,6 @@ package org.apache.maven.cli;
 import java.io.File;
 import java.util.Properties;
 
-import org.apache.commons.cli.CommandLine;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.codehaus.plexus.classworlds.ClassWorld;
@@ -34,7 +33,7 @@ public class CliRequest
 {
     String[] args;
 
-    CommandLine commandLine;
+    CommandLineWrapper commandLine;
 
     ClassWorld classWorld;
 
@@ -66,7 +65,7 @@ public class CliRequest
         return args;
     }
 
-    public CommandLine getCommandLine()
+    public CommandLineWrapper getCommandLine()
     {
         return commandLine;
     }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CommandLineWrapper.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CommandLineWrapper.java
@@ -1,0 +1,80 @@
+package org.apache.maven.cli;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+
+import java.util.List;
+
+public class CommandLineWrapper
+{
+    private CommandLine commandLine;
+
+    CommandLineWrapper( CommandLine commandLine )
+    {
+        this.commandLine = commandLine;
+    }
+
+    public List<String> getArgList()
+    {
+        return commandLine.getArgList();
+    }
+
+    public String[] getArgs()
+    {
+        return commandLine.getArgs();
+    }
+
+    public Option[] getOptions()
+    {
+        return commandLine.getOptions();
+    }
+
+    public boolean hasOption( char opt )
+    {
+        return commandLine.hasOption( opt );
+    }
+
+    public boolean hasOption( String opt )
+    {
+        return commandLine.hasOption( opt );
+    }
+
+    public String getOptionValue( char opt )
+    {
+        return commandLine.getOptionValue( opt );
+    }
+
+    public String getOptionValue( String opt )
+    {
+        return commandLine.getOptionValue( opt );
+    }
+
+    public String[] getOptionValues( char opt )
+    {
+        return commandLine.getOptionValues( opt );
+    }
+
+    public String[] getOptionValues( String opt )
+    {
+        return commandLine.getOptionValues( opt );
+    }
+}

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CommandLineWrapper.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CommandLineWrapper.java
@@ -32,6 +32,9 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @author Anatoly Zaretsky
+ */
 public class CommandLineWrapper
 {
     private CommandLine commandLine;

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -383,7 +383,7 @@ public class MavenCli
                     }
                 }
 
-                mavenConfig = cliManager.parse( args.toArray( new String[0] ) );
+                mavenConfig = cliManager.parse( cliRequest.multiModuleProjectDirectory.getPath(), args.toArray( new String[0] ) );
                 List<?> unrecongized = mavenConfig.getArgList();
                 if ( !unrecongized.isEmpty() )
                 {
@@ -402,11 +402,11 @@ public class MavenCli
         {
             if ( mavenConfig == null )
             {
-                cliRequest.commandLine = cliManager.parse( cliRequest.args );
+                cliRequest.commandLine = cliManager.parse( cliRequest.workingDirectory, cliRequest.args );
             }
             else
             {
-                cliRequest.commandLine = cliManager.parse( cliRequest.args ).mergeMavenConfig( mavenConfig );
+                cliRequest.commandLine = cliManager.parse( cliRequest.workingDirectory, cliRequest.args ).mergeMavenConfig( mavenConfig );
             }
         }
         catch ( ParseException e )
@@ -471,17 +471,15 @@ public class MavenCli
                 + "]. Supported values are (auto|always|never)." );
         }
         else if ( cliRequest.commandLine.hasOption( CLIManager.BATCH_MODE )
-            || cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
+            || cliRequest.commandLine.hasOption( CLIManager.FileOption.LOG_FILE ) )
         {
             MessageUtils.setColorEnabled( false );
         }
 
         // LOG STREAMS
-        if ( cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
+        File logFile = cliRequest.commandLine.getFile( CLIManager.FileOption.LOG_FILE );
+        if ( logFile != null )
         {
-            File logFile = new File( cliRequest.commandLine.getOptionValue( CLIManager.LOG_FILE ) );
-            logFile = resolveFile( logFile, cliRequest.workingDirectory );
-
             // redirect stdout and stderr to file
             try
             {
@@ -1164,14 +1162,10 @@ public class MavenCli
     void toolchains( CliRequest cliRequest )
         throws Exception
     {
-        File userToolchainsFile;
+        File userToolchainsFile = cliRequest.commandLine.getFile( CLIManager.FileOption.ALTERNATE_USER_TOOLCHAINS );
 
-        if ( cliRequest.commandLine.hasOption( CLIManager.ALTERNATE_USER_TOOLCHAINS ) )
+        if ( userToolchainsFile != null )
         {
-            userToolchainsFile =
-                new File( cliRequest.commandLine.getOptionValue( CLIManager.ALTERNATE_USER_TOOLCHAINS ) );
-            userToolchainsFile = resolveFile( userToolchainsFile, cliRequest.workingDirectory );
-
             if ( !userToolchainsFile.isFile() )
             {
                 throw new FileNotFoundException(
@@ -1183,14 +1177,10 @@ public class MavenCli
             userToolchainsFile = DEFAULT_USER_TOOLCHAINS_FILE;
         }
 
-        File globalToolchainsFile;
+        File globalToolchainsFile = cliRequest.commandLine.getFile( CLIManager.FileOption.ALTERNATE_GLOBAL_TOOLCHAINS );
 
-        if ( cliRequest.commandLine.hasOption( CLIManager.ALTERNATE_GLOBAL_TOOLCHAINS ) )
+        if ( globalToolchainsFile != null )
         {
-            globalToolchainsFile =
-                new File( cliRequest.commandLine.getOptionValue( CLIManager.ALTERNATE_GLOBAL_TOOLCHAINS ) );
-            globalToolchainsFile = resolveFile( globalToolchainsFile, cliRequest.workingDirectory );
-
             if ( !globalToolchainsFile.isFile() )
             {
                 throw new FileNotFoundException(
@@ -1389,7 +1379,7 @@ public class MavenCli
         {
             transferListener = new QuietMavenTransferListener();
         }
-        else if ( request.isInteractiveMode() && !cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
+        else if ( request.isInteractiveMode() && !cliRequest.commandLine.hasOption( CLIManager.FileOption.LOG_FILE ) )
         {
             //
             // If we're logging to a file then we don't want the console transfer listener as it will spew
@@ -1408,12 +1398,6 @@ public class MavenCli
             executionListener = eventSpyDispatcher.chainListener( executionListener );
         }
 
-        String alternatePomFile = null;
-        if ( commandLine.hasOption( CLIManager.ALTERNATE_POM_FILE ) )
-        {
-            alternatePomFile = commandLine.getOptionValue( CLIManager.ALTERNATE_POM_FILE );
-        }
-
         request.setBaseDirectory( baseDirectory ).setGoals( goals ).setSystemProperties(
             cliRequest.systemProperties ).setUserProperties( cliRequest.userProperties ).setReactorFailureBehavior(
             reactorFailureBehaviour ) // default: fail fast
@@ -1428,9 +1412,10 @@ public class MavenCli
             .setGlobalChecksumPolicy( globalChecksumPolicy ) // default: warn
             .setMultiModuleProjectDirectory( cliRequest.multiModuleProjectDirectory );
 
+        File alternatePomFile = commandLine.getFile( CLIManager.FileOption.ALTERNATE_POM_FILE );
         if ( alternatePomFile != null )
         {
-            File pom = resolveFile( new File( alternatePomFile ), workingDirectory );
+            File pom = alternatePomFile;
             if ( pom.isDirectory() )
             {
                 pom = new File( pom, "pom.xml" );

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -369,7 +369,7 @@ public class MavenCli
         CLIManager cliManager = new CLIManager();
 
         List<String> args = new ArrayList<>();
-        CommandLine mavenConfig = null;
+        CommandLineWrapper mavenConfig = null;
         try
         {
             File configFile = new File( cliRequest.multiModuleProjectDirectory, MVN_MAVEN_CONFIG );
@@ -430,7 +430,7 @@ public class MavenCli
         }
     }
 
-    private CommandLine cliMerge( CommandLine mavenArgs, CommandLine mavenConfig )
+    private CommandLineWrapper cliMerge( CommandLineWrapper mavenArgs, CommandLineWrapper mavenConfig )
     {
         CommandLine.Builder commandLineBuilder = new CommandLine.Builder();
 
@@ -466,7 +466,7 @@ public class MavenCli
         {
             commandLineBuilder.addOption( opt );
         }
-        return commandLineBuilder.build();
+        return new CommandLineWrapper( commandLineBuilder.build() );
     }
 
     /**
@@ -1300,7 +1300,7 @@ public class MavenCli
     @SuppressWarnings( "checkstyle:methodlength" )
     private MavenExecutionRequest populateRequest( CliRequest cliRequest, MavenExecutionRequest request )
     {
-        CommandLine commandLine = cliRequest.commandLine;
+        CommandLineWrapper commandLine = cliRequest.commandLine;
         String workingDirectory = cliRequest.workingDirectory;
         boolean quiet = cliRequest.quiet;
         boolean showErrors = cliRequest.showErrors;
@@ -1637,7 +1637,7 @@ public class MavenCli
     // System properties handling
     // ----------------------------------------------------------------------
 
-    static void populateProperties( CommandLine commandLine, Properties systemProperties, Properties userProperties )
+    static void populateProperties( CommandLineWrapper commandLine, Properties systemProperties, Properties userProperties )
     {
         EnvironmentUtils.addEnvVars( systemProperties );
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -111,6 +111,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.maven.cli.ResolveFile.resolveFile;
 import static org.apache.maven.shared.utils.logging.MessageUtils.buffer;
 
 // TODO push all common bits back to plexus cli and prepare for transition to Guice. We don't need 50 ways to make CLIs
@@ -1569,27 +1570,6 @@ public class MavenCli
     {
         int procs = Runtime.getRuntime().availableProcessors();
         return (int) ( Float.valueOf( threadConfiguration.replace( "C", "" ) ) * procs );
-    }
-
-    static File resolveFile( File file, String workingDirectory )
-    {
-        if ( file == null )
-        {
-            return null;
-        }
-        else if ( file.isAbsolute() )
-        {
-            return file;
-        }
-        else if ( file.getPath().startsWith( File.separator ) )
-        {
-            // drive-relative Windows path
-            return file.getAbsoluteFile();
-        }
-        else
-        {
-            return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
-        }
     }
 
     // ----------------------------------------------------------------------

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -383,7 +383,8 @@ public class MavenCli
                     }
                 }
 
-                mavenConfig = cliManager.parse( cliRequest.multiModuleProjectDirectory.getPath(), args.toArray( new String[0] ) );
+                mavenConfig = cliManager.parse( cliRequest.multiModuleProjectDirectory.getPath(),
+                        args.toArray( new String[0] ) );
                 List<?> unrecongized = mavenConfig.getArgList();
                 if ( !unrecongized.isEmpty() )
                 {
@@ -406,7 +407,8 @@ public class MavenCli
             }
             else
             {
-                cliRequest.commandLine = cliManager.parse( cliRequest.workingDirectory, cliRequest.args ).mergeMavenConfig( mavenConfig );
+                cliRequest.commandLine = cliManager.parse( cliRequest.workingDirectory,
+                        cliRequest.args ).mergeMavenConfig( mavenConfig );
             }
         }
         catch ( ParseException e )
@@ -1561,7 +1563,9 @@ public class MavenCli
     // System properties handling
     // ----------------------------------------------------------------------
 
-    static void populateProperties( CommandLineWrapper commandLine, Properties systemProperties, Properties userProperties )
+    static void populateProperties( CommandLineWrapper commandLine,
+                                    Properties systemProperties,
+                                    Properties userProperties )
     {
         EnvironmentUtils.addEnvVars( systemProperties );
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -20,8 +20,6 @@ package org.apache.maven.cli;
  */
 
 import com.google.inject.AbstractModule;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.maven.BuildAbort;
@@ -407,7 +405,7 @@ public class MavenCli
             }
             else
             {
-                cliRequest.commandLine = cliMerge( cliManager.parse( cliRequest.args ), mavenConfig );
+                cliRequest.commandLine = cliManager.parse( cliRequest.args ).mergeMavenConfig( mavenConfig );
             }
         }
         catch ( ParseException e )
@@ -428,45 +426,6 @@ public class MavenCli
             System.out.println( CLIReportingUtils.showVersion() );
             throw new ExitException( 0 );
         }
-    }
-
-    private CommandLineWrapper cliMerge( CommandLineWrapper mavenArgs, CommandLineWrapper mavenConfig )
-    {
-        CommandLine.Builder commandLineBuilder = new CommandLine.Builder();
-
-        // the args are easy, cli first then config file
-        for ( String arg : mavenArgs.getArgs() )
-        {
-            commandLineBuilder.addArg( arg );
-        }
-        for ( String arg : mavenConfig.getArgs() )
-        {
-            commandLineBuilder.addArg( arg );
-        }
-
-        // now add all options, except for -D with cli first then config file
-        List<Option> setPropertyOptions = new ArrayList<>();
-        for ( Option opt : mavenArgs.getOptions() )
-        {
-            if ( String.valueOf( CLIManager.SET_SYSTEM_PROPERTY ).equals( opt.getOpt() ) )
-            {
-                setPropertyOptions.add( opt );
-            }
-            else
-            {
-                commandLineBuilder.addOption( opt );
-            }
-        }
-        for ( Option opt : mavenConfig.getOptions() )
-        {
-            commandLineBuilder.addOption( opt );
-        }
-        // finally add the CLI system properties
-        for ( Option opt : setPropertyOptions )
-        {
-            commandLineBuilder.addOption( opt );
-        }
-        return new CommandLineWrapper( commandLineBuilder.build() );
     }
 
     /**

--- a/maven-embedder/src/main/java/org/apache/maven/cli/ResolveFile.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/ResolveFile.java
@@ -21,9 +21,12 @@ package org.apache.maven.cli;
 
 import java.io.File;
 
+/**
+ * Resolve relative file path against the given base directory
+ */
 public class ResolveFile
 {
-    public static File resolveFile( File file, String workingDirectory )
+    public static File resolveFile( File file, String baseDirectory )
     {
         if ( file == null )
         {
@@ -40,7 +43,7 @@ public class ResolveFile
         }
         else
         {
-            return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
+            return new File( baseDirectory, file.getPath() ).getAbsoluteFile();
         }
     }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/ResolveFile.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/ResolveFile.java
@@ -1,0 +1,46 @@
+package org.apache.maven.cli;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+public class ResolveFile
+{
+    public static File resolveFile( File file, String workingDirectory )
+    {
+        if ( file == null )
+        {
+            return null;
+        }
+        else if ( file.isAbsolute() )
+        {
+            return file;
+        }
+        else if ( file.getPath().startsWith( File.separator ) )
+        {
+            // drive-relative Windows path
+            return file.getAbsoluteFile();
+        }
+        else
+        {
+            return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
+        }
+    }
+}

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -27,12 +27,12 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.cli.CommandLine;
 import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.bridge.MavenRepositorySystem;
 import org.apache.maven.building.Source;
 import org.apache.maven.cli.CLIManager;
 import org.apache.maven.cli.CliRequest;
+import org.apache.maven.cli.CommandLineWrapper;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequestPopulationException;
 import org.apache.maven.settings.Mirror;
@@ -81,7 +81,7 @@ public class SettingsXmlConfigurationProcessor
     public void process( CliRequest cliRequest )
         throws Exception
     {
-        CommandLine commandLine = cliRequest.getCommandLine();
+        CommandLineWrapper commandLine = cliRequest.getCommandLine();
         String workingDirectory = cliRequest.getWorkingDirectory();
         MavenExecutionRequest request = cliRequest.getRequest();
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -50,6 +50,8 @@ import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.maven.cli.ResolveFile.resolveFile;
+
 /**
  * SettingsXmlConfigurationProcessor
  */
@@ -271,26 +273,5 @@ public class SettingsXmlConfigurationProcessor
             return source.getLocation();
         }
         return defaultLocation;
-    }
-
-    static File resolveFile( File file, String workingDirectory )
-    {
-        if ( file == null )
-        {
-            return null;
-        }
-        else if ( file.isAbsolute() )
-        {
-            return file;
-        }
-        else if ( file.getPath().startsWith( File.separator ) )
-        {
-            // drive-relative Windows path
-            return file.getAbsoluteFile();
-        }
-        else
-        {
-            return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
-        }
     }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -50,8 +50,6 @@ import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.maven.cli.ResolveFile.resolveFile;
-
 /**
  * SettingsXmlConfigurationProcessor
  */
@@ -87,13 +85,10 @@ public class SettingsXmlConfigurationProcessor
         String workingDirectory = cliRequest.getWorkingDirectory();
         MavenExecutionRequest request = cliRequest.getRequest();
 
-        File userSettingsFile;
+        File userSettingsFile = commandLine.getFile( CLIManager.FileOption.ALTERNATE_USER_SETTINGS );
 
-        if ( commandLine.hasOption( CLIManager.ALTERNATE_USER_SETTINGS ) )
+        if ( userSettingsFile != null )
         {
-            userSettingsFile = new File( commandLine.getOptionValue( CLIManager.ALTERNATE_USER_SETTINGS ) );
-            userSettingsFile = resolveFile( userSettingsFile, workingDirectory );
-
             if ( !userSettingsFile.isFile() )
             {
                 throw new FileNotFoundException( "The specified user settings file does not exist: "
@@ -105,13 +100,10 @@ public class SettingsXmlConfigurationProcessor
             userSettingsFile = DEFAULT_USER_SETTINGS_FILE;
         }
 
-        File globalSettingsFile;
+        File globalSettingsFile = commandLine.getFile( CLIManager.FileOption.ALTERNATE_GLOBAL_SETTINGS );
 
-        if ( commandLine.hasOption( CLIManager.ALTERNATE_GLOBAL_SETTINGS ) )
+        if ( globalSettingsFile != null )
         {
-            globalSettingsFile = new File( commandLine.getOptionValue( CLIManager.ALTERNATE_GLOBAL_SETTINGS ) );
-            globalSettingsFile = resolveFile( globalSettingsFile, workingDirectory );
-
             if ( !globalSettingsFile.isFile() )
             {
                 throw new FileNotFoundException( "The specified global settings file does not exist: "

--- a/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerTest.java
@@ -40,7 +40,9 @@ public class CLIManagerTest
     public void spacedOptions()
         throws Exception
     {
-        CommandLineWrapper cmdLine = cliManager.parse( "-X -Dx=1 -D y=2 test".split( " " ) );
+        // specify null as baseDirectory to ensure that it's not used here
+        // (because there are no file options)
+        CommandLineWrapper cmdLine = cliManager.parse( null, "-X -Dx=1 -D y=2 test".split( " " ) );
         assertTrue( cmdLine.hasOption( CLIManager.DEBUG ) );
         assertThat( cmdLine.getOptionValues( CLIManager.SET_SYSTEM_PROPERTY )[0], is( "x=1" ) );
         assertThat( cmdLine.getOptionValues( CLIManager.SET_SYSTEM_PROPERTY )[1], is( "y=2" ) );

--- a/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.commons.cli.CommandLine;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +40,7 @@ public class CLIManagerTest
     public void spacedOptions()
         throws Exception
     {
-        CommandLine cmdLine = cliManager.parse( "-X -Dx=1 -D y=2 test".split( " " ) );
+        CommandLineWrapper cmdLine = cliManager.parse( "-X -Dx=1 -D y=2 test".split( " " ) );
         assertTrue( cmdLine.hasOption( CLIManager.DEBUG ) );
         assertThat( cmdLine.getOptionValues( CLIManager.SET_SYSTEM_PROPERTY )[0], is( "x=1" ) );
         assertThat( cmdLine.getOptionValues( CLIManager.SET_SYSTEM_PROPERTY )[1], is( "y=2" ) );

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -244,7 +244,7 @@ public class MavenCliTest
         assertEquals( "bar ", request.getSystemProperties().getProperty( "foo" ) );
         assertEquals( "bar two", request.getSystemProperties().getProperty( "foo2" ) );
 
-        assertEquals( "-Dpom.xml", request.getCommandLine().getOptionValue( CLIManager.ALTERNATE_POM_FILE ) );
+        assertEquals( "-Dpom.xml", request.getCommandLine().getFile( CLIManager.FileOption.ALTERNATE_POM_FILE ).getName() );
     }
 
     @Test


### PR DESCRIPTION
This pull requests implements the proposed change in the resolving of relative paths from maven.config options: instead of using the current working directory whatever it happens to be, it uses the parent of the .mvn directory containing the maven.config file.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)