### PR TITLE
MNG-6759: Fix issue where MavenMetadataSource failed to set the right…

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/artifact/MavenMetadataSource.java
+++ b/maven-core/src/main/java/org/apache/maven/project/artifact/MavenMetadataSource.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
@@ -53,6 +54,7 @@ import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.DistributionManagement;
@@ -191,6 +193,10 @@ public class MavenMetadataSource
             dependencies = model.getDependencies();
             DependencyManagement dependencyManagement = model.getDependencyManagement();
             managedDependencies = dependencyManagement == null ? null : dependencyManagement.getDependencies();
+            MavenSession session = legacySupport.getSession();
+            MavenProject project = session.getProjectMap().get(
+                ArtifactUtils.key( artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion() ) );
+            pomRepositories = project.getRemoteArtifactRepositories();
         }
         else if ( artifact instanceof ArtifactWithDependencies )
         {


### PR DESCRIPTION
… repositories when preparing artifact metadata

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

Please see the issue description at https://issues.apache.org/jira/browse/MNG-6759. The basic issue is that when there's a dependency graph like A -> B -> C, and C is in some non-Central repository listed by B's POM, Maven is supposed to look for it in the repositories listed by B. As of 3.6.2, this doesn't always happen.

The issue is caused by an oversight in https://github.com/apache/maven/commit/d3ace78602405079d6416a63c13216568ba97995. When the optimization is triggered, the "pomRepositories" variable is not set. In the slow path, it will be set to the remoteRepositories of the parent artifact in the dependency trail. 

I'd like advice on improving this fix, as I'm using a deprecated method which is probably not a good idea. The optimized path gets the Model of the artifact. I need a list of ArtifactRepository, but the Model only contains a list of Repository. Should I use a RepositorySystem to map them? It feels like a waste, as they already exist in the session's set of MavenProject. I'd get them from the ReactorReader, but it unfortunately only exposes the Model.
