### PR TITLE
[MNG-7345] Fix exported packages

### DIFF
--- a/maven-core/src/main/resources/META-INF/maven/extension.xml
+++ b/maven-core/src/main/resources/META-INF/maven/extension.xml
@@ -30,6 +30,7 @@ under the License.
     <exportedPackage>org.apache.maven.exception</exportedPackage>
     <exportedPackage>org.apache.maven.execution</exportedPackage>
     <exportedPackage>org.apache.maven.execution.scope</exportedPackage>
+    <exportedPackage>org.apache.maven.feature</exportedPackage>
     <exportedPackage>org.apache.maven.graph</exportedPackage>
     <exportedPackage>org.apache.maven.lifecycle</exportedPackage>
     <exportedPackage>org.apache.maven.model</exportedPackage>
@@ -39,7 +40,7 @@ under the License.
     <exportedPackage>org.apache.maven.project</exportedPackage>
     <exportedPackage>org.apache.maven.reporting</exportedPackage>
     <exportedPackage>org.apache.maven.repository</exportedPackage>
-    <exportedPackage>org.apache.maven.rtinfo</exportedPackage>
+    <exportedPackage>org.apache.maven.rtinfo.*</exportedPackage>
     <exportedPackage>org.apache.maven.settings</exportedPackage>
     <exportedPackage>org.apache.maven.toolchain</exportedPackage>
     <exportedPackage>org.apache.maven.usability</exportedPackage>
@@ -93,6 +94,7 @@ under the License.
     <exportedPackage>org.codehaus.plexus.lifecycle</exportedPackage>
     <exportedPackage>org.codehaus.plexus.logging</exportedPackage>
     <exportedPackage>org.codehaus.plexus.personality</exportedPackage>
+    <exportedPackage>org.eclipse.sisu.*</exportedPackage>
 
     <!-- javax.inject (JSR-330) -->
     <exportedPackage>javax.inject.*</exportedPackage>

--- a/maven-core/src/main/resources/META-INF/maven/extension.xml
+++ b/maven-core/src/main/resources/META-INF/maven/extension.xml
@@ -94,7 +94,6 @@ under the License.
     <exportedPackage>org.codehaus.plexus.lifecycle</exportedPackage>
     <exportedPackage>org.codehaus.plexus.logging</exportedPackage>
     <exportedPackage>org.codehaus.plexus.personality</exportedPackage>
-    <exportedPackage>org.eclipse.sisu.*</exportedPackage>
 
     <!-- javax.inject (JSR-330) -->
     <exportedPackage>javax.inject.*</exportedPackage>


### PR DESCRIPTION
Packages not exported from maven-core:
* o.a.m.bridge
* o.a.m.eventspy
* o.a.m.execution.infoproviders
* o.a.m.lifecycle.mapping
* o.a.m.feature

Packages not exported from dependencies
* org.eclipse.sisu
the above one is required for @Priority, but there may be others needed, not sure.

Packages that should not be exported
* o.a.m.rtinfo.internal

My commit only fixes `o.a.m.feature`, `org.eclipse.sisu` and `o.a.m.rtinfo.internal`.