### PR TITLE
[MNG-4660] Increase usefulness of logging (2)

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -283,13 +283,13 @@ class ReactorReader
                     File alternative = determineLooseDirectoryForArtifact( project, artifact );
                     if ( alternative != null )
                     {
-                        LOGGER.warn( "File {} is more recent than the packaged artifact for {}; using {} instead",
+                        LOGGER.warn( "File '{}' is more recent than the packaged artifact for '{}'; using '{}' instead",
                                 relativizeOutputFile( outputFile ), project.getArtifactId(),
                                 relativizeOutputFile( alternative.toPath() ) );
                     }
                     else
                     {
-                        LOGGER.warn( "File {} is more recent than the packaged artifact for {}; "
+                        LOGGER.warn( "File '{}' is more recent than the packaged artifact for '{}'; "
                                 + "cannot use a loose directory for this type of artifact",
                                 relativizeOutputFile( outputFile ), project.getArtifactId() );
                     }

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -290,7 +290,7 @@ class ReactorReader
                     else
                     {
                         LOGGER.warn( "File '{}' is more recent than the packaged artifact for '{}'; "
-                                + "cannot use a loose directory for this type of artifact",
+                                + "cannot use the build output directory for this type of artifact",
                                 relativizeOutputFile( outputFile ), project.getArtifactId() );
                     }
                     return false;

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -186,7 +186,7 @@ class ReactorReader
         {
             // fallback to loose class files only if artifacts haven't been packaged yet
             // and only for plain old jars. Not war files, not ear files, not anything else.
-            return determineLooseDirectoryForArtifact( project, artifact );
+            return determineBuildOutputDirectoryForArtifact( project, artifact );
         }
 
         // The fall-through indicates that the artifact cannot be found;
@@ -194,7 +194,7 @@ class ReactorReader
         return null;
     }
 
-    private File determineLooseDirectoryForArtifact( final MavenProject project, final Artifact artifact )
+    private File determineBuildOutputDirectoryForArtifact( final MavenProject project, final Artifact artifact )
     {
         if ( isTestArtifact( artifact ) )
         {
@@ -280,7 +280,7 @@ class ReactorReader
                 long outputFileLastModified = Files.getLastModifiedTime( outputFile ).toMillis();
                 if ( outputFileLastModified > artifactLastModified )
                 {
-                    File alternative = determineLooseDirectoryForArtifact( project, artifact );
+                    File alternative = determineBuildOutputDirectoryForArtifact( project, artifact );
                     if ( alternative != null )
                     {
                         LOGGER.warn( "File '{}' is more recent than the packaged artifact for '{}'; using '{}' instead",

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -271,19 +271,25 @@ class ReactorReader
             while ( iterator.hasNext() )
             {
                 Path outputFile = iterator.next();
+
+                if ( Files.isDirectory(  outputFile ) )
+                {
+                    continue;
+                }
+
                 long outputFileLastModified = Files.getLastModifiedTime( outputFile ).toMillis();
                 if ( outputFileLastModified > artifactLastModified )
                 {
                     File alternative = determineLooseDirectoryForArtifact( project, artifact );
                     if ( alternative != null )
                     {
-                        LOGGER.warn( "The file {} is more recent than the packaged artifact for {}; using {} instead",
+                        LOGGER.warn( "File {} is more recent than the packaged artifact for {}; using {} instead",
                                 relativizeOutputFile( outputFile ), project.getArtifactId(),
                                 relativizeOutputFile( alternative.toPath() ) );
                     }
                     else
                     {
-                        LOGGER.warn( "The file {} is more recent than the packaged artifact for {}; "
+                        LOGGER.warn( "File {} is more recent than the packaged artifact for {}; "
                                 + "cannot use a loose directory for this type of artifact",
                                 relativizeOutputFile( outputFile ), project.getArtifactId() );
                     }


### PR DESCRIPTION
When the user resumes a build (MNG-4660), they could see a message "Packaged artifact is not up-to-date compared to the build output directory". This could even be logged multiple times for one build. It was unclear why it was logged and what a user could do to address it. This change adds a little bit of detail to that message so it becomes more clear to the user what has happened and where to look for solutions. It also adds a few words so the user knows what Maven will decide to do to address the situation (i.e. resolve using build output directory or consider artifact "not found").

The [integration test](https://github.com/apache/maven-integration-testing/pull/91) is updated as well.

ICLA and CCLA signed.