### PR TITLE
[MNG-6827] replace deprecations for StringUtils#defaultString()

### DIFF
--- a/maven-compat/src/test/java/org/apache/maven/artifact/testutils/TestFileManager.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/testutils/TestFileManager.java
@@ -44,9 +44,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import junit.framework.Assert;
-
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.Assert;
 
 public class TestFileManager
 {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.Dependency;
@@ -258,7 +259,7 @@ public class DefaultPluginDependenciesResolver
                 {
                     final String premanagedScope = DependencyManagerUtils.getPremanagedScope( node );
                     buffer.append( " (scope managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedScope, "default" ) );
+                    buffer.append( Objects.toString( premanagedScope, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -266,7 +267,7 @@ public class DefaultPluginDependenciesResolver
                 {
                     final String premanagedVersion = DependencyManagerUtils.getPremanagedVersion( node );
                     buffer.append( " (version managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedVersion, "default" ) );
+                    buffer.append( Objects.toString( premanagedVersion, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -274,7 +275,7 @@ public class DefaultPluginDependenciesResolver
                 {
                     final Boolean premanagedOptional = DependencyManagerUtils.getPremanagedOptional( node );
                     buffer.append( " (optionality managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedOptional, "default" ) );
+                    buffer.append( Objects.toString( premanagedOptional, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -285,7 +286,7 @@ public class DefaultPluginDependenciesResolver
                         DependencyManagerUtils.getPremanagedExclusions( node );
 
                     buffer.append( " (exclusions managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedExclusions, "default" ) );
+                    buffer.append( Objects.toString( premanagedExclusions, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -296,7 +297,7 @@ public class DefaultPluginDependenciesResolver
                         DependencyManagerUtils.getPremanagedProperties( node );
 
                     buffer.append( " (properties managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedProperties, "default" ) );
+                    buffer.append( Objects.toString( premanagedProperties, "default" ) );
                     buffer.append( ')' );
                 }
             }

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
@@ -269,7 +270,7 @@ public class DefaultProjectDependenciesResolver
                 {
                     final String premanagedScope = DependencyManagerUtils.getPremanagedScope( node );
                     buffer.append( " (scope managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedScope, "default" ) );
+                    buffer.append( Objects.toString( premanagedScope, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -277,7 +278,7 @@ public class DefaultProjectDependenciesResolver
                 {
                     final String premanagedVersion = DependencyManagerUtils.getPremanagedVersion( node );
                     buffer.append( " (version managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedVersion, "default" ) );
+                    buffer.append( Objects.toString( premanagedVersion, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -285,7 +286,7 @@ public class DefaultProjectDependenciesResolver
                 {
                     final Boolean premanagedOptional = DependencyManagerUtils.getPremanagedOptional( node );
                     buffer.append( " (optionality managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedOptional, "default" ) );
+                    buffer.append( Objects.toString( premanagedOptional, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -296,7 +297,7 @@ public class DefaultProjectDependenciesResolver
                         DependencyManagerUtils.getPremanagedExclusions( node );
 
                     buffer.append( " (exclusions managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedExclusions, "default" ) );
+                    buffer.append( Objects.toString( premanagedExclusions, "default" ) );
                     buffer.append( ')' );
                 }
 
@@ -307,7 +308,7 @@ public class DefaultProjectDependenciesResolver
                         DependencyManagerUtils.getPremanagedProperties( node );
 
                     buffer.append( " (properties managed from " );
-                    buffer.append( StringUtils.defaultString( premanagedProperties, "default" ) );
+                    buffer.append( Objects.toString( premanagedProperties, "default" ) );
                     buffer.append( ')' );
                 }
             }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -527,12 +528,12 @@ public class DefaultModelValidator
                 if ( equals( existing.getVersion(), dependency.getVersion() ) )
                 {
                     msg = "duplicate declaration of version "
-                        + StringUtils.defaultString( dependency.getVersion(), "(?)" );
+                        + Objects.toString( dependency.getVersion(), "(?)" );
                 }
                 else
                 {
-                    msg = "version " + StringUtils.defaultString( existing.getVersion(), "(?)" ) + " vs "
-                        + StringUtils.defaultString( dependency.getVersion(), "(?)" );
+                    msg = "version " + Objects.toString( existing.getVersion(), "(?)" ) + " vs "
+                        + Objects.toString( dependency.getVersion(), "(?)" );
                 }
 
                 addViolation( problems, errOn31, Version.V20, prefix + prefix2 + "(groupId:artifactId:type:classifier)",


### PR DESCRIPTION


`StringUtils.defaultString` from plexus-utils is deprecated and suggests to use `Objects#toString(Object, String)`


Also replace one more deprecation `import junit.framework.Assert;` -> `import org.junit.Assert;`

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

[core-its]: https://maven.apache.org/core-its/core-it-suite/
