### PR TITLE
[MNG-5760] resume from without args

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -302,16 +302,14 @@ public class DefaultMavenExecutionRequest
         return excludedProjects;
     }
 
+    /**
+     * @return the project where the build should be resumed from,
+     *  or empty when it should start from the last failed project.
+     */
     @Override
     public String getResumeFrom()
     {
         return resumeFrom;
-    }
-
-    @Override
-    public boolean isResumeFromLastFailedProject()
-    {
-        return resumeFromLastFailedProject;
     }
 
     @Override
@@ -606,18 +604,15 @@ public class DefaultMavenExecutionRequest
         return this;
     }
 
+    /**
+     * @param project The project where the build should be started from,
+     *                or empty string when it should resume from the last failed project.
+     * @return this MavenExecutionRequest
+     */
     @Override
     public MavenExecutionRequest setResumeFrom( String project )
     {
         this.resumeFrom = project;
-
-        return this;
-    }
-
-    @Override
-    public MavenExecutionRequest setResumeFromLastFailedProject()
-    {
-        this.resumeFromLastFailedProject = true;
 
         return this;
     }

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -118,6 +118,8 @@ public class DefaultMavenExecutionRequest
 
     private String resumeFrom;
 
+    private boolean resumeFromLastFailedProject = false;
+
     private String makeBehavior;
 
     private Properties systemProperties;
@@ -304,6 +306,12 @@ public class DefaultMavenExecutionRequest
     public String getResumeFrom()
     {
         return resumeFrom;
+    }
+
+    @Override
+    public boolean isResumeFromLastFailedProject()
+    {
+        return resumeFromLastFailedProject;
     }
 
     @Override
@@ -602,6 +610,14 @@ public class DefaultMavenExecutionRequest
     public MavenExecutionRequest setResumeFrom( String project )
     {
         this.resumeFrom = project;
+
+        return this;
+    }
+
+    @Override
+    public MavenExecutionRequest setResumeFromLastFailedProject()
+    {
+        this.resumeFromLastFailedProject = true;
 
         return this;
     }

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -175,6 +175,10 @@ public interface MavenExecutionRequest
 
     String getResumeFrom();
 
+    MavenExecutionRequest setResumeFromLastFailedProject();
+
+    boolean isResumeFromLastFailedProject();
+
     MavenExecutionRequest setMakeBehavior( String makeBehavior );
 
     String getMakeBehavior();

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -171,13 +171,18 @@ public interface MavenExecutionRequest
      */
     List<String> getExcludedProjects();
 
+    /**
+     * @param project The project where the build should be started from,
+     *                or empty string when it should start from the last failed project.
+     * @return this MavenExecutionRequest
+     */
     MavenExecutionRequest setResumeFrom( String project );
 
+    /**
+     * @return the project where the build should be started from,
+     *  or empty when it should start from the last failed project.
+     */
     String getResumeFrom();
-
-    MavenExecutionRequest setResumeFromLastFailedProject();
-
-    boolean isResumeFromLastFailedProject();
 
     MavenExecutionRequest setMakeBehavior( String makeBehavior );
 

--- a/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -344,6 +344,12 @@ public class DefaultGraphBuilder
                         "Could not determine build directory for root project", request.getPom() ) );
 
         Path resumeFromCacheFile = Paths.get( buildDirectory, "resume-from-cache" );
