### PR TITLE
[MNG-6968] Updated Apache Maven Site Plugin version

### DIFF
--- a/maven-core/src/main/resources/META-INF/plexus/components.xml
+++ b/maven-core/src/main/resources/META-INF/plexus/components.xml
@@ -101,10 +101,10 @@ under the License.
         </phases>
         <default-phases>
           <site>
-            org.apache.maven.plugins:maven-site-plugin:3.3:site
+            org.apache.maven.plugins:maven-site-plugin:3.9.1:site
           </site>
           <site-deploy>
-            org.apache.maven.plugins:maven-site-plugin:3.3:deploy
+            org.apache.maven.plugins:maven-site-plugin:3.9.1:deploy
           </site-deploy>
         </default-phases>
         <!-- END SNIPPET: site -->


### PR DESCRIPTION
Previous version change [commit](https://github.com/apache/maven/commit/4ec06bf67cc6bdffa026f46c5836e3bc895865ed).

Reason:
[Why does maven-site-plugin always use version 3.3](https://stackoverflow.com/questions/51103120/why-does-maven-site-plugin-always-use-version-3-3) question on StackOverflow reached 2k views.


