### PR TITLE
[MNG-7035] Migrate all tests to JUnit 4

### DIFF
--- a/apache-maven/src/test/java/org/apache/maven/settings/GlobalSettingsTest.java
+++ b/apache-maven/src/test/java/org/apache/maven/settings/GlobalSettingsTest.java
@@ -19,14 +19,16 @@ package org.apache.maven.settings;
  * under the License.
  */
 
-import junit.framework.TestCase;
-import org.apache.maven.settings.io.xpp3.SettingsXpp3Reader;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+
+import org.apache.maven.settings.io.xpp3.SettingsXpp3Reader;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests that the global settings.xml shipped with the distribution is in good state.
@@ -34,9 +36,9 @@ import java.nio.charset.StandardCharsets;
  * @author Benjamin Bentmann
  */
 public class GlobalSettingsTest
-    extends TestCase
 {
 
+    @Test
     public void testValidGlobalSettings()
         throws Exception
     {

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/ArtifactUtilsTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/ArtifactUtilsTest.java
@@ -24,8 +24,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests {@link ArtifactUtils}.
@@ -33,7 +35,6 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ArtifactUtilsTest
-    extends TestCase
 {
 
     private Artifact newArtifact( String aid )
@@ -41,6 +42,7 @@ public class ArtifactUtilsTest
         return new DefaultArtifact( "group", aid, VersionRange.createFromVersion( "1.0" ), "test", "jar", "tests", null );
     }
 
+    @Test
     public void testIsSnapshot()
     {
         assertEquals( false, ArtifactUtils.isSnapshot( null ) );
@@ -52,6 +54,7 @@ public class ArtifactUtilsTest
         assertEquals( false, ArtifactUtils.isSnapshot( "1.2.3-20090413X094722-2"));
     }
 
+    @Test
     public void testToSnapshotVersion()
     {
         assertEquals( "1.2.3", ArtifactUtils.toSnapshotVersion( "1.2.3" ) );
@@ -63,6 +66,7 @@ public class ArtifactUtilsTest
     /**
      * Tests that the ordering of the map resembles the ordering of the input collection of artifacts.
      */
+    @Test
     public void testArtifactMapByVersionlessIdOrdering()
         throws Exception
     {

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/DefaultArtifactTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/DefaultArtifactTest.java
@@ -19,13 +19,15 @@ package org.apache.maven.artifact;
  * under the License.
  */
 
-import junit.framework.TestCase;
-
 import org.apache.maven.artifact.handler.ArtifactHandlerMock;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultArtifactTest
-    extends TestCase
 {
 
     private DefaultArtifact artifact;
@@ -43,10 +45,10 @@ public class DefaultArtifactTest
 
     private ArtifactHandlerMock artifactHandler;
 
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
         artifactHandler = new ArtifactHandlerMock();
         versionRange = VersionRange.createFromVersion( version );
         artifact = new DefaultArtifact( groupId, artifactId, versionRange, scope, type, classifier, artifactHandler );
@@ -55,6 +57,7 @@ public class DefaultArtifactTest
         snapshotArtifact = new DefaultArtifact( groupId, artifactId, snapshotVersionRange, scope, type, classifier, artifactHandler );
     }
 
+    @Test
     public void testGetVersionReturnsResolvedVersionOnSnapshot()
     {
         assertEquals( snapshotResolvedVersion, snapshotArtifact.getVersion() );
@@ -65,53 +68,62 @@ public class DefaultArtifactTest
         assertEquals( snapshotSpecVersion, snapshotArtifact.getBaseVersion() );
     }
 
+    @Test
     public void testGetDependencyConflictId()
     {
         assertEquals( groupId + ":" + artifactId + ":" + type + ":" + classifier, artifact.getDependencyConflictId() );
     }
 
+    @Test
     public void testGetDependencyConflictIdNullGroupId()
     {
         artifact.setGroupId( null );
         assertEquals( null + ":" + artifactId + ":" + type + ":" + classifier, artifact.getDependencyConflictId() );
     }
 
+    @Test
     public void testGetDependencyConflictIdNullClassifier()
     {
         artifact = new DefaultArtifact( groupId, artifactId, versionRange, scope, type, null, artifactHandler );
         assertEquals( groupId + ":" + artifactId + ":" + type, artifact.getDependencyConflictId() );
     }
 
+    @Test
     public void testGetDependencyConflictIdNullScope()
     {
         artifact.setScope( null );
         assertEquals( groupId + ":" + artifactId + ":" + type + ":" + classifier, artifact.getDependencyConflictId() );
     }
 
+    @Test
     public void testToString()
     {
         assertEquals( groupId + ":" + artifactId + ":" + type + ":" + classifier + ":" + version + ":" + scope,
                       artifact.toString() );
     }
 
+    @Test
     public void testToStringNullGroupId()
     {
         artifact.setGroupId( null );
         assertEquals( artifactId + ":" + type + ":" + classifier + ":" + version + ":" + scope, artifact.toString() );
     }
 
+    @Test
     public void testToStringNullClassifier()
     {
         artifact = new DefaultArtifact( groupId, artifactId, versionRange, scope, type, null, artifactHandler );
         assertEquals( groupId + ":" + artifactId + ":" + type + ":" + version + ":" + scope, artifact.toString() );
     }
 
+    @Test
     public void testToStringNullScope()
     {
         artifact.setScope( null );
         assertEquals( groupId + ":" + artifactId + ":" + type + ":" + classifier + ":" + version, artifact.toString() );
     }
 
+    @Test
     public void testComparisonByVersion()
     {
         Artifact artifact1 = new DefaultArtifact( groupId, artifactId, VersionRange.createFromVersion( "5.0" ), scope,
@@ -128,6 +140,7 @@ public class DefaultArtifactTest
         assertTrue( artifact1.compareTo( artifact ) == 0 );
     }
 
+    @Test
     public void testNonResolvedVersionRangeConsistentlyYieldsNullVersions()
         throws Exception
     {

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionIT.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionIT.java
@@ -19,9 +19,6 @@ package org.apache.maven.artifact.versioning;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -32,6 +29,9 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ComparableVersionIT
 {

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionIT.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionIT.java
@@ -20,6 +20,7 @@ package org.apache.maven.artifact.versioning;
  */
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +32,6 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class ComparableVersionIT
 {
@@ -64,7 +64,7 @@ public class ComparableVersionIT
                     }
                     catch ( InterruptedException e )
                     {
-                        fail( e.getMessage() );
+                        throw new InterruptedIOException( e.toString() );
                     }
                     return FileVisitResult.TERMINATE;
                 }

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -21,7 +21,10 @@ package org.apache.maven.artifact.versioning;
 
 import java.util.Locale;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test ComparableVersion.
@@ -30,7 +33,6 @@ import junit.framework.TestCase;
  */
 @SuppressWarnings( "unchecked" )
 public class ComparableVersionTest
-    extends TestCase
 {
     private Comparable newComparable( String version )
     {
@@ -101,16 +103,19 @@ public class ComparableVersionTest
         assertTrue( "expected " + v2 + " > " + v1, c2.compareTo( c1 ) > 0 );
     }
 
+    @Test
     public void testVersionsQualifier()
     {
         checkVersionsOrder( VERSIONS_QUALIFIER );
     }
 
+    @Test
     public void testVersionsNumber()
     {
         checkVersionsOrder( VERSIONS_NUMBER );
     }
 
+    @Test
     public void testVersionsEqual()
     {
         newComparable( "1.0-alpha" );
@@ -164,6 +169,7 @@ public class ComparableVersionTest
         checkVersionsEqual( "1m3", "1MILESTONE3" );
     }
 
+    @Test
     public void testVersionComparing()
     {
         checkVersionsOrder( "1", "2" );
@@ -202,6 +208,7 @@ public class ComparableVersionTest
      * see Netbeans issues <a href="https://netbeans.org/bugzilla/show_bug.cgi?id=240845">240845</a> and
      * <a href="https://netbeans.org/bugzilla/show_bug.cgi?id=226100">226100</a>
      */
+    @Test
     public void testMng5568()
     {
         String a = "6.1.0";
@@ -216,6 +223,7 @@ public class ComparableVersionTest
     /**
      * Test <a href="https://jira.apache.org/jira/browse/MNG-6572">MNG-6572</a> optimization.
      */
+    @Test
     public void testMng6572()
     {
         String a = "20190126.230843"; // resembles a SNAPSHOT
@@ -235,6 +243,7 @@ public class ComparableVersionTest
      * Test all versions are equal when starting with many leading zeroes regardless of string length
      * (related to MNG-6572 optimization)
      */
+    @Test
     public void testVersionEqualWithLeadingZeroes()
     {
         // versions with string lengths from 1 to 19
@@ -267,6 +276,7 @@ public class ComparableVersionTest
      * Test all "0" versions are equal when starting with many leading zeroes regardless of string length
      * (related to MNG-6572 optimization)
      */
+    @Test
     public void testVersionZeroEqualWithLeadingZeroes()
     {
         // versions with string lengths from 1 to 19
@@ -299,6 +309,7 @@ public class ComparableVersionTest
      * Test <a href="https://issues.apache.org/jira/browse/MNG-6964">MNG-6964</a> edge cases
      * for qualifiers that start with "-0.", which was showing A == C and B == C but A &lt; B.
      */
+    @Test
     public void testMng6964()
     {
         String a = "1-0.alpha";
@@ -310,6 +321,7 @@ public class ComparableVersionTest
         checkVersionsOrder( a, b ); // Should still be true
     }
 
+    @Test
     public void testLocaleIndependent()
     {
         Locale orig = Locale.getDefault();
@@ -328,6 +340,7 @@ public class ComparableVersionTest
         }
     }
 
+    @Test
     public void testReuse()
     {
         ComparableVersion c1 = new ComparableVersion( "1" );

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/DefaultArtifactVersionTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/DefaultArtifactVersionTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.artifact.versioning;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test DefaultArtifactVersion.
@@ -27,7 +31,6 @@ import junit.framework.TestCase;
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  */
 public class DefaultArtifactVersionTest
-    extends TestCase
 {
     private ArtifactVersion newArtifactVersion( String version )
     {
@@ -50,6 +53,7 @@ public class DefaultArtifactVersionTest
         assertEquals( "check " + version + " string value", version, artifactVersion.toString() );
     }
 
+    @Test
     public void testVersionParsing()
     {
         checkVersionParsing( "1", 1, 0, 0, 0, null );
@@ -87,6 +91,7 @@ public class DefaultArtifactVersionTest
         checkVersionParsing( "1.2.3-200705301630", 1, 2, 3, 0, "200705301630" );
     }
 
+    @Test
     public void testVersionComparing()
     {
         assertVersionEqual( "1", "1" );
@@ -134,6 +139,7 @@ public class DefaultArtifactVersionTest
         assertVersionOlder( "2.0.0.v200706041905-7C78EK9E_EkMNfNOd2d8qq", "2.0.0.v200706041906-7C78EK9E_EkMNfNOd2d8qq" );
     }
 
+    @Test
     public void testVersionSnapshotComparing()
     {
         assertVersionEqual( "1-SNAPSHOT", "1-SNAPSHOT" );
@@ -168,6 +174,7 @@ public class DefaultArtifactVersionTest
         assertVersionOlder( "2.0.1-xyz-SNAPSHOT", "2.0.1-123-SNAPSHOT" );
     }
 
+    @Test
     public void testSnapshotVsReleases()
     {
         assertVersionOlder( "1.0-RC1", "1.0-SNAPSHOT" );
@@ -175,6 +182,7 @@ public class DefaultArtifactVersionTest
         assertVersionOlder( "1.0-rc-1", "1.0-SNAPSHOT" );
     }
 
+    @Test
     public void testHashCode()
     {
         ArtifactVersion v1 = newArtifactVersion( "1" );
@@ -183,16 +191,19 @@ public class DefaultArtifactVersionTest
         assertEquals( v1.hashCode(), v2.hashCode() );
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( newArtifactVersion( "1" ).equals( null ) );
     }
 
+    @Test
     public void testEqualsTypeSafe()
     {
         assertFalse( newArtifactVersion( "1" ).equals( "non-an-artifact-version-instance" ) );
     }
 
+    @Test
     public void testNonNumericVersionRepresentationReturnsANumberFormatException()
     {
         try

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
@@ -21,9 +21,15 @@ package org.apache.maven.artifact.versioning;
 
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.apache.maven.artifact.Artifact;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests version range construction.
@@ -31,7 +37,6 @@ import org.apache.maven.artifact.Artifact;
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  */
 public class VersionRangeTest
-    extends TestCase
 {
     private static final String CHECK_NUM_RESTRICTIONS = "check number of restrictions";
 
@@ -49,6 +54,7 @@ public class VersionRangeTest
 
     private static final String CHECK_SELECTED_VERSION = "check selected version";
 
+    @Test
     public void testRange()
         throws InvalidVersionSpecificationException, OverConstrainedVersionException
     {
@@ -154,6 +160,7 @@ public class VersionRangeTest
         assertTrue( range.containsVersion( new DefaultArtifactVersion( "5.0.9.0" ) ) );
     }
 
+    @Test
     public void testInvalidRanges()
     {
         checkInvalidRange( "(1.0)" );
@@ -172,6 +179,7 @@ public class VersionRangeTest
         checkInvalidRange( "(1.1,1.2],[1.0,1.1)" );
     }
 
+    @Test
     public void testIntersections()
         throws InvalidVersionSpecificationException
     {
@@ -654,6 +662,7 @@ public class VersionRangeTest
         assertEquals( CHECK_NUM_RESTRICTIONS, 0, restrictions.size() );
     }
 
+    @Test
     public void testReleaseRangeBoundsContainsSnapshots()
         throws InvalidVersionSpecificationException
     {
@@ -664,6 +673,7 @@ public class VersionRangeTest
         assertFalse( range.containsVersion( new DefaultArtifactVersion( "1.0-SNAPSHOT" ) ) );
     }
 
+    @Test
     public void testSnapshotRangeBoundsCanContainSnapshots()
         throws InvalidVersionSpecificationException
     {
@@ -678,6 +688,7 @@ public class VersionRangeTest
         assertTrue( range.containsVersion( new DefaultArtifactVersion( "1.1-SNAPSHOT" ) ) );
     }
 
+    @Test
     public void testSnapshotSoftVersionCanContainSnapshot()
         throws InvalidVersionSpecificationException
     {
@@ -699,6 +710,7 @@ public class VersionRangeTest
         }
     }
 
+    @Test
     public void testContains() throws InvalidVersionSpecificationException
     {
         ArtifactVersion actualVersion = new DefaultArtifactVersion( "2.0.5" );
@@ -723,11 +735,13 @@ public class VersionRangeTest
         return vr.containsVersion( actualVersion );
     }
 
+    @Test
     public void testOrder0()
     {
         // assertTrue( new DefaultArtifactVersion( "1.0-alpha10" ).compareTo( new DefaultArtifactVersion( "1.0-alpha1" ) ) > 0 );
     }
 
+    @Test
     public void testCache()
         throws InvalidVersionSpecificationException
     {

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Tests version range construction.
@@ -699,15 +699,9 @@ public class VersionRangeTest
 
     private void checkInvalidRange( String version )
     {
-        try
-        {
-            VersionRange.createFromVersionSpec( version );
-            fail( "Version " + version + " should have failed to construct" );
-        }
-        catch ( InvalidVersionSpecificationException expected )
-        {
-            // expected
-        }
+        assertThrows( "Version " + version + " should have failed to construct",
+                InvalidVersionSpecificationException.class,
+                () -> VersionRange.createFromVersionSpec( version ) );
     }
 
     @Test

--- a/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemCollectorTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemCollectorTest.java
@@ -19,10 +19,11 @@ package org.apache.maven.building;
  * under the License.
  */
 
-import static org.junit.Assert.*;
-
 import org.apache.maven.building.Problem.Severity;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class DefaultProblemCollectorTest
 {

--- a/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemTest.java
@@ -19,11 +19,11 @@ package org.apache.maven.building;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-
 import org.apache.maven.building.Problem.Severity;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class DefaultProblemTest
 {

--- a/maven-builder-support/src/test/java/org/apache/maven/building/FileSourceTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/FileSourceTest.java
@@ -19,11 +19,11 @@ package org.apache.maven.building;
  * under the License.
  */
 
-import org.junit.Test;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.Scanner;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/maven-builder-support/src/test/java/org/apache/maven/building/FileSourceTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/FileSourceTest.java
@@ -26,7 +26,7 @@ import java.util.Scanner;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class FileSourceTest
 {
@@ -34,15 +34,10 @@ public class FileSourceTest
     @Test
     public void testFileSource()
     {
-        try
-        {
-            new FileSource( null );
-            fail( "Should fail, since you must specify a file" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "file cannot be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( "Should fail, since you must specify a file",
+                NullPointerException.class,
+                () -> new FileSource( null ) );
+        assertEquals( "file cannot be null", e.getMessage() );
     }
 
     @Test

--- a/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
@@ -19,12 +19,12 @@ package org.apache.maven.building;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-
 import java.util.Collections;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 public class ProblemCollectorFactoryTest
 {

--- a/maven-builder-support/src/test/java/org/apache/maven/building/StringSourceTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/StringSourceTest.java
@@ -19,10 +19,10 @@ package org.apache.maven.building;
  * under the License.
  */
 
-import org.junit.Test;
-
 import java.io.InputStream;
 import java.util.Scanner;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 

--- a/maven-builder-support/src/test/java/org/apache/maven/building/UrlSourceTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/UrlSourceTest.java
@@ -19,12 +19,12 @@ package org.apache.maven.building;
  * under the License.
  */
 
-import org.junit.Test;
-
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Scanner;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/maven-builder-support/src/test/java/org/apache/maven/building/UrlSourceTest.java
+++ b/maven-builder-support/src/test/java/org/apache/maven/building/UrlSourceTest.java
@@ -27,7 +27,7 @@ import java.util.Scanner;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class UrlSourceTest
 {
@@ -35,15 +35,10 @@ public class UrlSourceTest
     @Test
     public void testUrlSource()
     {
-        try
-        {
-            new UrlSource( null );
-            fail( "Should fail, since you must specify a url" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "url cannot be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( "Should fail, since you must specify a url",
+                NullPointerException.class,
+                () -> new UrlSource( null ) );
+        assertEquals( "url cannot be null", e.getMessage() );
     }
 
     @Test

--- a/maven-compat/src/test/java/org/apache/maven/PlexusTestCase.java
+++ b/maven-compat/src/test/java/org/apache/maven/PlexusTestCase.java
@@ -1,0 +1,317 @@
+package org.apache.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright 2001-2006 Codehaus Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.context.DefaultContext;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * This is a slightly modified version of the original plexus class
+ * available at https://raw.githubusercontent.com/codehaus-plexus/plexus-containers/master/plexus-container-default/src/main/java/org/codehaus/plexus/PlexusTestCase.java
+ * in order to migrate the tests to JUnit 4.
+ *
+ * @author Jason van Zyl
+ * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
+ * @author <a href="mailto:michal@codehaus.org">Michal Maczka</a>
+ * @author Guillaume Nodet
+ */
+public abstract class PlexusTestCase
+{
+    private PlexusContainer container;
+
+    private static String basedir;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        basedir = getBasedir();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    protected void setupContainer()
+    {
+        // ----------------------------------------------------------------------------
+        // Context Setup
+        // ----------------------------------------------------------------------------
+
+        DefaultContext context = new DefaultContext();
+
+        context.put( "basedir", getBasedir() );
+
+        customizeContext( context );
+
+        boolean hasPlexusHome = context.contains( "plexus.home" );
+
+        if ( !hasPlexusHome )
+        {
+            File f = getTestFile( "target/plexus-home" );
+
+            if ( !f.isDirectory() )
+            {
+                f.mkdir();
+            }
+
+            context.put( "plexus.home", f.getAbsolutePath() );
+        }
+
+        // ----------------------------------------------------------------------------
+        // Configuration
+        // ----------------------------------------------------------------------------
+
+        String config = getCustomConfigurationName();
+
+        ContainerConfiguration containerConfiguration = new DefaultContainerConfiguration()
+                .setName( "test" )
+                .setContext( context.getContextData() );
+
+        if ( config != null )
+        {
+            containerConfiguration.setContainerConfiguration( config );
+        }
+        else
+        {
+            String resource = getConfigurationName( null );
+
+            containerConfiguration.setContainerConfiguration( resource );
+        }
+
+        customizeContainerConfiguration( containerConfiguration );
+
+        try
+        {
+            container = new DefaultPlexusContainer( containerConfiguration );
+        }
+        catch ( PlexusContainerException e )
+        {
+            throw new IllegalArgumentException( "Failed to create plexus container.", e );
+        }
+    }
+
+    /**
+     * Allow custom test case implementations do augment the default container configuration before
+     * executing tests.
+     *
+     * @param containerConfiguration {@link ContainerConfiguration}.
+     */
+    protected void customizeContainerConfiguration( ContainerConfiguration containerConfiguration )
+    {
+    }
+
+    protected void customizeContext( Context context )
+    {
+    }
+
+    protected PlexusConfiguration customizeComponentConfiguration()
+    {
+        return null;
+    }
+
+    @After
+    public void tearDown()
+            throws Exception
+    {
+        if ( container != null )
+        {
+            container.dispose();
+
+            container = null;
+        }
+    }
+
+    protected PlexusContainer getContainer()
+    {
+        if ( container == null )
+        {
+            setupContainer();
+        }
+
+        return container;
+    }
+
+    protected InputStream getConfiguration()
+            throws Exception
+    {
+        return getConfiguration( null );
+    }
+
+    protected InputStream getConfiguration( String subname )
+            throws Exception
+    {
+        return getResourceAsStream( getConfigurationName( subname ) );
+    }
+
+    protected String getCustomConfigurationName()
+    {
+        return null;
+    }
+
+    /**
+     * Allow the retrieval of a container configuration that is based on the name
+     * of the test class being run. So if you have a test class called org.foo.FunTest, then
+     * this will produce a resource name of org/foo/FunTest.xml which would be used to
+     * configure the Plexus container before running your test.
+     *
+     * @param subname the subname
+     * @return A configruation name
+     */
+    protected String getConfigurationName( String subname )
+    {
+        return getClass().getName().replace( '.', '/' ) + ".xml";
+    }
+
+    protected InputStream getResourceAsStream( String resource )
+    {
+        return getClass().getResourceAsStream( resource );
+    }
+
+    protected ClassLoader getClassLoader()
+    {
+        return getClass().getClassLoader();
+    }
+
+    // ----------------------------------------------------------------------
+    // Container access
+    // ----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    protected <T> T lookup( String componentKey )
+            throws ComponentLookupException
+    {
+        return (T) getContainer().lookup( componentKey );
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T lookup( String role,
+                            String roleHint )
+            throws ComponentLookupException
+    {
+        return (T) getContainer().lookup( role, roleHint );
+    }
+
+    protected <T> T lookup( Class<T> componentClass )
+            throws ComponentLookupException
+    {
+        return getContainer().lookup( componentClass );
+    }
+
+    protected <T> T lookup( Class<T> componentClass, String roleHint )
+            throws ComponentLookupException
+    {
+        return getContainer().lookup( componentClass, roleHint );
+    }
+
+    protected void release( Object component )
+            throws ComponentLifecycleException
+    {
+        getContainer().release( component );
+    }
+
+    // ----------------------------------------------------------------------
+    // Helper methods for sub classes
+    // ----------------------------------------------------------------------
+
+    public static File getTestFile( String path )
+    {
+        return new File( getBasedir(), path );
+    }
+
+    public static File getTestFile( String basedir,
+                                    String path )
+    {
+        File basedirFile = new File( basedir );
+
+        if ( !basedirFile.isAbsolute() )
+        {
+            basedirFile = getTestFile( basedir );
+        }
+
+        return new File( basedirFile, path );
+    }
+
+    public static String getTestPath( String path )
+    {
+        return getTestFile( path ).getAbsolutePath();
+    }
+
+    public static String getTestPath( String basedir,
+                                      String path )
+    {
+        return getTestFile( basedir, path ).getAbsolutePath();
+    }
+
+    public static String getBasedir()
+    {
+        if ( basedir != null )
+        {
+            return basedir;
+        }
+
+        basedir = System.getProperty( "basedir" );
+
+        if ( basedir == null )
+        {
+            basedir = new File( "" ).getAbsolutePath();
+        }
+
+        return basedir;
+    }
+
+    public String getTestConfiguration()
+    {
+        return getTestConfiguration( getClass() );
+    }
+
+    public static String getTestConfiguration( Class<?> clazz )
+    {
+        String s = clazz.getName().replace( '.', '/' );
+
+        return s.substring( 0, s.indexOf( "$" ) ) + ".xml";
+    }
+}

--- a/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
@@ -70,7 +70,8 @@ import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
 import org.junit.After;
 import org.junit.Before;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:jason@maven.org">Jason van Zyl </a>
@@ -198,10 +199,7 @@ public abstract class AbstractArtifactComponentTestCase
 
         File file = new File( remoteRepo.getBasedir(), path );
 
-        if ( !file.exists() )
-        {
-            fail( "Remote artifact " + file + " should be present." );
-        }
+        assertTrue( "Remote artifact " + file + " should be present.", file.exists() );
     }
 
     protected void assertLocalArtifactPresent( Artifact artifact )
@@ -213,10 +211,7 @@ public abstract class AbstractArtifactComponentTestCase
 
         File file = new File( localRepo.getBasedir(), path );
 
-        if ( !file.exists() )
-        {
-            fail( "Local artifact " + file + " should be present." );
-        }
+        assertTrue( "Local artifact " + file + " should be present.", file.exists() );
     }
 
     protected void assertRemoteArtifactNotPresent( Artifact artifact )
@@ -228,10 +223,7 @@ public abstract class AbstractArtifactComponentTestCase
 
         File file = new File( remoteRepo.getBasedir(), path );
 
-        if ( file.exists() )
-        {
-            fail( "Remote artifact " + file + " should not be present." );
-        }
+        assertFalse( "Remote artifact " + file + " should not be present.", file.exists() );
     }
 
     protected void assertLocalArtifactNotPresent( Artifact artifact )
@@ -243,10 +235,7 @@ public abstract class AbstractArtifactComponentTestCase
 
         File file = new File( localRepo.getBasedir(), path );
 
-        if ( file.exists() )
-        {
-            fail( "Local artifact " + file + " should not be present." );
-        }
+        assertFalse( "Local artifact " + file + " should not be present.", file.exists() );
     }
 
     // ----------------------------------------------------------------------

--- a/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
@@ -19,6 +19,20 @@ package org.apache.maven.artifact;
  * under the License.
  */
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
@@ -31,7 +45,6 @@ import org.apache.maven.repository.legacy.repository.ArtifactRepositoryFactory;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
@@ -54,18 +67,10 @@ import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
 import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.eclipse.aether.util.graph.traverser.FatArtifactTraverser;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
+import org.junit.After;
+import org.junit.Before;
 
-import javax.inject.Inject;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import static org.junit.Assert.fail;
 
 /**
  * @author <a href="mailto:jason@maven.org">Jason van Zyl </a>
@@ -90,8 +95,8 @@ public abstract class AbstractArtifactComponentTestCase
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
         super.setUp();
@@ -107,8 +112,9 @@ public abstract class AbstractArtifactComponentTestCase
         legacySupport.setSession( session );
     }
 
+    @After
     @Override
-    protected void tearDown()
+    public void tearDown()
         throws Exception
     {
         release( artifactFactory );

--- a/maven-compat/src/test/java/org/apache/maven/artifact/deployer/ArtifactDeployerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/deployer/ArtifactDeployerTest.java
@@ -25,6 +25,11 @@ import org.apache.maven.artifact.AbstractArtifactComponentTestCase;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
 
@@ -37,11 +42,22 @@ public class ArtifactDeployerTest
     @Inject
     private ArtifactDeployer artifactDeployer;
 
+    @Before
+    @Override
+    public void setUp()
+        throws Exception
+    {
+        super.setUp();
+
+        artifactDeployer = (ArtifactDeployer) lookup( ArtifactDeployer.ROLE );
+    }
+
     protected String component()
     {
         return "deployer";
     }
 
+    @Test
     public void testArtifactInstallation()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/artifact/factory/DefaultArtifactFactoryTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/factory/DefaultArtifactFactoryTest.java
@@ -19,19 +19,19 @@ package org.apache.maven.artifact.factory;
  * under the License.
  */
 
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.execution.DefaultMavenExecutionRequest;
-import org.apache.maven.execution.DefaultMavenExecutionResult;
-import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
-import org.eclipse.aether.RepositorySystemSession;
+import org.junit.Test;
 
-import javax.inject.Inject;
-import java.util.Collections;
+import static org.junit.Assert.assertEquals;
 
 public class DefaultArtifactFactoryTest
     extends PlexusTestCase
@@ -49,7 +49,7 @@ public class DefaultArtifactFactoryTest
     }
 
     @Override
-    protected void setUp()
+    public void setUp()
             throws Exception
     {
         super.setUp();
@@ -59,6 +59,7 @@ public class DefaultArtifactFactoryTest
                         binder ->  binder.requestInjection( this ) );
     }
 
+    @Test
     public void testPropagationOfSystemScopeRegardlessOfInheritedScope()
     {
         Artifact artifact = factory.createDependencyArtifact( "test-grp", "test-artifact", VersionRange.createFromVersion("1.0"), "type", null, "system", "provided" );

--- a/maven-compat/src/test/java/org/apache/maven/artifact/installer/ArtifactInstallerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/installer/ArtifactInstallerTest.java
@@ -23,6 +23,8 @@ import java.io.File;
 
 import org.apache.maven.artifact.AbstractArtifactComponentTestCase;
 import org.apache.maven.artifact.Artifact;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.inject.Inject;
 
@@ -35,11 +37,22 @@ public class ArtifactInstallerTest
     @Inject
     private ArtifactInstaller artifactInstaller;
 
+    @Before
+    @Override
+    public void setUp()
+        throws Exception
+    {
+        super.setUp();
+
+        artifactInstaller = (ArtifactInstaller) lookup( ArtifactInstaller.ROLE );
+    }
+
     protected String component()
     {
         return "installer";
     }
 
+    @Test
     public void testArtifactInstallation()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/artifact/repository/MavenArtifactRepositoryTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/repository/MavenArtifactRepositoryTest.java
@@ -20,10 +20,12 @@ package org.apache.maven.artifact.repository;
  */
 
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MavenArtifactRepositoryTest
-    extends TestCase
 {
     private static class MavenArtifactRepositorySubclass extends MavenArtifactRepository
     {
@@ -41,6 +43,7 @@ public class MavenArtifactRepositoryTest
         }
     }
 
+    @Test
     public void testHashCodeEquals()
     {
         MavenArtifactRepositorySubclass r1 = new MavenArtifactRepositorySubclass( "foo" );

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolutionExceptionTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolutionExceptionTest.java
@@ -22,7 +22,9 @@ package org.apache.maven.artifact.resolver;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test the artifact resolution exception message
@@ -30,10 +32,10 @@ import junit.framework.TestCase;
  * @author Mauro Talevi
  */
 public class ArtifactResolutionExceptionTest
-    extends TestCase
 {
     private static final String LS = System.lineSeparator();
 
+    @Test
     public void testMissingArtifactMessageFormat()
     {
         String message = "Missing artifact";

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolverTest.java
@@ -40,8 +40,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 
@@ -170,15 +170,9 @@ public class ArtifactResolverTest
     {
         Artifact k = createArtifact( "k", "1.0" );
 
-        try
-        {
-            artifactResolver.resolve( k, remoteRepositories(), localRepository() );
-            fail( "Resolution succeeded when it should have failed" );
-        }
-        catch ( ArtifactNotFoundException expected )
-        {
-            assertTrue( true );
-        }
+        assertThrows( "Resolution succeeded when it should have failed",
+                ArtifactNotFoundException.class,
+                () -> artifactResolver.resolve( k, remoteRepositories(), localRepository() ) );
     }
 
     @Test

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolverTest.java
@@ -35,6 +35,13 @@ import org.apache.maven.artifact.metadata.ResolutionGroup;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.repository.legacy.metadata.MetadataResolutionRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 
@@ -55,8 +62,9 @@ public class ArtifactResolverTest
 
     private Artifact projectArtifact;
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();
@@ -64,8 +72,9 @@ public class ArtifactResolverTest
         projectArtifact = createLocalArtifact( "project", "3.0" );
     }
 
+    @After
     @Override
-    protected void tearDown()
+    public void tearDown()
         throws Exception
     {
         projectArtifact = null;
@@ -78,6 +87,7 @@ public class ArtifactResolverTest
         return "resolver";
     }
 
+    @Test
     public void testResolutionOfASingleArtifactWhereTheArtifactIsPresentInTheLocalRepository()
         throws Exception
     {
@@ -88,6 +98,7 @@ public class ArtifactResolverTest
         assertLocalArtifactPresent( a );
     }
 
+    @Test
     public void testResolutionOfASingleArtifactWhereTheArtifactIsNotPresentLocallyAndMustBeRetrievedFromTheRemoteRepository()
         throws Exception
     {
@@ -105,6 +116,7 @@ public class ArtifactResolverTest
         return super.createArtifact( groupId, artifactId, version, type );
     }
 
+    @Test
     public void testTransitiveResolutionWhereAllArtifactsArePresentInTheLocalRepository()
         throws Exception
     {
@@ -127,6 +139,7 @@ public class ArtifactResolverTest
         assertLocalArtifactPresent( h );
     }
 
+    @Test
     public void testTransitiveResolutionWhereAllArtifactsAreNotPresentInTheLocalRepositoryAndMustBeRetrievedFromTheRemoteRepository()
         throws Exception
     {
@@ -151,6 +164,7 @@ public class ArtifactResolverTest
         assertLocalArtifactPresent( j );
     }
 
+    @Test
     public void testResolutionFailureWhenArtifactNotPresentInRemoteRepository()
         throws Exception
     {
@@ -167,6 +181,7 @@ public class ArtifactResolverTest
         }
     }
 
+    @Test
     public void testResolutionOfAnArtifactWhereOneRemoteRepositoryIsBadButOneIsGood()
         throws Exception
     {
@@ -182,6 +197,7 @@ public class ArtifactResolverTest
         assertLocalArtifactPresent( l );
     }
 
+    @Test
     public void testTransitiveResolutionOrder()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/DefaultArtifactResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/DefaultArtifactResolverTest.java
@@ -24,6 +24,11 @@ import java.util.Collections;
 import org.apache.maven.artifact.AbstractArtifactComponentTestCase;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.DefaultArtifactResolver.DaemonThreadCreator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
 
@@ -35,16 +40,18 @@ public class DefaultArtifactResolverTest
 
     private Artifact projectArtifact;
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();
         projectArtifact = createLocalArtifact( "project", "3.0" );
     }
 
+    @After
     @Override
-    protected void tearDown()
+    public void tearDown()
         throws Exception
     {
         projectArtifact = null;
@@ -57,6 +64,7 @@ public class DefaultArtifactResolverTest
         return "resolver";
     }
 
+    @Test
     public void testMNG4738()
         throws Exception
     {
@@ -102,6 +110,7 @@ public class DefaultArtifactResolverTest
         assertTrue( "Could not find ThreadGroup: " + DaemonThreadCreator.THREADGROUP_NAME, seen );
     }
 
+    @Test
     public void testLookup()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/AndArtifactFilterTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/AndArtifactFilterTest.java
@@ -21,7 +21,11 @@ package org.apache.maven.artifact.resolver.filter;
 
 import java.util.Arrays;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link AndArtifactFilter}.
@@ -29,7 +33,6 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class AndArtifactFilterTest
-    extends TestCase
 {
 
     private ArtifactFilter newSubFilter()
@@ -37,6 +40,7 @@ public class AndArtifactFilterTest
         return artifact -> false;
     }
 
+    @Test
     public void testEquals()
     {
         AndArtifactFilter filter1 = new AndArtifactFilter();

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/FilterHashEqualsTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/FilterHashEqualsTest.java
@@ -22,15 +22,17 @@ package org.apache.maven.artifact.resolver.filter;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Igor Fedorenko
  */
 public class FilterHashEqualsTest
-    extends TestCase
 {
 
+    @Test
     public void testIncludesExcludesArtifactFilter()
     {
         List<String> patterns = Arrays.asList( "c", "d", "e" );

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/OrArtifactFilterTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/OrArtifactFilterTest.java
@@ -21,7 +21,11 @@ package org.apache.maven.artifact.resolver.filter;
 
 import java.util.Arrays;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link OrArtifactFilter}.
@@ -29,7 +33,6 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class OrArtifactFilterTest
-    extends TestCase
 {
 
     private ArtifactFilter newSubFilter()
@@ -37,6 +40,7 @@ public class OrArtifactFilterTest
         return artifact -> false;
     }
 
+    @Test
     public void testEquals()
     {
         OrArtifactFilter filter1 = new OrArtifactFilter();

--- a/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/ScopeArtifactFilterTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/ScopeArtifactFilterTest.java
@@ -21,8 +21,10 @@ package org.apache.maven.artifact.resolver.filter;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link ScopeArtifactFilter}.
@@ -30,7 +32,6 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ScopeArtifactFilterTest
-    extends TestCase
 {
 
     private Artifact newArtifact( String scope )
@@ -38,6 +39,7 @@ public class ScopeArtifactFilterTest
         return new DefaultArtifact( "g", "a", "1.0", scope, "jar", "", null );
     }
 
+    @Test
     public void testInclude_Compile()
     {
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_COMPILE );
@@ -49,6 +51,7 @@ public class ScopeArtifactFilterTest
         assertFalse( filter.include( newArtifact( Artifact.SCOPE_TEST ) ) );
     }
 
+    @Test
     public void testInclude_CompilePlusRuntime()
     {
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_COMPILE_PLUS_RUNTIME );
@@ -60,6 +63,7 @@ public class ScopeArtifactFilterTest
         assertFalse( filter.include( newArtifact( Artifact.SCOPE_TEST ) ) );
     }
 
+    @Test
     public void testInclude_Runtime()
     {
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_RUNTIME );
@@ -71,6 +75,7 @@ public class ScopeArtifactFilterTest
         assertFalse( filter.include( newArtifact( Artifact.SCOPE_TEST ) ) );
     }
 
+    @Test
     public void testInclude_RuntimePlusSystem()
     {
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_RUNTIME_PLUS_SYSTEM );
@@ -82,6 +87,7 @@ public class ScopeArtifactFilterTest
         assertFalse( filter.include( newArtifact( Artifact.SCOPE_TEST ) ) );
     }
 
+    @Test
     public void testInclude_Test()
     {
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_TEST );

--- a/maven-compat/src/test/java/org/apache/maven/artifact/transform/TransformationManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/transform/TransformationManagerTest.java
@@ -26,7 +26,11 @@ import org.apache.maven.repository.legacy.resolver.transform.SnapshotTransformat
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
 
@@ -46,7 +50,7 @@ public class TransformationManagerTest
     }
 
     @Override
-    protected void setUp()
+    public void setUp()
             throws Exception
     {
         super.setUp();
@@ -56,6 +60,7 @@ public class TransformationManagerTest
                         binder ->  binder.requestInjection( this ) );
     }
 
+    @Test
     public void testTransformationManager()
     {
         List<ArtifactTransformation> tms = tm.getArtifactTransformations();

--- a/maven-compat/src/test/java/org/apache/maven/profiles/manager/DefaultProfileManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/profiles/manager/DefaultProfileManagerTest.java
@@ -19,23 +19,21 @@ package org.apache.maven.profiles.manager;
  * under the License.
  */
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.maven.execution.DefaultMavenExecutionRequest;
-import org.apache.maven.execution.DefaultMavenExecutionResult;
-import org.apache.maven.execution.MavenSession;
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.ActivationProperty;
 import org.apache.maven.model.Profile;
 import org.apache.maven.profiles.DefaultProfileManager;
 import org.apache.maven.profiles.ProfileManager;
 import org.codehaus.plexus.ContainerConfiguration;
-import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
-import org.eclipse.aether.RepositorySystemSession;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class DefaultProfileManagerTest
     extends PlexusTestCase
@@ -49,6 +47,7 @@ public class DefaultProfileManagerTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    @Test
     public void testShouldActivateDefaultProfile()
         throws Exception
     {
@@ -84,6 +83,7 @@ public class DefaultProfileManagerTest
         assertEquals( "defaultActivated", ( (Profile) active.get( 0 ) ).getId() );
     }
 
+    @Test
     public void testShouldNotActivateDefaultProfile()
         throws Exception
     {
@@ -123,6 +123,7 @@ public class DefaultProfileManagerTest
     }
 
 
+    @Test
     public void testShouldNotActivateReversalOfPresentSystemProperty()
         throws Exception
     {
@@ -150,6 +151,7 @@ public class DefaultProfileManagerTest
         assertEquals( 0, active.size() );
     }
 
+    @Test
     public void testShouldOverrideAndActivateInactiveProfile()
         throws Exception
     {
@@ -180,6 +182,7 @@ public class DefaultProfileManagerTest
         assertEquals( "syspropActivated", ( (Profile) active.get( 0 ) ).getId() );
     }
 
+    @Test
     public void testShouldOverrideAndDeactivateActiveProfile()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/AbstractMavenProjectTestCase.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/AbstractMavenProjectTestCase.java
@@ -23,11 +23,11 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 
+import javax.inject.Inject;
+
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
-import org.apache.maven.execution.DefaultMavenExecutionRequest;
-import org.apache.maven.execution.DefaultMavenExecutionResult;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.repository.RepositorySystem;
@@ -35,11 +35,11 @@ import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystemSession;
+import org.junit.After;
+import org.junit.Before;
 
-import javax.inject.Inject;
+import static org.junit.Assert.fail;
 
 /**
  * @author Jason van Zyl
@@ -61,8 +61,9 @@ public abstract class AbstractMavenProjectTestCase
     }
 
     @Override
-    protected void setUp()
-            throws Exception
+    @Before
+    public void setUp()
+        throws Exception
     {
         super.setUp();
 
@@ -81,8 +82,8 @@ public abstract class AbstractMavenProjectTestCase
         }
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         projectBuilder = null;

--- a/maven-compat/src/test/java/org/apache/maven/project/ModelUtilsTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/ModelUtilsTest.java
@@ -26,8 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
@@ -36,11 +34,17 @@ import org.apache.maven.model.PluginExecution;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class ModelUtilsTest
-    extends TestCase
 {
 
+    @Test
     public void testShouldUseMainPluginDependencyVersionOverManagedDepVersion()
     {
         Plugin mgtPlugin = createPlugin( "group", "artifact", "1", Collections.EMPTY_MAP );
@@ -68,6 +72,7 @@ public class ModelUtilsTest
         return dep;
     }
 
+    @Test
     public void testShouldNotInheritPluginWithInheritanceSetToFalse()
     {
         PluginContainer parent = new PluginContainer();
@@ -108,6 +113,7 @@ public class ModelUtilsTest
      *   X -&gt; Y -&gt; A -&gt; B -&gt; C -&gt; D -&gt; E -&gt; F
      * </pre>
      */
+    @Test
     public void testShouldPreserveChildOrderingOfPluginsAfterParentMerge()
     {
         PluginContainer parent = new PluginContainer();
@@ -176,6 +182,7 @@ public class ModelUtilsTest
         return plugin;
     }
 
+    @Test
     public void testShouldInheritOnePluginWithExecution()
     {
         Plugin parent = new Plugin();
@@ -198,6 +205,7 @@ public class ModelUtilsTest
         assertEquals( 1, child.getExecutions().size() );
     }
 
+    @Test
     public void testShouldMergeInheritedPluginHavingExecutionWithLocalPlugin()
     {
         Plugin parent = new Plugin();
@@ -225,6 +233,7 @@ public class ModelUtilsTest
         assertEquals( 2, child.getExecutions().size() );
     }
 
+    @Test
     public void testShouldMergeOnePluginWithInheritExecutionWithoutDuplicatingPluginInList()
     {
         Plugin parent = new Plugin();
@@ -259,6 +268,7 @@ public class ModelUtilsTest
         assertEquals( 1, plugin.getExecutions().size() );
     }
 
+    @Test
     public void testShouldMergePluginWithDifferentExecutionFromParentWithoutDuplicatingPluginInList()
     {
         Plugin parent = new Plugin();
@@ -299,6 +309,7 @@ public class ModelUtilsTest
         assertEquals( 2, plugin.getExecutions().size() );
     }
 
+    @Test
     public void testShouldNOTMergeInheritedPluginHavingInheritEqualFalse()
     {
         Plugin parent = new Plugin();
@@ -326,6 +337,7 @@ public class ModelUtilsTest
      * Verifies MNG-1499: The order of the merged list should be the plugins specified by the parent followed by the
      * child list.
      */
+    @Test
     public void testShouldKeepOriginalPluginOrdering()
     {
         Plugin parentPlugin1 = new Plugin();
@@ -390,6 +402,7 @@ public class ModelUtilsTest
     /**
      * Verifies MNG-1499: The ordering of plugin executions should also be in the specified order.
      */
+    @Test
     public void testShouldKeepOriginalPluginExecutionOrdering()
     {
         Plugin parent = new Plugin();
@@ -439,6 +452,7 @@ public class ModelUtilsTest
         assertEquals( dep.getManagementKey(), dep2.getManagementKey() );
     }
 
+    @Test
     public void testShouldOverwritePluginConfigurationSubItemsByDefault()
         throws XmlPullParserException, IOException
     {
@@ -465,6 +479,7 @@ public class ModelUtilsTest
         assertEquals( "three", item.getValue() );
     }
 
+    @Test
     public void testShouldMergePluginConfigurationSubItemsWithMergeAttributeSet()
         throws XmlPullParserException, IOException
     {
@@ -496,6 +511,7 @@ public class ModelUtilsTest
         assertEquals( expected, actual );
     }
 
+    @Test
     public void testShouldNotMergePluginExecutionWhenExecInheritedIsFalseAndTreatAsInheritanceIsTrue()
     {
         String gid = "group";
@@ -536,6 +552,7 @@ public class ModelUtilsTest
         assertNull( "test execution should not be inherited from parent.", executionMap.get( testId ) );
     }
 
+    @Test
     public void testShouldNotMergePluginExecutionWhenPluginInheritedIsFalseAndTreatAsInheritanceIsTrue()
     {
         String gid = "group";
@@ -576,6 +593,7 @@ public class ModelUtilsTest
         assertNull( "test execution should not be inherited from parent.", executionMap.get( testId ) );
     }
 
+    @Test
     public void testShouldMergePluginExecutionWhenExecInheritedIsTrueAndTreatAsInheritanceIsTrue()
     {
         String gid = "group";

--- a/maven-compat/src/test/java/org/apache/maven/project/ProjectClasspathTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/ProjectClasspathTest.java
@@ -54,7 +54,7 @@ public class ProjectClasspathTest
     }
 
     @Override
-    protected void setUp()
+    public void setUp()
             throws Exception
     {
         super.setUp();

--- a/maven-compat/src/test/java/org/apache/maven/project/ProjectClasspathTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/ProjectClasspathTest.java
@@ -34,6 +34,11 @@ import org.codehaus.plexus.PlexusConstants;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.ArtifactDescriptorReader;
 import org.eclipse.aether.impl.ArtifactResolver;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class ProjectClasspathTest
     extends AbstractMavenProjectTestCase
@@ -71,6 +76,7 @@ public class ProjectClasspathTest
         return null;
     }
 
+    @Test
     public void testProjectClasspath()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t00/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t00/ProjectInheritanceTest.java
@@ -21,6 +21,9 @@ package org.apache.maven.project.inheritance.t00;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * A test which demonstrates maven's recursive inheritance where
@@ -50,6 +53,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testProjectInheritance()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t01/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t01/ProjectInheritanceTest.java
@@ -21,6 +21,9 @@ package org.apache.maven.project.inheritance.t01;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * A test which demonstrates maven's recursive inheritance where
@@ -46,6 +49,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testProjectInheritance()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
@@ -26,12 +26,14 @@ import java.util.Map;
 
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A test which demonstrates maven's recursive inheritance where
@@ -139,33 +141,25 @@ public class ProjectInheritanceTest
         {
             String pluginArtifactId = plugin.getArtifactId();
 
-            if ( !validPluginCounts.containsKey( pluginArtifactId ) )
+            assertTrue( "Illegal plugin found: " + pluginArtifactId, validPluginCounts.containsKey( pluginArtifactId ) );
+
+            if ( pluginArtifactId.equals( testPluginArtifactId ) )
             {
-                fail( "Illegal plugin found: " + pluginArtifactId );
+                testPlugin = plugin;
             }
-            else
-            {
-                if ( pluginArtifactId.equals( testPluginArtifactId ) )
-                {
-                    testPlugin = plugin;
-                }
 
-                Integer count = validPluginCounts.get( pluginArtifactId );
+            Integer count = validPluginCounts.get( pluginArtifactId );
 
-                if ( count > 0 )
-                {
-                    fail( "Multiple copies of plugin: " + pluginArtifactId + " found in POM." );
-                }
-                else
-                {
-                    count = count + 1;
+            assertEquals( "Multiple copies of plugin: " + pluginArtifactId + " found in POM.", 0, (int) count );
 
-                    validPluginCounts.put( pluginArtifactId, count );
-                }
-            }
+            count = count + 1;
+
+            validPluginCounts.put( pluginArtifactId, count );
         }
 
-        List executions = testPlugin.getExecutions();
+        assertNotNull( testPlugin );
+
+        List<PluginExecution> executions = testPlugin.getExecutions();
 
         assertEquals( 1, executions.size() );
     }

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
@@ -28,6 +28,10 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * A test which demonstrates maven's recursive inheritance where
@@ -57,6 +61,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testProjectInheritance()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t03/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t03/ProjectInheritanceTest.java
@@ -23,6 +23,9 @@ import java.io.File;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * A test which demonstrates maven's recursive inheritance where
@@ -49,6 +52,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testProjectInheritance()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t04/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t04/ProjectInheritanceTest.java
@@ -25,6 +25,11 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Verifies the version of a dependency listed in a parent's
@@ -51,6 +56,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testDependencyManagementOverridesTransitiveDependencyVersion()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t05/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t05/ProjectInheritanceTest.java
@@ -25,6 +25,11 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A test which demonstrates maven's dependency management
@@ -45,6 +50,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testDependencyManagement()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t06/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t06/ProjectInheritanceTest.java
@@ -26,6 +26,11 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A test which demonstrates maven's dependency management
@@ -46,6 +51,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testDependencyManagement()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t07/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t07/ProjectInheritanceTest.java
@@ -25,6 +25,12 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A test which demonstrates maven's dependency management
@@ -45,6 +51,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testDependencyManagement()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t08/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t08/ProjectInheritanceTest.java
@@ -26,6 +26,11 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A test which demonstrates maven's dependency management
@@ -46,6 +51,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testDependencyManagement()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t09/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t09/ProjectInheritanceTest.java
@@ -23,6 +23,12 @@ import java.util.Map;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Verifies exclusions listed in dependencyManagement are valid for
@@ -56,6 +62,7 @@ public class ProjectInheritanceTest
      * We should see that the resulting size of collected artifacts is two:
      * a &amp; b only.
      */
+    @Test
     public void testDependencyManagementExclusionsExcludeTransitively()
         throws Exception
     {
@@ -92,6 +99,7 @@ public class ProjectInheritanceTest
      *
      * @throws Exception
      */
+    @Test
     public void testDependencyManagementExclusionDoesNotOverrideGloballyForTransitives()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t10/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t10/ProjectInheritanceTest.java
@@ -25,6 +25,11 @@ import java.util.Map;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Verifies scope inheritance of direct and transitive dependencies.
@@ -52,6 +57,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testDependencyManagementOverridesTransitiveDependencyVersion()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
@@ -23,6 +23,10 @@ import java.io.File;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Verifies scope of root project is preserved regardless of parent dependency management.
@@ -44,6 +48,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testDependencyManagementDoesNotOverrideScopeOfCurrentArtifact()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12/ProjectInheritanceTest.java
@@ -25,6 +25,10 @@ import java.util.Map;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Verifies that plugin execution sections in the parent POM that have
@@ -43,6 +47,7 @@ public class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testFalsePluginExecutionInheritValue() throws Exception
     {
         File localRepo = getLocalRepositoryPath();

--- a/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12scm/ProjectInheritanceTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12scm/ProjectInheritanceTest.java
@@ -23,6 +23,9 @@ import java.io.File;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Verifies SCM inheritance uses modules statement from parent.
@@ -43,6 +46,7 @@ public class ProjectInheritanceTest
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testScmInfoCalculatedCorrectlyOnParentAndChildRead()
         throws Exception
     {
@@ -76,6 +80,7 @@ public class ProjectInheritanceTest
                                                                   + "/modules/p1" );
     }
 
+    @Test
     public void testScmInfoCalculatedCorrectlyOnChildOnlyRead()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/project/path/DefaultPathTranslatorTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/path/DefaultPathTranslatorTest.java
@@ -21,13 +21,14 @@ package org.apache.maven.project.path;
 
 import java.io.File;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 @SuppressWarnings( "deprecation" )
 public class DefaultPathTranslatorTest
-    extends TestCase
 {
 
+    @Test
     public void testAlignToBasedirWhereBasedirExpressionIsTheCompleteValue()
     {
         File basedir = new File( System.getProperty( "java.io.tmpdir" ), "test" ).getAbsoluteFile();
@@ -37,6 +38,7 @@ public class DefaultPathTranslatorTest
         assertEquals( basedir.getAbsolutePath(), aligned );
     }
 
+    @Test
     public void testAlignToBasedirWhereBasedirExpressionIsTheValuePrefix()
     {
         File basedir = new File( System.getProperty( "java.io.tmpdir" ), "test" ).getAbsoluteFile();
@@ -46,6 +48,7 @@ public class DefaultPathTranslatorTest
         assertEquals( new File( basedir, "dir" ).getAbsolutePath(), aligned );
     }
 
+    @Test
     public void testUnalignToBasedirWherePathEqualsBasedir()
     {
         File basedir = new File( System.getProperty( "java.io.tmpdir" ), "test" ).getAbsoluteFile();

--- a/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
@@ -32,16 +32,21 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.RepositoryPolicy;
 import org.apache.maven.plugin.LegacySupport;
-import org.apache.maven.project.ProjectBuilder;
-import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.repository.legacy.LegacyRepositorySystem;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
 
@@ -66,8 +71,9 @@ public class LegacyRepositorySystemTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
             throws Exception
     {
         super.setUp();
@@ -75,6 +81,16 @@ public class LegacyRepositorySystemTest
         ((DefaultPlexusContainer)getContainer())
                 .addPlexusInjector( Collections.emptyList(),
                         binder ->  binder.requestInjection( this ) );
+    }
+
+    @After
+    @Override
+    public void tearDown()
+        throws Exception
+    {
+        repositorySystem = null;
+        resolutionErrorHandler = null;
+        super.tearDown();
     }
 
     protected List<ArtifactRepository> getRemoteRepositories()
@@ -104,6 +120,7 @@ public class LegacyRepositorySystemTest
         return repositorySystem.createLocalRepository( repoDir );
     }
 
+    @Test
     public void testThatASystemScopedDependencyIsNotResolvedFromRepositories()
         throws Exception
     {
@@ -186,6 +203,7 @@ public class LegacyRepositorySystemTest
         }
     }
 
+    @Test
     public void testLocalRepositoryBasedir()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/repository/MirrorProcessorTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/MirrorProcessorTest.java
@@ -23,14 +23,22 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.repository.legacy.repository.ArtifactRepositoryFactory;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.repository.legacy.repository.ArtifactRepositoryFactory;
 import org.apache.maven.settings.Mirror;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
 
@@ -50,9 +58,19 @@ public class MirrorProcessorTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    @Before
+    public void setUp()
+        throws Exception
+    {
+        super.setUp();
+        mirrorSelector = (DefaultMirrorSelector) lookup( MirrorSelector.class );
+        repositorySystem = lookup( ArtifactRepositoryFactory.class );
+    }
+
+    @After
     @Override
-    protected void setUp()
-            throws Exception
+    public void tearDown()
+        throws Exception
     {
         super.setUp();
 
@@ -61,6 +79,7 @@ public class MirrorProcessorTest
                         binder ->  binder.requestInjection( this ) );
     }
 
+    @Test
     public void testExternalURL()
     {
         assertTrue( DefaultMirrorSelector.isExternalRepo( getRepo( "foo", "http://somehost" ) ) );
@@ -83,6 +102,7 @@ public class MirrorProcessorTest
         assertFalse( DefaultMirrorSelector.isExternalRepo( getRepo( "foo", "" ) ) );
     }
 
+    @Test
     public void testMirrorLookup()
     {
         Mirror mirrorA = newMirror( "a", "a", "http://a" );
@@ -97,6 +117,7 @@ public class MirrorProcessorTest
         assertNull( mirrorSelector.getMirror( getRepo( "c", "http://c.c" ), mirrors ) );
     }
 
+    @Test
     public void testMirrorWildcardLookup()
     {
         Mirror mirrorA = newMirror( "a", "a", "http://a" );
@@ -112,6 +133,7 @@ public class MirrorProcessorTest
         assertSame( mirrorC, mirrorSelector.getMirror( getRepo( "c", "http://c.c" ), mirrors ) );
     }
 
+    @Test
     public void testMirrorStopOnFirstMatch()
     {
         // exact matches win first
@@ -140,6 +162,7 @@ public class MirrorProcessorTest
         assertSame( mirrorC2, mirrorSelector.getMirror( getRepo( "f", "http://f" ), mirrors ) );
     }
 
+    @Test
     public void testPatterns()
     {
         assertTrue( DefaultMirrorSelector.matchPattern( getRepo( "a" ), "*" ) );
@@ -176,6 +199,7 @@ public class MirrorProcessorTest
         assertFalse( DefaultMirrorSelector.matchPattern( getRepo( "d" ), "!a,!c*" ) );
     }
 
+    @Test
     public void testPatternsWithExternal()
     {
         assertTrue( DefaultMirrorSelector.matchPattern( getRepo( "a", "http://localhost" ), "*" ) );
@@ -190,6 +214,7 @@ public class MirrorProcessorTest
         assertTrue( DefaultMirrorSelector.matchPattern( getRepo( "c", "http://somehost" ), "!a,external:*" ) );
     }
 
+    @Test
     public void testLayoutPattern()
     {
         assertTrue( DefaultMirrorSelector.matchesLayout( "default", null ) );
@@ -209,6 +234,7 @@ public class MirrorProcessorTest
         assertFalse( DefaultMirrorSelector.matchesLayout( "default", "!default,*" ) );
     }
 
+    @Test
     public void testMirrorLayoutConsideredForMatching()
     {
         ArtifactRepository repo = getRepo( "a" );

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
@@ -27,9 +27,16 @@ import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
 import org.apache.maven.artifact.repository.metadata.RepositoryMetadata;
-import org.apache.maven.repository.legacy.DefaultUpdateCheckManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultUpdateCheckManagerTest
     extends AbstractArtifactComponentTestCase
@@ -43,8 +50,9 @@ public class DefaultUpdateCheckManagerTest
         return "updateCheckManager";
     }
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();
@@ -52,6 +60,7 @@ public class DefaultUpdateCheckManagerTest
         updateCheckManager = new DefaultUpdateCheckManager( new ConsoleLogger( Logger.LEVEL_DEBUG, "test" ) );
     }
 
+    @Test
     public void testArtifact() throws Exception
     {
         ArtifactRepository remoteRepository = remoteRepository();
@@ -81,6 +90,7 @@ public class DefaultUpdateCheckManagerTest
         assertFalse( updateCheckManager.getTouchfile( a ).exists() );
     }
 
+    @Test
     public void testMissingArtifact()
         throws Exception
     {
@@ -108,6 +118,7 @@ public class DefaultUpdateCheckManagerTest
                                                            updateCheckManager.getRepositoryKey( remoteRepository ) ) );
     }
 
+    @Test
     public void testPom() throws Exception
     {
         ArtifactRepository remoteRepository = remoteRepository();
@@ -137,6 +148,7 @@ public class DefaultUpdateCheckManagerTest
         assertFalse( updateCheckManager.getTouchfile( a ).exists() );
     }
 
+    @Test
     public void testMissingPom()
         throws Exception
     {
@@ -164,6 +176,7 @@ public class DefaultUpdateCheckManagerTest
                                                            updateCheckManager.getRepositoryKey( remoteRepository ) ) );
     }
 
+    @Test
     public void testMetadata() throws Exception
     {
         ArtifactRepository remoteRepository = remoteRepository();
@@ -191,6 +204,7 @@ public class DefaultUpdateCheckManagerTest
         assertNotNull( updateCheckManager.readLastUpdated( touchFile, updateCheckManager.getMetadataKey( remoteRepository, file ) ) );
     }
 
+    @Test
     public void testMissingMetadata() throws Exception
     {
         ArtifactRepository remoteRepository = remoteRepository();
@@ -216,6 +230,7 @@ public class DefaultUpdateCheckManagerTest
         assertNotNull( updateCheckManager.readLastUpdated( touchFile, updateCheckManager.getMetadataKey( remoteRepository, file ) ) );
     }
 
+    @Test
     public void testArtifactTouchFileName() throws Exception
     {
         ArtifactFactory artifactFactory = (ArtifactFactory) lookup( ArtifactFactory.ROLE );

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
@@ -30,16 +30,15 @@ import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.repository.legacy.repository.ArtifactRepositoryFactory;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.repository.legacy.repository.ArtifactRepositoryFactory;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
 import org.apache.maven.wagon.UnsupportedProtocolException;
 import org.apache.maven.wagon.Wagon;
-import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.events.TransferEvent;
 import org.apache.maven.wagon.events.TransferListener;
 import org.apache.maven.wagon.observers.AbstractTransferListener;
@@ -47,8 +46,18 @@ import org.apache.maven.wagon.observers.Debug;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 
@@ -77,8 +86,9 @@ public class DefaultWagonManagerTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
             throws Exception
     {
         super.setUp();
@@ -88,6 +98,17 @@ public class DefaultWagonManagerTest
                         binder ->  binder.requestInjection( this ) );
     }
 
+    @After
+    @Override
+    public void tearDown()
+        throws Exception
+    {
+        wagonManager = null;
+        artifactFactory = null;
+        super.tearDown();
+    }
+
+    @Test
     public void testUnnecessaryRepositoryLookup()
         throws Exception
     {
@@ -123,6 +144,7 @@ public class DefaultWagonManagerTest
         assertEquals( 1, listener.events.size() );
     }
 
+    @Test
     public void testGetMissingJar() throws TransferFailedException, UnsupportedProtocolException, IOException
     {
         Artifact artifact = createTestArtifact( "target/test-data/get-missing-jar", "jar" );
@@ -143,6 +165,7 @@ public class DefaultWagonManagerTest
         assertFalse( artifact.getFile().exists() );
     }
 
+    @Test
     public void testGetMissingJarForced() throws TransferFailedException, UnsupportedProtocolException, IOException
     {
         Artifact artifact = createTestArtifact( "target/test-data/get-missing-jar", "jar" );
@@ -163,6 +186,7 @@ public class DefaultWagonManagerTest
         assertFalse( artifact.getFile().exists() );
     }
 
+    @Test
     public void testGetRemoteJar()
         throws TransferFailedException, ResourceDoesNotExistException, UnsupportedProtocolException, IOException
     {
@@ -240,6 +264,7 @@ public class DefaultWagonManagerTest
         return getRepo( id, "http://something" );
     }
 
+    @Test
     public void testDefaultWagonManager()
         throws Exception
     {
@@ -267,6 +292,7 @@ public class DefaultWagonManagerTest
     /**
      * Check that transfer listeners are properly removed after getArtifact and putArtifact
      */
+    @Test
     public void testWagonTransferListenerRemovedAfterGetArtifactAndPutArtifact()
         throws Exception
     {
@@ -390,6 +416,7 @@ public class DefaultWagonManagerTest
         }
     }
 
+    @Test
     public void testPerLookupInstantiation()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
@@ -50,14 +50,15 @@ import org.apache.maven.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 
@@ -151,16 +152,8 @@ public class DefaultWagonManagerTest
 
         ArtifactRepository repo = createStringRepo();
 
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, false );
-
-            fail();
-        }
-        catch ( ResourceDoesNotExistException e )
-        {
-            assertTrue( true );
-        }
+        assertThrows( ResourceDoesNotExistException.class,
+                () -> wagonManager.getArtifact( artifact, repo, null, false ) );
 
         assertFalse( artifact.getFile().exists() );
     }
@@ -172,16 +165,8 @@ public class DefaultWagonManagerTest
 
         ArtifactRepository repo = createStringRepo();
 
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, true );
-
-            fail();
-        }
-        catch ( ResourceDoesNotExistException e )
-        {
-            assertTrue( true );
-        }
+        assertThrows( ResourceDoesNotExistException.class,
+                () -> wagonManager.getArtifact( artifact, repo, null, true ) );
 
         assertFalse( artifact.getFile().exists() );
     }
@@ -276,17 +261,7 @@ public class DefaultWagonManagerTest
 
         assertWagon( "string" );
 
-        try
-        {
-            assertWagon( "d" );
-
-            fail( "Expected :" + UnsupportedProtocolException.class.getName() );
-        }
-        catch ( UnsupportedProtocolException e )
-        {
-            // ok
-            assertTrue( true );
-        }
+        assertThrows( UnsupportedProtocolException.class, () -> assertWagon( "d" ) );
     }
 
     /**
@@ -321,7 +296,9 @@ public class DefaultWagonManagerTest
     /**
      * Checks the verification of checksums.
      */
-    public void xtestChecksumVerification()
+    @Ignore
+    @Test
+    public void testChecksumVerification()
         throws Exception
     {
         ArtifactRepositoryPolicy policy = new ArtifactRepositoryPolicy( true, ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS, ArtifactRepositoryPolicy.CHECKSUM_POLICY_FAIL );
@@ -338,82 +315,35 @@ public class DefaultWagonManagerTest
         wagon.clearExpectedContent();
         wagon.addExpectedContent( "path", "lower-case-checksum" );
         wagon.addExpectedContent( "path.sha1", "2a25dc564a3b34f68237fc849066cbc7bb7a36a1" );
-
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, false );
-        }
-        catch ( ChecksumFailedException e )
-        {
-            fail( "Checksum verification did not pass: " + e.getMessage() );
-        }
+        wagonManager.getArtifact( artifact, repo, null, false );
 
         wagon.clearExpectedContent();
         wagon.addExpectedContent( "path", "upper-case-checksum" );
         wagon.addExpectedContent( "path.sha1", "B7BB97D7D0B9244398D9B47296907F73313663E6" );
-
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, false );
-        }
-        catch ( ChecksumFailedException e )
-        {
-            fail( "Checksum verification did not pass: " + e.getMessage() );
-        }
+        wagonManager.getArtifact( artifact, repo, null, false );
 
         wagon.clearExpectedContent();
         wagon.addExpectedContent( "path", "expected-failure" );
         wagon.addExpectedContent( "path.sha1", "b7bb97d7d0b9244398d9b47296907f73313663e6" );
