### PR TITLE
[MNG-6754] Set the same timestamp in multi module builds

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/artifact/installer/DefaultArtifactInstaller.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/installer/DefaultArtifactInstaller.java
@@ -123,6 +123,7 @@ public class DefaultArtifactInstaller
         }
 
         Versioning versioning = new Versioning();
+        // TODO Should this be changed for MNG-6754 too?
         versioning.updateTimestamp();
         versioning.addVersion( artifact.getBaseVersion() );
         if ( artifact.isRelease() )

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/ReleaseArtifactTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/ReleaseArtifactTransformation.java
@@ -82,6 +82,7 @@ public class ReleaseArtifactTransformation
     private ArtifactMetadata createMetadata( Artifact artifact )
     {
         Versioning versioning = new Versioning();
+        // TODO Should this be changed for MNG-6754 too?
         versioning.updateTimestamp();
         versioning.addVersion( artifact.getVersion() );
 

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/SnapshotTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/SnapshotTransformation.java
@@ -91,6 +91,7 @@ public class SnapshotTransformation
         {
             Snapshot snapshot = new Snapshot();
 
+            // TODO Should this be changed for MNG-6754 too?
             snapshot.setTimestamp( getDeploymentTimestamp() );
 
             // we update the build number anyway so that it doesn't get lost. It requires the timestamp to take effect

--- a/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/AbstractRepositoryMetadata.java
+++ b/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/AbstractRepositoryMetadata.java
@@ -164,7 +164,6 @@ public abstract class AbstractRepositoryMetadata
     {
         Versioning versioning = new Versioning();
         versioning.setSnapshot( snapshot );
-        versioning.updateTimestamp();
         return versioning;
     }
 

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -113,6 +113,7 @@ public class DefaultRepositorySystemSessionFactory
         Map<Object, Object> configProps = new LinkedHashMap<>();
         configProps.put( ConfigurationProperties.USER_AGENT, getUserAgent() );
         configProps.put( ConfigurationProperties.INTERACTIVE, request.isInteractiveMode() );
+        configProps.put( "maven.startTime", request.getStartTime() );
         configProps.putAll( request.getSystemProperties() );
         configProps.putAll( request.getUserProperties() );
 
@@ -281,14 +282,14 @@ public class DefaultRepositorySystemSessionFactory
 
         return props.getProperty( "version", "unknown-version" );
     }
-    
+
     private Collection<FileTransformer> getTransformersForArtifact( final Artifact artifact,
                                                                     final SessionData sessionData )
     {
         TransformerContext context = (TransformerContext) sessionData.get( TransformerContext.KEY );
         Collection<FileTransformer> transformers = new ArrayList<>();
-        
-        // In case of install:install-file there's no transformer context, as the goal is unrelated to the lifecycle. 
+
+        // In case of install:install-file there's no transformer context, as the goal is unrelated to the lifecycle.
         if ( "pom".equals( artifact.getExtension() ) && context != null )
         {
             transformers.add( new FileTransformer()
@@ -306,7 +307,7 @@ public class DefaultRepositorySystemSessionFactory
                         throw new TransformException( e );
                     }
                 }
-                
+
                 @Override
                 public Artifact transformArtifact( Artifact artifact )
                 {

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/LocalSnapshotMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/LocalSnapshotMetadata.java
@@ -22,6 +22,7 @@ package org.apache.maven.repository.internal;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -42,15 +43,15 @@ final class LocalSnapshotMetadata
 
     private final boolean legacyFormat;
 
-    LocalSnapshotMetadata( Artifact artifact, boolean legacyFormat )
+    LocalSnapshotMetadata( Artifact artifact, boolean legacyFormat, Date timestamp )
     {
-        super( createMetadata( artifact, legacyFormat ), null );
+        super( createMetadata( artifact, legacyFormat ), null, timestamp );
         this.legacyFormat = legacyFormat;
     }
 
-    LocalSnapshotMetadata( Metadata metadata, File file, boolean legacyFormat )
+    LocalSnapshotMetadata( Metadata metadata, File file, boolean legacyFormat, Date timestamp )
     {
-        super( metadata, file );
+        super( metadata, file, timestamp );
         this.legacyFormat = legacyFormat;
     }
 
@@ -82,7 +83,7 @@ final class LocalSnapshotMetadata
 
     public MavenMetadata setFile( File file )
     {
-        return new LocalSnapshotMetadata( metadata, file, legacyFormat );
+        return new LocalSnapshotMetadata( metadata, file, legacyFormat, timestamp );
     }
 
     public Object getKey()
@@ -98,7 +99,7 @@ final class LocalSnapshotMetadata
     @Override
     protected void merge( Metadata recessive )
     {
-        metadata.getVersioning().updateTimestamp();
+        metadata.getVersioning().setLastUpdatedTimestamp( timestamp );
 
         if ( !legacyFormat )
         {

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/LocalSnapshotMetadataGenerator.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/LocalSnapshotMetadataGenerator.java
@@ -21,6 +21,7 @@ package org.apache.maven.repository.internal;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -42,9 +43,13 @@ class LocalSnapshotMetadataGenerator
 
     private final boolean legacyFormat;
 
+    private final Date timestamp;
+
     LocalSnapshotMetadataGenerator( RepositorySystemSession session, InstallRequest request )
     {
         legacyFormat = ConfigUtils.getBoolean( session.getConfigProperties(), false, "maven.metadata.legacy" );
+
+        timestamp = (Date) ConfigUtils.getObject( session, new Date(), "maven.startTime" );
 
         snapshots = new LinkedHashMap<>();
     }
@@ -59,7 +64,7 @@ class LocalSnapshotMetadataGenerator
                 LocalSnapshotMetadata snapshotMetadata = snapshots.get( key );
                 if ( snapshotMetadata == null )
                 {
-                    snapshotMetadata = new LocalSnapshotMetadata( artifact, legacyFormat );
+                    snapshotMetadata = new LocalSnapshotMetadata( artifact, legacyFormat, timestamp );
                     snapshots.put( key, snapshotMetadata );
                 }
                 snapshotMetadata.bind( artifact );

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenMetadata.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -46,16 +47,19 @@ abstract class MavenMetadata
 
     static final String MAVEN_METADATA_XML = "maven-metadata.xml";
 
+    protected Metadata metadata;
+
     private final File file;
 
-    protected Metadata metadata;
+    protected final Date timestamp;
 
     private boolean merged;
 
-    protected MavenMetadata( Metadata metadata, File file )
+    protected MavenMetadata( Metadata metadata, File file, Date timestamp )
     {
         this.metadata = metadata;
         this.file = file;
+        this.timestamp = timestamp;
     }
 
     public String getType()

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenSnapshotMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenSnapshotMetadata.java
@@ -22,6 +22,7 @@ package org.apache.maven.repository.internal;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.eclipse.aether.artifact.Artifact;
@@ -38,9 +39,9 @@ abstract class MavenSnapshotMetadata
 
     protected final boolean legacyFormat;
 
-    protected MavenSnapshotMetadata( Metadata metadata, File file, boolean legacyFormat )
+    protected MavenSnapshotMetadata( Metadata metadata, File file, boolean legacyFormat, Date timestamp )
     {
-        super( metadata, file );
+        super( metadata, file, timestamp );
         this.legacyFormat = legacyFormat;
     }
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RemoteSnapshotMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RemoteSnapshotMetadata.java
@@ -47,19 +47,19 @@ final class RemoteSnapshotMetadata
 
     private final Map<String, SnapshotVersion> versions = new LinkedHashMap<>();
 
-    RemoteSnapshotMetadata( Artifact artifact, boolean legacyFormat )
+    RemoteSnapshotMetadata( Artifact artifact, boolean legacyFormat, Date timestamp )
     {
-        super( createRepositoryMetadata( artifact, legacyFormat ), null, legacyFormat );
+        super( createRepositoryMetadata( artifact, legacyFormat ), null, legacyFormat, timestamp );
     }
 
-    private RemoteSnapshotMetadata( Metadata metadata, File file, boolean legacyFormat )
+    private RemoteSnapshotMetadata( Metadata metadata, File file, boolean legacyFormat, Date timestamp )
     {
-        super( metadata, file, legacyFormat );
+        super( metadata, file, legacyFormat, timestamp );
     }
 
     public MavenMetadata setFile( File file )
     {
-        return new RemoteSnapshotMetadata( metadata, file, legacyFormat );
+        return new RemoteSnapshotMetadata( metadata, file, legacyFormat, timestamp );
     }
 
     public String getExpandedVersion( Artifact artifact )
@@ -82,11 +82,11 @@ final class RemoteSnapshotMetadata
 
             snapshot = new Snapshot();
             snapshot.setBuildNumber( getBuildNumber( recessive ) + 1 );
-            snapshot.setTimestamp( utcDateFormatter.format( new Date() ) );
+            snapshot.setTimestamp( utcDateFormatter.format( timestamp ) );
 
             Versioning versioning = new Versioning();
             versioning.setSnapshot( snapshot );
-            versioning.setLastUpdated( snapshot.getTimestamp().replace( ".", "" ) );
+            versioning.setLastUpdatedTimestamp( timestamp );
             lastUpdated = versioning.getLastUpdated();
 
             metadata.setVersioning( versioning );

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RemoteSnapshotMetadataGenerator.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RemoteSnapshotMetadataGenerator.java
@@ -21,6 +21,7 @@ package org.apache.maven.repository.internal;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -42,9 +43,13 @@ class RemoteSnapshotMetadataGenerator
 
     private final boolean legacyFormat;
 
+    private final Date timestamp;
+
     RemoteSnapshotMetadataGenerator( RepositorySystemSession session, DeployRequest request )
     {
-        legacyFormat = ConfigUtils.getBoolean( session.getConfigProperties(), false, "maven.metadata.legacy" );
+        legacyFormat = ConfigUtils.getBoolean( session, false, "maven.metadata.legacy" );
+
+        timestamp = (Date) ConfigUtils.getObject( session, new Date(), "maven.startTime" );
 
         snapshots = new LinkedHashMap<>();
 
@@ -74,7 +79,7 @@ class RemoteSnapshotMetadataGenerator
                 RemoteSnapshotMetadata snapshotMetadata = snapshots.get( key );
                 if ( snapshotMetadata == null )
                 {
-                    snapshotMetadata = new RemoteSnapshotMetadata( artifact, legacyFormat );
+                    snapshotMetadata = new RemoteSnapshotMetadata( artifact, legacyFormat, timestamp );
                     snapshots.put( key, snapshotMetadata );
                 }
                 snapshotMetadata.bind( artifact );

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadata.java
@@ -22,6 +22,7 @@ package org.apache.maven.repository.internal;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.LinkedHashSet;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
@@ -38,15 +39,15 @@ final class VersionsMetadata
 
     private final Artifact artifact;
 
-    VersionsMetadata( Artifact artifact )
+    VersionsMetadata( Artifact artifact, Date timestamp )
     {
-        super( createRepositoryMetadata( artifact ), null );
+        super( createRepositoryMetadata( artifact ), null, timestamp );
         this.artifact = artifact;
     }
 
-    VersionsMetadata( Artifact artifact, File file )
+    VersionsMetadata( Artifact artifact, File file, Date timestamp )
     {
-        super( createRepositoryMetadata( artifact ), file );
+        super( createRepositoryMetadata( artifact ), file, timestamp );
         this.artifact = artifact;
     }
 
@@ -76,7 +77,7 @@ final class VersionsMetadata
     protected void merge( Metadata recessive )
     {
         Versioning versioning = metadata.getVersioning();
-        versioning.updateTimestamp();
+        versioning.setLastUpdatedTimestamp( timestamp );
 
         if ( recessive.getVersioning() != null )
         {
@@ -107,7 +108,7 @@ final class VersionsMetadata
 
     public MavenMetadata setFile( File file )
     {
-        return new VersionsMetadata( artifact, file );
+        return new VersionsMetadata( artifact, file, timestamp );
     }
 
     public String getGroupId()

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadataGenerator.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadataGenerator.java
@@ -21,6 +21,7 @@ package org.apache.maven.repository.internal;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -31,6 +32,7 @@ import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.impl.MetadataGenerator;
 import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.util.ConfigUtils;
 
 /**
  * @author Benjamin Bentmann
@@ -42,6 +44,8 @@ class VersionsMetadataGenerator
     private Map<Object, VersionsMetadata> versions;
 
     private Map<Object, VersionsMetadata> processedVersions;
+
+    private final Date timestamp;
 
     VersionsMetadataGenerator( RepositorySystemSession session, InstallRequest request )
     {
@@ -57,6 +61,7 @@ class VersionsMetadataGenerator
     {
         versions = new LinkedHashMap<>();
         processedVersions = new LinkedHashMap<>();
+        timestamp = (Date) ConfigUtils.getObject( session, new Date(), "maven.startTime" );
 
         /*
          * NOTE: This should be considered a quirk to support interop with Maven's legacy ArtifactDeployer which
@@ -96,7 +101,7 @@ class VersionsMetadataGenerator
                 VersionsMetadata versionsMetadata = versions.get( key );
                 if ( versionsMetadata == null )
                 {
-                    versionsMetadata = new VersionsMetadata( artifact );
+                    versionsMetadata = new VersionsMetadata( artifact, timestamp );
                     versions.put( key, versionsMetadata );
                 }
             }

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RemoteSnapshotMetadataTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RemoteSnapshotMetadataTest.java
@@ -66,7 +66,7 @@ public class RemoteSnapshotMetadataTest
         String dateBefore = gregorianDate();
 
         RemoteSnapshotMetadata metadata = new RemoteSnapshotMetadata(
-                new DefaultArtifact( "a:b:1-SNAPSHOT" ), false);
+                new DefaultArtifact( "a:b:1-SNAPSHOT" ), false, new Date() );
         metadata.merge( new Metadata() );
 
         String dateAfter = gregorianDate();


### PR DESCRIPTION
Reuse `MavenExecutionRequest#getStartTime()` for expanded snapshot
versions when deploying to a remote repository throughout the entire
reactor for all modules.

This closes #381