### PR TITLE
[Fix] Security resolver 1.4.1 CVE 2020-15777

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ under the License.
     <cipherVersion>1.7</cipherVersion>
     <modelloVersion>1.11</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.4.1</resolverVersion>
+    <resolverVersion>1.6.1</resolverVersion>
     <slf4jVersion>1.7.29</slf4jVersion>
     <xmlunitVersion>2.2.1</xmlunitVersion>
     <powermockVersion>1.7.4</powermockVersion>


### PR DESCRIPTION
Update resolver from 1.4.1 to 1.6.1
No Jira open on this subject
https://nvd.nist.gov/vuln/detail/CVE-2020-15777