-
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, false );
-            fail( "Checksum verification did not fail" );
-        }
-        catch ( ChecksumFailedException e )
-        {
-            // expected
-        }
+        assertThrows( "Checksum verification did not fail", ChecksumFailedException.class, () ->
+                wagonManager.getArtifact( artifact, repo, null, false ) );
 
         wagon.clearExpectedContent();
         wagon.addExpectedContent( "path", "lower-case-checksum" );
         wagon.addExpectedContent( "path.md5", "50b2cf50a103a965efac62b983035cac" );
-
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, false );
-        }
-        catch ( ChecksumFailedException e )
-        {
-            fail( "Checksum verification did not pass: " + e.getMessage() );
-        }
+        wagonManager.getArtifact( artifact, repo, null, false );
 
         wagon.clearExpectedContent();
         wagon.addExpectedContent( "path", "upper-case-checksum" );
         wagon.addExpectedContent( "path.md5", "842F568FCCFEB7E534DC72133D42FFDC" );
-
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, false );
-        }
-        catch ( ChecksumFailedException e )
-        {
-            fail( "Checksum verification did not pass: " + e.getMessage() );
-        }
+        wagonManager.getArtifact( artifact, repo, null, false );
 
         wagon.clearExpectedContent();
         wagon.addExpectedContent( "path", "expected-failure" );
         wagon.addExpectedContent( "path.md5", "b7bb97d7d0b9244398d9b47296907f73313663e6" );
