### PR TITLE
[MNG-6268] When a reactor build fails Maven should include -f (if used) in command line suggestion

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1030,9 +1030,15 @@ public class MavenCli
                 }
             }
 
+            String altPomFileArg = "";
+            if ( cliRequest.commandLine.hasOption( CLIManager.ALTERNATE_POM_FILE ) )
+            {
+                String alternatePomFile = cliRequest.commandLine.getOptionValue( CLIManager.ALTERNATE_POM_FILE );
+                altPomFileArg = "-f " + alternatePomFile + " ";
+            }
             if ( result.canResume() )
             {
-                logBuildResumeHint( "mvn <args> -r" );
+                logBuildResumeHint( "mvn " + altPomFileArg + "<args> -r" );
             }
             else if ( !failedProjects.isEmpty() )
             {
@@ -1045,7 +1051,7 @@ public class MavenCli
                 if ( !firstFailedProject.equals( sortedProjects.get( 0 ) ) )
                 {
                     String resumeFromSelector = getResumeFromSelector( sortedProjects, firstFailedProject );
-                    logBuildResumeHint( "mvn <args> -rf " + resumeFromSelector );
+                    logBuildResumeHint( "mvn " + altPomFileArg + "<args> -rf " + resumeFromSelector );
                 }
             }
 


### PR DESCRIPTION
I don't know whether this should be included, but it is trivial to provide. I will let the community decide. If accepted someone should write an IT for that.