### PR TITLE
[MNG-6865] "copy" in object scope rather in class scope

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -167,6 +167,7 @@ public class DefaultMavenExecutionRequest
     {
     }
 
+    @Deprecated
     public static MavenExecutionRequest copy( MavenExecutionRequest original )
     {
         DefaultMavenExecutionRequest copy = new DefaultMavenExecutionRequest();
@@ -1282,5 +1283,11 @@ public class DefaultMavenExecutionRequest
         }
 
         return data;
+    }
+
+    @Override
+    public MavenExecutionRequest copy()
+    {
+        return copy( this );
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -442,4 +442,11 @@ public interface MavenExecutionRequest
      * @since 3.3.0
      */
     Map<String, Object> getData();
+    
+    /**
+     * @return a copy of this
+     * @since 3.7.0
+     */
+    MavenExecutionRequest copy();
+    
 }

--- a/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionTest.java
@@ -38,7 +38,7 @@ public class DefaultMavenExecutionTest
     public void testCopyDefault()
     {
         MavenExecutionRequest original = new DefaultMavenExecutionRequest();
-        MavenExecutionRequest copy = DefaultMavenExecutionRequest.copy( original );
+        MavenExecutionRequest copy = original.copy();
         assertNotNull( copy );
         assertNotSame( copy, original );
     }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -762,7 +762,7 @@ public class MavenCli
 
                 configure( cliRequest );
 
-				MavenExecutionRequest request = cliRequest.request.copy();
+                MavenExecutionRequest request = cliRequest.request.copy();
 
                 populateRequest( cliRequest, request );
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -48,7 +48,6 @@ import org.apache.maven.eventspy.internal.EventSpyDispatcher;
 import org.apache.maven.exception.DefaultExceptionHandler;
 import org.apache.maven.exception.ExceptionHandler;
 import org.apache.maven.exception.ExceptionSummary;
-import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.ExecutionListener;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequestPopulationException;
@@ -763,7 +762,7 @@ public class MavenCli
 
                 configure( cliRequest );
 
-                MavenExecutionRequest request = DefaultMavenExecutionRequest.copy( cliRequest.request );
+				MavenExecutionRequest request = cliRequest.request.copy();
 
                 populateRequest( cliRequest, request );
 


### PR DESCRIPTION
This refactoring refers to a more intuitive API approach.

The interface "MavenExecutionRequest" now provides an object scope method to copy itself. This has to be implemented by each sub type of "MavenExecutionRequest". Neverteless: I only found the class "DefaultMavenExecutionRequest" implementing the interface.

1. Providing an object scope copy method makes the usage less verbose.
2. As the copy method is defined abstract: the MavenCli class got rid of the concrete class "DefaultMavenExecutionRequest" dependency

The static copy method has been declared deprecated and can be made private in the future.