-
-        try
-        {
-            wagonManager.getArtifact( artifact, repo, null, false );
-            fail( "Checksum verification did not fail" );
-        }
-        catch ( ChecksumFailedException e )
-        {
-            // expected
-        }
+        assertThrows( "Checksum verification did not fail",
+                ChecksumFailedException.class,
+                () -> wagonManager.getArtifact( artifact, repo, null, false ) );
     }
 
     @Test

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/LegacyRepositorySystemTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/LegacyRepositorySystemTest.java
@@ -26,7 +26,13 @@ import org.apache.maven.settings.Server;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import javax.inject.Inject;
 
@@ -49,8 +55,9 @@ public class LegacyRepositorySystemTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
             throws Exception
     {
         super.setUp();
@@ -60,6 +67,16 @@ public class LegacyRepositorySystemTest
                         binder ->  binder.requestInjection( this ) );
     }
 
+    @After
+    @Override
+    public void tearDown()
+        throws Exception
+    {
+        repositorySystem = null;
+        super.tearDown();
+    }
+
+    @Test
     public void testThatLocalRepositoryWithSpacesIsProperlyHandled()
         throws Exception
     {
@@ -68,6 +85,7 @@ public class LegacyRepositorySystemTest
         assertEquals( basedir, new File( repo.getBasedir() ) );
     }
 
+    @Test
     public void testAuthenticationHandling()
     {
         Server server = new Server();

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
@@ -19,6 +19,16 @@ package org.apache.maven.repository.legacy.resolver;
  * under the License.
  */
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
@@ -39,17 +49,15 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.repository.legacy.metadata.MetadataResolutionRequest;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test the default artifact collector.
@@ -77,8 +85,9 @@ public class DefaultArtifactCollectorTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();
@@ -90,8 +99,9 @@ public class DefaultArtifactCollectorTest
         projectArtifact = createArtifactSpec( "project", "1.0", null );
     }
 
+    @After
     @Override
-    protected void tearDown()
+    public void tearDown()
         throws Exception
     {
         artifactCollector = null;
@@ -135,6 +145,7 @@ public class DefaultArtifactCollectorTest
         }
     }
 
+    @Test
     public void testResolveWithFilter()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -154,6 +165,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifact list", createSet( new Object[] { a.artifact, c.artifact } ), res.getArtifacts() );
     }
 
+    @Test
     public void testResolveCorrectDependenciesWhenDifferentDependenciesOnNearest()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -212,6 +224,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "2.0", getArtifact( "b", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testResolveNearestNewestIsNearest()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -227,6 +240,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "3.0", getArtifact( "c", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testResolveNearestOldestIsNearest()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -242,6 +256,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "2.0", getArtifact( "c", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testResolveLocalNewestIsLocal()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -254,6 +269,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "3.0", getArtifact( "b", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testResolveLocalOldestIsLocal()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -266,6 +282,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "2.0", getArtifact( "b", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testResolveLocalWithNewerVersionButLesserScope()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -279,6 +296,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifactScope", Artifact.SCOPE_TEST, getArtifact( "junit", res.getArtifacts() ).getScope() );
     }
 
+    @Test
     public void testResolveLocalWithNewerVersionButLesserScopeResolvedFirst()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -292,6 +310,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifactScope", Artifact.SCOPE_TEST, getArtifact( "junit", res.getArtifacts() ).getScope() );
     }
 
+    @Test
     public void testResolveNearestWithRanges()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -307,6 +326,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "2.0", getArtifact( "c", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testResolveRangeWithManagedVersion()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -321,6 +341,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "5.0", getArtifact( "b", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testCompatibleRanges()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -337,6 +358,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "2.5", getArtifact( "c", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testIncompatibleRanges()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -351,6 +373,7 @@ public class DefaultArtifactCollectorTest
         assertTrue( res.hasVersionRangeViolations() );
     }
 
+    @Test
     public void testUnboundedRangeWhenVersionUnavailable()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -364,6 +387,7 @@ public class DefaultArtifactCollectorTest
         assertTrue( res.hasVersionRangeViolations() );
     }
 
+    @Test
     public void testUnboundedRangeBelowLastRelease()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -379,6 +403,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "2.0", getArtifact( "c", res.getArtifacts() ).getVersion() );
     }
 
+    @Test
     public void testUnboundedRangeAboveLastRelease()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -391,6 +416,7 @@ public class DefaultArtifactCollectorTest
         assertTrue( res.hasVersionRangeViolations() );
     }
 
+    @Test
     public void testResolveManagedVersion()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -404,6 +430,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifact list", createSet( new Object[] { a.artifact, modifiedB } ), res.getArtifacts() );
     }
 
+    @Test
     public void testCollectChangesVersionOfOriginatingArtifactIfInDependencyManagementHasDifferentVersion()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -421,6 +448,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Resolved version don't match original artifact version", "1.0", resolvedArtifact.getVersion() );
     }
 
+    @Test
     public void testResolveCompileScopeOverTestScope()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -439,6 +467,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifactScope", Artifact.SCOPE_TEST, artifact.getScope() );
     }
 
+    @Test
     public void testResolveRuntimeScopeOverTestScope()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -457,6 +486,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifactScope", Artifact.SCOPE_TEST, artifact.getScope() );
     }
 
+    @Test
     public void testResolveCompileScopeOverRuntimeScope()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -475,6 +505,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifactScope", Artifact.SCOPE_COMPILE, artifact.getScope() );
     }
 
+    @Test
     public void testResolveCompileScopeOverProvidedScope()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -493,6 +524,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifactScope", Artifact.SCOPE_PROVIDED, artifact.getScope() );
     }
 
+    @Test
     public void testResolveRuntimeScopeOverProvidedScope()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -511,6 +543,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifactScope", Artifact.SCOPE_PROVIDED, artifact.getScope() );
     }
 
+    @Test
     public void testProvidedScopeNotTransitive()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -522,6 +555,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifact list", createSet( new Object[] { a.artifact, b.artifact } ), res.getArtifacts() );
     }
 
+    @Test
     public void testOptionalNotTransitive()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -533,6 +567,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifact list", createSet( new Object[] { a.artifact, b.artifact } ), res.getArtifacts() );
     }
 
+    @Test
     public void testOptionalIncludedAtRoot()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -544,6 +579,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifact list", createSet( new Object[] { a.artifact, b.artifact } ), res.getArtifacts() );
     }
 
+    @Test
     public void testScopeUpdate()
         throws InvalidVersionSpecificationException, ArtifactResolutionException
     {
@@ -674,6 +710,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check version", "3.0", artifact.getVersion() );
     }
 
+    @Test
     public void testTestScopeNotTransitive()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -685,6 +722,7 @@ public class DefaultArtifactCollectorTest
         assertEquals( "Check artifact list", createSet( new Object[] { a.artifact, b.artifact } ), res.getArtifacts() );
     }
 
+    @Test
     public void testSnapshotNotIncluded()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {
@@ -703,6 +741,7 @@ public class DefaultArtifactCollectorTest
          */
     }
 
+    @Test
     public void testOverConstrainedVersionException()
         throws ArtifactResolutionException, InvalidVersionSpecificationException
     {

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
@@ -56,8 +56,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test the default artifact collector.
@@ -116,15 +116,9 @@ public class DefaultArtifactCollectorTest
         ArtifactSpec a = createArtifactSpec( "a", "1.0" );
         ArtifactSpec b = a.addDependency( "b", "1.0" );
         b.addDependency( "a", "1.0" );
-        try
-        {
-            collect( a );
-            fail( "Should have failed on cyclic dependency not involving project" );
-        }
-        catch ( CyclicDependencyException expected )
-        {
-            assertTrue( true );
-        }
+        assertThrows( "Should have failed on cyclic dependency not involving project",
+                CyclicDependencyException.class,
+                () -> collect( a ) );
     }
 
     // works, but we don't fail on cycles presently
@@ -134,15 +128,9 @@ public class DefaultArtifactCollectorTest
         ArtifactSpec a = createArtifactSpec( "a", "1.0" );
         ArtifactSpec b = a.addDependency( "b", "1.0" );
         b.addDependency( "project", "1.0" );
-        try
-        {
-            collect( a );
-            fail( "Should have failed on cyclic dependency involving project" );
-        }
-        catch ( CyclicDependencyException expected )
-        {
-            assertTrue( true );
-        }
+        assertThrows( "Should have failed on cyclic dependency not involving project",
+                CyclicDependencyException.class,
+                () -> collect( a ) );
     }
 
     @Test

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/AbstractConflictResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/AbstractConflictResolverTest.java
@@ -19,20 +19,26 @@ package org.apache.maven.repository.legacy.resolver.conflict;
  * under the License.
  */
 
+import java.util.Collections;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ResolutionNode;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.repository.legacy.resolver.conflict.ConflictResolver;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
+import org.junit.After;
+import org.junit.Before;
 
 import javax.inject.Inject;
 import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Provides a basis for testing conflict resolvers.
