### PR TITLE
Avoid empty locations

### DIFF
--- a/maven-builder-support/src/main/java/org/apache/maven/building/DefaultProblem.java
+++ b/maven-builder-support/src/main/java/org/apache/maven/building/DefaultProblem.java
@@ -153,7 +153,13 @@ class DefaultProblem
 
         buffer.append( '[' ).append( getSeverity() ).append( "] " );
         buffer.append( getMessage() );
-        buffer.append( " @ " ).append( getLocation() );
+        String location = getLocation();
+        if ( !location.isEmpty() )
+        {
+             buffer.append( " @ " );
+             buffer.append( location );
+        }
+
 
         return buffer.toString();
     }

--- a/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -149,7 +149,8 @@ public class DefaultExceptionHandler
         }
 
         String message = System.lineSeparator()
-            + "The project " + result.getProjectId() + " (" + result.getPomFile() + ") has "
+            + "The project " + ( result.getProjectId().isEmpty() ? "" : result.getProjectId() + " " )
+            + "(" + result.getPomFile() + ") has "
             + children.size() + " error" + ( children.size() == 1 ? "" : "s" );
 
         return new ExceptionSummary( null, message, null, children );

--- a/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -163,7 +163,7 @@ public class DefaultExceptionHandler
 
             String location = ModelProblemUtils.formatLocation( problem, projectId );
 
-            if ( StringUtils.isNotEmpty( location ) )
+            if ( !location.isEmpty() )
             {
                 message += " @ " + location;
             }

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1154,15 +1154,10 @@ public class MavenProject
         sb.append( getArtifactId() );
         sb.append( ':' );
         sb.append( getVersion() );
-        sb.append( " @ " );
-
-        try
+        if ( getFile() != null )
         {
+            sb.append( " @ " );
             sb.append( getFile().getPath() );
-        }
-        catch ( NullPointerException e )
-        {
-            // don't log it.
         }
 
         return sb.toString();

--- a/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
@@ -135,8 +135,12 @@ public class ProjectBuildingException
                     writer.print( problem.getSeverity() );
                     writer.print( "] " );
                     writer.print( problem.getMessage() );
-                    writer.print( " @ " );
-                    writer.println( ModelProblemUtils.formatLocation( problem, result.getProjectId() ) );
+                    String location = ModelProblemUtils.formatLocation( problem, result.getProjectId() );
+                    if ( !location.isEmpty() )
+                    {
+                        writer.print( " @ " );
+                        writer.println( location );
+                    }
                 }
             }
         }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelProblem.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelProblem.java
@@ -168,7 +168,12 @@ public class DefaultModelProblem
 
         buffer.append( '[' ).append( getSeverity() ).append( "] " );
         buffer.append( getMessage() );
-        buffer.append( " @ " ).append( ModelProblemUtils.formatLocation( this, null ) );
+        String location = ModelProblemUtils.formatLocation( this, null );
+        if ( !location.isEmpty() )
+        {
+            buffer.append( " @ " );
+            buffer.append( location );
+        }
 
         return buffer.toString();
     }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingException.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingException.java
@@ -170,8 +170,12 @@ public class ModelBuildingException
             writer.print( problem.getSeverity() );
             writer.print( "] " );
             writer.print( problem.getMessage() );
-            writer.print( " @ " );
-            writer.println( ModelProblemUtils.formatLocation( problem, modelId ) );
+            String location = ModelProblemUtils.formatLocation( problem, modelId );
+            if ( !location.isEmpty() )
+            {
+                writer.print( " @ " );
+                writer.println( location );
+            }
         }
 
         return buffer.toString();

--- a/maven-settings-builder/src/main/java/org/apache/maven/settings/building/DefaultSettingsProblem.java
+++ b/maven-settings-builder/src/main/java/org/apache/maven/settings/building/DefaultSettingsProblem.java
@@ -158,7 +158,12 @@ public class DefaultSettingsProblem
 
         buffer.append( '[' ).append( getSeverity() ).append( "] " );
         buffer.append( getMessage() );
-        buffer.append( " @ " ).append( getLocation() );
+        String location = getLocation();
+        if ( !location.isEmpty() )
+        {
+             buffer.append( " @ " );
+             buffer.append( location );
+        }
 
         return buffer.toString();
     }

--- a/maven-settings-builder/src/main/java/org/apache/maven/settings/building/SettingsBuildingException.java
+++ b/maven-settings-builder/src/main/java/org/apache/maven/settings/building/SettingsBuildingException.java
@@ -80,8 +80,12 @@ public class SettingsBuildingException
             writer.print( problem.getSeverity() );
             writer.print( "] " );
             writer.print( problem.getMessage() );
-            writer.print( " @ " );
-            writer.println( problem.getLocation() );
+            String location = problem.getLocation();
+            if ( !location.isEmpty() )
+            {
+                writer.print( " @ " );
+                writer.println( location );
+            }
         }
 
         return buffer.toString();


### PR DESCRIPTION
This one turns non-sense output like this:
```
[DEBUG] Looking up lifecycle mappings for packaging jar from ClassRealm[plexus.core, parent: null]
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] input contained no data @
 @
[ERROR] The build could not read 1 project -> [Help 1]
org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
[FATAL] input contained no data @
```
to this:
```
[DEBUG] Looking up lifecycle mappings for packaging jar from ClassRealm[plexus.core, parent: null]
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] input contained no data
[ERROR] The build could not read 1 project -> [Help 1]
org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
[FATAL] input contained no data
```