### PR TITLE
[MNG-6987] Reorder groupId before artifactId when writing an exclusion using maven-model

### DIFF
--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1191,16 +1191,16 @@
       </description>
       <fields>
         <field>
-          <name>artifactId</name>
+          <name>groupId</name>
           <version>4.0.0+</version>
-          <description>The artifact ID of the project to exclude.</description>
+          <description>The group ID of the project to exclude.</description>
           <type>String</type>
           <required>true</required>
         </field>
         <field>
-          <name>groupId</name>
+          <name>artifactId</name>
           <version>4.0.0+</version>
-          <description>The group ID of the project to exclude.</description>
+          <description>The artifact ID of the project to exclude.</description>
           <type>String</type>
           <required>true</required>
         </field>


### PR DESCRIPTION
In most other places, we order the groupId before the artefactId in POM files. Exclusion was the odd one out, so I changed it to be in line with the others.

We observe this when using `maven-model` to parse, modify, and write back a POM file roughly like so:
```java
MavenXpp3Reader reader = new MavenXpp3Reader();
Model model = reader.read(new FileReader(input));
// make modifications to the model
MavenXpp3Writer writer = new MavenXpp3Writer();
writer.write(new FileWriter(output), model);
```

Before this change, exclusions in the output file would be ordered like so:
```xml
        <exclusions>
          <exclusion>
            <artifactId>plexus-cipher</artifactId>
            <groupId>org.sonatype.plexus</groupId>
          </exclusion>
        </exclusions>
```

After:
```xml
        <exclusions>
          <exclusion>
            <groupId>org.sonatype.plexus</groupId>
            <artifactId>plexus-cipher</artifactId>
          </exclusion>
        </exclusions>
```

To be honest, I'm not entirely sure what other consequences this has, or if it would cause breaking changes for users of the library. But I thought I'd put it up anyway.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

