### PR TITLE
[MNG-7347] SessionScoped beans should be singletons for a given session

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
@@ -89,8 +89,12 @@ public class LifecycleModuleBuilder
 
         // session may be different from rootSession seeded in DefaultMaven
         // explicitly seed the right session here to make sure it is used by Guice
-        sessionScope.enter( reactorContext.getSessionScopeMemento() );
-        sessionScope.seed( MavenSession.class, session );
+        final boolean scoped = session != rootSession;
+        if ( scoped )
+        {
+            sessionScope.enter();
+            sessionScope.seed( MavenSession.class, session );
+        }
         try
         {
 
@@ -144,7 +148,10 @@ public class LifecycleModuleBuilder
         }
         finally
         {
-            sessionScope.exit();
+            if ( scoped )
+            {
+                sessionScope.exit();
+            }
 
             session.setCurrentProject( null );
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleStarter.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleStarter.java
@@ -122,8 +122,7 @@ public class LifecycleStarter
             ClassLoader oldContextClassLoader = Thread.currentThread().getContextClassLoader();
             ReactorBuildStatus reactorBuildStatus = new ReactorBuildStatus( session.getProjectDependencyGraph() );
             reactorContext =
-                new ReactorContext( result, projectIndex, oldContextClassLoader, reactorBuildStatus,
-                                    sessionScope.memento() );
+                new ReactorContext( result, projectIndex, oldContextClassLoader, reactorBuildStatus );
 
             String builderId = session.getRequest().getBuilderId();
             Builder builder = builders.get( builderId );

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ReactorContext.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ReactorContext.java
@@ -20,7 +20,6 @@ package org.apache.maven.lifecycle.internal;
  */
 
 import org.apache.maven.execution.MavenExecutionResult;
-import org.apache.maven.session.scope.internal.SessionScope;
 
 /**
  * Context that is fixed for the entire reactor build.
@@ -40,17 +39,13 @@ public class ReactorContext
 
     private final ReactorBuildStatus reactorBuildStatus;
 
-    private final SessionScope.Memento sessionScope;
-
     public ReactorContext( MavenExecutionResult result, ProjectIndex projectIndex,
-                           ClassLoader originalContextClassLoader, ReactorBuildStatus reactorBuildStatus,
-                           SessionScope.Memento sessionScope )
+                           ClassLoader originalContextClassLoader, ReactorBuildStatus reactorBuildStatus )
     {
         this.result = result;
         this.projectIndex = projectIndex;
         this.originalContextClassLoader = originalContextClassLoader;
         this.reactorBuildStatus = reactorBuildStatus;
-        this.sessionScope = sessionScope;
     }
 
     public ReactorBuildStatus getReactorBuildStatus()
@@ -73,11 +68,4 @@ public class ReactorContext
         return originalContextClassLoader;
     }
 
-    /**
-     * @since 3.3.0
-     */
-    public SessionScope.Memento getSessionScopeMemento()
-    {
-        return sessionScope;
-    }
 }

--- a/maven-core/src/test/java/org/apache/maven/session/scope/internal/SessionScopeTest.java
+++ b/maven-core/src/test/java/org/apache/maven/session/scope/internal/SessionScopeTest.java
@@ -1,0 +1,81 @@
+package org.apache.maven.session.scope.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Provider;
+
+import com.google.inject.Key;
+import com.google.inject.OutOfScopeException;
+import org.apache.maven.model.building.DefaultModelSourceTransformer;
+import org.apache.maven.model.building.ModelSourceTransformer;
+import org.apache.maven.model.locator.DefaultModelLocator;
+import org.apache.maven.model.locator.ModelLocator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SessionScopeTest {
+
+    @Test
+    public void testScope() throws Exception
+    {
+        SessionScope scope = new SessionScope();
+
+        assertThrows( OutOfScopeException.class, () -> scope.seed( ModelLocator.class, new DefaultModelLocator() ) );
+
+        Provider<ModelLocator> pml = scope.scope( Key.get( ModelLocator.class), DefaultModelLocator::new );
+        assertNotNull( pml );
+        assertThrows( OutOfScopeException.class, pml::get );
+
+        Provider<ModelSourceTransformer> pmst = scope.scope( Key.get( ModelSourceTransformer.class ), DefaultModelSourceTransformer::new );
+        assertNotNull( pmst );
+
+        scope.enter();
+
+        final DefaultModelLocator dml1 = new DefaultModelLocator();
+        scope.seed( ModelLocator.class, dml1 );
+
+        assertSame( dml1, pml.get() );
+
+        ModelSourceTransformer mst1 = pmst.get();
+        assertSame( mst1, pmst.get() );
+        Provider<ModelSourceTransformer> pmst1 = scope.scope( Key.get( ModelSourceTransformer.class ), DefaultModelSourceTransformer::new );
+        assertNotNull( pmst1 );
+        assertSame( mst1, pmst1.get() );
+
+        scope.enter();
+
+        pmst1 = scope.scope( Key.get( ModelSourceTransformer.class ), DefaultModelSourceTransformer::new );
+        assertNotNull( pmst1 );
+        assertNotSame( mst1, pmst1.get() );
+
+        scope.exit();
+
+        assertSame( mst1, pmst.get() );
+
+        scope.exit();
+
+        assertThrows( OutOfScopeException.class, pmst::get );
+        assertThrows( OutOfScopeException.class, () -> scope.seed( ModelLocator.class, new DefaultModelLocator() ) );
+    }
+}


### PR DESCRIPTION
Related to 
 *  https://github.com/apache/maven/commit/45563ff5cbfd066761913ae35a4e3e8e6e25e83c
 *  https://github.com/apache/maven/commit/702acd2e8beb7d5c159edbc59bcbf752b5f1963d

The original scopes were working correctly but did not support multithreaded builds.

The new scope implementation does not use threading at all, so it's safer in a multithreaded build.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

[core-its]: https://maven.apache.org/core-its/core-it-suite/
