### PR TITLE
[MNG-6991] Restore how the local repository is determined

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1389,7 +1389,11 @@ public class MavenCli
         request.addActiveProfiles( profileActivation.activeProfiles );
         request.addInactiveProfiles( profileActivation.inactiveProfiles );
 
-        request.setLocalRepositoryPath( determineLocalRepositoryPath( request ) );
+        final String localRepositoryPath = determineLocalRepositoryPath( request );
+        if ( localRepositoryPath != null )
+        {
+            request.setLocalRepositoryPath( localRepositoryPath );
+        }
 
         //
         // Builder, concurrency and parallelism
@@ -1428,10 +1432,13 @@ public class MavenCli
 
     private String determineLocalRepositoryPath( final MavenExecutionRequest request )
     {
-        return request.getUserProperties().getProperty(
-                MavenCli.LOCAL_REPO_PROPERTY,
-                request.getSystemProperties().getProperty( MavenCli.LOCAL_REPO_PROPERTY ) // null if not found
-        );
+        String userDefinedLocalRepo = request.getUserProperties().getProperty( MavenCli.LOCAL_REPO_PROPERTY );
+        if ( userDefinedLocalRepo != null )
+        {
+            return userDefinedLocalRepo;
+        }
+
+        return request.getSystemProperties().getProperty( MavenCli.LOCAL_REPO_PROPERTY );
     }
 
     private File determinePom( final CommandLine commandLine, final String workingDirectory, final File baseDirectory )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1338,7 +1338,7 @@ public class MavenCli
         return defaultLocation;
     }
 
-    private MavenExecutionRequest populateRequest( CliRequest cliRequest )
+    protected MavenExecutionRequest populateRequest( CliRequest cliRequest )
     {
         return populateRequest( cliRequest, cliRequest.request );
     }


### PR DESCRIPTION
The refactoring of MavenCli.populateRequest introduced a subtle bug. It would select ~/.m2/repository as the local repository instead of something that is configured in ~/.m2/settings.xml.

See [MNG-6991](https://issues.apache.org/jira/browse/MNG-6991) and [this Slack discussion](https://the-asf.slack.com/archives/C7Q9JB404/p1601016907001000) for additional details.

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed for the change (usually before you start working on it).
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`, where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice is to use the JIRA issue title in the pull request title and in the first line of the commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the [Core IT][core-its] successfully.

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
