### PR TITLE
[MNG-7075] mvnDebug should only enter debug mode if not an informative or encryption switch has been passed

### DIFF
--- a/apache-maven/src/assembly/maven/bin/mvnDebug
+++ b/apache-maven/src/assembly/maven/bin/mvnDebug
@@ -28,8 +28,25 @@
 #   MAVEN_DEBUG_ADDRESS (Optional) Set the debug address. Default value is localhost:8000
 # -----------------------------------------------------------------------------
 
-MAVEN_DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=${MAVEN_DEBUG_ADDRESS:-localhost:8000}"
+found_informative_switch=0
+found_encryption_switch=0
+for arg in "$@"; do
+  if [ "$arg" = "-v" -o "$arg" = "--version" \
+       -o "$arg" = "-h" -o "$arg" = "--help" ]; then
+    found_informative_switch=1
+    break
+  fi
+  if [ "$arg" = "-emp" -o "$arg" = "--encrypt-master-password" \
+       -o "$arg" = "-ep" -o "$arg" = "--encrypt-password" ]; then
+    found_encryption_switch=1
+    break
+  fi
+done
 
-echo Preparing to execute Maven in debug mode
+if [ $found_informative_switch -eq 0 -a $found_encryption_switch -eq 0 ] ; then
+  MAVEN_DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=${MAVEN_DEBUG_ADDRESS:-localhost:8000}"
+
+  echo Preparing to execute Maven in debug mode
+fi
 
 env MAVEN_OPTS="$MAVEN_OPTS" MAVEN_DEBUG_OPTS="$MAVEN_DEBUG_OPTS" "`dirname "$0"`/mvn" "$@"

--- a/apache-maven/src/assembly/maven/bin/mvnDebug.cmd
+++ b/apache-maven/src/assembly/maven/bin/mvnDebug.cmd
@@ -37,8 +37,22 @@ title %0
 
 @setlocal
 
-if "%MAVEN_DEBUG_ADDRESS%"=="" @set MAVEN_DEBUG_ADDRESS=localhost:8000
+for %%a in (%*) do (
+  if "%%a" == "-v" goto runMvnCmd
+  if "%%a" == "--version" goto runMvnCmd
+  if "%%a" == "-h" goto runMvnCmd
+  if "%%a" == "--help" goto runMvnCmd
+  if "%%a" == "-emp" goto runMvnCmd
+  if "%%a" == "--encrypt-master-password" goto runMvnCmd
+  if "%%a" == "-ep" goto runMvnCmd
+  if "%%a" == "--encrypt-password" goto runMvnCmd
+)
+goto setDebugFlags
 
-@set MAVEN_DEBUG_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%MAVEN_DEBUG_ADDRESS%
+:setDebugFlags
+if "%MAVEN_DEBUG_ADDRESS%"=="" set MAVEN_DEBUG_ADDRESS=localhost:8000
 
-@call "%~dp0"mvn.cmd %*
+set MAVEN_DEBUG_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%MAVEN_DEBUG_ADDRESS%
+
+:runMvnCmd
+call "%~dp0"mvn.cmd %*


### PR DESCRIPTION
This closes #515


Please review especially the Windows part, it works for me in PowerShell, but who knows.

One thing is missing: Shall It touch `mvnwDebug` and `mvnwDebug.cmd` also?