### PR TITLE
[MNG-6949] Get the correct PR origin user and branch for Pull Requests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -89,7 +89,7 @@ jobs:
             branch=${GITHUB_REF#refs/heads/}
           fi
           if [ $branch != "master" ]; then
-            git ls-remote https://github.com/$user/$repo.git | grep $GITHUB_REF > /dev/null
+            git ls-remote https://github.com/$user/$repo.git | grep "refs/heads/${branch}$" > /dev/null
             if [ $? -eq 0 ]; then
               echo "Found a branch \"$branch\" in fork \"$user/$repo\", configuring this for the integration tests to be run against."
               target_branch=$branch

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -74,13 +74,20 @@ jobs:
     steps:
       - name: Collect environment context variables
         shell: bash
+        env:
+          PR_HEAD_LABEL: ${{ github.event.pull_request.head.label }}
         run: |
           set +e
           repo=maven-integration-testing
-          user=${GITHUB_REPOSITORY%/*}
-          branch=${GITHUB_REF#refs/heads/}
           target_branch=master
           target_user=apache
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            source_repo=${PR_HEAD_LABEL%:*}
+            source_branch=${PR_HEAD_LABEL#*:}
+          else
+            source_repo=${GITHUB_REPOSITORY%/*}
+            source_branch=${GITHUB_REF#refs/heads/}
+          fi
           if [ $branch != "master" ]; then
             git ls-remote https://github.com/$user/$repo.git | grep $GITHUB_REF > /dev/null
             if [ $? -eq 0 ]; then

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -82,11 +82,11 @@ jobs:
           target_branch=master
           target_user=apache
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-            source_repo=${PR_HEAD_LABEL%:*}
-            source_branch=${PR_HEAD_LABEL#*:}
+            user=${PR_HEAD_LABEL%:*}
+            branch=${PR_HEAD_LABEL#*:}
           else
-            source_repo=${GITHUB_REPOSITORY%/*}
-            source_branch=${GITHUB_REF#refs/heads/}
+            user=${GITHUB_REPOSITORY%/*}
+            branch=${GITHUB_REF#refs/heads/}
           fi
           if [ $branch != "master" ]; then
             git ls-remote https://github.com/$user/$repo.git | grep $GITHUB_REF > /dev/null


### PR DESCRIPTION
Get the correct PR origin user and branch name from the GitHub Actions context, in order to run the matching integration tests repo and branch.
This didn't work before, one example is this run: https://github.com/apache/maven/actions/runs/246744958
The reason why it failed on pull requests, was that GitHub Actions creates a new ref for running the workflow on (refs/pull/...), this broke the script which determines the base branch name and repo user.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
