### PR TITLE
Consistent logging

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -458,7 +458,7 @@ public class DefaultGraphBuilder
 
                     if ( projectsMap.containsKey( pluginKey ) )
                     {
-                        LOGGER.warn( "{} uses {} as extensions, which is not possible within the same reactor build. "
+                        LOGGER.warn( "'{}' uses '{}' as extension which is not possible within the same reactor build. "
                             + "This plugin was pulled from the local repository!", project.getName(), plugin.getKey() );
                     }
                 }

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -936,7 +936,7 @@ public class MavenProject
         int index = attachedArtifacts.indexOf( artifact );
         if ( index >= 0 )
         {
-            LOGGER.warn( "artifact {} already attached, replace previous instance", artifact );
+            LOGGER.warn( "artifact '{}' already attached, replacing previous instance", artifact );
             attachedArtifacts.set( index, artifact );
         }
         else

--- a/maven-core/src/main/java/org/apache/maven/project/collector/DefaultProjectsSelector.java
+++ b/maven-core/src/main/java/org/apache/maven/project/collector/DefaultProjectsSelector.java
@@ -74,7 +74,7 @@ public class DefaultProjectsSelector implements ProjectsSelector
             if ( !result.getProblems().isEmpty() && LOGGER.isWarnEnabled() )
             {
                 LOGGER.warn( "" );
-                LOGGER.warn( "Some problems were encountered while building the effective model for {}",
+                LOGGER.warn( "Some problems were encountered while building the effective model for '{}'",
                         result.getProject().getId() );
 
                 for ( ModelProblem problem : result.getProblems() )

--- a/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
+++ b/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
@@ -76,7 +76,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy
             }
             else
             {
-                logger.debug( "Multi module project collection failed: {}"
+                logger.debug( "Multi module project collection failed:{}"
                         + "Detected a POM file next to a .mvn folder in a parent directory ({}). "
                         + "Maven assumed that POM file to be the parent of the requested project ({}), but it turned "
                         + "out that it was not. Another project collection strategy will be executed as result.",
@@ -91,7 +91,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy
 
             if ( fallThrough )
             {
-                logger.debug( "Multi module project collection failed: {}"
+                logger.debug( "Multi module project collection failed:{}"
                         + "Detected that one of the modules of this multi module project uses another module as "
                         + "plugin extension which still needed to be built. This is not possible within the same "
                         + "reactor build. Another project collection strategy will be executed as result.",
@@ -115,8 +115,8 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy
             if ( !multiModuleProjectPom.exists() )
             {
                 logger.info( "Maven detected that the requested POM file is part of a multi module project, "
-                        + "but could not find a pom.xml file in the multi module root directory: '"
-                        + request.getMultiModuleProjectDirectory() + "'. " );
+                        + "but could not find a pom.xml file in the multi module root directory '{}'.",
+                        request.getMultiModuleProjectDirectory() );
                 logger.info( "The reactor is limited to all projects under: " + request.getPom().getParent() );
                 return request.getPom();
             }

--- a/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
+++ b/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
@@ -50,7 +50,7 @@ import java.util.function.Predicate;
 @Singleton
 public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( MultiModuleCollectionStrategy.class );
     private final ModelLocator modelLocator;
     private final ProjectsSelector projectsSelector;
 
@@ -76,7 +76,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy
             }
             else
             {
-                logger.debug( "Multi module project collection failed:{}"
+                LOGGER.debug( "Multi module project collection failed:{}"
                         + "Detected a POM file next to a .mvn folder in a parent directory ({}). "
                         + "Maven assumed that POM file to be the parent of the requested project ({}), but it turned "
                         + "out that it was not. Another project collection strategy will be executed as result.",
@@ -91,7 +91,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy
 
             if ( fallThrough )
             {
-                logger.debug( "Multi module project collection failed:{}"
+                LOGGER.debug( "Multi module project collection failed:{}"
                         + "Detected that one of the modules of this multi module project uses another module as "
                         + "plugin extension which still needed to be built. This is not possible within the same "
                         + "reactor build. Another project collection strategy will be executed as result.",
@@ -114,10 +114,10 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy
             File multiModuleProjectPom = modelLocator.locatePom( request.getMultiModuleProjectDirectory() );
             if ( !multiModuleProjectPom.exists() )
             {
-                logger.info( "Maven detected that the requested POM file is part of a multi module project, "
+                LOGGER.info( "Maven detected that the requested POM file is part of a multi module project, "
                         + "but could not find a pom.xml file in the multi module root directory '{}'.",
                         request.getMultiModuleProjectDirectory() );
-                logger.info( "The reactor is limited to all projects under: " + request.getPom().getParent() );
+                LOGGER.info( "The reactor is limited to all projects under: " + request.getPom().getParent() );
                 return request.getPom();
             }
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -793,7 +793,7 @@ public class MavenCli
         }
         catch ( Exception e )
         {
-            slf4jLogger.warn( "Failed to read extensions descriptor {}: {}", extensionsFile, e.getMessage() );
+            slf4jLogger.warn( "Failed to read extensions descriptor from '{}'", extensionsFile, e );
         }
         return Collections.emptyList();
     }
@@ -821,11 +821,11 @@ public class MavenCli
 
             extRealm.setParentRealm( coreRealm );
 
-            slf4jLogger.debug( "Populating class realm {}", extRealm.getId() );
+            slf4jLogger.debug( "Populating class realm '{}'", extRealm.getId() );
 
             for ( File file : extClassPath )
             {
-                slf4jLogger.debug( "  Included {}", file );
+                slf4jLogger.debug( "  included '{}'", file );
 
                 extRealm.addURL( file.toURI().toURL() );
             }
@@ -874,7 +874,7 @@ public class MavenCli
             {
                 File file = resolveFile( new File( jar ), cliRequest.workingDirectory );
 
-                slf4jLogger.debug( "  Included {}", file );
+                slf4jLogger.debug( "  included '{}'", file );
 
                 jars.add( file );
             }
@@ -1009,12 +1009,12 @@ public class MavenCli
 
             if ( !cliRequest.showErrors )
             {
-                slf4jLogger.error( "To see the full stack trace of the errors, re-run Maven with the {} switch.",
+                slf4jLogger.error( "To see the full stack trace of the errors, re-run Maven with the '{}' switch.",
                         buffer().strong( "-e" ) );
             }
             if ( !slf4jLogger.isDebugEnabled() )
             {
-                slf4jLogger.error( "Re-run Maven using the {} switch to enable full debug logging.",
+                slf4jLogger.error( "Re-run Maven using the '{}' switch to enable full debug logging.",
                         buffer().strong( "-X" ) );
             }
 
@@ -1302,9 +1302,9 @@ public class MavenCli
 
         eventSpyDispatcher.onEvent( toolchainsRequest );
 
-        slf4jLogger.debug( "Reading global toolchains from {}",
+        slf4jLogger.debug( "Reading global toolchains from '{}'",
                 getLocation( toolchainsRequest.getGlobalToolchainsSource(), globalToolchainsFile ) );
-        slf4jLogger.debug( "Reading user toolchains from {}",
+        slf4jLogger.debug( "Reading user toolchains from '{}'",
                 getLocation( toolchainsRequest.getUserToolchainsSource(), userToolchainsFile ) );
 
         ToolchainsBuildingResult toolchainsResult = toolchainsBuilder.build( toolchainsRequest );

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -71,7 +71,7 @@ public class SettingsXmlConfigurationProcessor
     public static final File DEFAULT_GLOBAL_SETTINGS_FILE =
         new File( System.getProperty( "maven.conf" ), "settings.xml" );
 
-    private final Logger logger = LoggerFactory.getLogger( SettingsXmlConfigurationProcessor.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( SettingsXmlConfigurationProcessor.class );
 
     @Inject
     private SettingsBuilder settingsBuilder;
@@ -137,9 +137,9 @@ public class SettingsXmlConfigurationProcessor
             request.getEventSpyDispatcher().onEvent( settingsRequest );
         }
 
-        logger.debug( "Reading global settings from '{}'",
+        LOGGER.debug( "Reading global settings from '{}'",
             getLocation( settingsRequest.getGlobalSettingsSource(), settingsRequest.getGlobalSettingsFile() ) );
-        logger.debug( "Reading user settings from '{}'",
+        LOGGER.debug( "Reading user settings from '{}'",
             getLocation( settingsRequest.getUserSettingsSource(), settingsRequest.getUserSettingsFile() ) );
 
         SettingsBuildingResult settingsResult = settingsBuilder.build( settingsRequest );
@@ -151,16 +151,16 @@ public class SettingsXmlConfigurationProcessor
 
         populateFromSettings( request, settingsResult.getEffectiveSettings() );
 
-        if ( !settingsResult.getProblems().isEmpty() && logger.isWarnEnabled() )
+        if ( !settingsResult.getProblems().isEmpty() && LOGGER.isWarnEnabled() )
         {
-            logger.warn( "" );
-            logger.warn( "Some problems were encountered while building the effective settings" );
+            LOGGER.warn( "" );
+            LOGGER.warn( "Some problems were encountered while building the effective settings" );
 
             for ( SettingsProblem problem : settingsResult.getProblems() )
             {
-                logger.warn( "{} @ {}", problem.getMessage(), problem.getLocation() );
+                LOGGER.warn( "{} @ {}", problem.getMessage(), problem.getLocation() );
             }
-            logger.warn( "" );
+            LOGGER.warn( "" );
         }
     }
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -137,9 +137,9 @@ public class SettingsXmlConfigurationProcessor
             request.getEventSpyDispatcher().onEvent( settingsRequest );
         }
 
-        logger.debug( "Reading global settings from {}",
+        logger.debug( "Reading global settings from '{}'",
             getLocation( settingsRequest.getGlobalSettingsSource(), settingsRequest.getGlobalSettingsFile() ) );
-        logger.debug( "Reading user settings from {}",
+        logger.debug( "Reading user settings from '{}'",
             getLocation( settingsRequest.getUserSettingsSource(), settingsRequest.getUserSettingsFile() ) );
 
         SettingsBuildingResult settingsResult = settingsBuilder.build( settingsRequest );

--- a/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
@@ -361,7 +361,7 @@ public class ExecutionEventLogger extends AbstractExecutionListener
     {
         if ( logger.isWarnEnabled() )
         {
-            logger.warn( "Goal {} requires online mode for execution but Maven is currently offline, skipping",
+            logger.warn( "Goal '{}' requires online mode for execution but Maven is currently offline, skipping",
                     event.getMojoExecution().getGoal() );
         }
     }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/logging/BaseSlf4jConfiguration.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/logging/BaseSlf4jConfiguration.java
@@ -31,15 +31,15 @@ import org.slf4j.LoggerFactory;
 public class BaseSlf4jConfiguration
     implements Slf4jConfiguration
 {
-    private final Logger logger = LoggerFactory.getLogger( BaseSlf4jConfiguration.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( BaseSlf4jConfiguration.class );
 
     public void setRootLoggerLevel( Level level )
     {
-        logger.warn( "setRootLoggerLevel: operation not supported" );
+        LOGGER.warn( "setRootLoggerLevel: operation not supported" );
     }
 
     public void activate()
     {
-        logger.warn( "reset(): operation not supported" );
+        LOGGER.warn( "reset(): operation not supported" );
     }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/UnsupportedSlf4jBindingConfiguration.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/UnsupportedSlf4jBindingConfiguration.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public class UnsupportedSlf4jBindingConfiguration
     extends BaseSlf4jConfiguration
 {
-    private final Logger logger = LoggerFactory.getLogger( UnsupportedSlf4jBindingConfiguration.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( UnsupportedSlf4jBindingConfiguration.class );
 
     private String slf4jBinding;
 
@@ -51,8 +51,8 @@ public class UnsupportedSlf4jBindingConfiguration
     @Override
     public void activate()
     {
-        logger.warn( "The SLF4J binding actually used is not supported by Maven: {}", slf4jBinding );
-        logger.warn( "Maven supported bindings are:" );
+        LOGGER.warn( "The SLF4J binding actually used is not supported by Maven: {}", slf4jBinding );
+        LOGGER.warn( "Maven supported bindings are:" );
 
         String ls = System.lineSeparator();
 
@@ -66,7 +66,7 @@ public class UnsupportedSlf4jBindingConfiguration
                 sb.append( ls ).append( "- " ).append( binding );
             }
 
-            logger.warn( sb.toString() );
+            LOGGER.warn( sb.toString() );
         }
     }
 }


### PR DESCRIPTION
This strives to consistently quote non-numeric args and bracketing collections as done in other spots of the codebase. `DefaultBuildResumptionDataRepository` wasn't touched intentionally as this will be subject so a separate PR. I also have likely missed something and have left out dynamically composed messages.

IT PR: https://github.com/apache/maven-integration-testing/pull/97