### PR TITLE
[MNG-7129] - Changes in maven core required to support incremental mave…

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/DefaultMojosExecutionStrategy.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/DefaultMojosExecutionStrategy.java
@@ -1,0 +1,46 @@
+package org.apache.maven.plugin;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.List;
+
+/**
+ * Default mojo execution strategy. It just iterates over mojo executions and runs one by one
+ */
+@Named
+@Singleton
+public class DefaultMojosExecutionStrategy implements MojosExecutionStrategy
+{
+    @Override
+    public void execute( List<MojoExecution> mojos, MavenSession session, MojoExecutionRunner mojoRunner )
+            throws LifecycleExecutionException
+    {
+        for ( MojoExecution mojoExecution : mojos )
+        {
+            mojoRunner.run( mojoExecution );
+        }
+
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/MojoExecutionRunner.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/MojoExecutionRunner.java
@@ -1,0 +1,37 @@
+package org.apache.maven.plugin;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+
+/**
+ * Provides context for mojo execution. Invocation of #run will result in actual execution
+ */
+@FunctionalInterface
+public interface MojoExecutionRunner
+{
+    /**
+     * Runs mojo execution
+     *
+     * @param execution mojo execution
+     * @throws LifecycleExecutionException
+     */
+    void run( MojoExecution execution ) throws LifecycleExecutionException;
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/MojosExecutionStrategy.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/MojosExecutionStrategy.java
@@ -1,0 +1,45 @@
+package org.apache.maven.plugin;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+
+import java.util.List;
+
+/**
+ * Interface allows overriding default mojo execution strategy For example it is possible wrap some mojo execution to
+ * decorate default functionality or skip some executions
+ */
+public interface MojosExecutionStrategy
+{
+
+    /**
+     * Entry point to the execution strategy
+     *
+     * @param mojos             list of mojos representing a project build
+     * @param session           current session
+     * @param mojoExecutionRunner mojo execution task which must be invoked by a strategy to actually run it
+     * @throws LifecycleExecutionException
+     */
+    void execute( List<MojoExecution> mojos, MavenSession session, MojoExecutionRunner mojoExecutionRunner )
+            throws LifecycleExecutionException;
+
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -492,6 +492,21 @@ public class DefaultMavenPluginManager
 
         ClassRealm pluginRealm = pluginDescriptor.getClassRealm();
 
+        if ( pluginRealm == null )
+        {
+            try
+            {
+                setupPluginRealm( pluginDescriptor, session, null, null, null );
+            }
+            catch ( PluginResolutionException e )
+            {
+                String msg = "Cannot setup plugin realm [mojoDescriptor=" + mojoDescriptor.getId()
+                        + ", pluginDescriptor=" + pluginDescriptor.getId() + "]";
+                throw new PluginConfigurationException( pluginDescriptor, msg, e );
+            }
+            pluginRealm = pluginDescriptor.getClassRealm();
+        }
+
         if ( logger.isDebugEnabled() )
         {
             logger.debug( "Configuring mojo " + mojoDescriptor.getId() + " from plugin realm " + pluginRealm );

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/MojoExecutorStub.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/MojoExecutorStub.java
@@ -17,15 +17,14 @@ package org.apache.maven.lifecycle.internal.stub;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
-import org.apache.maven.lifecycle.internal.DependencyContext;
 import org.apache.maven.lifecycle.internal.ExecutionEventCatapult;
 import org.apache.maven.lifecycle.internal.LifecycleDependencyResolver;
 import org.apache.maven.lifecycle.internal.MojoExecutor;
-import org.apache.maven.lifecycle.internal.PhaseRecorder;
 import org.apache.maven.lifecycle.internal.ProjectIndex;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MavenPluginManager;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojosExecutionStrategy;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 
@@ -46,17 +45,10 @@ public class MojoExecutorStub
             BuildPluginManager pluginManager,
             MavenPluginManager mavenPluginManager,
             LifecycleDependencyResolver lifeCycleDependencyResolver,
-            ExecutionEventCatapult eventCatapult )
+            ExecutionEventCatapult eventCatapult,
+            MojosExecutionStrategy mojosExecutionStrategy )
     {
-        super( pluginManager, mavenPluginManager, lifeCycleDependencyResolver, eventCatapult );
-    }
-
-    @Override
-    public void execute( MavenSession session, MojoExecution mojoExecution, ProjectIndex projectIndex,
-                         DependencyContext dependencyContext, PhaseRecorder phaseRecorder )
-        throws LifecycleExecutionException
-    {
-        executions.add( mojoExecution );
+        super( pluginManager, mavenPluginManager, lifeCycleDependencyResolver, eventCatapult, mojosExecutionStrategy );
     }
 
     @Override


### PR DESCRIPTION
Changes in maven core  to inject caching extension

CC @ansip

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