@@ -79,8 +85,12 @@ public abstract class AbstractConflictResolverTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    /*
+     * @see junit.framework.TestCase#setUp()
+     */
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
             throws Exception
     {
         super.setUp();
@@ -99,7 +109,9 @@ public abstract class AbstractConflictResolverTest
     /*
      * @see org.codehaus.plexus.PlexusTestCase#tearDown()
      */
-    protected void tearDown() throws Exception
+    @After
+    @Override
+    public void tearDown() throws Exception
     {
         a1 = null;
         a2 = null;

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/FarthestConflictResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/FarthestConflictResolverTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.repository.legacy.resolver.conflict;
  */
 
 import org.apache.maven.artifact.resolver.ResolutionNode;
+import org.junit.Test;
 
 /**
  * Tests <code>FarthestConflictResolver</code>.
@@ -47,6 +48,7 @@ public class FarthestConflictResolverTest
      * b:1.0 -&gt; a:2.0
      * </pre>
      */
+    @Test
     public void testDepth()
     {
         ResolutionNode a1n = createResolutionNode( a1);
@@ -63,6 +65,7 @@ public class FarthestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testDepthReversed()
     {
         ResolutionNode b1n = createResolutionNode( b1  );
@@ -79,6 +82,7 @@ public class FarthestConflictResolverTest
      * a:2.0
      * </pre>
      */
+    @Test
     public void testEqual()
     {
         ResolutionNode a1n = createResolutionNode( a1 );
@@ -94,6 +98,7 @@ public class FarthestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testEqualReversed()
     {
         ResolutionNode a2n = createResolutionNode( a2);

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolverTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.repository.legacy.resolver.conflict;
  */
 
 import org.apache.maven.artifact.resolver.ResolutionNode;
+import org.junit.Test;
 
 /**
  * Tests <code>NearestConflictResolver</code>.
@@ -47,6 +48,7 @@ public class NearestConflictResolverTest
      * b:1.0 -&gt; a:2.0
      * </pre>
      */
+    @Test
     public void testDepth()
     {
         ResolutionNode a1n = createResolutionNode( a1);
@@ -63,6 +65,7 @@ public class NearestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testDepthReversed()
     {
         ResolutionNode b1n = createResolutionNode( b1 );
@@ -79,6 +82,7 @@ public class NearestConflictResolverTest
      * a:2.0
      * </pre>
      */
+    @Test
     public void testEqual()
     {
         ResolutionNode a1n = createResolutionNode( a1 );
@@ -94,6 +98,7 @@ public class NearestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testEqualReversed()
     {
         ResolutionNode a2n = createResolutionNode( a2);

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NewestConflictResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NewestConflictResolverTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.repository.legacy.resolver.conflict;
  */
 
 import org.apache.maven.artifact.resolver.ResolutionNode;
+import org.junit.Test;
 
 /**
  * Tests <code>NewestConflictResolver</code>.
@@ -47,6 +48,7 @@ public class NewestConflictResolverTest
      * b:1.0 -&gt; a:2.0
      * </pre>
      */
+    @Test
     public void testDepth()
     {
         ResolutionNode a1n = createResolutionNode( a1 );
@@ -63,6 +65,7 @@ public class NewestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testDepthReversed()
     {
         ResolutionNode b1n = createResolutionNode( b1 );
@@ -79,6 +82,7 @@ public class NewestConflictResolverTest
      * a:2.0
      * </pre>
      */
+    @Test
     public void testEqual()
     {
         ResolutionNode a1n = createResolutionNode( a1 );
@@ -94,6 +98,7 @@ public class NewestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testEqualReversed()
     {
         ResolutionNode a2n = createResolutionNode( a2 );

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/OldestConflictResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/OldestConflictResolverTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.repository.legacy.resolver.conflict;
  */
 
 import org.apache.maven.artifact.resolver.ResolutionNode;
+import org.junit.Test;
 
 /**
  * Tests <code>OldestConflictResolver</code>.
@@ -47,6 +48,7 @@ public class OldestConflictResolverTest
      * b:1.0 -&gt; a:2.0
      * </pre>
      */
+    @Test
     public void testDepth()
     {
         ResolutionNode a1n = createResolutionNode( a1 );
@@ -64,6 +66,7 @@ public class OldestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testDepthReversed()
     {
         ResolutionNode b1n = createResolutionNode( b1 );
@@ -80,6 +83,7 @@ public class OldestConflictResolverTest
      * a:2.0
      * </pre>
      */
+    @Test
     public void testEqual()
     {
         ResolutionNode a1n = createResolutionNode( a1 );
@@ -95,6 +99,7 @@ public class OldestConflictResolverTest
      * a:1.0
      * </pre>
      */
+    @Test
     public void testEqualReversed()
     {
         ResolutionNode a2n = createResolutionNode( a2);

--- a/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultClasspathTransformationTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultClasspathTransformationTest.java
@@ -16,13 +16,12 @@ package org.apache.maven.repository.metadata;
  */
 
 import org.apache.maven.artifact.ArtifactScopeEnum;
-import org.apache.maven.repository.metadata.ArtifactMetadata;
-import org.apache.maven.repository.metadata.ClasspathContainer;
-import org.apache.maven.repository.metadata.ClasspathTransformation;
-import org.apache.maven.repository.metadata.MetadataGraph;
-import org.apache.maven.repository.metadata.MetadataGraphEdge;
-import org.apache.maven.repository.metadata.MetadataGraphVertex;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  *
@@ -42,8 +41,9 @@ extends PlexusTestCase
     MetadataGraphVertex v3;
     MetadataGraphVertex v4;
     //------------------------------------------------------------------------------------------
+	@Before
     @Override
-    protected void setUp() throws Exception
+    public void setUp() throws Exception
     {
         super.setUp();
         transform = (ClasspathTransformation) lookup( ClasspathTransformation.ROLE, "default" );
@@ -74,6 +74,7 @@ extends PlexusTestCase
         graph.addEdge(v3, v4, new MetadataGraphEdge( "1.2", true, ArtifactScopeEnum.test, null, 2, 2 ) );
     }
     //------------------------------------------------------------------------------------------
+	@Test
     public void testCompileClasspathTransform()
     throws Exception
     {
@@ -86,6 +87,7 @@ extends PlexusTestCase
         assertEquals("compile classpath should have 3 entries", 3, res.getClasspath().size() );
     }
     //------------------------------------------------------------------------------------------
+	@Test
     public void testRuntimeClasspathTransform()
     throws Exception
     {
@@ -101,6 +103,7 @@ extends PlexusTestCase
         assertEquals("runtime artifact version should be 1.1", "1.1", md.getVersion() );
     }
     //------------------------------------------------------------------------------------------
+	@Test
     public void testTestClasspathTransform()
     throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolutionPolicyTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolutionPolicyTest.java
@@ -15,10 +15,10 @@ package org.apache.maven.repository.metadata;
  * the License.
  */
 
-import org.apache.maven.repository.metadata.GraphConflictResolutionPolicy;
-import org.apache.maven.repository.metadata.MetadataGraphEdge;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 /**
  *
@@ -27,23 +27,22 @@ import junit.framework.TestCase;
  */
 
 public class DefaultGraphConflictResolutionPolicyTest
-    extends TestCase
 {
     GraphConflictResolutionPolicy policy;
     MetadataGraphEdge e1;
     MetadataGraphEdge e2;
     MetadataGraphEdge e3;
     //------------------------------------------------------------------------------------------
-    @Override
-    protected void setUp() throws Exception
-    {
-        super.setUp();
-        policy = new DefaultGraphConflictResolutionPolicy();
-        e1 = new MetadataGraphEdge( "1.1", true, null, null, 2, 1 );
-        e2 = new MetadataGraphEdge( "1.2", true, null, null, 3, 2 );
-        e3 = new MetadataGraphEdge( "1.2", true, null, null, 2, 3 );
-    }
+	@Before
+    public void setUp() throws Exception
+	{
+		policy = new DefaultGraphConflictResolutionPolicy();
+    	e1 = new MetadataGraphEdge( "1.1", true, null, null, 2, 1 );
+    	e2 = new MetadataGraphEdge( "1.2", true, null, null, 3, 2 );
+    	e3 = new MetadataGraphEdge( "1.2", true, null, null, 2, 3 );
+	}
     //------------------------------------------------------------------------------------------
+	@Test
     public void testDefaultPolicy()
         throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolverTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolverTest.java
@@ -16,13 +16,13 @@ package org.apache.maven.repository.metadata;
  */
 
 import org.apache.maven.artifact.ArtifactScopeEnum;
-import org.apache.maven.repository.metadata.ArtifactMetadata;
-import org.apache.maven.repository.metadata.GraphConflictResolver;
-import org.apache.maven.repository.metadata.MetadataGraph;
-import org.apache.maven.repository.metadata.MetadataGraphEdge;
-import org.apache.maven.repository.metadata.MetadataGraphVertex;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
 import org.codehaus.plexus.logging.Logger;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  *
@@ -44,8 +44,9 @@ extends PlexusTestCase
     MetadataGraphVertex v3;
     MetadataGraphVertex v4;
     //------------------------------------------------------------------------------------------
+	@Before
     @Override
-    protected void setUp() throws Exception
+    public void setUp() throws Exception
     {
         super.setUp();
         resolver = (GraphConflictResolver) lookup( GraphConflictResolver.ROLE, "default" );
@@ -76,6 +77,7 @@ extends PlexusTestCase
         graph.addEdge(v3, v4, new MetadataGraphEdge( "1.2", true, ArtifactScopeEnum.provided, null, 2, 2 ) );
     }
     //------------------------------------------------------------------------------------------
+	@Test
     public void testCompileResolution()
     throws Exception
     {
@@ -101,6 +103,7 @@ extends PlexusTestCase
         assertEquals( "wrong edge v3-v4 in the resulting graph after resolver", "1.2", res.getIncidentEdges(v4).get(0).getVersion() );
     }
     //------------------------------------------------------------------------------------------
+	@Test
     public void testRuntimeResolution()
     throws Exception
     {
@@ -125,6 +128,7 @@ extends PlexusTestCase
         assertEquals( "wrong edge v3-v4 in the resulting graph after resolver", "1.1", res.getIncidentEdges(v4).get(0).getVersion() );
     }
     //------------------------------------------------------------------------------------------
+	@Test
     public void testTestResolution()
     throws Exception
     {

--- a/maven-compat/src/test/java/org/apache/maven/repository/metadata/TestMetadataSource.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/metadata/TestMetadataSource.java
@@ -19,6 +19,10 @@ package org.apache.maven.repository.metadata;
  * under the License.
  */
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -31,9 +35,6 @@ import org.apache.maven.repository.legacy.metadata.ResolutionGroup;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 @Named
 @Singleton

--- a/maven-core/src/test/java/org/apache/maven/AbstractCoreMavenComponentTestCase.java
+++ b/maven-core/src/test/java/org/apache/maven/AbstractCoreMavenComponentTestCase.java
@@ -48,11 +48,11 @@ import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
+import org.junit.Before;
 
 import javax.inject.Inject;
 
@@ -66,7 +66,9 @@ public abstract class AbstractCoreMavenComponentTestCase
     protected org.apache.maven.project.ProjectBuilder projectBuilder;
 
     @Override
-    protected void setUp() throws Exception
+    @Before
+    public void setUp()
+            throws Exception
     {
         super.setUp();
         getContainer();
@@ -80,6 +82,7 @@ public abstract class AbstractCoreMavenComponentTestCase
         ( (DefaultPlexusContainer) getContainer() ).addPlexusInjector( Collections.emptyList(),
                 binder -> binder.requestInjection( this ) );
     }
+
 
     abstract protected String getProjectsDirectory();
 

--- a/maven-core/src/test/java/org/apache/maven/DefaultMavenTest.java
+++ b/maven-core/src/test/java/org/apache/maven/DefaultMavenTest.java
@@ -1,23 +1,9 @@
 package org.apache.maven;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+import java.io.File;
+import java.nio.file.Files;
+
+import javax.inject.Inject;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
@@ -25,13 +11,10 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-
-import java.io.File;
-import java.nio.file.Files;
-
-import javax.inject.Inject;
+import org.junit.Test;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
 
 public class DefaultMavenTest
     extends AbstractCoreMavenComponentTestCase
@@ -40,6 +23,14 @@ public class DefaultMavenTest
     @Inject
     private Maven maven;
 
+    @Override
+    protected String getProjectsDirectory()
+    {
+        return "src/test/projects/default-maven";
+    }
+
+
+    @Test
     public void testThatErrorDuringProjectDependencyGraphCreationAreStored()
             throws Exception
     {
@@ -50,13 +41,7 @@ public class DefaultMavenTest
         assertEquals( ProjectCycleException.class, result.getExceptions().get( 0 ).getClass() );
     }
 
-    @Override
-    protected String getProjectsDirectory()
-    {
-        return "src/test/projects/default-maven";
-    }
-
-
+    @Test
     public void testMavenProjectNoDuplicateArtifacts()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/DefaultMavenTest.java
+++ b/maven-core/src/test/java/org/apache/maven/DefaultMavenTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven;
 
 import java.io.File;

--- a/maven-core/src/test/java/org/apache/maven/MavenLifecycleParticipantTest.java
+++ b/maven-core/src/test/java/org/apache/maven/MavenLifecycleParticipantTest.java
@@ -29,6 +29,10 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class MavenLifecycleParticipantTest
     extends AbstractCoreMavenComponentTestCase
@@ -109,6 +113,7 @@ public class MavenLifecycleParticipantTest
         return "src/test/projects/lifecycle-listener";
     }
 
+    @Test
     public void testDependencyInjection()
         throws Exception
     {
@@ -138,6 +143,7 @@ public class MavenLifecycleParticipantTest
         assertEquals( INJECTED_ARTIFACT_ID, artifacts.get( 0 ).getArtifactId() );
     }
 
+    @Test
     public void testReactorDependencyInjection()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/MavenTest.java
+++ b/maven-core/src/test/java/org/apache/maven/MavenTest.java
@@ -17,14 +17,11 @@ package org.apache.maven;
 
 
 import org.apache.maven.exception.ExceptionHandler;
-import org.apache.maven.exception.ExceptionSummary;
-import org.apache.maven.execution.MavenExecutionRequest;
-import org.apache.maven.execution.MavenExecutionResult;
 import org.codehaus.plexus.DefaultPlexusContainer;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.util.Collections;
+import org.junit.Test;
 
 public class MavenTest
     extends AbstractCoreMavenComponentTestCase
@@ -49,6 +46,7 @@ public class MavenTest
         return "src/test/projects/lifecycle-executor";
     }
 
+    @Test
     public void testLifecycleExecutionUsingADefaultLifecyclePhase()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/PlexusTestCase.java
+++ b/maven-core/src/test/java/org/apache/maven/PlexusTestCase.java
@@ -1,0 +1,317 @@
+package org.apache.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright 2001-2006 Codehaus Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.context.DefaultContext;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * This is a slightly modified version of the original plexus class
+ * available at https://raw.githubusercontent.com/codehaus-plexus/plexus-containers/master/plexus-container-default/src/main/java/org/codehaus/plexus/PlexusTestCase.java
+ * in order to migrate the tests to JUnit 4.
+ *
+ * @author Jason van Zyl
+ * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
+ * @author <a href="mailto:michal@codehaus.org">Michal Maczka</a>
+ * @author Guillaume Nodet
+ */
+public abstract class PlexusTestCase
+{
+    private PlexusContainer container;
+
+    private static String basedir;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        basedir = getBasedir();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    protected void setupContainer()
+    {
+        // ----------------------------------------------------------------------------
+        // Context Setup
+        // ----------------------------------------------------------------------------
+
+        DefaultContext context = new DefaultContext();
+
+        context.put( "basedir", getBasedir() );
+
+        customizeContext( context );
+
+        boolean hasPlexusHome = context.contains( "plexus.home" );
+
+        if ( !hasPlexusHome )
+        {
+            File f = getTestFile( "target/plexus-home" );
+
+            if ( !f.isDirectory() )
+            {
+                f.mkdir();
+            }
+
+            context.put( "plexus.home", f.getAbsolutePath() );
+        }
+
+        // ----------------------------------------------------------------------------
+        // Configuration
+        // ----------------------------------------------------------------------------
+
+        String config = getCustomConfigurationName();
+
+        ContainerConfiguration containerConfiguration = new DefaultContainerConfiguration()
+                .setName( "test" )
+                .setContext( context.getContextData() );
+
+        if ( config != null )
+        {
+            containerConfiguration.setContainerConfiguration( config );
+        }
+        else
+        {
+            String resource = getConfigurationName( null );
+
+            containerConfiguration.setContainerConfiguration( resource );
+        }
+
+        customizeContainerConfiguration( containerConfiguration );
+
+        try
+        {
+            container = new DefaultPlexusContainer( containerConfiguration );
+        }
+        catch ( PlexusContainerException e )
+        {
+            throw new IllegalArgumentException( "Failed to create plexus container.", e );
+        }
+    }
+
+    /**
+     * Allow custom test case implementations do augment the default container configuration before
+     * executing tests.
+     *
+     * @param containerConfiguration {@link ContainerConfiguration}.
+     */
+    protected void customizeContainerConfiguration( ContainerConfiguration containerConfiguration )
+    {
+    }
+
+    protected void customizeContext( Context context )
+    {
+    }
+
+    protected PlexusConfiguration customizeComponentConfiguration()
+    {
+        return null;
+    }
+
+    @After
+    public void tearDown()
+            throws Exception
+    {
+        if ( container != null )
+        {
+            container.dispose();
+
+            container = null;
+        }
+    }
+
+    protected PlexusContainer getContainer()
+    {
+        if ( container == null )
+        {
+            setupContainer();
+        }
+
+        return container;
+    }
+
+    protected InputStream getConfiguration()
+            throws Exception
+    {
+        return getConfiguration( null );
+    }
+
+    protected InputStream getConfiguration( String subname )
+            throws Exception
+    {
+        return getResourceAsStream( getConfigurationName( subname ) );
+    }
+
+    protected String getCustomConfigurationName()
+    {
+        return null;
+    }
+
+    /**
+     * Allow the retrieval of a container configuration that is based on the name
+     * of the test class being run. So if you have a test class called org.foo.FunTest, then
+     * this will produce a resource name of org/foo/FunTest.xml which would be used to
+     * configure the Plexus container before running your test.
+     *
+     * @param subname the subname
+     * @return A configruation name
+     */
+    protected String getConfigurationName( String subname )
+    {
+        return getClass().getName().replace( '.', '/' ) + ".xml";
+    }
+
+    protected InputStream getResourceAsStream( String resource )
+    {
+        return getClass().getResourceAsStream( resource );
+    }
+
+    protected ClassLoader getClassLoader()
+    {
+        return getClass().getClassLoader();
+    }
+
+    // ----------------------------------------------------------------------
+    // Container access
+    // ----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    protected <T> T lookup( String componentKey )
+            throws ComponentLookupException
+    {
+        return (T) getContainer().lookup( componentKey );
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T lookup( String role,
+                            String roleHint )
+            throws ComponentLookupException
+    {
+        return (T) getContainer().lookup( role, roleHint );
+    }
+
+    protected <T> T lookup( Class<T> componentClass )
+            throws ComponentLookupException
+    {
+        return getContainer().lookup( componentClass );
+    }
+
+    protected <T> T lookup( Class<T> componentClass, String roleHint )
+            throws ComponentLookupException
+    {
+        return getContainer().lookup( componentClass, roleHint );
+    }
+
+    protected void release( Object component )
+            throws ComponentLifecycleException
+    {
+        getContainer().release( component );
+    }
+
+    // ----------------------------------------------------------------------
+    // Helper methods for sub classes
+    // ----------------------------------------------------------------------
+
+    public static File getTestFile( String path )
+    {
+        return new File( getBasedir(), path );
+    }
+
+    public static File getTestFile( String basedir,
+                                    String path )
+    {
+        File basedirFile = new File( basedir );
+
+        if ( !basedirFile.isAbsolute() )
+        {
+            basedirFile = getTestFile( basedir );
+        }
+
+        return new File( basedirFile, path );
+    }
+
+    public static String getTestPath( String path )
+    {
+        return getTestFile( path ).getAbsolutePath();
+    }
+
+    public static String getTestPath( String basedir,
+                                      String path )
+    {
+        return getTestFile( basedir, path ).getAbsolutePath();
+    }
+
+    public static String getBasedir()
+    {
+        if ( basedir != null )
+        {
+            return basedir;
+        }
+
+        basedir = System.getProperty( "basedir" );
+
+        if ( basedir == null )
+        {
+            basedir = new File( "" ).getAbsolutePath();
+        }
+
+        return basedir;
+    }
+
+    public String getTestConfiguration()
+    {
+        return getTestConfiguration( getClass() );
+    }
+
+    public static String getTestConfiguration( Class<?> clazz )
+    {
+        String s = clazz.getName().replace( '.', '/' );
+
+        return s.substring( 0, s.indexOf( "$" ) ) + ".xml";
+    }
+}

--- a/maven-core/src/test/java/org/apache/maven/ProjectDependenciesResolverTest.java
+++ b/maven-core/src/test/java/org/apache/maven/ProjectDependenciesResolverTest.java
@@ -15,9 +15,6 @@ package org.apache.maven;
  * the License.
  */
 
-import static org.hamcrest.Matchers.endsWith;
-import static org.junit.Assert.assertThat;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +26,11 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
 import javax.inject.Inject;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class ProjectDependenciesResolverTest
     extends AbstractCoreMavenComponentTestCase
@@ -42,6 +44,7 @@ public class ProjectDependenciesResolverTest
     }
 
     /*
+    @Test
     public void testExclusionsInDependencies()
         throws Exception
     {
@@ -65,6 +68,7 @@ public class ProjectDependenciesResolverTest
     }
     */
 
+    @Test
     public void testSystemScopeDependencies()
         throws Exception
     {
@@ -79,6 +83,7 @@ public class ProjectDependenciesResolverTest
         assertEquals( 1, artifactDependencies.size() );
     }
 
+    @Test
     public void testSystemScopeDependencyIsPresentInTheCompileClasspathElements()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/artifact/handler/ArtifactHandlerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/artifact/handler/ArtifactHandlerTest.java
@@ -22,12 +22,16 @@ package org.apache.maven.artifact.handler;
 import java.io.File;
 import java.util.List;
 
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ArtifactHandlerTest
     extends PlexusTestCase
 {
+    @Test
     public void testAptConsistency()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorTest.java
@@ -27,34 +27,32 @@ import org.apache.maven.configuration.internal.DefaultBeanConfigurator;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Benjamin Bentmann
  */
 public class DefaultBeanConfiguratorTest
-    extends TestCase
 {
 
     private BeanConfigurator configurator;
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
-
         configurator = new DefaultBeanConfigurator();
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         configurator = null;
-
-        super.tearDown();
     }
 
     private Xpp3Dom toConfig( String xml )
@@ -69,6 +67,7 @@ public class DefaultBeanConfiguratorTest
         }
     }
 
+    @Test
     public void testMinimal()
         throws BeanConfigurationException
     {
@@ -84,6 +83,7 @@ public class DefaultBeanConfiguratorTest
         assertEquals( new File( "test" ), bean.file );
     }
 
+    @Test
     public void testPreAndPostProcessing()
         throws BeanConfigurationException
     {
@@ -111,6 +111,7 @@ public class DefaultBeanConfiguratorTest
         assertEquals( new File( "base/test" ).getAbsoluteFile(), bean.file );
     }
 
+    @Test
     public void testChildConfigurationElement()
         throws BeanConfigurationException
     {

--- a/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulatorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulatorTest.java
@@ -9,6 +9,7 @@ import org.apache.maven.settings.Profile;
 import org.apache.maven.settings.Repository;
 import org.apache.maven.settings.Settings;
 import org.eclipse.sisu.launch.InjectedTestCase;
+import org.junit.Test;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -35,6 +36,7 @@ public class DefaultMavenExecutionRequestPopulatorTest
     @Inject
     MavenExecutionRequestPopulator testee;
 
+    @Test
     public void testPluginRepositoryInjection()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeTest.java
@@ -16,17 +16,19 @@ package org.apache.maven.execution.scope.internal;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.inject.Key;
 import org.apache.maven.execution.MojoExecutionEvent;
 import org.apache.maven.execution.scope.WeakMojoExecutionListener;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-import com.google.inject.Key;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 public class MojoExecutionScopeTest
-    extends TestCase
 {
+    @Test
     public void testNestedEnter()
         throws Exception
     {
@@ -58,6 +60,7 @@ public class MojoExecutionScopeTest
         }
     }
 
+    @Test
     public void testMultiKeyInstance()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class MojoExecutionScopeTest
 {
@@ -50,14 +50,7 @@ public class MojoExecutionScopeTest
 
         scope.exit();
 
-        try
-        {
-            scope.exit();
-            fail();
-        }
-        catch ( IllegalStateException expected )
-        {
-        }
+        assertThrows( IllegalStateException.class, () -> scope.exit() );
     }
 
     @Test

--- a/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
@@ -14,21 +14,22 @@
  */
 package org.apache.maven.graph;
 
-import junit.framework.TestCase;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.DuplicateProjectException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.dag.CycleDetectedException;
+import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Kristian Rosenvold
  */
 public class DefaultProjectDependencyGraphTest
-    extends TestCase
 {
 
     private final MavenProject aProject = createA();
@@ -45,6 +46,7 @@ public class DefaultProjectDependencyGraphTest
     private final MavenProject transitiveOnly =
         createProject( Arrays.asList( toDependency( depender3 ) ), "depender5" );
 
+    @Test
     public void testGetSortedProjects()
         throws DuplicateProjectException, CycleDetectedException
     {
@@ -54,6 +56,7 @@ public class DefaultProjectDependencyGraphTest
         assertEquals( depender1, sortedProjects.get( 1 ) );
     }
 
+    @Test
     public void testVerifyExpectedParentStructure()
         throws CycleDetectedException, DuplicateProjectException
     {
@@ -66,6 +69,7 @@ public class DefaultProjectDependencyGraphTest
         assertEquals( depender3, sortedProjects.get( 3 ) );
     }
 
+    @Test
     public void testVerifyThatDownstreamProjectsComeInSortedOrder()
         throws CycleDetectedException, DuplicateProjectException
     {
@@ -76,6 +80,7 @@ public class DefaultProjectDependencyGraphTest
         assertEquals( depender3, downstreamProjects.get( 2 ) );
     }
 
+    @Test
     public void testTransitivesInOrder()
         throws CycleDetectedException, DuplicateProjectException
     {
@@ -89,6 +94,7 @@ public class DefaultProjectDependencyGraphTest
         assertEquals( depender2, downstreamProjects.get( 3 ) );
     }
 
+    @Test
     public void testNonTransitivesInOrder()
         throws CycleDetectedException, DuplicateProjectException
     {
@@ -102,6 +108,7 @@ public class DefaultProjectDependencyGraphTest
         assertEquals( depender2, downstreamProjects.get( 3 ) );
     }
 
+    @Test
     public void testWithTransitiveOnly()
         throws CycleDetectedException, DuplicateProjectException
     {
@@ -115,6 +122,7 @@ public class DefaultProjectDependencyGraphTest
         assertEquals( depender2, downstreamProjects.get( 3 ) );
     }
 
+    @Test
     public void testWithMissingTransitiveOnly()
         throws CycleDetectedException, DuplicateProjectException
     {
@@ -127,6 +135,7 @@ public class DefaultProjectDependencyGraphTest
         assertEquals( depender2, downstreamProjects.get( 2 ) );
     }
 
+    @Test
     public void testGetUpstreamProjects()
         throws CycleDetectedException, DuplicateProjectException
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -15,25 +15,25 @@ package org.apache.maven.lifecycle;
  * the License.
  */
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.hasSize;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
+import org.apache.maven.PlexusTestCase;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.junit.Before;
+import org.junit.Test;
 
-import javax.inject.Inject;
-import java.util.Collections;
-import java.util.List;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 /**
  * @author Kristian Rosenvold
@@ -54,7 +54,9 @@ public class DefaultLifecyclesTest
     }
 
     @Override
-    protected void setUp() throws Exception
+    @Before
+    public void setUp()
+        throws Exception
     {
         super.setUp();
         getContainer();
@@ -69,6 +71,7 @@ public class DefaultLifecyclesTest
                 binder -> binder.requestInjection( this ) );
     }
 
+    @Test
     public void testDefaultLifecycles()
     {
         final List<Lifecycle> lifecycles = defaultLifeCycles.getLifeCycles();
@@ -76,6 +79,7 @@ public class DefaultLifecyclesTest
         assertThat( DefaultLifecycles.STANDARD_LIFECYCLES,  arrayWithSize( 4 ) );
     }
 
+    @Test
     public void testDefaultLifecycle()
     {
         final Lifecycle lifecycle = getLifeCycleById( "default" );
@@ -83,6 +87,7 @@ public class DefaultLifecyclesTest
         assertThat( lifecycle.getPhases(), hasSize( 23 ) );
     }
 
+    @Test
     public void testCleanLifecycle()
     {
         final Lifecycle lifecycle = getLifeCycleById( "clean" );
@@ -90,6 +95,7 @@ public class DefaultLifecyclesTest
         assertThat( lifecycle.getPhases(), hasSize( 3 ) );
     }
 
+    @Test
     public void testSiteLifecycle()
     {
         final Lifecycle lifecycle = getLifeCycleById( "site" );
@@ -97,6 +103,7 @@ public class DefaultLifecyclesTest
         assertThat( lifecycle.getPhases(), hasSize( 4 ) );
     }
 
+    @Test
     public void testWrapperLifecycle()
     {
         final Lifecycle lifecycle = getLifeCycleById( "wrapper" );
@@ -104,6 +111,7 @@ public class DefaultLifecyclesTest
         assertThat( lifecycle.getPhases(), hasSize( 1 ) );
     }
 
+    @Test
     public void testCustomLifecycle()
     {
         List<Lifecycle> myLifecycles = new ArrayList<>();

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorSubModulesTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorSubModulesTest.java
@@ -25,6 +25,11 @@ import org.apache.maven.lifecycle.internal.LifecycleTaskSegmentCalculator;
 import org.apache.maven.lifecycle.internal.MojoExecutor;
 
 import javax.inject.Inject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Just asserts that it's able to create those components. Handy when CDI container gets a nervous breakdown.
@@ -64,6 +69,7 @@ public class LifecycleExecutorSubModulesTest
         return "src/test/projects/lifecycle-executor";
     }
 
+    @Test
     public void testCreation()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
@@ -15,9 +15,6 @@ package org.apache.maven.lifecycle;
  * the License.
  */
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,6 +42,16 @@ import org.apache.maven.plugin.MojoNotFoundException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 
@@ -72,6 +79,7 @@ public class LifecycleExecutorTest
     // Tests which exercise the lifecycle executor when it is dealing with default lifecycle phases.
     // -----------------------------------------------------------------------------------------------
 
+    @Test
     public void testCalculationOfBuildPlanWithIndividualTaskWherePluginIsSpecifiedInThePom()
         throws Exception
     {
@@ -92,6 +100,7 @@ public class LifecycleExecutorTest
         assertEquals( "0.1", mojoExecution.getMojoDescriptor().getPluginDescriptor().getVersion() );
     }
 
+    @Test
     public void testCalculationOfBuildPlanWithIndividualTaskOfTheCleanLifecycle()
         throws Exception
     {
@@ -111,6 +120,7 @@ public class LifecycleExecutorTest
         assertEquals( "0.1", mojoExecution.getMojoDescriptor().getPluginDescriptor().getVersion() );
     }
 
+    @Test
     public void testCalculationOfBuildPlanWithIndividualTaskOfTheCleanCleanGoal()
         throws Exception
     {
@@ -233,6 +243,7 @@ public class LifecycleExecutorTest
                           "configuration/models[1]/model" ) );
     }
 
+    @Test
     public void testLifecycleQueryingUsingADefaultLifecyclePhase()
         throws Exception
     {
@@ -263,6 +274,7 @@ public class LifecycleExecutorTest
         assertEquals( "jar:jar", executionPlan.get( 7 ).getMojoDescriptor().getFullGoalName() );
     }
 
+    @Test
     public void testLifecyclePluginsRetrievalForDefaultLifecycle()
         throws Exception
     {
@@ -272,6 +284,7 @@ public class LifecycleExecutorTest
         assertThat( plugins.toString(), plugins, hasSize( 9 ) );
     }
 
+    @Test
     public void testPluginConfigurationCreation()
         throws Exception
     {
@@ -301,6 +314,7 @@ public class LifecycleExecutorTest
                                                                         mergedSegment.getTasks() );
     }
 
+    @Test
     public void testInvalidGoalName()
         throws Exception
     {
@@ -328,6 +342,7 @@ public class LifecycleExecutorTest
     }
 
 
+    @Test
     public void testPluginPrefixRetrieval()
         throws Exception
     {
@@ -340,6 +355,7 @@ public class LifecycleExecutorTest
 
     // Prefixes
 
+    @Test
     public void testFindingPluginPrefixforCleanClean()
         throws Exception
     {
@@ -349,6 +365,7 @@ public class LifecycleExecutorTest
         assertNotNull( plugin );
     }
 
+    @Test
     public void testSetupMojoExecution()
         throws Exception
     {
@@ -371,6 +388,7 @@ public class LifecycleExecutorTest
         assertEquals("1.0", execution.getConfiguration().getChild( "version" ).getAttribute( "default-value" ));
     }
 
+    @Test
     public void testExecutionListeners()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
@@ -51,7 +51,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import javax.inject.Inject;
 
@@ -320,25 +320,15 @@ public class LifecycleExecutorTest
     {
         File pom = getProject( "project-basic" );
         MavenSession session = createMavenSession( pom );
-        try
-        {
-            getExecutions( calculateExecutionPlan( session, "resources:" ) );
-            fail( "expected a MojoNotFoundException" );
-        }
-        catch ( MojoNotFoundException e )
-        {
-            assertEquals( "", e.getGoal() );
-        }
+        MojoNotFoundException e = assertThrows( "expected a MojoNotFoundException",
+                MojoNotFoundException.class,
+                () -> getExecutions( calculateExecutionPlan( session, "resources:" ) ) );
+        assertEquals( "", e.getGoal() );
 
-        try
-        {
-            getExecutions( calculateExecutionPlan( session, "org.apache.maven.plugins:maven-resources-plugin:0.1:resources:toomany" ) );
-            fail( "expected a MojoNotFoundException" );
-        }
-        catch ( MojoNotFoundException e )
-        {
-            assertEquals( "resources:toomany", e.getGoal() );
-        }
+        e = assertThrows( "expected a MojoNotFoundException",
+                MojoNotFoundException.class,
+                () -> getExecutions( calculateExecutionPlan( session, "org.apache.maven.plugins:maven-resources-plugin:0.1:resources:toomany" ) ) );
+        assertEquals( "resources:toomany", e.getGoal() );
     }
 
 

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/MavenExecutionPlanTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/MavenExecutionPlanTest.java
@@ -15,21 +15,24 @@
 
 package org.apache.maven.lifecycle;
 
-import junit.framework.TestCase;
+import java.util.Set;
 
 import org.apache.maven.lifecycle.internal.ExecutionPlanItem;
 import org.apache.maven.lifecycle.internal.stub.LifecycleExecutionPlanCalculatorStub;
 import org.apache.maven.model.Plugin;
+import org.junit.Test;
 
-import java.util.Set;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Kristian Rosenvold
  */
 public class MavenExecutionPlanTest
-    extends TestCase
 {
 
+    @Test
     public void testFindLastInPhase()
         throws Exception
     {
@@ -41,6 +44,7 @@ public class MavenExecutionPlanTest
         assertNotNull( expected );
     }
 
+    @Test
     public void testThreadSafeMojos()
         throws Exception
     {
@@ -52,6 +56,7 @@ public class MavenExecutionPlanTest
     }
 
 
+    @Test
     public void testFindLastWhenFirst()
         throws Exception
     {
@@ -62,6 +67,7 @@ public class MavenExecutionPlanTest
         assertNull( beerPhase );
     }
 
+    @Test
     public void testFindLastInPhaseMisc()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/BuildListCalculatorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/BuildListCalculatorTest.java
@@ -15,17 +15,20 @@ package org.apache.maven.lifecycle.internal;
  * the License.
  */
 
-import junit.framework.TestCase;
+import java.util.List;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.internal.stub.LifecycleTaskSegmentCalculatorStub;
 import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
+import org.junit.Test;
 
-import java.util.List;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class BuildListCalculatorTest
-    extends TestCase
 {
 
+    @Test
     public void testCalculateProjectBuilds()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/BuilderCommonTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/BuilderCommonTest.java
@@ -15,9 +15,7 @@ package org.apache.maven.lifecycle.internal;
  * the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import java.util.HashSet;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
@@ -27,8 +25,9 @@ import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
 import org.codehaus.plexus.logging.Logger;
 import org.junit.Test;
 
-
-import java.util.HashSet;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Kristian Rosenvold
@@ -78,16 +77,19 @@ public class BuilderCommonTest
             + "you should define versions in pluginManagement section of your pom.xml or parent");
     }
 
+    @Test
     public void testHandleBuildError()
         throws Exception
     {
     }
 
+    @Test
     public void testAttachToThread()
         throws Exception
     {
     }
 
+    @Test
     public void testGetKey()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ConcurrencyDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ConcurrencyDependencyGraphTest.java
@@ -15,6 +15,8 @@ package org.apache.maven.lifecycle.internal;
  * the License.
  */
 
+import java.util.List;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.lifecycle.LifecycleNotFoundException;
@@ -29,10 +31,15 @@ import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
 import org.apache.maven.project.MavenProject;
+import org.junit.Test;
 
-import java.util.List;
-
-import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.*;
+import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.A;
+import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.B;
+import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.C;
+import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.X;
+import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.Y;
+import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.Z;
+import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub.getProjectBuildList;
 
 /**
  * @author Kristian Rosenvold
@@ -40,6 +47,7 @@ import static org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStu
 public class ConcurrencyDependencyGraphTest
     extends junit.framework.TestCase
 {
+    @Test
     public void testConcurrencyGraphPrimaryVersion()
         throws InvalidPluginDescriptorException, PluginVersionResolutionException, PluginDescriptorParsingException,
         NoPluginFoundForPrefixException, MojoNotFoundException, PluginNotFoundException, PluginResolutionException,
@@ -70,6 +78,7 @@ public class ConcurrencyDependencyGraphTest
         assertEquals( Z, cDescendants.get( 1 ) );
     }
 
+    @Test
     public void testConcurrencyGraphDifferentCompletionOrder()
         throws InvalidPluginDescriptorException, PluginVersionResolutionException, PluginDescriptorParsingException,
         NoPluginFoundForPrefixException, MojoNotFoundException, PluginNotFoundException, PluginResolutionException,

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolverTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolverTest.java
@@ -32,6 +32,10 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
 import javax.inject.Inject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class LifecycleDependencyResolverTest extends AbstractCoreMavenComponentTestCase
 {
@@ -44,6 +48,15 @@ public class LifecycleDependencyResolverTest extends AbstractCoreMavenComponentT
         return null;
     }
 
+    @Before
+    public void setUp()
+        throws Exception
+    {
+        super.setUp();
+        resolver = lookup( LifecycleDependencyResolver.class );
+    }
+
+    @Test
     public void testCachedReactorProjectDependencies() throws Exception
     {
         MavenSession session = createMavenSession( new File( "src/test/projects/lifecycle-dependency-resolver/pom.xml" ), new Properties(), true );

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
@@ -23,6 +23,9 @@ import org.apache.maven.lifecycle.internal.stub.DefaultLifecyclesStub;
 import org.apache.maven.lifecycle.internal.stub.PluginPrefixResolverStub;
 import org.apache.maven.lifecycle.internal.stub.PluginVersionResolverStub;
 import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Kristian Rosenvold
@@ -31,6 +34,7 @@ public class LifecycleExecutionPlanCalculatorTest
     extends AbstractCoreMavenComponentTestCase
 {
 
+    @Test
     public void testCalculateExecutionPlanWithGoalTasks()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleTaskSegmentCalculatorImplTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleTaskSegmentCalculatorImplTest.java
@@ -19,19 +19,22 @@ package org.apache.maven.lifecycle.internal;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import java.util.List;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.internal.stub.LifecycleTaskSegmentCalculatorStub;
 import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
+import org.junit.Test;
 
-import java.util.List;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Kristian Rosenvold
  */
 public class LifecycleTaskSegmentCalculatorImplTest
-    extends TestCase
 {
+    @Test
     public void testCalculateProjectBuilds()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/PhaseRecorderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/PhaseRecorderTest.java
@@ -15,20 +15,23 @@ package org.apache.maven.lifecycle.internal;
  * the License.
  */
 
-import junit.framework.TestCase;
+import java.util.List;
 
 import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.lifecycle.internal.stub.LifecycleExecutionPlanCalculatorStub;
 import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
 import org.apache.maven.plugin.MojoExecution;
+import org.junit.Test;
 
-import java.util.List;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Kristian Rosenvold
  */
-public class PhaseRecorderTest extends TestCase
+public class PhaseRecorderTest
 {
+    @Test
     public void testObserveExecution() throws Exception {
         PhaseRecorder phaseRecorder = new PhaseRecorder( ProjectDependencyGraphStub.A);
         MavenExecutionPlan plan = LifecycleExecutionPlanCalculatorStub.getProjectAExceutionPlan();

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ConcurrencyDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ConcurrencyDependencyGraphTest.java
@@ -14,17 +14,20 @@ package org.apache.maven.lifecycle.internal.builder.multithreaded;
  * the License.
  */
 
-import junit.framework.TestCase;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.lifecycle.internal.ProjectBuildList;
 import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
 import org.apache.maven.project.MavenProject;
+import org.junit.Test;
 
-import java.util.List;
-import java.util.Set;
+import static org.junit.Assert.assertEquals;
 
-public class ConcurrencyDependencyGraphTest extends TestCase {
+public class ConcurrencyDependencyGraphTest {
 
+    @Test
     public void testGraph() throws Exception {
 
         ProjectBuildList projectBuildList = ProjectDependencyGraphStub.getProjectBuildList(

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ThreadOutputMuxerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ThreadOutputMuxerTest.java
@@ -15,23 +15,6 @@ package org.apache.maven.lifecycle.internal.builder.multithreaded;
  * the License.
  */
 
-import junit.framework.TestCase;
-
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.lifecycle.LifecycleNotFoundException;
-import org.apache.maven.lifecycle.LifecyclePhaseNotFoundException;
-import org.apache.maven.lifecycle.internal.ProjectBuildList;
-import org.apache.maven.lifecycle.internal.ProjectSegment;
-import org.apache.maven.lifecycle.internal.builder.multithreaded.ThreadOutputMuxer;
-import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
-import org.apache.maven.plugin.InvalidPluginDescriptorException;
-import org.apache.maven.plugin.MojoNotFoundException;
-import org.apache.maven.plugin.PluginDescriptorParsingException;
-import org.apache.maven.plugin.PluginNotFoundException;
-import org.apache.maven.plugin.PluginResolutionException;
-import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
-import org.apache.maven.plugin.version.PluginVersionResolutionException;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -45,11 +28,27 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleNotFoundException;
+import org.apache.maven.lifecycle.LifecyclePhaseNotFoundException;
+import org.apache.maven.lifecycle.internal.ProjectBuildList;
+import org.apache.maven.lifecycle.internal.ProjectSegment;
+import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
+import org.apache.maven.plugin.InvalidPluginDescriptorException;
+import org.apache.maven.plugin.MojoNotFoundException;
+import org.apache.maven.plugin.PluginDescriptorParsingException;
+import org.apache.maven.plugin.PluginNotFoundException;
+import org.apache.maven.plugin.PluginResolutionException;
+import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
+import org.apache.maven.plugin.version.PluginVersionResolutionException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author Kristian Rosenvold
  */
 public class ThreadOutputMuxerTest
-    extends TestCase
 {
 
     final String paid = "Paid";
@@ -58,6 +57,7 @@ public class ThreadOutputMuxerTest
 
     final String full = "Full";
 
+    @Test
     public void testSingleThreaded()
         throws Exception
     {
@@ -86,6 +86,7 @@ public class ThreadOutputMuxerTest
         assertEquals( ( paid + in + full ).length(), byteArrayOutputStream.size() );
     }
 
+    @Test
     public void testMultiThreaded()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/ProjectDependencyGraphStubTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/ProjectDependencyGraphStubTest.java
@@ -15,11 +15,13 @@
 
 package org.apache.maven.lifecycle.internal.stub;
 
-import junit.framework.TestCase;
-import org.apache.maven.project.MavenProject;
-
 import java.util.List;
 
+import org.apache.maven.project.MavenProject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the stub. Yeah, I know.
@@ -28,30 +30,34 @@ import java.util.List;
  */
 
 public class ProjectDependencyGraphStubTest
-    extends TestCase
 {
+    ProjectDependencyGraphStub stub = new ProjectDependencyGraphStub();
+
+    @Test
     public void testADependencies()
     {
-        ProjectDependencyGraphStub stub = new ProjectDependencyGraphStub();
         final List<MavenProject> mavenProjects = stub.getUpstreamProjects( ProjectDependencyGraphStub.A, false );
         assertEquals( 0, mavenProjects.size() );
     }
 
-    public void testBDepenencies( ProjectDependencyGraphStub stub )
+    @Test
+    public void testBDepenencies()
     {
         final List<MavenProject> bProjects = stub.getUpstreamProjects( ProjectDependencyGraphStub.B, false );
         assertEquals( 1, bProjects.size() );
         assertTrue( bProjects.contains( ProjectDependencyGraphStub.A ) );
     }
 
-    public void testCDepenencies( ProjectDependencyGraphStub stub )
+    @Test
+    public void testCDepenencies()
     {
         final List<MavenProject> cProjects = stub.getUpstreamProjects( ProjectDependencyGraphStub.C, false );
         assertEquals( 1, cProjects.size() );
-        assertTrue( cProjects.contains( ProjectDependencyGraphStub.C ) );
+        assertTrue( cProjects.contains( ProjectDependencyGraphStub.A ) );
     }
 
-    public void testXDepenencies( ProjectDependencyGraphStub stub )
+    @Test
+    public void testXDepenencies()
     {
         final List<MavenProject> cProjects = stub.getUpstreamProjects( ProjectDependencyGraphStub.X, false );
         assertEquals( 2, cProjects.size() );

--- a/maven-core/src/test/java/org/apache/maven/plugin/PluginManagerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/PluginManagerTest.java
@@ -32,6 +32,13 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 
@@ -41,12 +48,12 @@ public class PluginManagerTest
     @Inject
     private DefaultBuildPluginManager pluginManager;
 
-
     protected String getProjectsDirectory()
     {
         return "src/test/projects/plugin-manager";
     }
 
+    @Test
     public void testPluginLoading()
         throws Exception
     {
@@ -61,6 +68,7 @@ public class PluginManagerTest
         assertNotNull( pluginDescriptor );
     }
 
+    @Test
     public void testMojoDescriptorRetrieval()
         throws Exception
     {
@@ -97,6 +105,7 @@ public class PluginManagerTest
     //      only deal in concrete terms -- all version finding mumbo jumbo is a customization to base functionality
     //      the plugin manager provides.
 
+    @Test
     public void testRemoteResourcesPlugin()
         throws Exception
     {
@@ -150,6 +159,7 @@ public class PluginManagerTest
         */
     }
 
+    @Test
     public void testMojoConfigurationIsMergedCorrectly()
         throws Exception
     {
@@ -160,6 +170,7 @@ public class PluginManagerTest
      * is in the Antlr plugin which comes bundled with a version of Antlr but the user often times needs
      * to use a specific version. We need to make sure the version that they specify takes precedence.
      */
+    @Test
     public void testMojoWhereInternallyStatedDependencyIsOverriddenByProject()
         throws Exception
     {
@@ -169,6 +180,7 @@ public class PluginManagerTest
      * The case where you have a plugin in the current build that you want to be used on projects in
      * the current build.
      */
+    @Test
     public void testMojoThatIsPresentInTheCurrentBuild()
         throws Exception
     {
@@ -178,6 +190,7 @@ public class PluginManagerTest
      * This is the case where the Mojo wants to execute on every project and then do something at the end
      * with the results of each project.
      */
+    @Test
     public void testAggregatorMojo()
         throws Exception
     {
@@ -187,6 +200,7 @@ public class PluginManagerTest
      * This is the case where a Mojo needs the lifecycle run to a certain phase before it can do
      * anything useful.
      */
+    @Test
     public void testMojoThatRequiresExecutionToAGivenPhaseBeforeExecutingItself()
         throws Exception
     {
@@ -198,6 +212,7 @@ public class PluginManagerTest
 
     // test a build where projects use different versions of the same plugin
 
+    @Test
     public void testThatPluginDependencyThatHasSystemScopeIsResolved()
         throws Exception
     {
@@ -241,6 +256,7 @@ public class PluginManagerTest
         assertEquals( version, pd.getVersion() );
     }
 
+    @Test
     public void testPluginRealmCache()
         throws Exception
     {
@@ -285,6 +301,7 @@ public class PluginManagerTest
         }
     }
 
+    @Test
     public void testBuildExtensionsPluginLoading()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExceptionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExceptionTest.java
@@ -24,8 +24,9 @@ import java.util.Collections;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 /**
  * MNG-3131
@@ -34,11 +35,11 @@ import junit.framework.TestCase;
  *
  */
 public class PluginParameterExceptionTest
-    extends TestCase
 {
 
     private final String LS = System.lineSeparator();
 
+    @Test
     public void testMissingRequiredStringArrayTypeParameter()
     {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();
@@ -69,6 +70,7 @@ public class PluginParameterExceptionTest
                 "</configuration>." + LS, exception.buildDiagnosticMessage() );
     }
 
+    @Test
     public void testMissingRequiredCollectionTypeParameter()
     {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();
@@ -99,6 +101,7 @@ public class PluginParameterExceptionTest
                 "</configuration>." + LS, exception.buildDiagnosticMessage() );
     }
 
+    @Test
     public void testMissingRequiredMapTypeParameter()
     {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();
@@ -129,6 +132,7 @@ public class PluginParameterExceptionTest
                 "</configuration>." + LS, exception.buildDiagnosticMessage() );
     }
 
+    @Test
     public void testMissingRequiredPropertiesTypeParameter()
     {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();

--- a/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorTest.java
@@ -46,6 +46,14 @@ import org.codehaus.plexus.MutablePlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.util.dag.CycleDetectedException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
 
@@ -60,14 +68,7 @@ public class PluginParameterExpressionEvaluatorTest
     @Inject
     private RepositorySystem factory;
 
-    @Override
-    protected void tearDown()
-        throws Exception
-    {
-        factory = null;
-        super.tearDown();
-    }
-
+    @Test
     public void testPluginDescriptorExpressionReference()
         throws Exception
     {
@@ -84,6 +85,7 @@ public class PluginParameterExpressionEvaluatorTest
                     result );
     }
 
+    @Test
     public void testPluginArtifactsExpressionReference()
         throws Exception
     {
@@ -109,6 +111,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertSame( "dependency artifact is wrong.", depArtifact, depResults.get( 0 ) );
     }
 
+    @Test
     public void testPluginArtifactMapExpressionReference()
         throws Exception
     {
@@ -136,6 +139,7 @@ public class PluginParameterExpressionEvaluatorTest
                     depResults.get( ArtifactUtils.versionlessKey( depArtifact ) ) );
     }
 
+    @Test
     public void testPluginArtifactIdExpressionReference()
         throws Exception
     {
@@ -152,6 +156,7 @@ public class PluginParameterExpressionEvaluatorTest
                     result );
     }
 
+    @Test
     public void testValueExtractionWithAPomValueContainingAPath()
         throws Exception
     {
@@ -174,6 +179,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( expected, actual );
     }
 
+    @Test
     public void testEscapedVariablePassthrough()
         throws Exception
     {
@@ -191,6 +197,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( var, value );
     }
 
+    @Test
     public void testEscapedVariablePassthroughInLargerExpression()
         throws Exception
     {
@@ -209,6 +216,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( "${var} with version: 1", value );
     }
 
+    @Test
     public void testMultipleSubExpressionsInLargerExpression()
         throws Exception
     {
@@ -227,6 +235,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( "test with version: 1", value );
     }
 
+    @Test
     public void testMissingPOMPropertyRefInLargerExpression()
         throws Exception
     {
@@ -241,6 +250,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( expr, value );
     }
 
+    @Test
     public void testPOMPropertyExtractionWithMissingProject_WithDotNotation()
         throws Exception
     {
@@ -262,6 +272,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( checkValue, value );
     }
 
+    @Test
     public void testBasedirExtractionWithMissingProject()
         throws Exception
     {
@@ -272,6 +283,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( System.getProperty( "user.dir" ), value );
     }
 
+    @Test
     public void testValueExtractionFromSystemPropertiesWithMissingProject()
         throws Exception
     {
@@ -291,6 +303,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( "value", value );
     }
 
+    @Test
     public void testValueExtractionFromSystemPropertiesWithMissingProject_WithDotNotation()
         throws Exception
     {
@@ -323,6 +336,7 @@ public class PluginParameterExpressionEvaluatorTest
         return new MavenSession( container, request, new DefaultMavenExecutionResult(), Collections.<MavenProject>emptyList()  );
     }
 
+    @Test
     public void testLocalRepositoryExtraction()
         throws Exception
     {
@@ -333,6 +347,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( "local", ( (ArtifactRepository) value ).getId() );
     }
 
+    @Test
     public void testTwoExpressions()
         throws Exception
     {
@@ -351,6 +366,7 @@ public class PluginParameterExpressionEvaluatorTest
         assertEquals( "expected-directory" + File.separatorChar + "expected-finalName", value );
     }
 
+    @Test
     public void testShouldExtractPluginArtifacts()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/plugin/internal/DefaultLegacySupportTest.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/internal/DefaultLegacySupportTest.java
@@ -18,20 +18,23 @@ package org.apache.maven.plugin.internal;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import java.util.concurrent.CountDownLatch;
+
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Kristian Rosenvold
  */
-public class DefaultLegacySupportTest extends TestCase {
+public class DefaultLegacySupportTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final DefaultLegacySupport defaultLegacySupport = new DefaultLegacySupport();
 
+    @Test
     public void testSetSession() throws Exception {
 
         MavenExecutionRequest mavenExecutionRequest = new DefaultMavenExecutionRequest();

--- a/maven-core/src/test/java/org/apache/maven/project/AbstractMavenProjectTestCase.java
+++ b/maven-core/src/test/java/org/apache/maven/project/AbstractMavenProjectTestCase.java
@@ -31,8 +31,10 @@ import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.junit.After;
+import org.junit.Before;
 
 import javax.inject.Inject;
 
@@ -64,7 +66,8 @@ public abstract class AbstractMavenProjectTestCase
                 binder -> binder.requestInjection( this ) );
     }
 
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
         super.setUp();
@@ -80,8 +83,8 @@ public abstract class AbstractMavenProjectTestCase
         }
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         projectBuilder = null;

--- a/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -28,12 +28,13 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class DefaultMavenProjectBuilderTest
@@ -128,15 +129,10 @@ public class DefaultMavenProjectBuilderTest
     {
         File f1 = getTestFile( "src/test/resources/projects/future-model-version-pom.xml" );
 
-        try
-        {
-            getProject( f1 );
-            fail( "Expected to fail for future versions" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            assertContains( "Building this project requires a newer version of Maven", e.getMessage() );
-        }
+        ProjectBuildingException e = assertThrows( "Expected to fail for future versions",
+                ProjectBuildingException.class,
+                () -> getProject( f1 ) );
+        assertContains( "Building this project requires a newer version of Maven", e.getMessage() );
     }
 
     @Test
@@ -147,15 +143,10 @@ public class DefaultMavenProjectBuilderTest
         // update the resource if we stop supporting modelVersion 4.0.0
         File f1 = getTestFile( "src/test/resources/projects/past-model-version-pom.xml" );
 
-        try
-        {
-            getProject( f1 );
-            fail( "Expected to fail for past versions" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            assertContains( "Building this project requires an older version of Maven", e.getMessage() );
-        }
+        ProjectBuildingException e = assertThrows( "Expected to fail for past versions",
+                ProjectBuildingException.class,
+                () -> getProject( f1 ) );
+        assertContains( "Building this project requires an older version of Maven", e.getMessage() );
     }
 
     @Test
@@ -164,15 +155,10 @@ public class DefaultMavenProjectBuilderTest
     {
         File f1 = getTestFile( "src/test/resources/projects/future-schema-model-version-pom.xml" );
 
-        try
-        {
-            getProject( f1 );
-            fail( "Expected to fail for future versions" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            assertContains( "Building this project requires a newer version of Maven", e.getMessage() );
-        }
+        ProjectBuildingException e = assertThrows( "Expected to fail for future versions",
+                ProjectBuildingException.class,
+                () -> getProject( f1 ) );
+        assertContains( "Building this project requires a newer version of Maven", e.getMessage() );
     }
 
     private void assertContains( String expected, String actual )
@@ -229,26 +215,21 @@ public class DefaultMavenProjectBuilderTest
     {
         File pomFile = getTestFile( "src/test/resources/projects/bad-dependency.xml" );
 
-        try
-        {
-            ProjectBuildingRequest request = newBuildingRequest();
-            request.setProcessPlugins( false );
-            request.setResolveDependencies( true );
-            projectBuilder.build( pomFile, request );
-            fail( "Project building did not fail despite invalid POM" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            List<ProjectBuildingResult> results = e.getResults();
-            assertNotNull( results );
-            assertEquals( 1, results.size() );
-            ProjectBuildingResult result = results.get( 0 );
-            assertNotNull( result );
-            assertNotNull( result.getProject() );
-            assertEquals( 1, result.getProblems().size() );
-            assertEquals( 1, result.getProject().getArtifacts().size() );
-            assertNotNull( result.getDependencyResolutionResult() );
-        }
+        ProjectBuildingRequest request = newBuildingRequest();
+        request.setProcessPlugins( false );
+        request.setResolveDependencies( true );
+        ProjectBuildingException e = assertThrows( "Project building did not fail despite invalid POM",
+                ProjectBuildingException.class,
+                () -> projectBuilder.build( pomFile, request ) );
+        List<ProjectBuildingResult> results = e.getResults();
+        assertNotNull( results );
+        assertEquals( 1, results.size() );
+        ProjectBuildingResult result = results.get( 0 );
+        assertNotNull( result );
+        assertNotNull( result.getProject() );
+        assertEquals( 1, result.getProblems().size() );
+        assertEquals( 1, result.getProject().getArtifacts().size() );
+        assertNotNull( result.getDependencyResolutionResult() );
     }
 
     /**
@@ -282,16 +263,11 @@ public class DefaultMavenProjectBuilderTest
         File f1 =
             getTestFile( "src/test/resources/projects/parent-version-range-local-child-without-version/child/pom.xml" );
 
-        try
-        {
-            getProject( f1 );
-            fail( "Expected 'ProjectBuildingException' not thrown." );
-        }
-        catch ( final ProjectBuildingException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
-        }
+        ProjectBuildingException e = assertThrows( "Expected 'ProjectBuildingException' not thrown.",
+                ProjectBuildingException.class,
+                () -> getProject( f1 ) );
+        assertNotNull( e.getMessage() );
+        assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
     }
 
     /**
@@ -306,16 +282,11 @@ public class DefaultMavenProjectBuilderTest
             getTestFile(
                 "src/test/resources/projects/parent-version-range-local-child-version-expression/child/pom.xml" );
 
-        try
-        {
-            getProject( f1 );
-            fail( "Expected 'ProjectBuildingException' not thrown." );
-        }
-        catch ( final ProjectBuildingException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
-        }
+        ProjectBuildingException e = assertThrows( "Expected 'ProjectBuildingException' not thrown.",
+                ProjectBuildingException.class,
+                () -> getProject( f1 ) );
+        assertNotNull( e.getMessage() );
+        assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
     }
 
     /**
@@ -350,16 +321,11 @@ public class DefaultMavenProjectBuilderTest
             getTestFile(
                 "src/test/resources/projects/parent-version-range-external-child-without-version/pom.xml" );
 
-        try
-        {
-            this.getProjectFromRemoteRepository( f1 );
-            fail( "Expected 'ProjectBuildingException' not thrown." );
-        }
-        catch ( final ProjectBuildingException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
-        }
+        ProjectBuildingException e = assertThrows( "Expected 'ProjectBuildingException' not thrown.",
+                ProjectBuildingException.class,
+                () -> getProjectFromRemoteRepository( f1 ) );
+        assertNotNull( e.getMessage() );
+        assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
     }
 
     /**
@@ -374,16 +340,11 @@ public class DefaultMavenProjectBuilderTest
             getTestFile(
                 "src/test/resources/projects/parent-version-range-external-child-version-expression/pom.xml" );
 
-        try
-        {
-            this.getProjectFromRemoteRepository( f1 );
-            fail( "Expected 'ProjectBuildingException' not thrown." );
-        }
-        catch ( final ProjectBuildingException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
-        }
+        ProjectBuildingException e = assertThrows( "Expected 'ProjectBuildingException' not thrown.",
+                ProjectBuildingException.class,
+                () -> getProjectFromRemoteRepository( f1 ) );
+        assertNotNull( e.getMessage() );
+        assertThat( e.getMessage(), containsString( "Version must be a constant" ) );
     }
 
 }

--- a/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -18,8 +18,6 @@ package org.apache.maven.project;
  * specific language governing permissions and limitations
  * under the License.
  */
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -27,8 +25,16 @@ import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class DefaultMavenProjectBuilderTest
     extends AbstractMavenProjectTestCase
@@ -91,6 +97,7 @@ public class DefaultMavenProjectBuilderTest
      * Check that we can build ok from the middle pom of a (parent,child,grandchild) hierarchy
      * @throws Exception
      */
+    @Test
     public void testBuildFromMiddlePom() throws Exception
     {
         File f1 = getTestFile( "src/test/resources/projects/grandchild-check/child/pom.xml");
@@ -103,6 +110,7 @@ public class DefaultMavenProjectBuilderTest
         getProject( f2 );
     }
 
+    @Test
     public void testDuplicatePluginDefinitionsMerged()
         throws Exception
     {
@@ -114,6 +122,7 @@ public class DefaultMavenProjectBuilderTest
         assertEquals( "first", project.getBuildPlugins().get( 0 ).getExecutions().get( 0 ).getId() );
     }
 
+    @Test
     public void testFutureModelVersion()
         throws Exception
     {
@@ -130,6 +139,7 @@ public class DefaultMavenProjectBuilderTest
         }
     }
 
+    @Test
     public void testPastModelVersion()
         throws Exception
     {
@@ -148,6 +158,7 @@ public class DefaultMavenProjectBuilderTest
         }
     }
 
+    @Test
     public void testFutureSchemaModelVersion()
         throws Exception
     {
@@ -174,6 +185,7 @@ public class DefaultMavenProjectBuilderTest
         }
     }
 
+    @Test
     public void testBuildStubModelForMissingRemotePom()
         throws Exception
     {
@@ -211,6 +223,7 @@ public class DefaultMavenProjectBuilderTest
         }
     }
 
+    @Test
     public void testPartialResultUponBadDependencyDeclaration()
         throws Exception
     {
@@ -243,6 +256,7 @@ public class DefaultMavenProjectBuilderTest
      *
      * @throws Exception
      */
+    @Test
     public void testBuildValidParentVersionRangeLocally() throws Exception
     {
         File f1 = getTestFile( "src/test/resources/projects/parent-version-range-local-valid/child/pom.xml" );
@@ -262,6 +276,7 @@ public class DefaultMavenProjectBuilderTest
      *
      * @throws Exception
      */
+    @Test
     public void testBuildParentVersionRangeLocallyWithoutChildVersion() throws Exception
     {
         File f1 =
@@ -284,6 +299,7 @@ public class DefaultMavenProjectBuilderTest
      *
      * @throws Exception
      */
+    @Test
     public void testBuildParentVersionRangeLocallyWithChildVersionExpression() throws Exception
     {
         File f1 =
@@ -307,6 +323,7 @@ public class DefaultMavenProjectBuilderTest
      *
      * @throws Exception
      */
+    @Test
     public void testBuildParentVersionRangeExternally() throws Exception
     {
         File f1 = getTestFile( "src/test/resources/projects/parent-version-range-external-valid/pom.xml" );
@@ -326,6 +343,7 @@ public class DefaultMavenProjectBuilderTest
      *
      * @throws Exception
      */
+    @Test
     public void testBuildParentVersionRangeExternallyWithoutChildVersion() throws Exception
     {
         File f1 =
@@ -349,6 +367,7 @@ public class DefaultMavenProjectBuilderTest
      *
      * @throws Exception
      */
+    @Test
     public void testBuildParentVersionRangeExternallyWithChildVersionExpression() throws Exception
     {
         File f1 =

--- a/maven-core/src/test/java/org/apache/maven/project/ExtensionDescriptorBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ExtensionDescriptorBuilderTest.java
@@ -19,16 +19,20 @@ package org.apache.maven.project;
  * under the License.
  */
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests {@link ExtensionDescriptorBuilder}.
@@ -36,27 +40,22 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ExtensionDescriptorBuilderTest
-    extends TestCase
 {
 
     private ExtensionDescriptorBuilder builder;
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
-
         builder = new ExtensionDescriptorBuilder();
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         builder = null;
-
-        super.tearDown();
     }
 
     private InputStream toStream( String xml )
@@ -64,6 +63,7 @@ public class ExtensionDescriptorBuilderTest
         return new ByteArrayInputStream( xml.getBytes( StandardCharsets.UTF_8 ) );
     }
 
+    @Test
     public void testEmptyDescriptor()
         throws Exception
     {
@@ -78,6 +78,7 @@ public class ExtensionDescriptorBuilderTest
         assertThat( ed.getExportedArtifacts(), is( empty() ) );
     }
 
+    @Test
     public void testCompleteDescriptor()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
@@ -28,11 +28,19 @@ import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.model.Profile;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class MavenProjectTest
     extends AbstractMavenProjectTestCase
 {
 
+    @Test
     public void testShouldInterpretChildPathAdjustmentBasedOnModulePaths()
         throws IOException
     {
@@ -59,6 +67,7 @@ public class MavenProjectTest
         assertEquals( "..", adjustment );
     }
 
+    @Test
     public void testIdentityProtoInheritance()
     {
         Parent parent = new Parent();
@@ -82,6 +91,7 @@ public class MavenProjectTest
         project.getId();
     }
 
+    @Test
     public void testEmptyConstructor()
     {
         MavenProject project = new MavenProject();
@@ -90,6 +100,7 @@ public class MavenProjectTest
                         + MavenProject.EMPTY_PROJECT_VERSION, project.getId() );
     }
 
+    @Test
     public void testClone()
         throws Exception
     {
@@ -103,6 +114,7 @@ public class MavenProjectTest
         assertTrue( "ManagedVersionMap is not empty", clonedMap.isEmpty() );
     }
 
+    @Test
     public void testCloneWithDependencyManagement()
         throws Exception
     {
@@ -127,6 +139,7 @@ public class MavenProjectTest
                     clonedMap.containsKey( "maven-test:maven-test-b:jar" ) );
     }
 
+    @Test
     public void testGetModulePathAdjustment()
         throws IOException
     {
@@ -146,6 +159,7 @@ public class MavenProjectTest
         assertEquals( "..", pathAdjustment );
     }
 
+    @Test
     public void testCloneWithDistributionManagement()
         throws Exception
     {
@@ -157,6 +171,7 @@ public class MavenProjectTest
         assertNotNull( "clonedProject - distributionManagement", clonedProject.getDistributionManagementArtifactRepository() );
     }
 
+    @Test
     public void testCloneWithActiveProfile()
         throws Exception
     {
@@ -177,6 +192,7 @@ public class MavenProjectTest
                        activeProfilesClone );
     }
 
+    @Test
     public void testCloneWithBaseDir()
         throws Exception
     {
@@ -188,6 +204,7 @@ public class MavenProjectTest
         assertEquals( "Base directory is preserved across clone", projectToClone.getBasedir(), clonedProject.getBasedir() );
     }
 
+    @Test
     public void testUndefinedOutputDirectory()
         throws Exception
     {
@@ -198,6 +215,7 @@ public class MavenProjectTest
         assertNoNulls( p.getTestClasspathElements() );
     }
 
+    @Test
     public void testAddDotFile()
     {
         MavenProject project = new MavenProject();

--- a/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class PomConstructionTest
     extends PlexusTestCase
@@ -1689,15 +1689,9 @@ public class PomConstructionTest
     public void testValidationErrorUponNonUniqueArtifactRepositoryId()
         throws Exception
     {
-        try
-        {
-            buildPom( "unique-repo-id/artifact-repo" );
-            fail( "Non-unique repository ids did not cause validation error" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            // expected
-        }
+        assertThrows( "Non-unique repository ids did not cause validation error",
+                ProjectBuildingException.class,
+                () -> buildPom( "unique-repo-id/artifact-repo" ) );
     }
 
     /* MNG-4193 */
@@ -1705,15 +1699,9 @@ public class PomConstructionTest
     public void testValidationErrorUponNonUniquePluginRepositoryId()
         throws Exception
     {
-        try
-        {
-            buildPom( "unique-repo-id/plugin-repo" );
-            fail( "Non-unique repository ids did not cause validation error" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            // expected
-        }
+        assertThrows( "Non-unique repository ids did not cause validation error",
+                ProjectBuildingException.class,
+                () -> buildPom( "unique-repo-id/plugin-repo" ) );
     }
 
     /* MNG-4193 */
@@ -1721,15 +1709,9 @@ public class PomConstructionTest
     public void testValidationErrorUponNonUniqueArtifactRepositoryIdInProfile()
         throws Exception
     {
-        try
-        {
-            buildPom( "unique-repo-id/artifact-repo-in-profile" );
-            fail( "Non-unique repository ids did not cause validation error" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            // expected
-        }
+        assertThrows( "Non-unique repository ids did not cause validation error",
+                ProjectBuildingException.class,
+                () -> buildPom( "unique-repo-id/artifact-repo-in-profile" ) );
     }
 
     /* MNG-4193 */
@@ -1737,15 +1719,9 @@ public class PomConstructionTest
     public void testValidationErrorUponNonUniquePluginRepositoryIdInProfile()
         throws Exception
     {
-        try
-        {
-            buildPom( "unique-repo-id/plugin-repo-in-profile" );
-            fail( "Non-unique repository ids did not cause validation error" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            // expected
-        }
+        assertThrows( "Non-unique repository ids did not cause validation error",
+                ProjectBuildingException.class,
+                () -> buildPom( "unique-repo-id/plugin-repo-in-profile" ) );
     }
 
     /** MNG-3843 */
@@ -1824,15 +1800,9 @@ public class PomConstructionTest
     public void testParentPomPackagingMustBePom()
         throws Exception
     {
-        try
-        {
-            buildPom( "parent-pom-packaging/sub" );
-            fail( "Wrong packaging of parent POM was not rejected" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            // expected
-        }
+        assertThrows( "Wrong packaging of parent POM was not rejected",
+                ProjectBuildingException.class,
+                () -> buildPom( "parent-pom-packaging/sub" ) );
     }
 
     /** MNG-522, MNG-3018 */
@@ -1953,15 +1923,9 @@ public class PomConstructionTest
     public void testProjectArtifactIdIsNotInheritedButMandatory()
         throws Exception
     {
-        try
-        {
-            buildPom( "artifact-id-inheritance/child" );
-            fail( "Missing artifactId did not cause validation error" );
-        }
-        catch ( ProjectBuildingException e )
-        {
-            // expected
-        }
+        assertThrows( "Missing artifactId did not cause validation error",
+                ProjectBuildingException.class,
+                () -> buildPom( "artifact-id-inheritance/child" ) );
     }
 
     private void assertPathSuffixEquals( String expected, Object actual )

--- a/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.inject.Inject;
+
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
@@ -37,16 +40,23 @@ import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import javax.inject.Inject;
-
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class PomConstructionTest
     extends PlexusTestCase
@@ -82,7 +92,8 @@ public class PomConstructionTest
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
         getContainer();
@@ -90,8 +101,8 @@ public class PomConstructionTest
         new File( getBasedir(), BASE_MIXIN_DIR );
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         projectBuilder = null;
@@ -104,7 +115,7 @@ public class PomConstructionTest
      *
      * @throws Exception
      */
-
+    @Test
     public void testEmptyUrl()
         throws Exception
     {
@@ -117,6 +128,7 @@ public class PomConstructionTest
      * @throws Exception
      */
     /* MNG-786*/
+    @Test
     public void testProfileModules()
         throws Exception
     {
@@ -134,6 +146,7 @@ public class PomConstructionTest
      *
      * @throws Exception
      */
+    @Test
     public void testParentInheritance()
         throws Exception
     {
@@ -141,6 +154,7 @@ public class PomConstructionTest
     }
 
     /*MNG-3995*/
+    @Test
     public void testExecutionConfigurationJoin()
        throws Exception
     {
@@ -149,6 +163,7 @@ public class PomConstructionTest
     }
 
     /*MNG-3803*/
+    @Test
     public void testPluginConfigProperties()
        throws Exception
     {
@@ -157,6 +172,7 @@ public class PomConstructionTest
     }
 
     /*MNG-3900*/
+    @Test
     public void testProfilePropertiesInterpolation()
         throws Exception
     {
@@ -188,6 +204,7 @@ public class PomConstructionTest
     }
 
     /*MNG- 4010*/
+    @Test
     public void testDuplicateExclusionsDependency()
         throws Exception
     {
@@ -197,6 +214,7 @@ public class PomConstructionTest
     }
 
     /*MNG- 4008*/
+    @Test
     public void testMultipleFilters()
         throws Exception
     {
@@ -220,6 +238,7 @@ public class PomConstructionTest
         }
     }
 
+    @Test
     public void testValidationErrorUponNonUniqueDependencyManagementKey()
         throws Exception
     {
@@ -234,6 +253,7 @@ public class PomConstructionTest
         }
     }
 
+    @Test
     public void testValidationErrorUponNonUniqueDependencyKeyInProfile()
         throws Exception
     {
@@ -248,6 +268,7 @@ public class PomConstructionTest
         }
     }
 
+    @Test
     public void testValidationErrorUponNonUniqueDependencyManagementKeyInProfile()
         throws Exception
     {
@@ -262,7 +283,7 @@ public class PomConstructionTest
         }
     }
     */
-
+    @Test
     public void testDuplicateDependenciesCauseLastDeclarationToBePickedInLenientMode()
         throws Exception
     {
@@ -272,6 +293,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3567*/
+    @Test
     public void testParentInterpolation()
         throws Exception
     {
@@ -295,6 +317,7 @@ public class PomConstructionTest
     */
 
     /* MNG-3567*/
+    @Test
     public void testPluginManagementInherited()
         throws Exception
     {
@@ -303,6 +326,7 @@ public class PomConstructionTest
     }
 
      /* MNG-2174*/
+    @Test
     public void testPluginManagementDependencies()
         throws Exception
     {
@@ -313,6 +337,7 @@ public class PomConstructionTest
 
 
     /* MNG-3877*/
+    @Test
     public void testReportingInterpolation()
         throws Exception
     {
@@ -323,6 +348,7 @@ public class PomConstructionTest
     }
 
 
+    @Test
     public void testPluginOrder()
         throws Exception
     {
@@ -331,6 +357,7 @@ public class PomConstructionTest
         assertEquals( "maven-surefire-plugin", pom.getValue( "build/plugins[2]/artifactId" ) );
     }
 
+    @Test
     public void testErroneousJoiningOfDifferentPluginsWithEqualDependencies()
         throws Exception
     {
@@ -342,6 +369,7 @@ public class PomConstructionTest
     }
 
     /** MNG-3821 */
+    @Test
     public void testErroneousJoiningOfDifferentPluginsWithEqualExecutionIds()
         throws Exception
     {
@@ -357,6 +385,7 @@ public class PomConstructionTest
     }
 
      /** MNG-3998 */
+    @Test
     public void testExecutionConfiguration()
         throws Exception
     {
@@ -375,8 +404,7 @@ public class PomConstructionTest
     PomTestWrapper pom = buildPom( "plugin-config-duplicate/dup" );
 }
 */
-
-
+    @Test
     public void testSingleConfigurationInheritance()
         throws Exception
     {
@@ -389,6 +417,7 @@ public class PomConstructionTest
                       pom.getValue( "build/plugins[1]/executions[1]/configuration[1]/rules[1]/requireJavaVersion[1]/version" ) );
     }
 
+    @Test
     public void testConfigWithPluginManagement()
         throws Exception
     {
@@ -399,6 +428,7 @@ public class PomConstructionTest
     }
 
     /** MNG-3965 */
+    @Test
     public void testExecutionConfigurationSubcollections()
         throws Exception
     {
@@ -407,6 +437,7 @@ public class PomConstructionTest
     }
 
     /** MNG-3985 */
+    @Test
     public void testMultipleRepositories()
         throws Exception
     {
@@ -415,6 +446,7 @@ public class PomConstructionTest
     }
 
     /** MNG-3965 */
+    @Test
     public void testMultipleExecutionIds()
         throws Exception
     {
@@ -423,12 +455,14 @@ public class PomConstructionTest
     }
 
     /** MNG-3997 */
+    @Test
     public void testConsecutiveEmptyElements()
         throws Exception
     {
         buildPom( "consecutive_empty_elements" );
     }
 
+    @Test
     public void testOrderOfGoalsFromPluginExecutionWithoutPluginManagement()
         throws Exception
     {
@@ -442,6 +476,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3886*/
+    @Test
     public void testOrderOfGoalsFromPluginExecutionWithPluginManagement()
         throws Exception
     {
@@ -454,6 +489,7 @@ public class PomConstructionTest
         assertEquals( "e", pom.getValue( "build/plugins[1]/executions[1]/goals[5]" ) );
     }
 
+    @Test
     public void testOrderOfPluginExecutionsWithoutPluginManagement()
         throws Exception
     {
@@ -467,6 +503,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3887 */
+    @Test
     public void testOrderOfPluginExecutionsWithPluginManagement()
         throws Exception
     {
@@ -479,6 +516,7 @@ public class PomConstructionTest
         assertEquals( "e", pom.getValue( "build/plugins[1]/executions[5]/id" ) );
     }
 
+    @Test
     public void testMergeOfPluginExecutionsWhenChildInheritsPluginVersion()
         throws Exception
     {
@@ -487,6 +525,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3943*/
+    @Test
     public void testMergeOfPluginExecutionsWhenChildAndParentUseDifferentPluginVersions()
         throws Exception
     {
@@ -495,6 +534,7 @@ public class PomConstructionTest
     }
 
 
+    @Test
     public void testInterpolationWithXmlMarkup()
         throws Exception
     {
@@ -503,6 +543,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3925 */
+    @Test
     public void testOrderOfMergedPluginExecutionsWithoutPluginManagement()
         throws Exception
     {
@@ -515,6 +556,7 @@ public class PomConstructionTest
         assertEquals( "child-2", pom.getValue( "build/plugins[1]/executions[5]/goals[1]" ) );
     }
 
+    @Test
     public void testOrderOfMergedPluginExecutionsWithPluginManagement()
         throws Exception
     {
@@ -528,6 +570,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3984*/
+    @Test
     public void testDifferentContainersWithSameId()
         throws Exception
     {
@@ -537,6 +580,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3937*/
+    @Test
     public void testOrderOfMergedPluginExecutionGoalsWithoutPluginManagement()
         throws Exception
     {
@@ -550,6 +594,7 @@ public class PomConstructionTest
         assertEquals( "parent-a", pom.getValue( "build/plugins[1]/executions[1]/goals[5]" ) );
     }
 
+    @Test
     public void testOrderOfMergedPluginExecutionGoalsWithPluginManagement()
         throws Exception
     {
@@ -563,6 +608,7 @@ public class PomConstructionTest
     }
 
     /*MNG-3938*/
+    @Test
     public void testOverridingOfInheritedPluginExecutionsWithoutPluginManagement()
         throws Exception
     {
@@ -573,6 +619,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3938 */
+    @Test
     public void testOverridingOfInheritedPluginExecutionsWithPluginManagement()
         throws Exception
     {
@@ -584,6 +631,7 @@ public class PomConstructionTest
 
 
     /* MNG-3906*/
+    @Test
     public void testOrderOfMergedPluginDependenciesWithoutPluginManagement()
         throws Exception
     {
@@ -603,6 +651,7 @@ public class PomConstructionTest
         assertEquals( "1", pom.getValue( "build/plugins[1]/dependencies[5]/version" ) );
     }
 
+    @Test
     public void testOrderOfMergedPluginDependenciesWithPluginManagement()
         throws Exception
     {
@@ -620,6 +669,7 @@ public class PomConstructionTest
         assertEquals( "1", pom.getValue( "build/plugins[1]/dependencies[5]/version" ) );
     }
 
+    @Test
     public void testInterpolationOfNestedBuildDirectories()
         throws Exception
     {
@@ -632,6 +682,7 @@ public class PomConstructionTest
                       new File( (String) pom.getValue( "properties/dir2" ) ) );
     }
 
+    @Test
     public void testAppendArtifactIdOfChildToInheritedUrls()
         throws Exception
     {
@@ -651,6 +702,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3846*/
+    @Test
     public void testAppendArtifactIdOfParentAndChildToInheritedUrls()
         throws Exception
     {
@@ -669,7 +721,7 @@ public class PomConstructionTest
         assertEquals( "https://parent.url/download", pom.getValue( "distributionManagement/downloadUrl" ) );
     }
     //*/
-
+    @Test
     public void testNonInheritedElementsInSubtreesOverriddenByChild()
         throws Exception
     {
@@ -692,6 +744,7 @@ public class PomConstructionTest
         assertEquals( null, pom.getValue( "distributionManagement/site/name" ) );
     }
 
+    @Test
     public void testXmlTextCoalescing()
         throws Exception
     {
@@ -702,6 +755,7 @@ public class PomConstructionTest
                       pom.getValue( "properties/prop2" ).toString().trim().replaceAll( "[\n\r]", "" ).length() );
     }
 
+    @Test
     public void testFullInterpolationOfNestedExpressions()
         throws Exception
     {
@@ -713,6 +767,7 @@ public class PomConstructionTest
         }
     }
 
+    @Test
     public void testInterpolationOfLegacyExpressionsThatDontIncludeTheProjectPrefix()
         throws Exception
     {
@@ -747,6 +802,7 @@ public class PomConstructionTest
         assertThat( pom.getValue( "properties/projectSiteOut" ).toString(), endsWith( "doc" ) );
     }
 
+    @Test
     public void testInterpolationWithBasedirAlignedDirectories()
         throws Exception
     {
@@ -768,6 +824,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3944*/
+    @Test
     public void testInterpolationOfBasedirInPomWithUnusualName()
         throws Exception
     {
@@ -777,6 +834,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3979 */
+    @Test
     public void testJoiningOfContainersWhenChildHasEmptyElements()
         throws Exception
     {
@@ -784,6 +842,7 @@ public class PomConstructionTest
         assertNotNull( pom );
     }
 
+    @Test
     public void testOrderOfPluginConfigurationElementsWithoutPluginManagement()
         throws Exception
     {
@@ -795,6 +854,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3827*/
+    @Test
     public void testOrderOfPluginConfigurationElementsWithPluginManagement()
         throws Exception
     {
@@ -805,6 +865,7 @@ public class PomConstructionTest
         assertEquals( "four", pom.getValue( "build/plugins[1]/configuration/stringParams/stringParam[4]" ) );
     }
 
+    @Test
     public void testOrderOfPluginExecutionConfigurationElementsWithoutPluginManagement()
         throws Exception
     {
@@ -819,6 +880,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3864*/
+    @Test
     public void testOrderOfPluginExecutionConfigurationElementsWithPluginManagement()
         throws Exception
     {
@@ -833,6 +895,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3836*/
+    @Test
     public void testMergeOfInheritedPluginConfiguration()
         throws Exception
     {
@@ -852,6 +915,7 @@ public class PomConstructionTest
     }
 
     /* MNG-2591 */
+    @Test
     public void testAppendOfInheritedPluginConfigurationWithNoProfile()
         throws Exception
     {
@@ -859,6 +923,7 @@ public class PomConstructionTest
     }
 
     /* MNG-2591*/
+    @Test
     public void testAppendOfInheritedPluginConfigurationWithActiveProfile()
         throws Exception
     {
@@ -891,6 +956,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4000 */
+    @Test
     public void testMultiplePluginExecutionsWithAndWithoutIdsWithoutPluginManagement()
         throws Exception
     {
@@ -900,6 +966,7 @@ public class PomConstructionTest
         assertEquals( "log-string", pom.getValue( "build/plugins[1]/executions[2]/goals[1]" ) );
     }
 
+    @Test
     public void testMultiplePluginExecutionsWithAndWithoutIdsWithPluginManagement()
         throws Exception
     {
@@ -909,6 +976,7 @@ public class PomConstructionTest
         assertEquals( "log-string", pom.getValue( "build/plugins[1]/executions[2]/goals[1]" ) );
     }
 
+    @Test
     public void testDependencyOrderWithoutPluginManagement()
         throws Exception
     {
@@ -920,6 +988,7 @@ public class PomConstructionTest
         assertEquals( "d", pom.getValue( "dependencies[4]/artifactId" ) );
     }
 
+    @Test
     public void testDependencyOrderWithPluginManagement()
         throws Exception
     {
@@ -931,6 +1000,7 @@ public class PomConstructionTest
         assertEquals( "d", pom.getValue( "dependencies[4]/artifactId" ) );
     }
 
+    @Test
     public void testBuildDirectoriesUsePlatformSpecificFileSeparator()
         throws Exception
     {
@@ -947,6 +1017,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4008 */
+    @Test
     public void testMergedFilterOrder()
         throws Exception
     {
@@ -963,6 +1034,7 @@ public class PomConstructionTest
     }
 
     /** MNG-4027*/
+    @Test
     public void testProfileInjectedDependencies()
         throws Exception
     {
@@ -975,6 +1047,7 @@ public class PomConstructionTest
     }
 
     /** IT-0021*/
+    @Test
     public void testProfileDependenciesMultipleProfiles()
         throws Exception
     {
@@ -982,6 +1055,7 @@ public class PomConstructionTest
         assertEquals(2,  ( (List<?>) pom.getValue( "dependencies" ) ).size() );
     }
 
+    @Test
     public void testDependencyInheritance()
         throws Exception
     {
@@ -991,6 +1065,7 @@ public class PomConstructionTest
     }
 
     /** MNG-4034 */
+    @Test
     public void testManagedProfileDependency()
         throws Exception
     {
@@ -1005,6 +1080,7 @@ public class PomConstructionTest
     }
 
     /** MNG-4040 */
+    @Test
     public void testProfileModuleInheritance()
         throws Exception
     {
@@ -1013,6 +1089,7 @@ public class PomConstructionTest
     }
 
     /** MNG-3621 */
+    @Test
     public void testUncPath()
         throws Exception
     {
@@ -1021,6 +1098,7 @@ public class PomConstructionTest
     }
 
     /** MNG-2006 */
+    @Test
     public void testUrlAppendWithChildPathAdjustment()
         throws Exception
     {
@@ -1033,6 +1111,7 @@ public class PomConstructionTest
     }
 
     /** MNG-0479 */
+    @Test
     public void testRepoInheritance()
         throws Exception
     {
@@ -1041,6 +1120,7 @@ public class PomConstructionTest
         assertEquals( "it0043", pom.getValue( "repositories[1]/name" ) );
     }
 
+    @Test
     public void testEmptyScm()
         throws Exception
     {
@@ -1048,6 +1128,7 @@ public class PomConstructionTest
         assertNull( pom.getValue( "scm" ) );
     }
 
+    @Test
     public void testPluginConfigurationUsingAttributesWithoutPluginManagement()
         throws Exception
     {
@@ -1060,6 +1141,7 @@ public class PomConstructionTest
     }
 
     /** MNG-4053*/
+    @Test
     public void testPluginConfigurationUsingAttributesWithPluginManagement()
         throws Exception
     {
@@ -1071,6 +1153,7 @@ public class PomConstructionTest
         assertEquals( null, pom.getValue( "build/plugins[1]/configuration/domParam/copy/fileset/@overwrite" ) );
     }
 
+    @Test
     public void testPluginConfigurationUsingAttributesWithPluginManagementAndProfile()
         throws Exception
     {
@@ -1082,6 +1165,7 @@ public class PomConstructionTest
         assertEquals( null, pom.getValue( "build/plugins[1]/configuration/domParam/copy/fileset/@overwrite" ) );
     }
 
+    @Test
     public void testPomEncoding()
         throws Exception
     {
@@ -1092,6 +1176,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4070 */
+    @Test
     public void testXmlWhitespaceHandling()
         throws Exception
     {
@@ -1100,6 +1185,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3760*/
+    @Test
     public void testInterpolationOfBaseUri()
         throws Exception
     {
@@ -1108,6 +1194,7 @@ public class PomConstructionTest
     }
 
     /* MNG-6386 */
+    @Test
     public void testInterpolationOfRfc3986BaseUri()
         throws Exception
     {
@@ -1118,6 +1205,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3811*/
+    @Test
     public void testReportingPluginConfig()
         throws Exception
     {
@@ -1130,6 +1218,7 @@ public class PomConstructionTest
         assertEquals( "true", pom.getValue( "reporting/plugins[1]/configuration/booleanParam" ) );
     }
 
+    @Test
     public void testPropertiesNoDuplication()
         throws Exception
     {
@@ -1138,6 +1227,7 @@ public class PomConstructionTest
         assertEquals( "child", pom.getValue( "properties/pomProfile" ) );
     }
 
+    @Test
     public void testPomInheritance()
         throws Exception
     {
@@ -1146,6 +1236,7 @@ public class PomConstructionTest
         assertEquals( "jar", pom.getValue( "packaging" ) );
     }
 
+    @Test
     public void testCompleteModelWithoutParent()
         throws Exception
     {
@@ -1154,6 +1245,7 @@ public class PomConstructionTest
         testCompleteModel( pom );
     }
 
+    @Test
     public void testCompleteModelWithParent()
         throws Exception
     {
@@ -1369,7 +1461,7 @@ public class PomConstructionTest
     }
 
     /* MNG-2309*/
-
+    @Test
     public void testProfileInjectionOrder()
         throws Exception
     {
@@ -1378,6 +1470,7 @@ public class PomConstructionTest
         assertEquals( "e", pom.getValue( "properties[1]/pomProperty" ) );
     }
 
+    @Test
     public void testPropertiesInheritance()
         throws Exception
     {
@@ -1388,6 +1481,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4102*/
+    @Test
     public void testInheritedPropertiesInterpolatedWithValuesFromChildWithoutProfiles()
         throws Exception
     {
@@ -1398,6 +1492,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4102 */
+    @Test
     public void testInheritedPropertiesInterpolatedWithValuesFromChildWithActiveProfiles()
         throws Exception
     {
@@ -1411,6 +1506,7 @@ public class PomConstructionTest
     }
 
     /* MNG-3545 */
+    @Test
     public void testProfileDefaultActivation()
         throws Exception
     {
@@ -1421,6 +1517,7 @@ public class PomConstructionTest
     }
 
     /* MNG-1995 */
+    @Test
     public void testBooleanInterpolation()
         throws Exception
     {
@@ -1431,6 +1528,7 @@ public class PomConstructionTest
 
 
     /* MNG-3899 */
+    @Test
     public void testBuildExtensionInheritance()
         throws Exception
     {
@@ -1443,6 +1541,7 @@ public class PomConstructionTest
     }
 
     /*MNG-1957*/
+    @Test
     public void testJdkActivation()
         throws Exception
     {
@@ -1457,6 +1556,7 @@ public class PomConstructionTest
     }
 
     /* MNG-2174 */
+    @Test
     public void testProfilePluginMngDependencies()
         throws Exception
     {
@@ -1465,6 +1565,7 @@ public class PomConstructionTest
     }
 
     /** MNG-4116 */
+    @Test
     public void testPercentEncodedUrlsMustNotBeDecoded()
         throws Exception
     {
@@ -1483,6 +1584,7 @@ public class PomConstructionTest
                       pom.getValue( "distributionManagement/site/url" ) );
     }
 
+    @Test
     public void testPluginManagementInheritance()
         throws Exception
     {
@@ -1491,6 +1593,7 @@ public class PomConstructionTest
                       pom.getValue( "build/pluginManagement/plugins[@artifactId='maven-compiler-plugin']/version" ) );
     }
 
+    @Test
     public void testProfilePlugins()
         throws Exception
     {
@@ -1499,6 +1602,7 @@ public class PomConstructionTest
         assertEquals( "maven-assembly2-plugin", pom.getValue( "build/plugins[2]/artifactId" ) );
     }
 
+    @Test
     public void testPluginInheritanceSimple()
         throws Exception
     {
@@ -1506,6 +1610,7 @@ public class PomConstructionTest
         assertEquals( 2, ( (List<?>) pom.getValue( "build/plugins" ) ).size() );
     }
 
+    @Test
     public void testPluginManagementDuplicate()
         throws Exception
     {
@@ -1513,6 +1618,7 @@ public class PomConstructionTest
         assertEquals( 8, ( (List<?>) pom.getValue( "build/pluginManagement/plugins" ) ).size() );
     }
 
+    @Test
     public void testDistributionManagement()
         throws Exception
     {
@@ -1520,6 +1626,7 @@ public class PomConstructionTest
         assertEquals( "legacy", pom.getValue( "distributionManagement/repository/layout" ) );
     }
 
+    @Test
     public void testDependencyScopeInheritance()
         throws Exception
     {
@@ -1528,6 +1635,7 @@ public class PomConstructionTest
         assertEquals( "compile", scope );
     }
 
+    @Test
     public void testDependencyScope()
         throws Exception
     {
@@ -1541,6 +1649,7 @@ public class PomConstructionTest
         buildPom( "dependency-management-with-interpolation/sub" );
     }
 
+    @Test
     public void testInterpolationWithSystemProperty()
         throws Exception
     {
@@ -1551,6 +1660,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4129 */
+    @Test
     public void testPluginExecutionInheritanceWhenChildDoesNotDeclarePlugin()
         throws Exception
     {
@@ -1562,6 +1672,7 @@ public class PomConstructionTest
         assertEquals( "inherited-execution", executions.get( 0 ).getId() );
     }
 
+    @Test
     public void testPluginExecutionInheritanceWhenChildDoesDeclarePluginAsWell()
         throws Exception
     {
@@ -1574,6 +1685,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4193 */
+    @Test
     public void testValidationErrorUponNonUniqueArtifactRepositoryId()
         throws Exception
     {
@@ -1589,6 +1701,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4193 */
+    @Test
     public void testValidationErrorUponNonUniquePluginRepositoryId()
         throws Exception
     {
@@ -1604,6 +1717,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4193 */
+    @Test
     public void testValidationErrorUponNonUniqueArtifactRepositoryIdInProfile()
         throws Exception
     {
@@ -1619,6 +1733,7 @@ public class PomConstructionTest
     }
 
     /* MNG-4193 */
+    @Test
     public void testValidationErrorUponNonUniquePluginRepositoryIdInProfile()
         throws Exception
     {
@@ -1634,6 +1749,7 @@ public class PomConstructionTest
     }
 
     /** MNG-3843 */
+    @Test
     public void testPrerequisitesAreNotInherited()
         throws Exception
     {
@@ -1641,6 +1757,7 @@ public class PomConstructionTest
         assertSame( null, pom.getValue( "prerequisites" ) );
     }
 
+    @Test
     public void testLicensesAreInheritedButNotAggregated()
         throws Exception
     {
@@ -1650,6 +1767,7 @@ public class PomConstructionTest
         assertEquals( "https://child.url/license", pom.getValue( "licenses[1]/url" ) );
     }
 
+    @Test
     public void testDevelopersAreInheritedButNotAggregated()
         throws Exception
     {
@@ -1658,6 +1776,7 @@ public class PomConstructionTest
         assertEquals( "child-developer", pom.getValue( "developers[1]/name" ) );
     }
 
+    @Test
     public void testContributorsAreInheritedButNotAggregated()
         throws Exception
     {
@@ -1666,6 +1785,7 @@ public class PomConstructionTest
         assertEquals( "child-contributor", pom.getValue( "contributors[1]/name" ) );
     }
 
+    @Test
     public void testMailingListsAreInheritedButNotAggregated()
         throws Exception
     {
@@ -1674,6 +1794,7 @@ public class PomConstructionTest
         assertEquals( "child-mailing-list", pom.getValue( "mailingLists[1]/name" ) );
     }
 
+    @Test
     public void testPluginInheritanceOrder()
         throws Exception
     {
@@ -1688,6 +1809,7 @@ public class PomConstructionTest
         assertEquals( "maven-it-plugin-configuration", pom.getValue( "reporting/plugins[3]/artifactId" ) );
     }
 
+    @Test
     public void testCliPropsDominateProjectPropsDuringInterpolation()
         throws Exception
     {
@@ -1698,6 +1820,7 @@ public class PomConstructionTest
         assertEquals( "PASSED", pom.getValue( "properties/interpolatedProperty" ) );
     }
 
+    @Test
     public void testParentPomPackagingMustBePom()
         throws Exception
     {
@@ -1713,6 +1836,7 @@ public class PomConstructionTest
     }
 
     /** MNG-522, MNG-3018 */
+    @Test
     public void testManagedPluginConfigurationAppliesToImplicitPluginsIntroducedByPackaging()
         throws Exception
     {
@@ -1723,6 +1847,7 @@ public class PomConstructionTest
                       pom.getValue( "build/plugins[@artifactId='maven-it-plugin-log-file']/configuration/logFile" ) );
     }
 
+    @Test
     public void testDefaultPluginsExecutionContributedByPackagingExecuteBeforeUserDefinedExecutions()
         throws Exception
     {
@@ -1738,6 +1863,7 @@ public class PomConstructionTest
         assertEquals( "test-2", executions.get( 3 ).getId() );
     }
 
+    @Test
     public void testPluginDeclarationsRetainPomOrderAfterInjectionOfDefaultPlugins()
         throws Exception
     {
@@ -1764,6 +1890,7 @@ public class PomConstructionTest
     }
 
     /** MNG-4415 */
+    @Test
     public void testPluginOrderAfterMergingWithInheritedPlugins()
         throws Exception
     {
@@ -1793,6 +1920,7 @@ public class PomConstructionTest
     }
 
     /** MNG-4416 */
+    @Test
     public void testPluginOrderAfterMergingWithInjectedPlugins()
         throws Exception
     {
@@ -1821,6 +1949,7 @@ public class PomConstructionTest
         assertEquals( actual, expected );
     }
 
+    @Test
     public void testProjectArtifactIdIsNotInheritedButMandatory()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -19,14 +19,6 @@ package org.apache.maven.project;
  * under the License.
  */
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,6 +34,18 @@ import org.apache.maven.model.building.FileModelSource;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 
 public class ProjectBuilderTest
@@ -53,6 +57,7 @@ public class ProjectBuilderTest
         return "src/test/projects/project-builder";
     }
 
+    @Test
     public void testSystemScopeDependencyIsPresentInTheCompileClasspathElements()
         throws Exception
     {
@@ -70,6 +75,7 @@ public class ProjectBuilderTest
         project.getCompileClasspathElements();
     }
 
+    @Test
     public void testBuildFromModelSource()
         throws Exception
     {
@@ -84,6 +90,7 @@ public class ProjectBuilderTest
         assertNotNull( result.getProject().getParentFile() );
     }
 
+    @Test
     public void testVersionlessManagedDependency()
         throws Exception
     {
@@ -99,6 +106,7 @@ public class ProjectBuilderTest
                         + "@ line 9, column 17" ) );
     }
 
+    @Test
     public void testResolveDependencies()
         throws Exception
     {
@@ -120,6 +128,7 @@ public class ProjectBuilderTest
         assertEquals( 1, mavenProject.getArtifacts().size() );
     }
 
+    @Test
     public void testDontResolveDependencies()
         throws Exception
     {
@@ -139,6 +148,7 @@ public class ProjectBuilderTest
         assertEquals( 0, mavenProject.getArtifacts().size() );
     }
 
+    @Test
     public void testReadModifiedPoms() throws Exception {
         String initialValue = System.setProperty( DefaultProjectBuilder.DISABLE_GLOBAL_MODEL_CACHE_SYSTEM_PROPERTY, Boolean.toString( true ) );
         // TODO a similar test should be created to test the dependency management (basically all usages
@@ -179,6 +189,7 @@ public class ProjectBuilderTest
         }
     }
 
+    @Test
     public void testReadErroneousMavenProjectContainsReference()
         throws Exception
     {
@@ -212,6 +223,7 @@ public class ProjectBuilderTest
         assertEquals( pomFile, project2.getFile() );
     }
 
+    @Test
     public void testReadInvalidPom()
         throws Exception
     {
@@ -237,6 +249,7 @@ public class ProjectBuilderTest
         assertThat( pex.getMessage(), containsString( "expected START_TAG or END_TAG not TEXT" ) );
     }
 
+    @Test
     public void testReadParentAndChildWithRegularVersionSetParentFile()
         throws Exception
     {
@@ -297,6 +310,7 @@ public class ProjectBuilderTest
         }
     }
 
+    @Test
     public void testBuildProperties()
             throws Exception
     {
@@ -314,6 +328,7 @@ public class ProjectBuilderTest
         assertEquals( 1, project.getResources().size() );
     }
 
+    @Test
     public void testPropertyInPluginManagementGroupId()
             throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Test cases for the project {@code ModelResolver} implementation.
@@ -66,16 +66,11 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         parent.setArtifactId( "apache" );
         parent.setVersion( "0" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( parent );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertThat( e.getMessage(), startsWith( "Could not find artifact org.apache:apache:pom:0 in central" ) );
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( parent ) );
+        assertNotNull( e.getMessage() );
+        assertThat( e.getMessage(), startsWith( "Could not find artifact org.apache:apache:pom:0 in central" ) );
     }
 
     @Test
@@ -86,17 +81,11 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         parent.setArtifactId( "apache" );
         parent.setVersion( "[2.0,2.1)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( parent );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "No versions matched the requested parent version range '[2.0,2.1)'",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( parent ) );
+        assertEquals( "No versions matched the requested parent version range '[2.0,2.1)'",
+                      e.getMessage() );
     }
 
     @Test
@@ -107,17 +96,11 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         parent.setArtifactId( "apache" );
         parent.setVersion( "[1,)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( parent );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "The requested parent version range '[1,)' does not specify an upper bound",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( parent ) );
+        assertEquals( "The requested parent version range '[1,)' does not specify an upper bound",
+                      e.getMessage() );
     }
 
     @Test
@@ -152,16 +135,11 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         dependency.setArtifactId( "apache" );
         dependency.setVersion( "0" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( dependency );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertThat( e.getMessage(), startsWith( "Could not find artifact org.apache:apache:pom:0 in central" ) );
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( dependency ) );
+        assertNotNull( e.getMessage() );
+        assertThat( e.getMessage(), startsWith( "Could not find artifact org.apache:apache:pom:0 in central" ) );
     }
 
     @Test
@@ -172,17 +150,11 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         dependency.setArtifactId( "apache" );
         dependency.setVersion( "[2.0,2.1)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( dependency );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "No versions matched the requested dependency version range '[2.0,2.1)'",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( dependency ) );
+        assertEquals( "No versions matched the requested dependency version range '[2.0,2.1)'",
+                      e.getMessage() );
     }
 
     @Test
@@ -193,17 +165,11 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         dependency.setArtifactId( "apache" );
         dependency.setVersion( "[1,)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( dependency );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "The requested dependency version range '[1,)' does not specify an upper bound",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( dependency ) );
+        assertEquals( "The requested dependency version range '[1,)' does not specify an upper bound",
+                      e.getMessage() );
     }
 
     @Test

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
@@ -19,9 +19,6 @@ package org.apache.maven.project;
  * under the License.
  */
 
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +33,13 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Test cases for the project {@code ModelResolver} implementation.
@@ -54,6 +58,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         super();
     }
 
+    @Test
     public void testResolveParentThrowsUnresolvableModelExceptionWhenNotFound() throws Exception
     {
         final Parent parent = new Parent();
@@ -73,6 +78,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         }
     }
 
+    @Test
     public void testResolveParentThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception
     {
         final Parent parent = new Parent();
@@ -93,6 +99,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         }
     }
 
+    @Test
     public void testResolveParentThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception
     {
         final Parent parent = new Parent();
@@ -113,6 +120,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         }
     }
 
+    @Test
     public void testResolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception
     {
         final Parent parent = new Parent();
@@ -124,6 +132,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         assertEquals( "1", parent.getVersion() );
     }
 
+    @Test
     public void testResolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception
     {
         final Parent parent = new Parent();
@@ -135,6 +144,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         assertEquals( "1", parent.getVersion() );
     }
 
+    @Test
     public void testResolveDependencyThrowsUnresolvableModelExceptionWhenNotFound() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -154,6 +164,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         }
     }
 
+    @Test
     public void testResolveDependencyThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -174,6 +185,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         }
     }
 
+    @Test
     public void testResolveDependencyThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -194,6 +206,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         }
     }
 
+    @Test
     public void testResolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -205,6 +218,7 @@ public class ProjectModelResolverTest extends AbstractMavenProjectTestCase
         assertEquals( "1", dependency.getVersion() );
     }
 
+    @Test
     public void testResolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception
     {
         final Dependency dependency = new Dependency();

--- a/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultMavenMetadataCacheTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultMavenMetadataCacheTest.java
@@ -29,32 +29,35 @@ import org.apache.maven.project.artifact.DefaultMavenMetadataCache.CacheKey;
 import org.apache.maven.repository.DelegatingLocalArtifactRepository;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.repository.TestRepositorySystem;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * @author Igor Fedorenko
  */
 public class DefaultMavenMetadataCacheTest
-    extends TestCase
 {
     private RepositorySystem repositorySystem;
 
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
         repositorySystem = new TestRepositorySystem( null, null );
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         repositorySystem = null;
-        super.tearDown();
     }
 
+    @Test
     public void testCacheKey()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCacheTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCacheTest.java
@@ -19,29 +19,28 @@ package org.apache.maven.project.artifact;
  * under the License.
  */
 
-import static org.junit.Assert.assertArrayEquals;
-
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class DefaultProjectArtifactsCacheTest extends TestCase
+import static org.junit.Assert.assertArrayEquals;
+public class DefaultProjectArtifactsCacheTest
 {
 
     private ProjectArtifactsCache cache;
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
         cache = new DefaultProjectArtifactsCache();
     }
 
+    @Test
     public void testProjectDependencyOrder() throws Exception
     {
         ProjectArtifactsCache.Key project1 = new ProjectArtifactsCache.Key(){};

--- a/maven-core/src/test/java/org/apache/maven/project/artifact/MavenMetadataSourceTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/artifact/MavenMetadataSourceTest.java
@@ -19,10 +19,13 @@ package org.apache.maven.project.artifact;
  * under the License.
  */
 
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.DefaultPlexusContainer;
-import org.codehaus.plexus.PlexusTestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -44,20 +47,23 @@ public class MavenMetadataSourceTest
     }
 
     @Override
-    protected void setUp() throws Exception
+    @Before
+    public void setUp()
+        throws Exception
     {
         super.setUp();
         getContainer();
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         repositorySystem = null;
         super.tearDown();
     }
 
+    @Test
     public void testShouldNotCarryExclusionsOverFromDependencyToDependency()
         throws Exception
     {
@@ -144,6 +150,7 @@ public class MavenMetadataSourceTest
         assertEquals( "default scope NOT back-propagated to dependency.", Artifact.SCOPE_COMPILE, dep.getScope() );
     }
 
+    @Test
     public void testShouldUseInjectedTestScopeFromDependencyManagement()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/project/canonical/CanonicalProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/canonical/CanonicalProjectBuilderTest.java
@@ -27,6 +27,10 @@ import org.apache.maven.model.PluginExecution;
 import org.apache.maven.project.AbstractMavenProjectTestCase;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Jason van Zyl
@@ -34,6 +38,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 public class CanonicalProjectBuilderTest
     extends AbstractMavenProjectTestCase
 {
+    @Test
     public void testProjectBuilder()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
+++ b/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
@@ -23,7 +23,13 @@ import org.apache.maven.rtinfo.RuntimeInformation;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -44,12 +50,6 @@ public class DefaultRuntimeInformationTest
     }
 
     @Override
-    protected void setUp() throws Exception
-    {
-        super.setUp();
-        getContainer();
-    }
-    @Override
     protected synchronized void setupContainer()
     {
         super.setupContainer();
@@ -58,6 +58,7 @@ public class DefaultRuntimeInformationTest
                 binder -> binder.requestInjection( this ) );
     }
 
+    @Test
     public void testGetMavenVersion()
     {
         String mavenVersion = rtInfo.getMavenVersion();
@@ -65,6 +66,7 @@ public class DefaultRuntimeInformationTest
         assertTrue( mavenVersion.length() > 0 );
     }
 
+    @Test
     public void testIsMavenVersion()
     {
         assertTrue( rtInfo.isMavenVersion( "2.0" ) );

--- a/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
+++ b/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -75,35 +75,17 @@ public class DefaultRuntimeInformationTest
         assertTrue( rtInfo.isMavenVersion( "[2.0.11,2.1.0),[3.0,)" ) );
         assertFalse( rtInfo.isMavenVersion( "[9.0,)" ) );
 
-        try
-        {
-            rtInfo.isMavenVersion( "[3.0," );
-            fail( "Bad version range wasn't rejected" );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            assertTrue( true );
-        }
+        assertThrows( "Bad version range wasn't rejected",
+                IllegalArgumentException.class,
+                () -> rtInfo.isMavenVersion( "[3.0," ) );
 
-        try
-        {
-            rtInfo.isMavenVersion( "" );
-            fail( "Bad version range wasn't rejected" );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            assertTrue( true );
-        }
+        assertThrows( "Bad version range wasn't rejected",
+                IllegalArgumentException.class,
+                () -> rtInfo.isMavenVersion( "" ) );
 
-        try
-        {
-            rtInfo.isMavenVersion( null );
-            fail( "Bad version range wasn't rejected" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertTrue( true );
-        }
+        assertThrows( "Bad version range wasn't rejected",
+                NullPointerException.class,
+                () -> rtInfo.isMavenVersion( null ) );
     }
 
 }

--- a/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
+++ b/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
@@ -24,6 +24,7 @@ import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
 import org.apache.maven.PlexusTestCase;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -47,6 +48,14 @@ public class DefaultRuntimeInformationTest
         super.customizeContainerConfiguration(configuration);
         configuration.setAutoWiring(true);
         configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception
+    {
+        super.setUp();
+        getContainer();
     }
 
     @Override

--- a/maven-core/src/test/java/org/apache/maven/settings/PomConstructionWithSettingsTest.java
+++ b/maven-core/src/test/java/org/apache/maven/settings/PomConstructionWithSettingsTest.java
@@ -19,6 +19,10 @@ package org.apache.maven.settings;
  * under the License.
  */
 
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.model.Profile;
 import org.apache.maven.project.DefaultProjectBuilder;
@@ -28,21 +32,27 @@ import org.apache.maven.project.harness.PomTestWrapper;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.apache.maven.settings.io.xpp3.SettingsXpp3Reader;
+import org.checkerframework.checker.units.qual.A;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.PlexusTestCase;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
 
 public class PomConstructionWithSettingsTest
     extends PlexusTestCase
@@ -76,22 +86,16 @@ public class PomConstructionWithSettingsTest
                 binder -> binder.requestInjection( this ) );
     }
 
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
+        super.setUp();
         getContainer();
         testDirectory = new File( getBasedir(), BASE_POM_DIR );
     }
 
-    @Override
-    protected void tearDown()
-        throws Exception
-    {
-        projectBuilder = null;
-
-        super.tearDown();
-    }
-
+    @Test
     public void testSettingsNoPom()
         throws Exception
     {
@@ -102,6 +106,7 @@ public class PomConstructionWithSettingsTest
     /**
      * MNG-4107
      */
+    @Test
     public void testPomAndSettingsInterpolation()
         throws Exception
     {
@@ -115,6 +120,7 @@ public class PomConstructionWithSettingsTest
     /**
      * MNG-4107
      */
+    @Test
     public void testRepositories()
         throws Exception
     {

--- a/maven-core/src/test/java/org/apache/maven/settings/SettingsUtilsTest.java
+++ b/maven-core/src/test/java/org/apache/maven/settings/SettingsUtilsTest.java
@@ -19,17 +19,20 @@ package org.apache.maven.settings;
  * under the License.
  */
 
-import junit.framework.TestCase;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 public class SettingsUtilsTest
-    extends TestCase
 {
 
+    @Test
     public void testShouldAppendRecessivePluginGroupIds()
     {
         Settings dominant = new Settings();
@@ -50,6 +53,7 @@ public class SettingsUtilsTest
         assertEquals( "org.codehaus.plexus", pluginGroups.get( 2 ) );
     }
 
+    @Test
     public void testRoundTripProfiles()
     {
         Random entropy = new Random();

--- a/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
@@ -19,24 +19,23 @@
 
 package org.apache.maven.toolchain;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
  * @author mkleint
  */
 public class RequirementMatcherFactoryTest
-    extends TestCase
 {
-
-    public RequirementMatcherFactoryTest( String testName )
-    {
-        super( testName );
-    }
 
     /**
      * Test of createExactMatcher method, of class RequirementMatcherFactory.
      */
+    @Test
     public void testCreateExactMatcher()
     {
         RequirementMatcher matcher;
@@ -50,6 +49,7 @@ public class RequirementMatcherFactoryTest
     /**
      * Test of createVersionMatcher method, of class RequirementMatcherFactory.
      */
+    @Test
     public void testCreateVersionMatcher()
     {
         RequirementMatcher matcher;

--- a/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerDocumentationTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerDocumentationTest.java
@@ -29,15 +29,13 @@ import java.util.List;
 
 import org.apache.commons.cli.Option;
 import org.codehaus.plexus.util.FileUtils;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Pseudo test to generate documentation fragment about supported CLI options. TODO such documentation generation code
  * should not be necessary as unit test but should be run during site generation (Velocity? Doxia macro?)
  */
 public class CLIManagerDocumentationTest
-    extends TestCase
 {
     private final static String LS = System.lineSeparator();
 
@@ -98,6 +96,7 @@ public class CLIManagerDocumentationTest
         return sb.toString();
     }
 
+    @Test
     public void testOptionsAsHtml()
         throws IOException
     {

--- a/maven-embedder/src/test/java/org/apache/maven/cli/CLIReportingUtilsTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/CLIReportingUtilsTest.java
@@ -19,12 +19,14 @@ package org.apache.maven.cli;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class CLIReportingUtilsTest
-    extends TestCase
 {
 
+    @Test
     public void testFormatDuration()
     {
         assertEquals( "0.001 s", CLIReportingUtils.formatDuration( 1 ) );

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -28,8 +28,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
@@ -149,15 +149,9 @@ public class MavenCliTest
         // -TC2.2
         assertEquals( (int) ( cores * 2.2 ), cli.calculateDegreeOfConcurrencyWithCoreMultiplier( "2.2C" ) );
 
-        try
-        {
-            cli.calculateDegreeOfConcurrencyWithCoreMultiplier( "CXXX" );
-            fail( "Should have failed with a NumberFormatException" );
-        }
-        catch ( NumberFormatException e )
-        {
-            // carry on
-        }
+        assertThrows( "Should have failed with a NumberFormatException",
+                NumberFormatException.class,
+                () -> cli.calculateDegreeOfConcurrencyWithCoreMultiplier( "CXXX" ) );
     }
 
     @Test
@@ -189,15 +183,7 @@ public class MavenCliTest
         CliRequest request = new CliRequest( new String[0], null );
 
         cli.initialize( request );
-        try
-        {
-            cli.cli( request );
-            fail();
-        }
-        catch ( ParseException expected )
-        {
-
-        }
+        assertThrows( ParseException.class, () -> cli.cli( request ) );
     }
 
     /**
@@ -359,19 +345,12 @@ public class MavenCliTest
         cli.logging( request );
         assertTrue( MessageUtils.isColorEnabled() );
 
-        try
-        {
-            MessageUtils.setColorEnabled( false );
-            request = new CliRequest( new String[] { "-Dstyle.color=maybe", "-B", "-l", "target/temp/mvn.log" }, null );
-            cli.cli( request );
-            cli.properties( request );
-            cli.logging( request );
-            fail( "maybe is not a valid option" );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            // noop
-        }
+        MessageUtils.setColorEnabled( false );
+        CliRequest maybeColorRequest = new CliRequest( new String[] { "-Dstyle.color=maybe", "-B", "-l", "target/temp/mvn.log" }, null );
+        cli.cli( maybeColorRequest );
+        cli.properties( maybeColorRequest );
+        assertThrows( "maybe is not a valid option", IllegalArgumentException.class,
+                () -> cli.logging( maybeColorRequest ) );
     }
 
     /**

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/ComplexActivationTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/ComplexActivationTest.java
@@ -19,16 +19,19 @@ package org.apache.maven.model.building;
  * under the License.
  */
 
-import junit.framework.TestCase;
-
 import java.io.File;
 import java.util.Properties;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Konstantin Perikov
  */
 public class ComplexActivationTest
-        extends TestCase
 {
 
     private File getPom( String name )
@@ -36,6 +39,7 @@ public class ComplexActivationTest
         return new File( "src/test/resources/poms/factory/" + name + ".xml" ).getAbsoluteFile();
     }
 
+    @Test
     public void testAndConditionInActivation()
             throws Exception
     {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderFactoryTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderFactoryTest.java
@@ -22,14 +22,15 @@ package org.apache.maven.model.building;
 import java.io.File;
 
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Benjamin Bentmann
  */
 public class DefaultModelBuilderFactoryTest
-    extends TestCase
 {
 
     private File getPom( String name )
@@ -37,6 +38,7 @@ public class DefaultModelBuilderFactoryTest
         return new File( "src/test/resources/poms/factory/" + name + ".xml" ).getAbsoluteFile();
     }
 
+    @Test
     public void testCompleteWiring()
         throws Exception
     {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
@@ -18,13 +18,16 @@ package org.apache.maven.model.building;
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import java.io.File;
 import java.io.IOException;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
-import org.apache.commons.lang3.SystemUtils;
 import static org.junit.Assume.assumeTrue;
-import org.junit.Test;
 
 /**
  * Test that validate the solution of MNG-6261 issue

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/FileToRawModelMergerTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/FileToRawModelMergerTest.java
@@ -19,9 +19,6 @@ package org.apache.maven.model.building;
  * under the License.
  */
 
-import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertThat;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -32,6 +29,9 @@ import java.util.stream.Stream;
 import org.apache.maven.model.building.DefaultModelBuilder.FileToRawModelMerger;
 import org.apache.maven.model.merge.ModelMerger;
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertThat;
 
 public class FileToRawModelMergerTest
 {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/SimpleProblemCollector.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/SimpleProblemCollector.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.maven.model.Model;
 
-
 /**
  * A simple model problem collector for testing the model building components.
  *

--- a/maven-model-builder/src/test/java/org/apache/maven/model/inheritance/DefaultInheritanceAssemblerTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/inheritance/DefaultInheritanceAssemblerTest.java
@@ -19,20 +19,6 @@ package org.apache.maven.model.inheritance;
  * under the License.
  */
 
-import org.apache.maven.model.Model;
-import org.apache.maven.model.building.AbstractModelSourceTransformer;
-import org.apache.maven.model.building.SimpleProblemCollector;
-import org.apache.maven.model.building.TransformerContext;
-import org.apache.maven.model.io.DefaultModelReader;
-import org.apache.maven.model.io.DefaultModelWriter;
-import org.apache.maven.model.io.ModelWriter;
-import org.apache.maven.xml.sax.filter.AbstractSAXFilter;
-import org.xml.sax.SAXException;
-import org.xml.sax.ext.LexicalHandler;
-import org.xmlunit.matchers.CompareMatcher;
-
-import junit.framework.TestCase;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -41,13 +27,29 @@ import java.util.function.Consumer;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerConfigurationException;
 
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.LexicalHandler;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.AbstractModelSourceTransformer;
+import org.apache.maven.model.building.SimpleProblemCollector;
+import org.apache.maven.model.building.TransformerContext;
+import org.apache.maven.model.io.DefaultModelReader;
+import org.apache.maven.model.io.DefaultModelWriter;
+import org.apache.maven.model.io.ModelWriter;
+import org.apache.maven.xml.sax.filter.AbstractSAXFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.xmlunit.matchers.CompareMatcher;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Hervé Boutemy
  */
 public class DefaultInheritanceAssemblerTest
-    extends TestCase
 {
     private DefaultModelReader reader;
 
@@ -55,12 +57,10 @@ public class DefaultInheritanceAssemblerTest
 
     private InheritanceAssembler assembler;
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
-
         reader = new DefaultModelReader();
         reader.setTransformer( new AbstractModelSourceTransformer()
         {
@@ -87,6 +87,7 @@ public class DefaultInheritanceAssemblerTest
         return reader.read( getPom( name ), null );
     }
 
+    @Test
     public void testPluginConfiguration()
         throws Exception
     {
@@ -98,6 +99,7 @@ public class DefaultInheritanceAssemblerTest
      * and child directory == artifactId
      * @throws IOException Model read problem
      */
+    @Test
     public void testUrls()
         throws Exception
     {
@@ -108,6 +110,7 @@ public class DefaultInheritanceAssemblerTest
      * Flat directory structure: parent &amp; child POMs in sibling directories, child directory == artifactId.
      * @throws IOException Model read problem
      */
+    @Test
     public void testFlatUrls()
         throws IOException
     {
@@ -118,6 +121,7 @@ public class DefaultInheritanceAssemblerTest
      * MNG-5951 MNG-6059 child.x.y.inherit.append.path="false" test
      * @throws Exception
      */
+    @Test
     public void testNoAppendUrls()
         throws Exception
     {
@@ -128,6 +132,7 @@ public class DefaultInheritanceAssemblerTest
      * MNG-5951 special case test: inherit with partial override
      * @throws Exception
      */
+    @Test
     public void testNoAppendUrls2()
         throws Exception
     {
@@ -138,6 +143,7 @@ public class DefaultInheritanceAssemblerTest
      * MNG-5951 special case test: child.x.y.inherit.append.path="true" in child should not reset content
      * @throws Exception
      */
+    @Test
     public void testNoAppendUrls3()
         throws Exception
     {
@@ -150,6 +156,7 @@ public class DefaultInheritanceAssemblerTest
      * This is why MNG-5000 fix in code is marked as bad practice (uses file names)
      * @throws IOException Model read problem
      */
+    @Test
     public void testFlatTrickyUrls()
         throws IOException
     {
@@ -189,6 +196,7 @@ public class DefaultInheritanceAssemblerTest
         }
     }
 
+    @Test
     public void testWithEmptyUrl()
         throws IOException
     {
@@ -232,6 +240,7 @@ public class DefaultInheritanceAssemblerTest
         assertThat( actual, CompareMatcher.isIdenticalTo( expected ).ignoreComments().ignoreWhitespace() );
     }
 
+    @Test
     public void testModulePathNotArtifactId()
         throws IOException
     {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/inheritance/DefaultInheritanceAssemblerTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/inheritance/DefaultInheritanceAssemblerTest.java
@@ -43,8 +43,8 @@ import org.junit.Test;
 import org.xmlunit.matchers.CompareMatcher;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Hervé Boutemy
@@ -182,18 +182,14 @@ public class DefaultInheritanceAssemblerTest
         // parent references child with directory name (which is not artifact id)
         // then relative path calculation will success during build from disk but fail when calculated from repo
         testInheritance( "tricky-flat-directory-urls", false );
-        try
-        {
-            testInheritance( "tricky-flat-directory-urls", true );
-            fail( "should have failed since module reference == directory name != artifactId" );
-        }
-        catch ( AssertionError afe )
-        {
-            // expected failure
-            assertTrue( afe.getMessage(), afe.getMessage().contains(
-                    "Expected text value 'http://www.apache.org/path/to/parent/../child-artifact-id/' but was " +
-                            "'http://www.apache.org/path/to/parent/child-artifact-id/'" ) );
-        }
+
+        AssertionError afe = assertThrows( "should have failed since module reference == directory name != artifactId",
+                AssertionError.class,
+                () -> testInheritance( "tricky-flat-directory-urls", true ) );
+        // expected failure
+        assertTrue( afe.getMessage(), afe.getMessage().contains(
+                "Expected text value 'http://www.apache.org/path/to/parent/../child-artifact-id/' but was " +
+                        "'http://www.apache.org/path/to/parent/child-artifact-id/'" ) );
     }
 
     @Test

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
@@ -19,6 +19,15 @@ package org.apache.maven.model.interpolation;
  * under the License.
  */
 
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.TimeZone;
+
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
@@ -29,20 +38,12 @@ import org.apache.maven.model.Scm;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.SimpleProblemCollector;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
-import java.util.TimeZone;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author jdcasey

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/MavenBuildTimestampTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/MavenBuildTimestampTest.java
@@ -22,11 +22,13 @@ package org.apache.maven.model.interpolation;
 import java.util.Date;
 import java.util.Properties;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class MavenBuildTimestampTest
-    extends TestCase
 {
+    @Test
     public void testMavenBuildTimestampUsesUTC()
     {
         Properties interpolationProperties = new Properties();

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringSearchModelInterpolatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringSearchModelInterpolatorTest.java
@@ -19,6 +19,19 @@ package org.apache.maven.model.interpolation;
  * under the License.
  */
 
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputSource;
 import org.apache.maven.model.Model;
@@ -26,14 +39,6 @@ import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.SimpleProblemCollector;
 import org.junit.Test;
-
-import java.io.File;
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;

--- a/maven-model-builder/src/test/java/org/apache/maven/model/merge/MavenModelMergerTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/merge/MavenModelMergerTest.java
@@ -20,15 +20,15 @@ package org.apache.maven.model.merge;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 import java.util.Collections;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Prerequisites;
 import org.apache.maven.model.Profile;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class MavenModelMergerTest
 {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/path/DefaultUrlNormalizerTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/path/DefaultUrlNormalizerTest.java
@@ -19,10 +19,10 @@ package org.apache.maven.model.path;
  * under the License.
  */
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
-import org.junit.Test;
 
 /**
  * @author Benjamin Bentmann

--- a/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/AbstractProfileActivatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/AbstractProfileActivatorTest.java
@@ -1,7 +1,5 @@
 package org.apache.maven.model.profile.activation;
 
-import java.util.Objects;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,14 +19,17 @@ import java.util.Objects;
  * under the License.
  */
 
+import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.maven.model.Profile;
 import org.apache.maven.model.building.SimpleProblemCollector;
 import org.apache.maven.model.profile.DefaultProfileActivationContext;
 import org.apache.maven.model.profile.ProfileActivationContext;
+import org.junit.After;
+import org.junit.Before;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Provides common services to test {@link ProfileActivator} implementations.
@@ -36,7 +37,6 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public abstract class AbstractProfileActivatorTest<T extends ProfileActivator>
-    extends TestCase
 {
 
     private Class<T> activatorClass;
@@ -48,22 +48,18 @@ public abstract class AbstractProfileActivatorTest<T extends ProfileActivator>
         this.activatorClass = Objects.requireNonNull( activatorClass, "activatorClass cannot be null" );;
     }
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
-
         activator = activatorClass.getConstructor().newInstance();
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         activator = null;
-
-        super.tearDown();
     }
 
     protected ProfileActivationContext newContext( final Properties userProperties, final Properties systemProperties )

--- a/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/JdkVersionProfileActivatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/JdkVersionProfileActivatorTest.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.Profile;
+import org.junit.Test;
 
 /**
  * Tests {@link JdkVersionProfileActivator}.
@@ -56,6 +57,7 @@ public class JdkVersionProfileActivatorTest
         return props;
     }
 
+    @Test
     public void testNullSafe()
         throws Exception
     {
@@ -68,6 +70,7 @@ public class JdkVersionProfileActivatorTest
         assertActivation( false, p, newContext( null, null ) );
     }
 
+    @Test
     public void testPrefix()
         throws Exception
     {
@@ -83,6 +86,7 @@ public class JdkVersionProfileActivatorTest
         assertActivation( false, profile, newContext( null, newProperties( "1.5" ) ) );
     }
 
+    @Test
     public void testPrefixNegated()
         throws Exception
     {
@@ -98,6 +102,7 @@ public class JdkVersionProfileActivatorTest
         assertActivation( true, profile, newContext( null, newProperties( "1.5" ) ) );
     }
 
+    @Test
     public void testVersionRangeInclusiveBounds()
         throws Exception
     {
@@ -120,6 +125,7 @@ public class JdkVersionProfileActivatorTest
         assertActivation( true, profile, newContext( null, newProperties( "1.6.0_09-b03" ) ) );
     }
 
+    @Test
     public void testVersionRangeExclusiveBounds()
         throws Exception
     {
@@ -143,6 +149,7 @@ public class JdkVersionProfileActivatorTest
         assertActivation( false, profile, newContext( null, newProperties( "1.6" ) ) );
     }
 
+    @Test
     public void testVersionRangeInclusiveLowerBound()
         throws Exception
     {
@@ -165,6 +172,7 @@ public class JdkVersionProfileActivatorTest
         assertActivation( true, profile, newContext( null, newProperties( "1.6.0_09-b03" ) ) );
     }
 
+    @Test
     public void testVersionRangeExclusiveUpperBound()
         throws Exception
     {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/PropertyProfileActivatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/PropertyProfileActivatorTest.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.ActivationProperty;
 import org.apache.maven.model.Profile;
+import org.junit.Test;
 
 /**
  * Tests {@link PropertyProfileActivator}.
@@ -61,6 +62,7 @@ public class PropertyProfileActivatorTest
         return props;
     }
 
+    @Test
     public void testNullSafe()
         throws Exception
     {
@@ -73,6 +75,7 @@ public class PropertyProfileActivatorTest
         assertActivation( false, p, newContext( null, null ) );
     }
 
+    @Test
     public void testWithNameOnly_UserProperty()
         throws Exception
     {
@@ -85,6 +88,7 @@ public class PropertyProfileActivatorTest
         assertActivation( false, profile, newContext( newProperties( "other", "value" ), null ) );
     }
 
+    @Test
     public void testWithNameOnly_SystemProperty()
         throws Exception
     {
@@ -97,6 +101,7 @@ public class PropertyProfileActivatorTest
         assertActivation( false, profile, newContext( null, newProperties( "other", "value" ) ) );
     }
 
+    @Test
     public void testWithNegatedNameOnly_UserProperty()
         throws Exception
     {
@@ -109,6 +114,7 @@ public class PropertyProfileActivatorTest
         assertActivation( true, profile, newContext( newProperties( "other", "value" ), null ) );
     }
 
+    @Test
     public void testWithNegatedNameOnly_SystemProperty()
         throws Exception
     {
@@ -121,6 +127,7 @@ public class PropertyProfileActivatorTest
         assertActivation( true, profile, newContext( null, newProperties( "other", "value" ) ) );
     }
 
+    @Test
     public void testWithValue_UserProperty()
         throws Exception
     {
@@ -133,6 +140,7 @@ public class PropertyProfileActivatorTest
         assertActivation( false, profile, newContext( newProperties( "prop", "" ), null ) );
     }
 
+    @Test
     public void testWithValue_SystemProperty()
         throws Exception
     {
@@ -145,6 +153,7 @@ public class PropertyProfileActivatorTest
         assertActivation( false, profile, newContext( null, newProperties( "other", "" ) ) );
     }
 
+    @Test
     public void testWithNegatedValue_UserProperty()
         throws Exception
     {
@@ -157,6 +166,7 @@ public class PropertyProfileActivatorTest
         assertActivation( true, profile, newContext( newProperties( "prop", "" ), null ) );
     }
 
+    @Test
     public void testWithNegatedValue_SystemProperty()
         throws Exception
     {
@@ -169,6 +179,7 @@ public class PropertyProfileActivatorTest
         assertActivation( true, profile, newContext( null, newProperties( "other", "" ) ) );
     }
 
+    @Test
     public void testWithValue_UserPropertyDominantOverSystemProperty()
         throws Exception
     {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -27,14 +27,18 @@ import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.SimpleProblemCollector;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
  */
 public class DefaultModelValidatorTest
-    extends TestCase
 {
 
     private ModelValidator validator;
@@ -95,22 +99,18 @@ public class DefaultModelValidatorTest
         assertTrue( "\"" + substring + "\" was not found in: " + msg, msg.contains( substring ) );
     }
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
-
         validator = new DefaultModelValidator();
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         this.validator = null;
-
-        super.tearDown();
     }
 
     private void assertViolations( SimpleProblemCollector result, int fatals, int errors, int warnings )
@@ -120,6 +120,7 @@ public class DefaultModelValidatorTest
         assertEquals( String.valueOf( result.getWarnings() ), warnings, result.getWarnings().size() );
     }
 
+    @Test
     public void testMissingModelVersion()
         throws Exception
     {
@@ -130,6 +131,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'modelVersion' is missing.", result.getErrors().get( 0 ) );
     }
 
+    @Test
     public void testBadModelVersion()
         throws Exception
     {
@@ -141,6 +143,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getFatals().get( 0 ).contains( "modelVersion" ) );
     }
 
+    @Test
     public void testMissingArtifactId()
         throws Exception
     {
@@ -151,6 +154,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'artifactId' is missing.", result.getErrors().get( 0 ) );
     }
 
+    @Test
     public void testMissingGroupId()
         throws Exception
     {
@@ -161,6 +165,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'groupId' is missing.", result.getErrors().get( 0 ) );
     }
 
+    @Test
     public void testInvalidIds()
         throws Exception
     {
@@ -174,6 +179,7 @@ public class DefaultModelValidatorTest
                       result.getErrors().get( 1 ) );
     }
 
+    @Test
     public void testMissingType()
         throws Exception
     {
@@ -184,6 +190,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'packaging' is missing.", result.getErrors().get( 0 ) );
     }
 
+    @Test
     public void testMissingVersion()
         throws Exception
     {
@@ -194,6 +201,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'version' is missing.", result.getErrors().get( 0 ) );
     }
 
+    @Test
     public void testInvalidAggregatorPackaging()
         throws Exception
     {
@@ -204,6 +212,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "Aggregator projects require 'pom' as packaging." ) );
     }
 
+    @Test
     public void testMissingDependencyArtifactId()
         throws Exception
     {
@@ -214,6 +223,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "'dependencies.dependency.artifactId' for groupId:null:jar is missing" ) );
     }
 
+    @Test
     public void testMissingDependencyGroupId()
         throws Exception
     {
@@ -224,6 +234,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "'dependencies.dependency.groupId' for null:artifactId:jar is missing" ) );
     }
 
+    @Test
     public void testMissingDependencyVersion()
         throws Exception
     {
@@ -234,6 +245,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "'dependencies.dependency.version' for groupId:artifactId:jar is missing" ) );
     }
 
+    @Test
     public void testMissingDependencyManagementArtifactId()
         throws Exception
     {
@@ -244,6 +256,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "'dependencyManagement.dependencies.dependency.artifactId' for groupId:null:jar is missing" ) );
     }
 
+    @Test
     public void testMissingDependencyManagementGroupId()
         throws Exception
     {
@@ -254,6 +267,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "'dependencyManagement.dependencies.dependency.groupId' for null:artifactId:jar is missing" ) );
     }
 
+    @Test
     public void testMissingAll()
         throws Exception
     {
@@ -270,6 +284,7 @@ public class DefaultModelValidatorTest
         // type is inherited from the super pom
     }
 
+    @Test
     public void testMissingPluginArtifactId()
         throws Exception
     {
@@ -280,6 +295,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'build.plugins.plugin.artifactId' is missing.", result.getErrors().get( 0 ) );
     }
 
+    @Test
     public void testEmptyPluginVersion()
         throws Exception
     {
@@ -291,6 +307,7 @@ public class DefaultModelValidatorTest
             + " must be a valid version but is ''.", result.getErrors().get( 0 ) );
     }
 
+    @Test
     public void testMissingRepositoryId()
         throws Exception
     {
@@ -308,6 +325,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'pluginRepositories.pluginRepository.[null].url' is missing.", result.getErrors().get( 3 ) );
     }
 
+    @Test
     public void testMissingResourceDirectory()
         throws Exception
     {
@@ -320,6 +338,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'build.testResources.testResource.directory' is missing.", result.getErrors().get( 1 ) );
     }
 
+    @Test
     public void testBadPluginDependencyScope()
         throws Exception
     {
@@ -334,6 +353,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 2 ).contains( "test:f" ) );
     }
 
+    @Test
     public void testBadDependencyScope()
         throws Exception
     {
@@ -346,6 +366,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getWarnings().get( 1 ).contains( "test:g" ) );
     }
 
+    @Test
     public void testBadDependencyManagementScope()
         throws Exception
     {
@@ -356,6 +377,7 @@ public class DefaultModelValidatorTest
         assertContains( result.getWarnings().get( 0 ), "test:g" );
     }
 
+    @Test
     public void testBadDependencyVersion()
         throws Exception
     {
@@ -369,6 +391,7 @@ public class DefaultModelValidatorTest
                         "'dependencies.dependency.version' for test:c:jar must not contain any of these characters" );
     }
 
+    @Test
     public void testDuplicateModule()
         throws Exception
     {
@@ -379,6 +402,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "child" ) );
     }
 
+    @Test
     public void testDuplicateProfileId()
         throws Exception
     {
@@ -389,6 +413,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "non-unique-id" ) );
     }
 
+    @Test
     public void testBadPluginVersion()
         throws Exception
     {
@@ -406,6 +431,7 @@ public class DefaultModelValidatorTest
                         "'build.plugins.plugin.version' for test:ifsc must not contain any of these characters" );
     }
 
+    @Test
     public void testDistributionManagementStatus()
         throws Exception
     {
@@ -416,6 +442,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "distributionManagement.status" ) );
     }
 
+    @Test
     public void testIncompleteParent()
         throws Exception
     {
@@ -427,6 +454,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getFatals().get( 2 ).contains( "parent.version" ) );
     }
 
+    @Test
     public void testHardCodedSystemPath()
         throws Exception
     {
@@ -451,6 +479,7 @@ public class DefaultModelValidatorTest
 
     }
 
+    @Test
     public void testEmptyModule()
         throws Exception
     {
@@ -461,6 +490,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "'modules.module[0]' has been specified without a path" ) );
     }
 
+    @Test
     public void testDuplicatePlugin()
         throws Exception
     {
@@ -474,6 +504,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getWarnings().get( 3 ).contains( "duplicate declaration of plugin profile:managed-duplicate" ) );
     }
 
+    @Test
     public void testDuplicatePluginExecution()
         throws Exception
     {
@@ -487,6 +518,7 @@ public class DefaultModelValidatorTest
         assertContains( result.getErrors().get( 3 ), "duplicate execution with id b" );
     }
 
+    @Test
     public void testReservedRepositoryId()
         throws Exception
     {
@@ -501,6 +533,7 @@ public class DefaultModelValidatorTest
                         "'distributionManagement.snapshotRepository.id' must not be 'local'" );
     }
 
+    @Test
     public void testMissingPluginDependencyGroupId()
         throws Exception
     {
@@ -511,6 +544,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( ":a:" ) );
     }
 
+    @Test
     public void testMissingPluginDependencyArtifactId()
         throws Exception
     {
@@ -521,6 +555,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "test:" ) );
     }
 
+    @Test
     public void testMissingPluginDependencyVersion()
         throws Exception
     {
@@ -531,6 +566,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "test:a" ) );
     }
 
+    @Test
     public void testBadPluginDependencyVersion()
         throws Exception
     {
@@ -541,6 +577,7 @@ public class DefaultModelValidatorTest
         assertTrue( result.getErrors().get( 0 ).contains( "test:b" ) );
     }
 
+    @Test
     public void testBadVersion()
         throws Exception
     {
@@ -551,6 +588,7 @@ public class DefaultModelValidatorTest
         assertContains( result.getWarnings().get( 0 ), "'version' must not contain any of these characters" );
     }
 
+    @Test
     public void testBadSnapshotVersion()
         throws Exception
     {
@@ -561,6 +599,7 @@ public class DefaultModelValidatorTest
         assertContains( result.getWarnings().get( 0 ), "'version' uses an unsupported snapshot version format" );
     }
 
+    @Test
     public void testBadRepositoryId()
         throws Exception
     {
@@ -578,6 +617,7 @@ public class DefaultModelValidatorTest
                         "'distributionManagement.snapshotRepository.id' must not contain any of these characters" );
     }
 
+    @Test
     public void testBadDependencyExclusionId()
         throws Exception
     {
@@ -599,6 +639,7 @@ public class DefaultModelValidatorTest
 
     }
 
+    @Test
     public void testMissingDependencyExclusionId()
         throws Exception
     {
@@ -612,6 +653,7 @@ public class DefaultModelValidatorTest
                         "'dependencies.dependency.exclusions.exclusion.artifactId' for gid:aid:jar is missing" );
     }
 
+    @Test
     public void testBadImportScopeType()
         throws Exception
     {
@@ -623,6 +665,7 @@ public class DefaultModelValidatorTest
                         "'dependencyManagement.dependencies.dependency.type' for test:a:jar must be 'pom'" );
     }
 
+    @Test
     public void testBadImportScopeClassifier()
         throws Exception
     {
@@ -634,6 +677,7 @@ public class DefaultModelValidatorTest
                         "'dependencyManagement.dependencies.dependency.classifier' for test:a:pom:cls must be empty" );
     }
 
+    @Test
     public void testSystemPathRefersToProjectBasedir()
         throws Exception
     {
@@ -661,6 +705,7 @@ public class DefaultModelValidatorTest
                         "'dependencies.dependency.systemPath' for test:b:jar should not point at files within the project directory" );
     }
 
+    @Test
     public void testInvalidVersionInPluginManagement()
         throws Exception
     {
@@ -673,6 +718,7 @@ public class DefaultModelValidatorTest
 
     }
 
+    @Test
     public void testInvalidGroupIdInPluginManagement()
         throws Exception
     {
@@ -685,6 +731,7 @@ public class DefaultModelValidatorTest
 
     }
 
+    @Test
     public void testInvalidArtifactIdInPluginManagement()
         throws Exception
     {
@@ -697,6 +744,7 @@ public class DefaultModelValidatorTest
 
     }
 
+    @Test
     public void testInvalidGroupAndArtifactIdInPluginManagement()
         throws Exception
     {
@@ -712,6 +760,7 @@ public class DefaultModelValidatorTest
 
     }
 
+    @Test
     public void testMissingReportPluginVersion()
         throws Exception
     {
@@ -720,6 +769,7 @@ public class DefaultModelValidatorTest
         assertViolations( result, 0, 0, 0 );
     }
 
+    @Test
     public void testDeprecatedDependencyMetaversionsLatestAndRelease()
         throws Exception
     {
@@ -733,6 +783,7 @@ public class DefaultModelValidatorTest
                         "'dependencies.dependency.version' for test:b:jar is either LATEST or RELEASE (both of them are being deprecated)" );
     }
 
+    @Test
     public void testSelfReferencingDependencyInRawModel()
         throws Exception
     {
@@ -745,6 +796,7 @@ public class DefaultModelValidatorTest
 
     }
 
+    @Test
     public void testSelfReferencingDependencyWithClassifierInRawModel() throws Exception
     {
         SimpleProblemCollector result = validateRaw( "raw-model/self-referencing-classifier.xml" );
@@ -752,6 +804,7 @@ public class DefaultModelValidatorTest
         assertViolations( result, 0, 0, 0 );
     }
 
+    @Test
     public void testCiFriendlySha1()
         throws Exception
     {
@@ -759,6 +812,7 @@ public class DefaultModelValidatorTest
         assertViolations( result, 0, 0, 0 );
     }
 
+    @Test
     public void testCiFriendlyRevision()
         throws Exception
     {
@@ -766,6 +820,7 @@ public class DefaultModelValidatorTest
         assertViolations( result, 0, 0, 0 );
     }
 
+    @Test
     public void testCiFriendlyChangeList()
         throws Exception
     {
@@ -773,6 +828,7 @@ public class DefaultModelValidatorTest
         assertViolations( result, 0, 0, 0 );
     }
 
+    @Test
     public void testCiFriendlyAllExpressions()
         throws Exception
     {
@@ -780,6 +836,7 @@ public class DefaultModelValidatorTest
         assertViolations( result, 0, 0, 0 );
     }
 
+    @Test
     public void testCiFriendlyBad()
         throws Exception
     {
@@ -788,6 +845,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'version' contains an expression but should be a constant.", result.getWarnings().get( 0 ) );
     }
 
+    @Test
     public void testCiFriendlyBadSha1Plus()
         throws Exception
     {
@@ -796,6 +854,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'version' contains an expression but should be a constant.", result.getWarnings().get( 0 ) );
     }
 
+    @Test
     public void testCiFriendlyBadSha1Plus2()
         throws Exception
     {
@@ -804,6 +863,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'version' contains an expression but should be a constant.", result.getWarnings().get( 0 ) );
     }
 
+    @Test
     public void testParentVersionLATEST()
         throws Exception
     {
@@ -812,6 +872,7 @@ public class DefaultModelValidatorTest
         assertEquals( "'parent.version' is either LATEST or RELEASE (both of them are being deprecated)", result.getWarnings().get( 0 ) );
     }
 
+    @Test
     public void testParentVersionRELEASE()
         throws Exception
     {

--- a/maven-model/src/test/java/org/apache/maven/model/ActivationFileTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ActivationFileTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code ActivationFile}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ActivationFileTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new ActivationFile().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new ActivationFile().equals( null ) );
@@ -42,12 +47,14 @@ public class ActivationFileTest
         new ActivationFile().equals( new ActivationFile() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         ActivationFile thing = new ActivationFile();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new ActivationFile().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ActivationOSTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ActivationOSTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code ActivationOS}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ActivationOSTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new ActivationOS().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new ActivationOS().equals( null ) );
@@ -42,12 +47,14 @@ public class ActivationOSTest
         new ActivationOS().equals( new ActivationOS() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         ActivationOS thing = new ActivationOS();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new ActivationOS().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ActivationPropertyTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ActivationPropertyTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code ActivationProperty}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ActivationPropertyTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new ActivationProperty().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new ActivationProperty().equals( null ) );
@@ -42,12 +47,14 @@ public class ActivationPropertyTest
         new ActivationProperty().equals( new ActivationProperty() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         ActivationProperty thing = new ActivationProperty();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new ActivationProperty().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ActivationTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ActivationTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Activation}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ActivationTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Activation().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Activation().equals( null ) );
@@ -42,12 +47,14 @@ public class ActivationTest
         new Activation().equals( new Activation() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Activation thing = new Activation();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Activation().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Build}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class BuildTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Build().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Build().equals( null ) );
@@ -42,12 +47,14 @@ public class BuildTest
         new Build().equals( new Build() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Build thing = new Build();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Build().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/CiManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/CiManagementTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code CiManagement}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class CiManagementTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new CiManagement().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new CiManagement().equals( null ) );
@@ -42,12 +47,14 @@ public class CiManagementTest
         new CiManagement().equals( new CiManagement() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         CiManagement thing = new CiManagement();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new CiManagement().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ContributorTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ContributorTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Contributor}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ContributorTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Contributor().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Contributor().equals( null ) );
@@ -42,12 +47,14 @@ public class ContributorTest
         new Contributor().equals( new Contributor() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Contributor thing = new Contributor();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Contributor().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/DependencyManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DependencyManagementTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code DependencyManagement}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class DependencyManagementTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new DependencyManagement().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new DependencyManagement().equals( null ) );
@@ -42,12 +47,14 @@ public class DependencyManagementTest
         new DependencyManagement().equals( new DependencyManagement() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         DependencyManagement thing = new DependencyManagement();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new DependencyManagement().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/DependencyTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DependencyTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Dependency}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class DependencyTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Dependency().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Dependency().equals( null ) );
@@ -42,12 +47,14 @@ public class DependencyTest
         new Dependency().equals( new Dependency() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Dependency thing = new Dependency();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Dependency().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/DeploymentRepositoryTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DeploymentRepositoryTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code DeploymentRepository}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class DeploymentRepositoryTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new DeploymentRepository().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new DeploymentRepository().equals( null ) );
@@ -42,12 +47,14 @@ public class DeploymentRepositoryTest
         new DeploymentRepository().equals( new DeploymentRepository() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         DeploymentRepository thing = new DeploymentRepository();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new DeploymentRepository().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Developer}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class DeveloperTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Developer().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Developer().equals( null ) );
@@ -42,12 +47,14 @@ public class DeveloperTest
         new Developer().equals( new Developer() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Developer thing = new Developer();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Developer().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/DistributionManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DistributionManagementTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code DistributionManagement}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class DistributionManagementTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new DistributionManagement().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new DistributionManagement().equals( null ) );
