### PR TITLE
[MNG-7279] Drop deprecated constructor

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluator.java
@@ -26,7 +26,6 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.path.PathTranslator;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.TypeAwareExpressionEvaluator;
 import org.codehaus.plexus.util.introspection.ReflectionValueExtractor;
@@ -83,14 +82,6 @@ public class PluginParameterExpressionEvaluator
     private String basedir;
 
     private Properties properties;
-
-    @Deprecated //TODO used by the Enforcer plugin (cstamas: not anymore, since 3.0.0)
-    public PluginParameterExpressionEvaluator( MavenSession session, MojoExecution mojoExecution,
-                                               PathTranslator pathTranslator, MavenProject project,
-                                               Properties properties )
-    {
-        this( session, mojoExecution );
-    }
 
     public PluginParameterExpressionEvaluator( MavenSession session )
     {


### PR DESCRIPTION
This constructor was deprecated in Maven 3.0-RC1 (!!!).
Removal also means that Maven4 will NOT work with
(Maven2 compatible) m-enforcer-p 2.x, only with
modern m-enforcer-p 3.x line.

https://issues.apache.org/jira/browse/MNG-7279
