### PR TITLE
[MNG-6777] - Remove duplicate resolveFile methods

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -113,6 +113,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.maven.cli.ResolveFile.resolveFile;
 import static org.apache.maven.shared.utils.logging.MessageUtils.buffer;
 
 // TODO push all common bits back to plexus cli and prepare for transition to Guice. We don't need 50 ways to make CLIs
@@ -1610,27 +1611,6 @@ public class MavenCli
     {
         int procs = Runtime.getRuntime().availableProcessors();
         return (int) ( Float.valueOf( threadConfiguration.replace( "C", "" ) ) * procs );
-    }
-
-    static File resolveFile( File file, String workingDirectory )
-    {
-        if ( file == null )
-        {
-            return null;
-        }
-        else if ( file.isAbsolute() )
-        {
-            return file;
-        }
-        else if ( file.getPath().startsWith( File.separator ) )
-        {
-            // drive-relative Windows path
-            return file.getAbsoluteFile();
-        }
-        else
-        {
-            return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
-        }
     }
 
     // ----------------------------------------------------------------------

--- a/maven-embedder/src/main/java/org/apache/maven/cli/ResolveFile.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/ResolveFile.java
@@ -1,0 +1,49 @@
+package org.apache.maven.cli;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+/**
+ * Resolve relative file path against the given base directory
+ */
+public class ResolveFile
+{
+    public static File resolveFile( File file, String baseDirectory )
+    {
+        if ( file == null )
+        {
+            return null;
+        }
+        else if ( file.isAbsolute() )
+        {
+            return file;
+        }
+        else if ( file.getPath().startsWith( File.separator ) )
+        {
+            // drive-relative Windows path
+            return file.getAbsoluteFile();
+        }
+        else
+        {
+            return new File( baseDirectory, file.getPath() ).getAbsoluteFile();
+        }
+    }
+}

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -50,6 +50,8 @@ import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.maven.cli.ResolveFile.resolveFile;
+
 /**
  * SettingsXmlConfigurationProcessor
  */
@@ -271,26 +273,5 @@ public class SettingsXmlConfigurationProcessor
             return source.getLocation();
         }
         return defaultLocation;
-    }
-
-    static File resolveFile( File file, String workingDirectory )
-    {
-        if ( file == null )
-        {
-            return null;
-        }
-        else if ( file.isAbsolute() )
-        {
-            return file;
-        }
-        else if ( file.getPath().startsWith( File.separator ) )
-        {
-            // drive-relative Windows path
-            return file.getAbsoluteFile();
-        }
-        else
-        {
-            return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
-        }
     }
 }


### PR DESCRIPTION
MavenCli.resolveFile and
configuration.SettingsXmlConfigurationProcessor.resolveFile
utility methods are identical. Moving them into separate
ResolveFile class.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)