@@ -42,12 +47,14 @@ public class DistributionManagementTest
         new DistributionManagement().equals( new DistributionManagement() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         DistributionManagement thing = new DistributionManagement();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new DistributionManagement().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ExclusionTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ExclusionTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Exclusion}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ExclusionTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Exclusion().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Exclusion().equals( null ) );
@@ -42,12 +47,14 @@ public class ExclusionTest
         new Exclusion().equals( new Exclusion() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Exclusion thing = new Exclusion();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Exclusion().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ExtensionTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ExtensionTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Extension}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ExtensionTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Extension().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Extension().equals( null ) );
@@ -42,12 +47,14 @@ public class ExtensionTest
         new Extension().equals( new Extension() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Extension thing = new Extension();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Extension().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code IssueManagement}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class IssueManagementTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new IssueManagement().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new IssueManagement().equals( null ) );
@@ -42,12 +47,14 @@ public class IssueManagementTest
         new IssueManagement().equals( new IssueManagement() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         IssueManagement thing = new IssueManagement();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new IssueManagement().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code License}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class LicenseTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new License().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new License().equals( null ) );
@@ -42,12 +47,14 @@ public class LicenseTest
         new License().equals( new License() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         License thing = new License();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new License().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code MailingList}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class MailingListTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new MailingList().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new MailingList().equals( null ) );
