### PR TITLE
[MNG-6983] Plugin key can get out of sync with artifactId and groupId

### DIFF
--- a/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 import org.apache.maven.AbstractCoreMavenComponentTestCase;
 import org.apache.maven.artifact.InvalidArtifactRTException;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.model.building.FileModelSource;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelSource;
@@ -329,5 +330,18 @@ public class ProjectBuilderTest
         assertEquals( 1, project.getCompileSourceRoots().size() );
         assertEquals( 1, project.getMailingLists().size() );
         assertEquals( 1, project.getResources().size() );
+    }
+
+    public void testPropertyInPluginManagementGroupId()
+            throws Exception
+    {
+        File pom = getProject( "MNG-6983" );
+
+        MavenSession session = createMavenSession( pom );
+        MavenProject project = session.getCurrentProject();
+
+        for (Plugin buildPlugin : project.getBuildPlugins()) {
+            assertNotNull( "Missing version for build plugin " + buildPlugin.getKey(), buildPlugin.getVersion() );
+        }
     }
 }

--- a/maven-core/src/test/projects/project-builder/MNG-6983/parent-pom.xml
+++ b/maven-core/src/test/projects/project-builder/MNG-6983/parent-pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <codehaus.group.id>org.codehaus.mojo</codehaus.group.id>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>${codehaus.group.id}</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <executions>
+                        <execution>
+                            <id>add-source-config</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>.</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/maven-core/src/test/projects/project-builder/MNG-6983/pom.xml
+++ b/maven-core/src/test/projects/project-builder/MNG-6983/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>./parent-pom.xml</relativePath>
+    </parent>
+
+    <artifactId>child</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${codehaus.group.id}</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -2314,18 +2314,12 @@
         return id.toString();
     }
 
-    //TODO we shall reset key variable when groupId/artifactId change
-    private String key = null;
     /**
      * @return the key of the plugin, ie <code>groupId:artifactId</code>
      */
     public String getKey()
     {
-        if ( key == null )
-        {
-            key = constructKey( groupId, artifactId );
-        }
-        return key;
+        return constructKey( groupId, artifactId );
     }
 
     /**


### PR DESCRIPTION
I came here because of a project where some maven plugins are not executed without any warning or error. Debugging the issue brought me to the implementation of the `key` field in `Plugin.java`. It constructs the key _once_ on first use from the plugins groupId and artifactId. The key is not updated when either of this values changes.

It is not easy for me to say where exactly this construct start to fail, but take a look on the following screenshot. At one point `ManagementModelMerger.mergePluginContainerPlugins` tries to enhance the child pom plugin instance with the version information from the parents pluginManagement. But it fails to match both plugin instances. Both plugins have the same (interpolated) groupId and artifactId but different keys. Obviously for one instance `getKey()` was called before the groupId was interpolated but not for the other, resulting in different keys for the same plugin.

![mvn-debug](https://user-images.githubusercontent.com/13628240/92512300-e2fe4500-f20e-11ea-8c65-8dd06b0324ac.png)

My suggested fix is to basically follow the TODO comment found on `key`. Reset the `key` if groupId or artifactId changes. Since the key calculation is so simple I actually see no reason to cache it at all.
Furthermore, while writing this description, I noticed that the implementation of `ReportPlugin` is very similar (looks like it was copy&pasted at one point) and it already does what I propose for this pull request.

PS: an additional note and warning if you want to debug the current code. All debuggers I know tend to call the `toString` method when inspecting object instances. In case of `Plugin` this also triggers the _one time calculation_ of `key`. I.e. inspecting the `Plugin` object in debugger can change the instance state and as result the issue does not appear anymore or at a different place as without debugging.