### PR TITLE
Update build matrix for release of Java 15

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 11, 14, 15-ea]
+        java: [8, 11, 14, 15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 11, 14, 15, 16-ea]
+        java: [8, 11, 15, 16-ea]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 11, 14, 15]
+        java: [8, 11, 14, 15, 16-ea]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
🎉 Java 15 is out! This change
* removes the EA builds of Java 15 from the GitHub Actions build matrix
* adds the EA builds of Java 16 to the GitHub Actions build matrix
* removes the Java 14 from the GitHub Actions build matrix