@@ -42,12 +47,14 @@ public class MailingListTest
         new MailingList().equals( new MailingList() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         MailingList thing = new MailingList();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new MailingList().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Model}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ModelTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Model().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Model().equals( null ) );
@@ -42,12 +47,14 @@ public class ModelTest
         new Model().equals( new Model() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Model thing = new Model();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Model().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/NotifierTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/NotifierTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Notifier}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class NotifierTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Notifier().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Notifier().equals( null ) );
@@ -42,12 +47,14 @@ public class NotifierTest
         new Notifier().equals( new Notifier() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Notifier thing = new Notifier();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Notifier().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Organization}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class OrganizationTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Organization().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Organization().equals( null ) );
@@ -42,12 +47,14 @@ public class OrganizationTest
         new Organization().equals( new Organization() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Organization thing = new Organization();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Organization().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ParentTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ParentTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Parent}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ParentTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Parent().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Parent().equals( null ) );
@@ -42,12 +47,14 @@ public class ParentTest
         new Parent().equals( new Parent() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Parent thing = new Parent();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Parent().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/PluginConfigurationTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/PluginConfigurationTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code PluginConfiguration}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class PluginConfigurationTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new PluginConfiguration().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new PluginConfiguration().equals( null ) );
@@ -42,12 +47,14 @@ public class PluginConfigurationTest
         new PluginConfiguration().equals( new PluginConfiguration() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         PluginConfiguration thing = new PluginConfiguration();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new PluginConfiguration().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/PluginContainerTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/PluginContainerTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code PluginContainer}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class PluginContainerTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new PluginContainer().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new PluginContainer().equals( null ) );
