### PR TITLE
[MNG-7131] maven.config doesn't handle arguments with spaces in them

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -104,6 +104,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -387,7 +388,7 @@ public class MavenCli
 
             if ( configFile.isFile() )
             {
-                for ( String arg : new String( Files.readAllBytes( configFile.toPath() ) ).split( "\\s+" ) )
+                for ( String arg : Files.readAllLines( configFile.toPath(), Charset.defaultCharset() ) )
                 {
                     if ( !arg.isEmpty() )
                     {

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -195,8 +195,10 @@ public class MavenCliTest
     /**
      * Read .mvn/maven.config with the following definitions:
      * <pre>
-     *   -T 3
+     *   -T
+     *   3
      *   -Drevision=1.3.0
+     *   "-Dlabel=Apache Maven"
      * </pre>
      * and check if the {@code -T 3} option can be overwritten via command line
      * argument.
@@ -221,8 +223,10 @@ public class MavenCliTest
     /**
      * Read .mvn/maven.config with the following definitions:
      * <pre>
-     *   -T 3
+     *   -T
+     *   3
      *   -Drevision=1.3.0
+     *   "-Dlabel=Apache Maven"
      * </pre>
      * and check if the {@code -Drevision-1.3.0} option can be overwritten via command line
      * argument.
@@ -249,8 +253,10 @@ public class MavenCliTest
     /**
      * Read .mvn/maven.config with the following definitions:
      * <pre>
-     *   -T 3
+     *   -T
+     *   3
      *   -Drevision=1.3.0
+     *   "-Dlabel=Apache Maven"
      * </pre>
      * and check if the {@code -Drevision-1.3.0} option can be overwritten via command line
      * argument.
@@ -277,8 +283,10 @@ public class MavenCliTest
     /**
      * Read .mvn/maven.config with the following definitions:
      * <pre>
-     *   -T 3
+     *   -T
+     *   3
      *   -Drevision=1.3.0
+     *   "-Dlabel=Apache Maven"
      * </pre>
      * and check if the {@code -Drevision-1.3.0} option can be overwritten via command line argument when there are
      * funky arguments present.
@@ -300,11 +308,14 @@ public class MavenCliTest
         cli.cli( request );
         cli.properties( request );
 
+        assertEquals( "3", request.commandLine.getOptionValue( CLIManager.THREADS ) );
+
         String revision = System.getProperty( "revision" );
         assertEquals( "8.2.0", revision );
 
         assertEquals( "bar ", request.getSystemProperties().getProperty( "foo" ) );
         assertEquals( "bar two", request.getSystemProperties().getProperty( "foo2" ) );
+        assertEquals( "Apache Maven", request.getSystemProperties().getProperty( "label" ) );
 
         assertEquals( "-Dpom.xml", request.getCommandLine().getOptionValue( CLIManager.ALTERNATE_POM_FILE ) );
     }

--- a/maven-embedder/src/test/projects/config/.mvn/maven.config
+++ b/maven-embedder/src/test/projects/config/.mvn/maven.config
@@ -1,2 +1,3 @@
--T8 --builder  
-  multithreaded
+-T8
+--builder
+multithreaded

--- a/maven-embedder/src/test/projects/mavenConfigProperties/.mvn/maven.config
+++ b/maven-embedder/src/test/projects/mavenConfigProperties/.mvn/maven.config
@@ -1,3 +1,5 @@
--T 3
+-T
+3
 -Drevision=1.3.0
+"-Dlabel=Apache Maven"
 


### PR DESCRIPTION
Since we don't have a clear specification of the file format change
reading of the file to a one-arg-per-line basis just like Java's
@argfiles or Python's argparse would handle it.
Consider that jvm.config suffers from the same issue its parsing is not
portable between Bourne shell and Windows Command prompt.


We also need to change [this](https://maven.apache.org/configure.html) and mention that `jvm.config` parsing is not portable.

I am inclined to backport this to 3.8.x although this might break for people for two reasons:
* Consistency between Maven 3 and 4
* Config files can be changed and will continue to work on older Maven versions
* All other arg file approaches use a one-arg-per-line approach