### PR TITLE
Upgrade github actions cache and use m2 cache for integration testing…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up cache for ~./m2/repository
-        uses: actions/cache@v1
+      - name: Set up cache for ~/.m2/repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: maven-${{ matrix.os }}-${{ hashFiles('**/pom.xml') }}
@@ -110,6 +110,14 @@ jobs:
           path: maven-integration-testing/
           ref: ${{ env.REPO_BRANCH }}
 
+      - name: Set up cache for ~/.m2/repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: it-m2-repo-${{ matrix.os }}-${{ hashFiles('maven-integration-testing/**/pom.xml') }}
+          restore-keys: |
+            it-m2-repo-${{ matrix.os }}-
+
       - name: Download built Maven
         uses: actions/download-artifact@v2
         with:
@@ -129,4 +137,4 @@ jobs:
 
       - name: Running integration tests
         shell: bash
-        run: mvn install -e -B -V -Prun-its,embedded -Dmaven.repo.local=$GITHUB_WORKSPACE/repo/ -DmavenDistro="$GITHUB_WORKSPACE/built-maven/apache-maven-bin.zip" -DwrapperDistroDir="$GITHUB_WORKSPACE/built-maven/" -DmavenWrapper="$GITHUB_WORKSPACE/built-maven-wrapper/maven-wrapper.jar" -f maven-integration-testing/pom.xml
+        run: mvn install -e -B -V -Prun-its,embedded -Dmaven.repo.local="$HOME/.m2/repository" -DmavenDistro="$GITHUB_WORKSPACE/built-maven/apache-maven-bin.zip" -DwrapperDistroDir="$GITHUB_WORKSPACE/built-maven/" -DmavenWrapper="$GITHUB_WORKSPACE/built-maven-wrapper/maven-wrapper.jar" -f maven-integration-testing/pom.xml


### PR DESCRIPTION
This merge request will cache .m2 dependencies for the integration tests that are running on currently 12 different OS + JDK versions.

This should solve the (relatively) many dependency retrieval failures we get in GA jobs currently. 

I've tested it under my own profile.