@@ -42,12 +47,14 @@ public class PluginContainerTest
         new PluginContainer().equals( new PluginContainer() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         PluginContainer thing = new PluginContainer();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new PluginContainer().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/PluginExecutionTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/PluginExecutionTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code PluginExecution}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class PluginExecutionTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new PluginExecution().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new PluginExecution().equals( null ) );
@@ -42,12 +47,14 @@ public class PluginExecutionTest
         new PluginExecution().equals( new PluginExecution() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         PluginExecution thing = new PluginExecution();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new PluginExecution().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/PluginManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/PluginManagementTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code PluginManagement}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class PluginManagementTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new PluginManagement().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new PluginManagement().equals( null ) );
@@ -42,12 +47,14 @@ public class PluginManagementTest
         new PluginManagement().equals( new PluginManagement() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         PluginManagement thing = new PluginManagement();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new PluginManagement().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/PluginTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/PluginTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Plugin}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class PluginTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Plugin().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Plugin().equals( null ) );
@@ -42,12 +47,14 @@ public class PluginTest
         new Plugin().equals( new Plugin() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Plugin thing = new Plugin();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Plugin().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/PrerequisitesTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/PrerequisitesTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Prerequisites}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class PrerequisitesTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Prerequisites().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Prerequisites().equals( null ) );
