### PR TITLE
[MNG-6790] - Redundant code in MavenCli.cliMerge

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -435,12 +435,10 @@ public class MavenCli
     {
         CommandLine.Builder commandLineBuilder = new CommandLine.Builder();
 
-        // the args are easy, cli first then config file
+        // This condition is enforced in the cli() method right before the invocation of cliMerge().
+        assert mavenConfig.getArgList().isEmpty();
+
         for ( String arg : mavenArgs.getArgs() )
-        {
-            commandLineBuilder.addArg( arg );
-        }
-        for ( String arg : mavenConfig.getArgs() )
         {
             commandLineBuilder.addArg( arg );
         }


### PR DESCRIPTION
cliMerge has a code to append all unrecognized arguments (i.e. goals)
from maven.config to the resulting CommandLine object. But this code
always does nothing since the result of maven.config parsing is checked
for absence of any such unrecognized arguments right before the merging
is performed.

A corresponding assert statement is added instead of this dead code, so
that anyone looking at this method can immediately see that this
arguments are not just being ignored, but are actually not present.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
