### PR TITLE
Run GitHub actions integration tests with Java 17-ea

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 11, 16]
+        java: [8, 11, 16, 17-ea]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Follow-up for #456, now adding Java 17-ea to the matrix.