@@ -42,12 +47,14 @@ public class PrerequisitesTest
         new Prerequisites().equals( new Prerequisites() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Prerequisites thing = new Prerequisites();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Prerequisites().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ProfileTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ProfileTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Profile}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ProfileTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Profile().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Profile().equals( null ) );
@@ -42,12 +47,14 @@ public class ProfileTest
         new Profile().equals( new Profile() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Profile thing = new Profile();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Profile().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/RelocationTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/RelocationTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Relocation}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class RelocationTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Relocation().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Relocation().equals( null ) );
@@ -42,12 +47,14 @@ public class RelocationTest
         new Relocation().equals( new Relocation() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Relocation thing = new Relocation();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Relocation().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ReportPluginTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ReportPluginTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code ReportPlugin}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ReportPluginTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new ReportPlugin().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new ReportPlugin().equals( null ) );
@@ -42,12 +47,14 @@ public class ReportPluginTest
         new ReportPlugin().equals( new ReportPlugin() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         ReportPlugin thing = new ReportPlugin();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new ReportPlugin().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ReportSetTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ReportSetTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code ReportSet}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ReportSetTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new ReportSet().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new ReportSet().equals( null ) );
@@ -42,12 +47,14 @@ public class ReportSetTest
         new ReportSet().equals( new ReportSet() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         ReportSet thing = new ReportSet();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new ReportSet().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ReportingTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ReportingTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Reporting}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ReportingTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Reporting().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Reporting().equals( null ) );
@@ -42,12 +47,14 @@ public class ReportingTest
         new Reporting().equals( new Reporting() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Reporting thing = new Reporting();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Reporting().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/RepositoryPolicyTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/RepositoryPolicyTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code RepositoryPolicy}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class RepositoryPolicyTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new RepositoryPolicy().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new RepositoryPolicy().equals( null ) );
@@ -42,12 +47,14 @@ public class RepositoryPolicyTest
         new RepositoryPolicy().equals( new RepositoryPolicy() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         RepositoryPolicy thing = new RepositoryPolicy();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new RepositoryPolicy().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/RepositoryTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/RepositoryTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Repository}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class RepositoryTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Repository().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Repository().equals( null ) );
@@ -42,12 +47,14 @@ public class RepositoryTest
         new Repository().equals( new Repository() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Repository thing = new Repository();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Repository().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ResourceTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ResourceTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Resource}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ResourceTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Resource().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Resource().equals( null ) );
@@ -42,12 +47,14 @@ public class ResourceTest
         new Resource().equals( new Resource() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Resource thing = new Resource();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Resource().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Scm}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class ScmTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Scm().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Scm().equals( null ) );
@@ -42,12 +47,14 @@ public class ScmTest
         new Scm().equals( new Scm() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Scm thing = new Scm();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Scm().toString() );

--- a/maven-model/src/test/java/org/apache/maven/model/SiteTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/SiteTest.java
@@ -19,7 +19,11 @@ package org.apache.maven.model;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Site}.
@@ -27,14 +31,15 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class SiteTest
-    extends TestCase
 {
 
+    @Test
     public void testHashCodeNullSafe()
     {
         new Site().hashCode();
     }
 
+    @Test
     public void testEqualsNullSafe()
     {
         assertFalse( new Site().equals( null ) );
@@ -42,12 +47,14 @@ public class SiteTest
         new Site().equals( new Site() );
     }
 
+    @Test
     public void testEqualsIdentity()
     {
         Site thing = new Site();
         assertTrue( thing.equals( thing ) );
     }
 
+    @Test
     public void testToStringNullSafe()
     {
         assertNotNull( new Site().toString() );

--- a/maven-plugin-api/src/test/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilderTest.java
+++ b/maven-plugin-api/src/test/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilderTest.java
@@ -27,8 +27,10 @@ import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.util.ReaderFactory;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests {@link PluginDescriptorBuilder}.
@@ -36,7 +38,6 @@ import junit.framework.TestCase;
  * @author Benjamin Bentmann
  */
 public class PluginDescriptorBuilderTest
-    extends TestCase
 {
 
     private PluginDescriptor build( String resource )
@@ -47,6 +48,7 @@ public class PluginDescriptorBuilderTest
         return new PluginDescriptorBuilder().build( reader );
     }
 
+    @Test
     public void testBuildReader()
         throws Exception
     {

--- a/maven-resolver-provider/src/test/java/org/apache/maven/PlexusTestCase.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/PlexusTestCase.java
@@ -1,0 +1,318 @@
+package org.apache.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright 2001-2006 Codehaus Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.InputStream;
+
+
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.context.DefaultContext;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * This is a slightly modified version of the original plexus class
+ * available at https://raw.githubusercontent.com/codehaus-plexus/plexus-containers/master/plexus-container-default/src/main/java/org/codehaus/plexus/PlexusTestCase.java
+ * in order to migrate the tests to JUnit 4.
+ *
+ * @author Jason van Zyl
+ * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
+ * @author <a href="mailto:michal@codehaus.org">Michal Maczka</a>
+ * @author Guillaume Nodet
+ */
+public abstract class PlexusTestCase
+{
+    private PlexusContainer container;
+
+    private static String basedir;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        basedir = getBasedir();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    protected void setupContainer()
+    {
+        // ----------------------------------------------------------------------------
+        // Context Setup
+        // ----------------------------------------------------------------------------
+
+        DefaultContext context = new DefaultContext();
+
+        context.put( "basedir", getBasedir() );
+
+        customizeContext( context );
+
+        boolean hasPlexusHome = context.contains( "plexus.home" );
+
+        if ( !hasPlexusHome )
+        {
+            File f = getTestFile( "target/plexus-home" );
+
+            if ( !f.isDirectory() )
+            {
+                f.mkdir();
+            }
+
+            context.put( "plexus.home", f.getAbsolutePath() );
+        }
+
+        // ----------------------------------------------------------------------------
+        // Configuration
+        // ----------------------------------------------------------------------------
+
+        String config = getCustomConfigurationName();
+
+        ContainerConfiguration containerConfiguration = new DefaultContainerConfiguration()
+                .setName( "test" )
+                .setContext( context.getContextData() );
+
+        if ( config != null )
+        {
+            containerConfiguration.setContainerConfiguration( config );
+        }
+        else
+        {
+            String resource = getConfigurationName( null );
+
+            containerConfiguration.setContainerConfiguration( resource );
+        }
+
+        customizeContainerConfiguration( containerConfiguration );
+
+        try
+        {
+            container = new DefaultPlexusContainer( containerConfiguration );
+        }
+        catch ( PlexusContainerException e )
+        {
+            throw new IllegalArgumentException( "Failed to create plexus container.", e );
+        }
+    }
+
+    /**
+     * Allow custom test case implementations do augment the default container configuration before
+     * executing tests.
+     *
+     * @param containerConfiguration {@link ContainerConfiguration}.
+     */
+    protected void customizeContainerConfiguration( ContainerConfiguration containerConfiguration )
+    {
+    }
+
+    protected void customizeContext( Context context )
+    {
+    }
+
+    protected PlexusConfiguration customizeComponentConfiguration()
+    {
+        return null;
+    }
+
+    @After
+    public void tearDown()
+            throws Exception
+    {
+        if ( container != null )
+        {
+            container.dispose();
+
+            container = null;
+        }
+    }
+
+    protected PlexusContainer getContainer()
+    {
+        if ( container == null )
+        {
+            setupContainer();
+        }
+
+        return container;
+    }
+
+    protected InputStream getConfiguration()
+            throws Exception
+    {
+        return getConfiguration( null );
+    }
+
+    protected InputStream getConfiguration( String subname )
+            throws Exception
+    {
+        return getResourceAsStream( getConfigurationName( subname ) );
+    }
+
+    protected String getCustomConfigurationName()
+    {
+        return null;
+    }
+
+    /**
+     * Allow the retrieval of a container configuration that is based on the name
+     * of the test class being run. So if you have a test class called org.foo.FunTest, then
+     * this will produce a resource name of org/foo/FunTest.xml which would be used to
+     * configure the Plexus container before running your test.
+     *
+     * @param subname the subname
+     * @return A configruation name
+     */
+    protected String getConfigurationName( String subname )
+    {
+        return getClass().getName().replace( '.', '/' ) + ".xml";
+    }
+
+    protected InputStream getResourceAsStream( String resource )
+    {
+        return getClass().getResourceAsStream( resource );
+    }
+
+    protected ClassLoader getClassLoader()
+    {
+        return getClass().getClassLoader();
+    }
+
+    // ----------------------------------------------------------------------
+    // Container access
+    // ----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    protected <T> T lookup( String componentKey )
+            throws ComponentLookupException
+    {
+        return (T) getContainer().lookup( componentKey );
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T lookup( String role,
+                            String roleHint )
+            throws ComponentLookupException
+    {
+        return (T) getContainer().lookup( role, roleHint );
+    }
+
+    protected <T> T lookup( Class<T> componentClass )
+            throws ComponentLookupException
+    {
+        return getContainer().lookup( componentClass );
+    }
+
+    protected <T> T lookup( Class<T> componentClass, String roleHint )
+            throws ComponentLookupException
+    {
+        return getContainer().lookup( componentClass, roleHint );
+    }
+
+    protected void release( Object component )
+            throws ComponentLifecycleException
+    {
+        getContainer().release( component );
+    }
+
+    // ----------------------------------------------------------------------
+    // Helper methods for sub classes
+    // ----------------------------------------------------------------------
+
+    public static File getTestFile( String path )
+    {
+        return new File( getBasedir(), path );
+    }
+
+    public static File getTestFile( String basedir,
+                                    String path )
+    {
+        File basedirFile = new File( basedir );
+
+        if ( !basedirFile.isAbsolute() )
+        {
+            basedirFile = getTestFile( basedir );
+        }
+
+        return new File( basedirFile, path );
+    }
+
+    public static String getTestPath( String path )
+    {
+        return getTestFile( path ).getAbsolutePath();
+    }
+
+    public static String getTestPath( String basedir,
+                                      String path )
+    {
+        return getTestFile( basedir, path ).getAbsolutePath();
+    }
+
+    public static String getBasedir()
+    {
+        if ( basedir != null )
+        {
+            return basedir;
+        }
+
+        basedir = System.getProperty( "basedir" );
+
+        if ( basedir == null )
+        {
+            basedir = new File( "" ).getAbsolutePath();
+        }
+
+        return basedir;
+    }
+
+    public String getTestConfiguration()
+    {
+        return getTestConfiguration( getClass() );
+    }
+
+    public static String getTestConfiguration( Class<?> clazz )
+    {
+        String s = clazz.getName().replace( '.', '/' );
+
+        return s.substring( 0, s.indexOf( "$" ) ) + ".xml";
+    }
+}

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/AbstractRepositoryTestCase.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/AbstractRepositoryTestCase.java
@@ -21,16 +21,18 @@ package org.apache.maven.repository.internal;
 
 import java.net.MalformedURLException;
 
+import org.apache.maven.PlexusTestCase;
 import org.apache.maven.repository.internal.util.ConsoleRepositoryListener;
 import org.apache.maven.repository.internal.util.ConsoleTransferListener;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.After;
+import org.junit.Before;
 
 public abstract class AbstractRepositoryTestCase
     extends PlexusTestCase
@@ -47,8 +49,9 @@ public abstract class AbstractRepositoryTestCase
         containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
     }
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();
@@ -56,8 +59,9 @@ public abstract class AbstractRepositoryTestCase
         session = newMavenRepositorySystemSession( system );
     }
 
+    @After
     @Override
-    protected void tearDown()
+    public void tearDown()
         throws Exception
     {
         session = null;

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -73,9 +73,7 @@ public class DefaultArtifactDescriptorReaderTest
             }
         }
 
-        if( !missingArtifactDescriptor )
-        {
-            fail( "Expected missing artifact descriptor for org.apache.maven.its:dep-mng5459:pom:0.4.0-20130404.090532-2" );
-        }
+        assertTrue( "Expected missing artifact descriptor for org.apache.maven.its:dep-mng5459:pom:0.4.0-20130404.090532-2",
+                missingArtifactDescriptor );
     }
 }

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderTest.java
@@ -19,21 +19,25 @@ package org.apache.maven.repository.internal;
  * under the License.
  */
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.ArtifactDescriptorReader;
 import org.eclipse.aether.impl.RepositoryEventDispatcher;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class DefaultArtifactDescriptorReaderTest
     extends AbstractRepositoryTestCase
 {
 
+    @Test
     public void testMng5459()
         throws Exception
     {

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
@@ -30,6 +30,12 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 import org.eclipse.aether.impl.ArtifactResolver;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.impl.VersionRangeResolver;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test cases for the default {@code ModelResolver} implementation.
@@ -48,6 +54,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         super();
     }
 
+    @Test
     public void testResolveParentThrowsUnresolvableModelExceptionWhenNotFound() throws Exception
     {
         final Parent parent = new Parent();
@@ -67,6 +74,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         }
     }
 
+    @Test
     public void testResolveParentThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception
     {
         final Parent parent = new Parent();
@@ -87,6 +95,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         }
     }
 
+    @Test
     public void testResolveParentThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception
     {
         final Parent parent = new Parent();
@@ -107,6 +116,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         }
     }
 
+    @Test
     public void testResolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception
     {
         final Parent parent = new Parent();
@@ -118,6 +128,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         assertEquals( "1.0", parent.getVersion() );
     }
 
+    @Test
     public void testResolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception
     {
         final Parent parent = new Parent();
@@ -129,6 +140,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         assertEquals( "1.0", parent.getVersion() );
     }
 
+    @Test
     public void testResolveDependencyThrowsUnresolvableModelExceptionWhenNotFound() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -148,6 +160,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         }
     }
 
+    @Test
     public void testResolveDependencyThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -168,6 +181,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         }
     }
 
+    @Test
     public void testResolveDependencyThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -188,6 +202,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         }
     }
 
+    @Test
     public void testResolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception
     {
         final Dependency dependency = new Dependency();
@@ -199,6 +214,7 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         assertEquals( "1.0", dependency.getVersion() );
     }
 
+    @Test
     public void testResolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception
     {
         final Dependency dependency = new Dependency();

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
@@ -34,8 +34,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test cases for the default {@code ModelResolver} implementation.
@@ -62,16 +62,11 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         parent.setArtifactId( "artifact" );
         parent.setVersion( "0" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( parent );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertTrue( e.getMessage().startsWith( "Could not find artifact ut.simple:artifact:pom:0 in repo" ) );
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( parent ) );
+        assertNotNull( e.getMessage() );
+        assertTrue( e.getMessage().startsWith( "Could not find artifact ut.simple:artifact:pom:0 in repo" ) );
     }
 
     @Test
@@ -82,17 +77,12 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         parent.setArtifactId( "artifact" );
         parent.setVersion( "[2.0,2.1)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( parent );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "No versions matched the requested parent version range '[2.0,2.1)'",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( parent ) );
+        assertNotNull( e.getMessage() );
+        assertEquals( "No versions matched the requested parent version range '[2.0,2.1)'",
+                      e.getMessage() );
     }
 
     @Test
@@ -103,17 +93,11 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         parent.setArtifactId( "artifact" );
         parent.setVersion( "[1.0,)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( parent );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "The requested parent version range '[1.0,)' does not specify an upper bound",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( parent ) );
+        assertEquals( "The requested parent version range '[1.0,)' does not specify an upper bound",
+                      e.getMessage() );
     }
 
     @Test
@@ -148,16 +132,11 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         dependency.setArtifactId( "artifact" );
         dependency.setVersion( "0" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( dependency );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertNotNull( e.getMessage() );
-            assertTrue( e.getMessage().startsWith( "Could not find artifact ut.simple:artifact:pom:0 in repo" ) );
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( dependency ) );
+        assertNotNull( e.getMessage() );
+        assertTrue( e.getMessage().startsWith( "Could not find artifact ut.simple:artifact:pom:0 in repo" ) );
     }
 
     @Test
@@ -168,17 +147,11 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         dependency.setArtifactId( "artifact" );
         dependency.setVersion( "[2.0,2.1)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( dependency );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "No versions matched the requested dependency version range '[2.0,2.1)'",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( dependency ) );
+        assertEquals( "No versions matched the requested dependency version range '[2.0,2.1)'",
+                      e.getMessage() );
     }
 
     @Test
@@ -189,17 +162,11 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTestCase
         dependency.setArtifactId( "artifact" );
         dependency.setVersion( "[1.0,)" );
 
-        try
-        {
-            this.newModelResolver().resolveModel( dependency );
-            fail( "Expected 'UnresolvableModelException' not thrown." );
-        }
-        catch ( final UnresolvableModelException e )
-        {
-            assertEquals( "The requested dependency version range '[1.0,)' does not specify an upper bound",
-                          e.getMessage() );
-
-        }
+        UnresolvableModelException e = assertThrows( "Expected 'UnresolvableModelException' not thrown.",
+                UnresolvableModelException.class,
+                () -> newModelResolver().resolveModel( dependency ) );
+        assertEquals( "The requested dependency version range '[1.0,)' does not specify an upper bound",
+                      e.getMessage() );
     }
 
     @Test

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
@@ -20,18 +20,24 @@ package org.apache.maven.repository.internal;
  */
 
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.resolution.VersionRequest;
 import org.eclipse.aether.resolution.VersionResult;
-import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class DefaultVersionResolverTest
     extends AbstractRepositoryTestCase
 {
     private DefaultVersionResolver versionResolver;
 
+    @Before
     @Override
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();
@@ -39,14 +45,16 @@ public class DefaultVersionResolverTest
         versionResolver = (DefaultVersionResolver) lookup( VersionResolver.class, "default" );
     }
 
+    @After
     @Override
-    protected void tearDown()
+    public void tearDown()
         throws Exception
     {
         versionResolver = null;
         super.tearDown();
     }
 
+    @Test
     public void testResolveSeparateInstalledClassifiedNonUniqueVersionedArtifacts()
         throws Exception
     {
@@ -70,6 +78,7 @@ public class DefaultVersionResolverTest
         assertEquals( "07.20.3-20120809.112124-88", resultA.getVersion() );
     }
 
+    @Test
     public void testResolveSeparateInstalledClassifiedNonVersionedArtifacts()
         throws Exception
     {

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/MavenRepositorySystemUtilsTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/MavenRepositorySystemUtilsTest.java
@@ -22,13 +22,15 @@ package org.apache.maven.repository.internal;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class MavenRepositorySystemUtilsTest
-    extends TestCase
 {
 
+    @Test
     public void testGetRepositorySystem()
     {
         ServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
@@ -36,6 +38,7 @@ public class MavenRepositorySystemUtilsTest
         assertNotNull( repoSys );
     }
 
+    @Test
     public void testGetMetadataGeneratorFactories()
     {
         ServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RemoteSnapshotMetadataTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RemoteSnapshotMetadataTest.java
@@ -19,8 +19,6 @@ package org.apache.maven.repository.internal;
  * under the License.
  */
 
-import static org.junit.Assert.assertTrue;
-
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
@@ -34,6 +32,8 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class RemoteSnapshotMetadataTest
 {

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RepositorySystemTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RepositorySystemTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.CollectResult;
 import org.eclipse.aether.graph.Dependency;
@@ -31,11 +32,18 @@ import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResult;
-import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class RepositorySystemTest
     extends AbstractRepositoryTestCase
 {
+    @Test
     public void testResolveVersionRange()
         throws Exception
     {
@@ -44,6 +52,7 @@ public class RepositorySystemTest
 
     }
 
+    @Test
     public void testResolveVersion()
         throws Exception
     {
@@ -51,6 +60,7 @@ public class RepositorySystemTest
         //                throws VersionResolutionException;
     }
 
+    @Test
     public void testReadArtifactDescriptor()
         throws Exception
     {
@@ -109,6 +119,7 @@ public class RepositorySystemTest
         assertEquals( 4, depArtifact.getProperties().size() );
     }
 
+    @Test
     public void testCollectDependencies()
         throws Exception
     {
@@ -126,6 +137,7 @@ public class RepositorySystemTest
         checkUtSimpleArtifactDependencies( nodes.get( 0 ).getDependency(), nodes.get( 1 ).getDependency() );
     }
 
+    @Test
     public void testResolveArtifact()
         throws Exception
     {
@@ -158,6 +170,7 @@ public class RepositorySystemTest
         assertEquals( filename, artifact.getFile().getName() );
     }
 
+    @Test
     public void testResolveArtifacts()
         throws Exception
     {
@@ -183,6 +196,7 @@ public class RepositorySystemTest
         checkArtifactResult( results.get( 2 ), "artifact-1.0-classifier.zip" );
     }
 
+    @Test
     public void testResolveMetadata()
         throws Exception
     {
@@ -190,6 +204,7 @@ public class RepositorySystemTest
         //                                      Collection<? extends MetadataRequest> requests );
     }
 
+    @Test
     public void testInstall()
         throws Exception
     {
@@ -198,6 +213,7 @@ public class RepositorySystemTest
         // release, snapshot unique ou non unique, attachment
     }
 
+    @Test
     public void testDeploy()
         throws Exception
     {
@@ -205,12 +221,14 @@ public class RepositorySystemTest
         //                throws DeploymentException;
     }
 
+    @Test
     public void testNewLocalRepositoryManager()
         throws Exception
     {
         //LocalRepositoryManager newLocalRepositoryManager( LocalRepository localRepository );
     }
 
+    @Test
     public void testNewSyncContext()
         throws Exception
     {

--- a/maven-settings-builder/src/test/java/org/apache/maven/settings/building/DefaultSettingsBuilderFactoryTest.java
+++ b/maven-settings-builder/src/test/java/org/apache/maven/settings/building/DefaultSettingsBuilderFactoryTest.java
@@ -21,13 +21,14 @@ package org.apache.maven.settings.building;
 
 import java.io.File;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Benjamin Bentmann
  */
 public class DefaultSettingsBuilderFactoryTest
-    extends TestCase
 {
 
     private File getSettings( String name )
@@ -35,6 +36,7 @@ public class DefaultSettingsBuilderFactoryTest
         return new File( "src/test/resources/settings/factory/" + name + ".xml" ).getAbsoluteFile();
     }
 
+    @Test
     public void testCompleteWiring()
         throws Exception
     {

--- a/maven-settings-builder/src/test/java/org/apache/maven/settings/validation/DefaultSettingsValidatorTest.java
+++ b/maven-settings-builder/src/test/java/org/apache/maven/settings/validation/DefaultSettingsValidatorTest.java
@@ -22,40 +22,41 @@ package org.apache.maven.settings.validation;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.apache.maven.settings.Mirror;
 import org.apache.maven.settings.Profile;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Repository;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
-import org.apache.maven.settings.building.SettingsProblemCollector;
 import org.apache.maven.settings.building.SettingsProblem.Severity;
+import org.apache.maven.settings.building.SettingsProblemCollector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author mkleint
  */
 public class DefaultSettingsValidatorTest
-    extends TestCase
 {
 
     private DefaultSettingsValidator validator;
 
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
-
         validator = new DefaultSettingsValidator();
     }
 
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
         validator = null;
-
-        super.tearDown();
     }
 
     private void assertContains( String msg, String substring )
@@ -63,6 +64,7 @@ public class DefaultSettingsValidatorTest
         assertTrue( "\"" + substring + "\" was not found in: " + msg, msg.contains( substring ) );
     }
 
+    @Test
     public void testValidate()
     {
         Settings model = new Settings();
@@ -90,6 +92,7 @@ public class DefaultSettingsValidatorTest
         assertEquals( 0, problems.messages.size() );
     }
 
+    @Test
     public void testValidateMirror()
         throws Exception
     {
@@ -112,6 +115,7 @@ public class DefaultSettingsValidatorTest
         assertContains( problems.messages.get( 3 ), "'mirrors.mirror.id' must not contain any of these characters" );
     }
 
+    @Test
     public void testValidateRepository()
         throws Exception
     {
@@ -137,6 +141,7 @@ public class DefaultSettingsValidatorTest
                         "'profiles.profile[default].repositories.repository.id' must not contain any of these characters" );
     }
 
+    @Test
     public void testValidateUniqueServerId()
         throws Exception
     {
@@ -155,6 +160,7 @@ public class DefaultSettingsValidatorTest
                         "'servers.server.id' must be unique but found duplicate server with id test" );
     }
 
+    @Test
     public void testValidateUniqueProfileId()
         throws Exception
     {
@@ -173,6 +179,7 @@ public class DefaultSettingsValidatorTest
                         "'profiles.profile.id' must be unique but found duplicate profile with id test" );
     }
 
+    @Test
     public void testValidateUniqueRepositoryId()
         throws Exception
     {
@@ -196,6 +203,7 @@ public class DefaultSettingsValidatorTest
             + " but found duplicate repository with id test" );
     }
 
+    @Test
     public void testValidateUniqueProxyId()
         throws Exception
     {
@@ -215,6 +223,7 @@ public class DefaultSettingsValidatorTest
 
     }
 
+    @Test
     public void testValidateProxy()
         throws Exception
     {

--- a/maven-wrapper/src/test/java/org/apache/maven/wrapper/WrapperExecutorTest.java
+++ b/maven-wrapper/src/test/java/org/apache/maven/wrapper/WrapperExecutorTest.java
@@ -19,6 +19,11 @@ package org.apache.maven.wrapper;
  * under the License.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -79,12 +84,12 @@ public class WrapperExecutorTest
     {
         WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile( propertiesFile );
 
-        Assert.assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getDistribution() );
-        Assert.assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getConfiguration().getDistribution() );
-        Assert.assertEquals( "testDistBase", wrapper.getConfiguration().getDistributionBase() );
-        Assert.assertEquals( "testDistPath", wrapper.getConfiguration().getDistributionPath() );
-        Assert.assertEquals( "testZipBase", wrapper.getConfiguration().getZipBase() );
-        Assert.assertEquals( "testZipPath", wrapper.getConfiguration().getZipPath() );
+        assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getDistribution() );
+        assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getConfiguration().getDistribution() );
+        assertEquals( "testDistBase", wrapper.getConfiguration().getDistributionBase() );
+        assertEquals( "testDistPath", wrapper.getConfiguration().getDistributionPath() );
+        assertEquals( "testZipBase", wrapper.getConfiguration().getZipBase() );
+        assertEquals( "testZipPath", wrapper.getConfiguration().getZipPath() );
     }
 
     @Test
@@ -93,12 +98,12 @@ public class WrapperExecutorTest
     {
         WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory( testDir.getRoot().toPath() );
 
-        Assert.assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getDistribution() );
-        Assert.assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getConfiguration().getDistribution() );
-        Assert.assertEquals( "testDistBase", wrapper.getConfiguration().getDistributionBase() );
-        Assert.assertEquals( "testDistPath", wrapper.getConfiguration().getDistributionPath() );
-        Assert.assertEquals( "testZipBase", wrapper.getConfiguration().getZipBase() );
-        Assert.assertEquals( "testZipPath", wrapper.getConfiguration().getZipPath() );
+        assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getDistribution() );
+        assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getConfiguration().getDistribution() );
+        assertEquals( "testDistBase", wrapper.getConfiguration().getDistributionBase() );
+        assertEquals( "testDistPath", wrapper.getConfiguration().getDistributionPath() );
+        assertEquals( "testZipBase", wrapper.getConfiguration().getZipBase() );
+        assertEquals( "testZipPath", wrapper.getConfiguration().getZipPath() );
     }
 
     @Test
@@ -107,12 +112,12 @@ public class WrapperExecutorTest
     {
         WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory( testDir.getRoot().toPath().resolve( "unknown" ) );
 
-        Assert.assertNull( wrapper.getDistribution() );
-        Assert.assertNull( wrapper.getConfiguration().getDistribution() );
-        Assert.assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getDistributionBase() );
-        Assert.assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getDistributionPath() );
-        Assert.assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getZipBase() );
-        Assert.assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getZipPath() );
+        assertNull( wrapper.getDistribution() );
+        assertNull( wrapper.getConfiguration().getDistribution() );
+        assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getDistributionBase() );
+        assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getDistributionPath() );
+        assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getZipBase() );
+        assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getZipPath() );
     }
 
     @Test
@@ -126,12 +131,12 @@ public class WrapperExecutorTest
 
         WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile( propertiesFile );
 
-        Assert.assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getDistribution() );
-        Assert.assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getConfiguration().getDistribution() );
-        Assert.assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getDistributionBase() );
-        Assert.assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getDistributionPath() );
-        Assert.assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getZipBase() );
-        Assert.assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getZipPath() );
+        assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getDistribution() );
+        assertEquals( new URI( "http://server/test/maven.zip" ), wrapper.getConfiguration().getDistribution() );
+        assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getDistributionBase() );
+        assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getDistributionPath() );
+        assertEquals( PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getZipBase() );
+        assertEquals( Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getZipPath() );
     }
 
     @Test
@@ -152,16 +157,11 @@ public class WrapperExecutorTest
         properties = new Properties();
         writePropertiesFile( properties, propertiesFile, "header" );
 
-        try
-        {
-            WrapperExecutor.forWrapperPropertiesFile( propertiesFile );
-            Assert.fail( "Expected RuntimeException" );
-        }
-        catch ( RuntimeException e )
-        {
-            Assert.assertEquals( "No value with key 'distributionUrl' specified in wrapper properties file '"
-                + propertiesFile + "'.", e.getMessage() );
-        }
+        RuntimeException e = assertThrows( "Expected RuntimeException",
+                RuntimeException.class,
+                () -> WrapperExecutor.forWrapperPropertiesFile( propertiesFile ) );
+        assertEquals( "No value with key 'distributionUrl' specified in wrapper properties file '"
+            + propertiesFile + "'.", e.getMessage() );
     }
 
     @Test
@@ -169,15 +169,10 @@ public class WrapperExecutorTest
     {
         propertiesFile = testDir.getRoot().toPath().resolve( "unknown.properties" );
 
-        try
-        {
-            WrapperExecutor.forWrapperPropertiesFile( propertiesFile );
-            Assert.fail( "Expected RuntimeException" );
-        }
-        catch ( RuntimeException e )
-        {
-            Assert.assertEquals( "Wrapper properties file '" + propertiesFile + "' does not exist.", e.getMessage() );
-        }
+        RuntimeException e = assertThrows( "Expected RuntimeException",
+                RuntimeException.class,
+                () -> WrapperExecutor.forWrapperPropertiesFile( propertiesFile ) );
+        assertEquals( "Wrapper properties file '" + propertiesFile + "' does not exist.", e.getMessage() );
     }
 
     @Test
@@ -190,8 +185,8 @@ public class WrapperExecutorTest
         writePropertiesFile( properties, propertiesFile, "header" );
 
         WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile( propertiesFile );
-        Assert.assertNotEquals( "some/relative/url/to/bin.zip", wrapper.getDistribution().getSchemeSpecificPart() );
-        Assert.assertTrue( wrapper.getDistribution().getSchemeSpecificPart().endsWith( "some/relative/url/to/bin.zip" ) );
+        assertNotEquals( "some/relative/url/to/bin.zip", wrapper.getDistribution().getSchemeSpecificPart() );
+        assertTrue( wrapper.getDistribution().getSchemeSpecificPart().endsWith( "some/relative/url/to/bin.zip" ) );
     }
 
     private void writePropertiesFile( Properties properties, Path propertiesFile, String message )


### PR DESCRIPTION
Migration of all tests to Unit 4 without any refactoring beyond the bare minimum (i.e. add @Test, @Before and @After) methods.
For plexus powered tests, I had to copy the migrated `PlexusTestCase` as there is currently no shared test jar.