### PR TITLE
[MNG-7032] do not print colours for --version when in batch mode.

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -425,6 +425,8 @@ public class MavenCli
             throw e;
         }
 
+        applyColorMode( cliRequest );
+
         if ( cliRequest.commandLine.hasOption( CLIManager.HELP ) )
         {
             cliManager.displayHelp( System.out );
@@ -433,8 +435,6 @@ public class MavenCli
 
         if ( cliRequest.commandLine.hasOption( CLIManager.VERSION ) )
         {
-            // MNG-7032: Also disable colours if in batch mode
-            disableColorsInLogfileOrBatch( cliRequest );
             System.out.println( CLIReportingUtils.showVersion() );
             throw new ExitException( 0 );
         }
@@ -522,7 +522,7 @@ public class MavenCli
         }
         else
         {
-            disableColorsInLogfileOrBatch( cliRequest );
+            applyColorMode( cliRequest );
         }
 
         // LOG STREAMS
@@ -575,7 +575,7 @@ public class MavenCli
      * or {@link CLIManager#LOG_FILE} option was given (or both). In those cases, ANSI output is never feasible.
      * @param cliRequest the arguments as request pojo.
      */
-    private void disableColorsInLogfileOrBatch( CliRequest cliRequest )
+    private void applyColorMode( CliRequest cliRequest )
     {
         if ( cliRequest.commandLine.hasOption( CLIManager.BATCH_MODE )
                 || cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -433,6 +433,8 @@ public class MavenCli
 
         if ( cliRequest.commandLine.hasOption( CLIManager.VERSION ) )
         {
+            // MNG-7032: Also disable colours if in batch mode
+            disableColorsInLogfileOrBatch( cliRequest );
             System.out.println( CLIReportingUtils.showVersion() );
             throw new ExitException( 0 );
         }
@@ -518,10 +520,9 @@ public class MavenCli
             throw new IllegalArgumentException( "Invalid color configuration option [" + styleColor
                 + "]. Supported values are (auto|always|never)." );
         }
-        else if ( cliRequest.commandLine.hasOption( CLIManager.BATCH_MODE )
-            || cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
+        else
         {
-            MessageUtils.setColorEnabled( false );
+            disableColorsInLogfileOrBatch( cliRequest );
         }
 
         // LOG STREAMS
@@ -566,6 +567,20 @@ public class MavenCli
                         + "The --fail-on-severity flag will not take effect.",
                         MavenSlf4jWrapperFactory.class.getName(), slf4jLoggerFactory.getClass().getName() );
             }
+        }
+    }
+
+    /**
+     * Disables the colour output in the case that the {@link CLIManager#BATCH_MODE} option
+     * or {@link CLIManager#LOG_FILE} option was given (or both). In those cases, ANSI output is never feasible.
+     * @param cliRequest the arguments as request pojo.
+     */
+    private void disableColorsInLogfileOrBatch( CliRequest cliRequest )
+    {
+        if ( cliRequest.commandLine.hasOption( CLIManager.BATCH_MODE )
+                || cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
+        {
+            MessageUtils.setColorEnabled( false );
         }
     }
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -520,10 +520,6 @@ public class MavenCli
             throw new IllegalArgumentException( "Invalid color configuration option [" + styleColor
                 + "]. Supported values are (auto|always|never)." );
         }
-        else
-        {
-            applyColorMode( cliRequest );
-        }
 
         // LOG STREAMS
         if ( cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -37,7 +37,10 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,7 +60,6 @@ import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.sisu.plexus.PlexusBeanModule;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -464,6 +466,38 @@ public class MavenCliTest
                 is( notNullValue() ) );
         assertThat( executionRequest.getLocalRepositoryPath().toString(),
                 is( "." + File.separatorChar + "custom2" ) );
+    }
+
+    /**
+     * MNG-7032: Disable colours for {@code --version} if {@code --batch-mode} is also given.
+     * @throws Exception cli invocation.
+     */
+    @Test
+    public void testVersionStringWithoutAnsi() throws Exception
+    {
+        // given
+        // - request with version and batch mode
+        CliRequest cliRequest = new CliRequest( new String[] {
+                "--version",
+                "--batch-mode"
+        }, null );
+        ByteArrayOutputStream systemOut = new ByteArrayOutputStream();
+        PrintStream oldOut = System.out;
+        System.setOut( new PrintStream( systemOut ) );
+
+        // when
+        try {
+            cli.cli( cliRequest );
+        } catch ( MavenCli.ExitException exitException ) {
+            // expected
+        } finally {
+            // restore sysout
+            System.setOut( oldOut );
+        }
+        String versionOut = new String( systemOut.toByteArray(), StandardCharsets.UTF_8 );
+
+        // then
+        assertEquals( MessageUtils.stripAnsiCodes( versionOut ), versionOut );
     }
 
     private MavenProject createMavenProject( String groupId, String artifactId )


### PR DESCRIPTION
This PR will fix MNG-7032: ANSI will not be used when using both `--batch-mode` and `--version`.
This is a bug because with batch mode, ANSI colours should not be used.

The tests works on a char level: By comparing the stripped and the non-stripped version, the test would fail if they differed. Or put in another way: If the sysout-version contained ANSI colour information, it would not match the stripped version.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
