### PR TITLE
[MNG-7246] Upgrade plexus-sec-dispatcher

### DIFF
--- a/maven-core/src/test/projects/lifecycle-executor/project-with-inheritance/pom.xml
+++ b/maven-core/src/test/projects/lifecycle-executor/project-with-inheritance/pom.xml
@@ -473,7 +473,7 @@ under the License.
         <version>${mercuryMp3Version}</version>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.plexus</groupId>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-sec-dispatcher</artifactId>
         <version>${securityDispatcherVersion}</version>
       </dependency>

--- a/maven-core/src/test/projects/plugin-manager/project-with-inheritance/pom.xml
+++ b/maven-core/src/test/projects/plugin-manager/project-with-inheritance/pom.xml
@@ -473,7 +473,7 @@ under the License.
         <version>${mercuryMp3Version}</version>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.plexus</groupId>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-sec-dispatcher</artifactId>
         <version>${securityDispatcherVersion}</version>
       </dependency>

--- a/maven-core/src/test/resources/org/apache/maven/lifecycle/pom.xml
+++ b/maven-core/src/test/resources/org/apache/maven/lifecycle/pom.xml
@@ -473,7 +473,7 @@ under the License.
         <version>${mercuryMp3Version}</version>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.plexus</groupId>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-sec-dispatcher</artifactId>
         <version>${securityDispatcherVersion}</version>
       </dependency>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -123,7 +123,7 @@ under the License.
       <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.plexus</groupId>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
     </dependency>
     <dependency>

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -62,7 +62,7 @@ under the License.
       <artifactId>maven-settings</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.plexus</groupId>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@ under the License.
     <sisuInjectVersion>0.3.4</sisuInjectVersion>
     <wagonVersion>3.4.3</wagonVersion>
     <jsoupVersion>1.12.1</jsoupVersion>
-    <securityDispatcherVersion>1.4</securityDispatcherVersion>
-    <cipherVersion>1.8</cipherVersion>
+    <securityDispatcherVersion>2.0</securityDispatcherVersion>
+    <cipherVersion>2.0</cipherVersion>
     <modelloVersion>1.11</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
     <resolverVersion>1.7.1</resolverVersion>
@@ -396,15 +396,9 @@ under the License.
         <version>${commonsLangVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.plexus</groupId>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-sec-dispatcher</artifactId>
         <version>${securityDispatcherVersion}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.sonatype.plexus</groupId>
-            <artifactId>plexus-cipher</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -655,15 +649,16 @@ under the License.
               <goal>enforce</goal>
             </goals>
             <phase>validate</phase>
-            <id>ensure-no-org.sonatype:plexus-cipher</id>
+            <id>ensure-no-sonatype-cipher-and-sec-dispatcher</id>
             <configuration>
               <rules>
                 <bannedDependencies>
                   <excludes>
+                    <exclude>org.sonatype.plexus:plexus-sec-dispatcher</exclude>
                     <exclude>org.sonatype.plexus:plexus-cipher</exclude>
                   </excludes>
                   <message>
-                    ensure no more org.sonatype.plexus:plexus-cipher as groupId changed. you have to add some exclusions.
+                    ensure no more org.sonatype.plexus:plexus-cipher and org.sonatype.plexus:plexus-sec-dispatcher.
                   </message>
                 </bannedDependencies>
               </rules>


### PR DESCRIPTION
Both plexus-cipher and plexus-sec-dispatcher had
groupId change, but plexus-cipher change was implemented
for 1.8 version.

Latest versions of artifacts are 2.0. This PR
ups plexus-cipher version and adds proper changes
for plexus-sec-dispatcher groupId change.

Following this checklist to help us incorporate your 
contribution quickly and easily:

https://issues.apache.org/jira/browse/MNG-7246