### PR TITLE
[MNG-7079] Upgrade to jansi 2.2.0

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -153,7 +153,7 @@ under the License.
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <includeArtifactIds>jansi</includeArtifactIds>
-          <includes>META-INF/native/**</includes>
+          <includes>org/fusesource/jansi/internal/native/**</includes>
         </configuration>
         <executions>
           <execution>

--- a/apache-maven/src/assembly/maven/component.xml
+++ b/apache-maven/src/assembly/maven/component.xml
@@ -64,7 +64,7 @@ under the License.
       </includes>
     </fileSet>
     <fileSet>
-      <directory>target/dependency/META-INF/native</directory>
+      <directory>target/dependency/org/fusesource/jansi/internal/native</directory>
       <outputDirectory>lib/jansi-native</outputDirectory>
       <includes>
         <include>**</include>

--- a/pom.xml
+++ b/pom.xml
@@ -308,12 +308,12 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.shared</groupId>
         <artifactId>maven-shared-utils</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.4</version>
       </dependency>
       <dependency>
         <groupId>org.fusesource.jansi</groupId>
         <artifactId>jansi</artifactId>
-        <version>1.18</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR depends on https://github.com/apache/maven-shared-utils/pull/69 and the release of `maven-shared-utils`.