### PR TITLE
[MNG-6843] Thread-safe artifacts in MavenProject

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -111,10 +111,6 @@ public class MavenProject
 
     private Set<Artifact> resolvedArtifacts;
 
-    private ArtifactFilter artifactFilter;
-
-    private Set<Artifact> artifacts;
-
     private Artifact parentArtifact;
 
     private Set<Artifact> pluginArtifacts;
@@ -151,8 +147,8 @@ public class MavenProject
 
     private Artifact artifact;
 
-    // calculated.
-    private Map<String, Artifact> artifactMap;
+    private final ThreadLocal<ArtifactsHolder> threadLocalArtifactsHolder =
+        ThreadLocal.withInitial( ArtifactsHolder::new );
 
     private Model originalModel;
 
@@ -695,10 +691,11 @@ public class MavenProject
 
     public void setArtifacts( Set<Artifact> artifacts )
     {
-        this.artifacts = artifacts;
+        ArtifactsHolder artifactsHolder = threadLocalArtifactsHolder.get();
+        artifactsHolder.artifacts = artifacts;
 
         // flush the calculated artifactMap
-        artifactMap = null;
+        artifactsHolder.artifactMap = null;
     }
 
     /**
@@ -711,34 +708,36 @@ public class MavenProject
      */
     public Set<Artifact> getArtifacts()
     {
-        if ( artifacts == null )
+        ArtifactsHolder artifactsHolder = threadLocalArtifactsHolder.get();
+        if ( artifactsHolder.artifacts == null )
         {
-            if ( artifactFilter == null || resolvedArtifacts == null )
+            if ( artifactsHolder.artifactFilter == null || resolvedArtifacts == null )
             {
-                artifacts = new LinkedHashSet<>();
+                artifactsHolder.artifacts = new LinkedHashSet<>();
             }
             else
             {
-                artifacts = new LinkedHashSet<>( resolvedArtifacts.size() * 2 );
+                artifactsHolder.artifacts = new LinkedHashSet<>( resolvedArtifacts.size() * 2 );
                 for ( Artifact artifact : resolvedArtifacts )
                 {
-                    if ( artifactFilter.include( artifact ) )
+                    if ( artifactsHolder.artifactFilter.include( artifact ) )
                     {
-                        artifacts.add( artifact );
+                        artifactsHolder.artifacts.add( artifact );
                     }
                 }
             }
         }
-        return artifacts;
+        return artifactsHolder.artifacts;
     }
 
     public Map<String, Artifact> getArtifactMap()
     {
-        if ( artifactMap == null )
+        ArtifactsHolder artifactsHolder = threadLocalArtifactsHolder.get();
+        if ( artifactsHolder.artifactMap == null )
         {
-            artifactMap = ArtifactUtils.artifactMapByVersionlessId( getArtifacts() );
+            artifactsHolder.artifactMap = ArtifactUtils.artifactMapByVersionlessId( getArtifacts() );
         }
-        return artifactMap;
+        return artifactsHolder.artifactMap;
     }
 
     public void setPluginArtifacts( Set<Artifact> pluginArtifacts )
@@ -1073,7 +1072,7 @@ public class MavenProject
         MavenProject that = (MavenProject) other;
 
         return Objects.equals( getArtifactId(), that.getArtifactId() )
-            && Objects.equals( getGroupId(), that.getGroupId() ) 
+            && Objects.equals( getGroupId(), that.getGroupId() )
             && Objects.equals( getVersion(), that.getVersion() );
     }
 
@@ -1433,8 +1432,9 @@ public class MavenProject
     public void setResolvedArtifacts( Set<Artifact> artifacts )
     {
         this.resolvedArtifacts = ( artifacts != null ) ? artifacts : Collections.<Artifact>emptySet();
-        this.artifacts = null;
-        this.artifactMap = null;
+        ArtifactsHolder artifactsHolder = threadLocalArtifactsHolder.get();
+        artifactsHolder.artifacts = null;
+        artifactsHolder.artifactMap = null;
     }
 
     /**
@@ -1447,9 +1447,10 @@ public class MavenProject
      */
     public void setArtifactFilter( ArtifactFilter artifactFilter )
     {
-        this.artifactFilter = artifactFilter;
-        this.artifacts = null;
-        this.artifactMap = null;
+        ArtifactsHolder artifactsHolder = threadLocalArtifactsHolder.get();
+        artifactsHolder.artifactFilter = artifactFilter;
+        artifactsHolder.artifacts = null;
+        artifactsHolder.artifactMap = null;
     }
 
     /**
@@ -1844,7 +1845,6 @@ public class MavenProject
         {
             reportArtifactMap = ArtifactUtils.artifactMapByVersionlessId( getReportArtifacts() );
         }
-
         return reportArtifactMap;
     }
 
@@ -1869,7 +1869,6 @@ public class MavenProject
         {
             extensionArtifactMap = ArtifactUtils.artifactMapByVersionlessId( getExtensionArtifacts() );
         }
-
         return extensionArtifactMap;
     }
 
@@ -1990,5 +1989,12 @@ public class MavenProject
     public void setProjectBuildingRequest( ProjectBuildingRequest projectBuildingRequest )
     {
         this.projectBuilderConfiguration = projectBuildingRequest;
+    }
+
+    private static class ArtifactsHolder
+    {
+        private ArtifactFilter artifactFilter;
+        private Set<Artifact> artifacts;
+        private Map<String, Artifact> artifactMap;
     }
 }


### PR DESCRIPTION
Avoids concurrency issues when aggregator plugins are involved.
A detailed summary of the problem can be found here: https://github.com/apache/maven/pull/310#issuecomment-617783528

Might also fix:
- https://issues.apache.org/jira/browse/MNG-4996
- https://issues.apache.org/jira/browse/MNG-5750
- https://issues.apache.org/jira/browse/MNG-5960

This is an alternative to #310 in which @rfscholte raised concerns whether cloning is the right approach.

I went with a wrapper and a single `ThreadLocal` because mutliple TLs would bloat the code and would theoretically increase overhead (haven't measured it, though).
I had to be creative with removing empty lines because Checkstyle was complaining about the class exceeding 2000 lines.

PS: I removed the checklist to avoid noise (checked everything, ICLA is present).