+        if ( !resumeFromCacheFile.toFile().isFile() )
+        {
+            throw new MavenExecutionException( "--resume-from without args expects a file called resume-from-cache "
+                    + "in the build directory with the last failed project descriptor.", request.getPom() );
+        }
+
         try ( Stream<String> allLines = Files.lines( resumeFromCacheFile ) )
         {
             return allLines.findFirst().orElseThrow(

--- a/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -308,13 +308,12 @@ public class DefaultGraphBuilder
                         .findFirst()
                         .map( mp -> mp.getBuild().getDirectory() )
                         .orElseThrow( () -> new MavenExecutionException(
-                                "Could not determine build directory for main pom", request.getPom() ) );
+                                "Could not determine build directory for root project", request.getPom() ) );
 
                 Path resumeFromCacheFile = Paths.get( buildDirectory, "resume-from-cache" );
                 try ( Stream<String> allLines = Files.lines( resumeFromCacheFile ) )
                 {
                     selector = allLines.findFirst().orElseThrow(
-                            // TODO - or should we not fail and fallback on all projects and warning log?
                             () -> new MavenExecutionException( "resume-from-cache file was empty", request.getPom() )
                     );
                 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -134,7 +134,7 @@ public class CLIManager
         options.addOption( Option.builder( FAIL_FAST ).longOpt( "fail-fast" ).desc( "Stop at first failure in reactorized builds" ).build() );
         options.addOption( Option.builder( FAIL_AT_END ).longOpt( "fail-at-end" ).desc( "Only fail the build afterwards; allow all non-impacted builds to continue" ).build() );
         options.addOption( Option.builder( FAIL_NEVER ).longOpt( "fail-never" ).desc( "NEVER fail the build, regardless of project result" ).build() );
-        options.addOption( Option.builder( RESUME_FROM ).longOpt( "resume-from" ).desc( "Resume reactor from last failed project or specified project" ).build() );
+        options.addOption( Option.builder( RESUME_FROM ).longOpt( "resume-from" ).hasArg().optionalArg( true ).desc( "Resume reactor from last failed project or specified project" ).build() );
         options.addOption( Option.builder( PROJECT_LIST ).longOpt( "projects" ).desc( "Comma-delimited list of specified reactor projects to build instead of all projects. A project can be specified by [groupId]:artifactId or by its relative path" ).hasArg().build() );
         options.addOption( Option.builder( ALSO_MAKE ).longOpt( "also-make" ).desc( "If project list is specified, also build projects required by the list" ).build() );
         options.addOption( Option.builder( ALSO_MAKE_DEPENDENTS ).longOpt( "also-make-dependents" ).desc( "If project list is specified, also build projects that depend on projects on the list" ).build() );

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -134,7 +134,7 @@ public class CLIManager
         options.addOption( Option.builder( FAIL_FAST ).longOpt( "fail-fast" ).desc( "Stop at first failure in reactorized builds" ).build() );
         options.addOption( Option.builder( FAIL_AT_END ).longOpt( "fail-at-end" ).desc( "Only fail the build afterwards; allow all non-impacted builds to continue" ).build() );
         options.addOption( Option.builder( FAIL_NEVER ).longOpt( "fail-never" ).desc( "NEVER fail the build, regardless of project result" ).build() );
-        options.addOption( Option.builder( RESUME_FROM ).longOpt( "resume-from" ).hasArg().desc( "Resume reactor from specified project" ).build() );
+        options.addOption( Option.builder( RESUME_FROM ).longOpt( "resume-from" ).desc( "Resume reactor from last failed project or specified project" ).build() );
         options.addOption( Option.builder( PROJECT_LIST ).longOpt( "projects" ).desc( "Comma-delimited list of specified reactor projects to build instead of all projects. A project can be specified by [groupId]:artifactId or by its relative path" ).hasArg().build() );
         options.addOption( Option.builder( ALSO_MAKE ).longOpt( "also-make" ).desc( "If project list is specified, also build projects required by the list" ).build() );
         options.addOption( Option.builder( ALSO_MAKE_DEPENDENTS ).longOpt( "also-make-dependents" ).desc( "If project list is specified, also build projects that depend on projects on the list" ).build() );

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1099,14 +1099,14 @@ public class MavenCli
             }
             catch ( IOException e )
             {
-                slf4jLogger.warn( "Failed writing last failed project to resume-from-cache file at: {}",
+                slf4jLogger.info( "Failed writing last failed project to resume-from-cache file at: {}",
                         resumeFromCache, e );
                 return false;
             }
         }
         else
         {
-            slf4jLogger.warn( "Failed creating build directory for root project to store resume-from-cache file" );
+            slf4jLogger.info( "Failed creating build directory for root project to store resume-from-cache file" );
             return false;
         }
     }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1518,7 +1518,15 @@ public class MavenCli
 
         if ( commandLine.hasOption( CLIManager.RESUME_FROM ) )
         {
-            request.setResumeFrom( commandLine.getOptionValue( CLIManager.RESUME_FROM ) );
+            String resumeFromProject = commandLine.getOptionValue( CLIManager.RESUME_FROM );
+            if ( StringUtils.isNotEmpty( resumeFromProject ) )
+            {
+                request.setResumeFrom( resumeFromProject );
+            }
+            else
+            {
+                request.setResumeFromLastFailedProject();
+            }
         }
 
         if ( commandLine.hasOption( CLIManager.PROJECT_LIST ) )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1088,7 +1088,7 @@ public class MavenCli
     {
         String buildDirectory = result.getProject().getBuild().getDirectory();
         File buildDirectoryFile = new File( buildDirectory );
-        boolean isBuildDirectoryPresent = ( buildDirectoryFile.exists() || buildDirectoryFile.mkdirs() );
+        boolean isBuildDirectoryPresent = buildDirectoryFile.exists() || buildDirectoryFile.mkdirs();
         if ( isBuildDirectoryPresent )
         {
             Path resumeFromCache = Paths.get( buildDirectory, "resume-from-cache" );
@@ -1099,14 +1099,14 @@ public class MavenCli
             }
             catch ( IOException e )
             {
-                slf4jLogger.debug( "Failed writing last failed project to resume-from-cache file at: {}",
+                slf4jLogger.warn( "Failed writing last failed project to resume-from-cache file at: {}",
                         resumeFromCache, e );
                 return false;
             }
         }
         else
         {
-            slf4jLogger.debug( "Failed creating build directory for root project to store resume-from-cache file" );
+            slf4jLogger.warn( "Failed creating build directory for root project to store resume-from-cache file" );
             return false;
         }
     }
@@ -1550,15 +1550,9 @@ public class MavenCli
 
         if ( commandLine.hasOption( CLIManager.RESUME_FROM ) )
         {
-            String resumeFromProject = commandLine.getOptionValue( CLIManager.RESUME_FROM );
-            if ( StringUtils.isNotEmpty( resumeFromProject ) )
-            {
-                request.setResumeFrom( resumeFromProject );
-            }
-            else
-            {
-                request.setResumeFromLastFailedProject();
-            }
+            String optionValue = commandLine.getOptionValue( CLIManager.RESUME_FROM );
+            String resumeFromProject = optionValue != null ? optionValue : "";
+            request.setResumeFrom( resumeFromProject );
         }
 
         if ( commandLine.hasOption( CLIManager.PROJECT_LIST ) )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1088,7 +1088,7 @@ public class MavenCli
     {
         String buildDirectory = result.getProject().getBuild().getDirectory();
         File buildDirectoryFile = new File( buildDirectory );
-        boolean isBuildDirectoryPresent = ( !buildDirectoryFile.exists() && buildDirectoryFile.mkdirs() );
+        boolean isBuildDirectoryPresent = ( buildDirectoryFile.exists() || buildDirectoryFile.mkdirs() );
         if ( isBuildDirectoryPresent )
         {
             Path resumeFromCache = Paths.get( buildDirectory, "resume-from-cache" );


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG-5760) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

This PR solves MNG-5760 which allows for resuming the build from the last failed module.
It works by saving a file in the build directory of the root pom including that module as file content.

Relevant integration test:
https://github.com/apache/maven-integration-testing/pull/56