### PR TITLE
[MNG-7103] VersionScheme provider

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
@@ -59,7 +59,6 @@ import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.MetadataRequest;
 import org.eclipse.aether.resolution.MetadataResult;
-import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionScheme;
@@ -85,18 +84,22 @@ public class DefaultPluginVersionResolver
     private final RepositorySystem repositorySystem;
     private final MetadataReader metadataReader;
     private final MavenPluginManager pluginManager;
+    private final VersionScheme versionScheme;
 
     @Inject
     public DefaultPluginVersionResolver(
             RepositorySystem repositorySystem,
             MetadataReader metadataReader,
-            MavenPluginManager pluginManager )
+            MavenPluginManager pluginManager,
+            VersionScheme versionScheme )
     {
         this.repositorySystem = repositorySystem;
         this.metadataReader = metadataReader;
         this.pluginManager = pluginManager;
+        this.versionScheme = versionScheme;
     }
 
+    @Override
     public PluginVersionResult resolve( PluginVersionRequest request )
         throws PluginVersionResolutionException
     {
@@ -199,8 +202,6 @@ public class DefaultPluginVersionResolver
 
         if ( version == null )
         {
-            VersionScheme versionScheme = new GenericVersionScheme();
-
             TreeSet<Version> releases = new TreeSet<>( Collections.reverseOrder() );
             TreeSet<Version> snapshots = new TreeSet<>( Collections.reverseOrder() );
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -40,7 +40,6 @@ import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.spi.synccontext.SyncContextFactory;
-import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionConstraint;
@@ -73,22 +72,24 @@ public class DefaultVersionRangeResolver
     private final MetadataResolver metadataResolver;
     private final SyncContextFactory syncContextFactory;
     private final RepositoryEventDispatcher repositoryEventDispatcher;
+    private final VersionScheme versionScheme;
 
     @Inject
-    public DefaultVersionRangeResolver( MetadataResolver metadataResolver, SyncContextFactory syncContextFactory,
-                                        RepositoryEventDispatcher repositoryEventDispatcher )
+    public DefaultVersionRangeResolver( MetadataResolver metadataResolver,
+                                        SyncContextFactory syncContextFactory,
+                                        RepositoryEventDispatcher repositoryEventDispatcher,
+                                        VersionScheme versionScheme )
     {
         this.metadataResolver = Objects.requireNonNull( metadataResolver, "metadataResolver cannot be null" );
         this.syncContextFactory = Objects.requireNonNull( syncContextFactory, "syncContextFactory cannot be null" );
         this.repositoryEventDispatcher = Objects.requireNonNull( repositoryEventDispatcher,
                 "repositoryEventDispatcher cannot be null" );
+        this.versionScheme = Objects.requireNonNull( versionScheme, "versionScheme cannot be null" );
     }
     public VersionRangeResult resolveVersionRange( RepositorySystemSession session, VersionRangeRequest request )
         throws VersionRangeResolutionException
     {
         VersionRangeResult result = new VersionRangeResult( request );
-
-        VersionScheme versionScheme = new GenericVersionScheme();
 
         VersionConstraint versionConstraint;
         try

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionSchemeProvider.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionSchemeProvider.java
@@ -1,0 +1,49 @@
+package org.apache.maven.repository.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.VersionScheme;
+
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ * Default version scheme provider: provides singleton {@link GenericVersionScheme} instance.
+ */
+@Singleton
+@Named
+public final class DefaultVersionSchemeProvider
+        implements Provider<VersionScheme>
+{
+    private final GenericVersionScheme genericVersionScheme;
+
+    public DefaultVersionSchemeProvider()
+    {
+        this.genericVersionScheme = new GenericVersionScheme();
+    }
+
+    @Override
+    public VersionScheme get()
+    {
+        return genericVersionScheme;
+    }
+}

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenResolverModule.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenResolverModule.java
@@ -34,6 +34,8 @@ import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.VersionRangeResolver;
 import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.impl.guice.AetherModule;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.VersionScheme;
 
 /**
  * MavenResolverModule
@@ -46,6 +48,7 @@ public final class MavenResolverModule
     protected void configure()
     {
         install( new AetherModule() );
+        bind( VersionScheme.class ).toProvider( new DefaultVersionSchemeProvider() );
         bind( ArtifactDescriptorReader.class ).to( DefaultArtifactDescriptorReader.class ).in( Singleton.class );
         bind( VersionResolver.class ).to( DefaultVersionResolver.class ).in( Singleton.class );
         bind( VersionRangeResolver.class ).to( DefaultVersionRangeResolver.class ).in( Singleton.class );

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenResolverModule.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenResolverModule.java
@@ -34,7 +34,6 @@ import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.VersionRangeResolver;
 import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.impl.guice.AetherModule;
-import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.VersionScheme;
 
 /**


### PR DESCRIPTION
This PR makes VersionScheme a component, is injected where needed
(instead of ad-hoc instantiation), but provides room for
different schemas, as GenericVersionScheme is "default"
but now nothing stops to add other schemes as well.