### PR TITLE
[MNG-7164] Add constructor MojoExecutionException(Throwable).

### DIFF
--- a/maven-plugin-api/src/main/java/org/apache/maven/plugin/AbstractMojoExecutionException.java
+++ b/maven-plugin-api/src/main/java/org/apache/maven/plugin/AbstractMojoExecutionException.java
@@ -41,6 +41,18 @@ public abstract class AbstractMojoExecutionException
         super( message, cause );
     }
 
+    /**
+     * Constructs a new {@code AbstractMojoExecutionException} exception wrapping an underlying {@code Throwable}.
+     *
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value
+     *        is permitted, and indicates that the cause is nonexistent or unknown.)
+     * @since 3.8.3
+     */
+    public AbstractMojoExecutionException( Throwable cause ) 
+    {
+        super( cause );
+    }
+
     public String getLongMessage()
     {
         return longMessage;

--- a/maven-plugin-api/src/main/java/org/apache/maven/plugin/MojoExecutionException.java
+++ b/maven-plugin-api/src/main/java/org/apache/maven/plugin/MojoExecutionException.java
@@ -76,4 +76,17 @@ public class MojoExecutionException
     {
         super( message );
     }
+    
+    /**
+     * Constructs a new {@code MojoExecutionException} exception wrapping an underlying {@code Throwable}.
+     *
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value
+     *        is permitted, and indicates that the cause is nonexistent or unknown.)
+     * @since 3.8.3
+     */
+    public MojoExecutionException( Throwable cause ) 
+    {
+        super( cause );
+    }
+
 }

--- a/maven-plugin-api/src/main/java/org/apache/maven/plugin/MojoFailureException.java
+++ b/maven-plugin-api/src/main/java/org/apache/maven/plugin/MojoFailureException.java
@@ -65,4 +65,17 @@ public class MojoFailureException
     {
         super( message, cause );
     }
+
+    /**
+     * Constructs a new {@code MojoFailureException} exception wrapping an underlying {@code Throwable}.
+     *
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value
+     *        is permitted, and indicates that the cause is nonexistent or unknown.)
+     * @since 3.8.3
+     */
+    public MojoFailureException( Throwable cause ) 
+    {
+        super( cause );
+    }
+
 }


### PR DESCRIPTION
Sometimes I have nothing additional to say in a message, I just want to propagate the Throwable.

See https://issues.apache.org/jira/browse/MNG-7164

