### PR TITLE
[MNG-7103] Make VersionScheme a component

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeSet;
 
 import javax.inject.Inject;
@@ -56,7 +57,6 @@ import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.MetadataRequest;
 import org.eclipse.aether.resolution.MetadataResult;
-import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionScheme;
@@ -75,17 +75,29 @@ public class DefaultPluginVersionResolver
 
     private static final String REPOSITORY_CONTEXT = "plugin";
 
-    @Inject
-    private Logger logger;
+    private final Logger logger;
+
+    private final RepositorySystem repositorySystem;
+
+    private final MetadataReader metadataReader;
+
+    private final MavenPluginManager pluginManager;
+
+    private final VersionScheme versionScheme;
 
     @Inject
-    private RepositorySystem repositorySystem;
-
-    @Inject
-    private MetadataReader metadataReader;
-
-    @Inject
-    private MavenPluginManager pluginManager;
+    public DefaultPluginVersionResolver( final Logger logger,
+                                         final RepositorySystem repositorySystem,
+                                         final MetadataReader metadataReader,
+                                         final MavenPluginManager pluginManager,
+                                         final VersionScheme versionScheme )
+    {
+        this.logger = Objects.requireNonNull( logger );
+        this.repositorySystem = Objects.requireNonNull( repositorySystem );
+        this.metadataReader = Objects.requireNonNull( metadataReader );
+        this.pluginManager = Objects.requireNonNull( pluginManager );
+        this.versionScheme = Objects.requireNonNull( versionScheme );
+    }
 
     public PluginVersionResult resolve( PluginVersionRequest request )
         throws PluginVersionResolutionException
@@ -175,8 +187,6 @@ public class DefaultPluginVersionResolver
 
         if ( version == null )
         {
-            VersionScheme versionScheme = new GenericVersionScheme();
-
             TreeSet<Version> releases = new TreeSet<>( Collections.reverseOrder() );
             TreeSet<Version> snapshots = new TreeSet<>( Collections.reverseOrder() );
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -78,18 +78,22 @@ public class DefaultVersionRangeResolver
 
     private RepositoryEventDispatcher repositoryEventDispatcher;
 
+    private final VersionScheme versionScheme;
+
     public DefaultVersionRangeResolver()
     {
         // enable default constructor
+        this.versionScheme = new GenericVersionScheme();
     }
 
     @Inject
     DefaultVersionRangeResolver( MetadataResolver metadataResolver, SyncContextFactory syncContextFactory,
-                                 RepositoryEventDispatcher repositoryEventDispatcher )
+                                 RepositoryEventDispatcher repositoryEventDispatcher, VersionScheme versionScheme )
     {
         setMetadataResolver( metadataResolver );
         setSyncContextFactory( syncContextFactory );
         setRepositoryEventDispatcher( repositoryEventDispatcher );
+        this.versionScheme = Objects.requireNonNull( versionScheme );
     }
 
     public void initService( ServiceLocator locator )
@@ -123,8 +127,6 @@ public class DefaultVersionRangeResolver
         throws VersionRangeResolutionException
     {
         VersionRangeResult result = new VersionRangeResult( request );
-
-        VersionScheme versionScheme = new GenericVersionScheme();
 
         VersionConstraint versionConstraint;
         try

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenResolverModule.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenResolverModule.java
@@ -34,6 +34,8 @@ import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.VersionRangeResolver;
 import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.impl.guice.AetherModule;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.VersionScheme;
 
 /**
  * MavenResolverModule
@@ -46,6 +48,7 @@ public final class MavenResolverModule
     protected void configure()
     {
         install( new AetherModule() );
+        bind( VersionScheme.class ).toInstance( new GenericVersionScheme() );
         bind( ArtifactDescriptorReader.class ).to( DefaultArtifactDescriptorReader.class ).in( Singleton.class );
         bind( VersionResolver.class ).to( DefaultVersionResolver.class ).in( Singleton.class );
         bind( VersionRangeResolver.class ).to( DefaultVersionRangeResolver.class ).in( Singleton.class );

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionSchemeProvider.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionSchemeProvider.java
@@ -1,0 +1,49 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.VersionScheme;
+
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ * Provider of {@link org.eclipse.aether.util.version.GenericVersionScheme}.
+ */
+@Named
+@Singleton
+public class VersionSchemeProvider
+    implements Provider<VersionScheme>
+{
+    private final VersionScheme genericVersionScheme;
+
+    public VersionSchemeProvider()
+    {
+        this.genericVersionScheme = new GenericVersionScheme();
+    }
+
+    @Override
+    public VersionScheme get()
+    {
+        return genericVersionScheme;
+    }
+}


### PR DESCRIPTION
MNG-7103: Instead to ad-hoc create the instance as needed, it is thread safe,
so is fine to have it shared across whole system.

Moreover, touched classes got converted from ancient plexus-field-like
injection to proper immutable components, something we really need
start doing.

Full conversion (of resolver classes) will become possible once ServiceLocator dropped
(see MRESOLVER-157).

Also, the idea of MNG-7104 that a "touched" (changed) class become refactored to ctor injection as well.