### PR TITLE
[MNG-6762] Resolve .mvn/settings.xml relatively in multi module projects

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -397,10 +397,10 @@ public class MavenCli
                 }
 
                 mavenConfig = cliManager.parse( args.toArray( new String[0] ) );
-                List<?> unrecongized = mavenConfig.getArgList();
-                if ( !unrecongized.isEmpty() )
+                List<?> unrecognized = mavenConfig.getArgList();
+                if ( !unrecognized.isEmpty() )
                 {
-                    throw new ParseException( "Unrecognized maven.config entries: " + unrecongized );
+                    throw new ParseException( "Unrecognized maven.config entries: " + unrecognized );
                 }
             }
         }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -90,7 +90,7 @@ public class SettingsXmlConfigurationProcessor
         throws Exception
     {
         CommandLine commandLine = cliRequest.getCommandLine();
-        String workingDirectory = cliRequest.getWorkingDirectory();
+        String multiModuleDirectory = cliRequest.getMultiModuleProjectDirectory().toString();
         MavenExecutionRequest request = cliRequest.getRequest();
 
         File userSettingsFile;
@@ -98,7 +98,7 @@ public class SettingsXmlConfigurationProcessor
         if ( commandLine.hasOption( CLIManager.ALTERNATE_USER_SETTINGS ) )
         {
             userSettingsFile = new File( commandLine.getOptionValue( CLIManager.ALTERNATE_USER_SETTINGS ) );
-            userSettingsFile = resolveFile( userSettingsFile, workingDirectory );
+            userSettingsFile = resolveFile( userSettingsFile, multiModuleDirectory );
 
             if ( !userSettingsFile.isFile() )
             {
@@ -116,7 +116,7 @@ public class SettingsXmlConfigurationProcessor
         if ( commandLine.hasOption( CLIManager.ALTERNATE_GLOBAL_SETTINGS ) )
         {
             globalSettingsFile = new File( commandLine.getOptionValue( CLIManager.ALTERNATE_GLOBAL_SETTINGS ) );
-            globalSettingsFile = resolveFile( globalSettingsFile, workingDirectory );
+            globalSettingsFile = resolveFile( globalSettingsFile, multiModuleDirectory );
 
             if ( !globalSettingsFile.isFile() )
             {


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG-6762) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.
 - [ ] 
If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/

----

Before, when a settings.xml file was referenced in `maven.config`, it was resolved against the working directory, which would break when maven is invoked in a submodule. This PR changes it to resolve against the multi module root.