### PR TITLE
[MNG-5760] --resume feature (part 2)

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/BuildResumptionData.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/BuildResumptionData.java
@@ -20,6 +20,9 @@ package org.apache.maven.execution;
  */
 
 import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 
 /**
  * This class holds the information required to enable resuming a Maven build with {@code --resume}.
@@ -32,7 +35,7 @@ public class BuildResumptionData
     private final String resumeFrom;
 
     /**
-     * List of projects to skip if the build would be resumed from {@link #resumeFrom}.
+     * List of projects to skip.
      */
     private final List<String> projectsToSkip;
 
@@ -42,13 +45,23 @@ public class BuildResumptionData
         this.projectsToSkip = projectsToSkip;
     }
 
-    public String getResumeFrom()
+    /**
+     * Returns the project where the next build can resume from.
+     * This is usually the first failed project in the order of the reactor.
+     * @return An optional containing the group and artifact id of the project. It does not make sense to resume
+     *   the build when the first project of the reactor has failed, so then it will return an empty optional.
+     */
+    public Optional<String> getResumeFrom()
     {
-        return this.resumeFrom;
+        return Optional.ofNullable( this.resumeFrom );
     }
 
+    /**
+     * A list of projects which can be skipped in the next build.
+     * @return A list of group and artifact ids. Can be empty when no projects can be skipped.
+     */
     public List<String> getProjectsToSkip()
     {
-        return this.projectsToSkip;
+        return ( projectsToSkip != null ) ? projectsToSkip : emptyList();
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzer.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzer.java
@@ -98,6 +98,7 @@ public class DefaultBuildResumptionAnalyzer implements BuildResumptionAnalyzer
                 .filter( LifecycleExecutionException.class::isInstance )
                 .map( LifecycleExecutionException.class::cast )
                 .map( LifecycleExecutionException::getProject )
+                .filter( Objects::nonNull )
                 .sorted( comparing( sortedProjects::indexOf ) )
                 .collect( Collectors.toList() );
     }

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
@@ -109,7 +109,7 @@ public class DefaultBuildResumptionDataRepository implements BuildResumptionData
     private Properties loadResumptionFile( Path rootBuildDirectory )
     {
         Properties properties = new Properties();
-        Path path = rootBuildDirectory.resolve( Paths.get( RESUME_PROPERTIES_FILENAME ) );
+        Path path = rootBuildDirectory.resolve( RESUME_PROPERTIES_FILENAME );
         if ( !Files.exists( path ) )
         {
             LOGGER.warn( "The {} file does not exist. The --resume / -r feature will not work.", path );

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
@@ -74,7 +74,9 @@ public class DefaultBuildResumptionDataRepository implements BuildResumptionData
     private Properties convertToProperties( final BuildResumptionData buildResumptionData )
     {
         Properties properties = new Properties();
-        properties.setProperty( RESUME_FROM_PROPERTY, buildResumptionData.getResumeFrom() );
+
+        buildResumptionData.getResumeFrom()
+                .ifPresent( resumeFrom -> properties.setProperty( RESUME_FROM_PROPERTY, resumeFrom ) );
 
         if ( !buildResumptionData.getProjectsToSkip().isEmpty() )
         {

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
@@ -75,8 +75,12 @@ public class DefaultBuildResumptionDataRepository implements BuildResumptionData
     {
         Properties properties = new Properties();
         properties.setProperty( RESUME_FROM_PROPERTY, buildResumptionData.getResumeFrom() );
-        String excludedProjects = String.join( PROPERTY_DELIMITER, buildResumptionData.getProjectsToSkip() );
-        properties.setProperty( EXCLUDED_PROJECTS_PROPERTY, excludedProjects );
+
+        if ( !buildResumptionData.getProjectsToSkip().isEmpty() )
+        {
+            String excludedProjects = String.join( PROPERTY_DELIMITER, buildResumptionData.getProjectsToSkip() );
+            properties.setProperty( EXCLUDED_PROJECTS_PROPERTY, excludedProjects );
+        }
 
         return properties;
     }
@@ -137,9 +141,12 @@ public class DefaultBuildResumptionDataRepository implements BuildResumptionData
         if ( properties.containsKey( EXCLUDED_PROJECTS_PROPERTY ) )
         {
             String propertyValue = properties.getProperty( EXCLUDED_PROJECTS_PROPERTY );
-            String[] excludedProjects = propertyValue.split( PROPERTY_DELIMITER );
-            request.getExcludedProjects().addAll( Arrays.asList( excludedProjects ) );
-            LOGGER.info( "Additionally excluding projects '{}' due to the --resume / -r feature.", propertyValue );
+            if ( !StringUtils.isEmpty( propertyValue ) )
+            {
+                String[] excludedProjects = propertyValue.split( PROPERTY_DELIMITER );
+                request.getExcludedProjects().addAll( Arrays.asList( excludedProjects ) );
+                LOGGER.info( "Additionally excluding projects '{}' due to the --resume / -r feature.", propertyValue );
+            }
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionDataRepository.java
@@ -105,7 +105,7 @@ public class DefaultBuildResumptionDataRepository implements BuildResumptionData
     private Properties loadResumptionFile( Path rootBuildDirectory )
     {
         Properties properties = new Properties();
-        Path path = Paths.get( RESUME_PROPERTIES_FILENAME ).resolve( rootBuildDirectory );
+        Path path = rootBuildDirectory.resolve( Paths.get( RESUME_PROPERTIES_FILENAME ) );
         if ( !Files.exists( path ) )
         {
             LOGGER.warn( "The {} file does not exist. The --resume / -r feature will not work.", path );

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -607,9 +607,9 @@ public class DefaultMavenExecutionRequest
     }
 
     @Override
-    public MavenExecutionRequest setResume()
+    public MavenExecutionRequest setResume( boolean resume )
     {
-        resume = true;
+        this.resume = resume;
 
         return this;
     }

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -173,9 +173,10 @@ public interface MavenExecutionRequest
 
     /**
      * Sets whether the build should be resumed from the data in the resume.properties file.
+     * @param resume Whether or not to resume a previous build.
      * @return This request, never {@code null}.
      */
-    MavenExecutionRequest setResume();
+    MavenExecutionRequest setResume( boolean resume );
 
     /**
      * @return Whether the build should be resumed from the data in the resume.properties file.

--- a/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzerTest.java
@@ -55,7 +55,7 @@ public class DefaultBuildResumptionAnalyzerTest
         Optional<BuildResumptionData> result = analyzer.determineBuildResumptionData( executionResult );
 
         assertThat( result.isPresent(), is( true ) );
-        assertThat( result.get().getResumeFrom(), is( "test:B" ) );
+        assertThat( result.get().getResumeFrom(), is( Optional.of ( "test:B" ) ) );
     }
 
     @Test
@@ -111,7 +111,7 @@ public class DefaultBuildResumptionAnalyzerTest
         Optional<BuildResumptionData> result = analyzer.determineBuildResumptionData( executionResult );
 
         assertThat( result.isPresent(), is( true ) );
-        assertThat( result.get().getResumeFrom(), is( "test:B" ) );
+        assertThat( result.get().getResumeFrom(), is( Optional.of ( "test:B" ) ) );
         assertThat( result.get().getProjectsToSkip(), contains( "test:C" ) );
         assertThat( result.get().getProjectsToSkip(), not( contains( "test:D" ) ) );
     }

--- a/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionDataRepositoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionDataRepositoryTest.java
@@ -30,7 +30,9 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 
 @RunWith( MockitoJUnitRunner.class )
 public class DefaultBuildResumptionDataRepositoryTest

--- a/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionDataRepositoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionDataRepositoryTest.java
@@ -19,6 +19,8 @@ package org.apache.maven.execution;
  * under the License.
  */
 
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -74,5 +76,20 @@ public class DefaultBuildResumptionDataRepositoryTest
         repository.applyResumptionProperties( request, properties );
 
         assertThat( request.getExcludedProjects(), contains( ":module-a", ":module-b", ":module-c" ) );
+    }
+
+    @Test
+    public void applyResumptionData_shouldLoadData()
+    {
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        Build build = new Build();
+        build.setDirectory( "src/test/resources/org/apache/maven/execution/" );
+        MavenProject rootProject = new MavenProject();
+        rootProject.setBuild( build );
+
+        repository.applyResumptionData( request,  rootProject );
+
+        assertThat( request.getResumeFrom(), is( "example:module-c" ) );
+        assertThat( request.getExcludedProjects(), contains( "example:module-a", "example:module-b" ) );
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionDataRepositoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionDataRepositoryTest.java
@@ -30,8 +30,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 @RunWith( MockitoJUnitRunner.class )
 public class DefaultBuildResumptionDataRepositoryTest
@@ -76,6 +75,18 @@ public class DefaultBuildResumptionDataRepositoryTest
         repository.applyResumptionProperties( request, properties );
 
         assertThat( request.getExcludedProjects(), contains( ":module-a", ":module-b", ":module-c" ) );
+    }
+
+    @Test
+    public void excludedProjectsAreNotAddedWhenPropertyValueIsEmpty()
+    {
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        Properties properties = new Properties();
+        properties.setProperty( "excludedProjects", "" );
+
+        repository.applyResumptionProperties( request, properties );
+
+        assertThat( request.getExcludedProjects(), is( empty() ) );
     }
 
     @Test

--- a/maven-core/src/test/resources/org/apache/maven/execution/resume.properties
+++ b/maven-core/src/test/resources/org/apache/maven/execution/resume.properties
@@ -1,0 +1,2 @@
+resumeFrom=example:module-c
+excludedProjects=example:module-a, example:module-b

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1531,7 +1531,7 @@ public class MavenCli
 
         if ( commandLine.hasOption( CLIManager.RESUME ) )
         {
-            request.setResume();
+            request.setResume( true );
         }
 
         if ( commandLine.hasOption( CLIManager.RESUME_FROM ) )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -48,7 +48,6 @@ import org.apache.maven.eventspy.internal.EventSpyDispatcher;
 import org.apache.maven.exception.DefaultExceptionHandler;
 import org.apache.maven.exception.ExceptionHandler;
 import org.apache.maven.exception.ExceptionSummary;
-import org.apache.maven.execution.BuildResumptionDataRepository;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.ExecutionListener;
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -168,8 +167,6 @@ public class MavenCli
     private DefaultSecDispatcher dispatcher;
 
     private Map<String, ConfigurationProcessor> configurationProcessors;
-
-    private BuildResumptionDataRepository buildResumptionDataRepository;
 
     public MavenCli()
     {
@@ -707,8 +704,6 @@ public class MavenCli
         toolchainsBuilder = container.lookup( ToolchainsBuilder.class );
 
         dispatcher = (DefaultSecDispatcher) container.lookup( SecDispatcher.class, "maven" );
-
-        buildResumptionDataRepository = container.lookup( BuildResumptionDataRepository.class );
 
         return container;
     }


### PR DESCRIPTION
This pull request is a follow-up on #342, in which two little bugs had sneaked in. Since the feature hasn't been released yet, I haven't added new JIRA tickets for these bugs.

1. Resolution of **resume.properties** file didn't work as expected. I have fixed it and added a unit test to illustrate how it should work.
1. When the `excludedProjects` property in the  **resume.properties** file was empty, the build would break (since it added an empty project to the list of excluded projects). Of course, this shouldn't happen, so that's fixed too.

 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`, where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice is to use the JIRA issue title in the pull request title and in the first line of the commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [X] You have run the [Core IT][core-its] successfully. Also, the previously added test case for this feature is now added to the suite.

**ICLA has been signed by @MartinKanters and myself. CCLA has been signed by our employer, Info Support.**

[core-its]: https://maven.apache.org/core-its/core-it-suite/
