### PR TITLE
[master][MNG-7156][MNG-7285] Add locking in MojoExecutor

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -265,6 +265,9 @@ public class MojoExecutor
         {
             final Lock acquiredProjectLock;
             SessionData data = session.getRepositorySession().getData();
+            // TODO: when resolver 1.7.3 is released, the code below should be changed to
+            // TODO: Map<MavenProject, Lock> locks = ( Map ) ((Map) data).computeIfAbsent(
+            // TODO:         ProjectLock.class, l -> new ConcurrentHashMap<>() );
             Map<MavenProject, Lock> locks = ( Map ) data.get( ProjectLock.class );
             // initialize the value if not already done (in case of a concurrent access) to the method
             if ( locks == null )

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -263,7 +263,6 @@ public class MojoExecutor
         @SuppressWarnings( { "unchecked", "rawtypes" } )
         private Lock getProjectLock( MavenSession session )
         {
-            final Lock acquiredProjectLock;
             SessionData data = session.getRepositorySession().getData();
             // TODO: when resolver 1.7.3 is released, the code below should be changed to
             // TODO: Map<MavenProject, Lock> locks = ( Map ) ((Map) data).computeIfAbsent(
@@ -276,8 +275,7 @@ public class MojoExecutor
                 data.set( ProjectLock.class, null, new ConcurrentHashMap<>() );
                 locks = ( Map ) data.get( ProjectLock.class );
             }
-            acquiredProjectLock = locks.computeIfAbsent( session.getCurrentProject(), p -> new ReentrantLock() );
-            return acquiredProjectLock;
+            return locks.computeIfAbsent( session.getCurrentProject(), p -> new ReentrantLock() );
         }
     }
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -27,6 +27,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -50,6 +55,7 @@ import org.apache.maven.plugin.PluginManagerException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.SessionData;
 
 /**
  * <p>
@@ -71,6 +77,8 @@ public class MojoExecutor
     private final MavenPluginManager mavenPluginManager;
     private final LifecycleDependencyResolver lifeCycleDependencyResolver;
     private final ExecutionEventCatapult eventCatapult;
+
+    private final ReadWriteLock aggregatorLock = new ReentrantReadWriteLock( true );
 
     @Inject
     public MojoExecutor(
@@ -201,6 +209,80 @@ public class MojoExecutor
                 return;
             }
         }
+
+        try ( ProjectLock lock = new ProjectLock( session, mojoDescriptor, aggregatorLock ) )
+        {
+            doExecute( session, mojoExecution, projectIndex, dependencyContext );
+        }
+    }
+
+    /**
+     * Aggregating mojo executions (possibly) modify all MavenProjects, including those that are currently in use
+     * by concurrently running mojo executions. To prevent race conditions, an aggregating execution will block
+     * all other executions until finished.
+     * We also lock on a given project to forbid a forked lifecycle to be executed concurrently with the project.
+     * TODO: ideally, the builder should take care of the ordering in a smarter way
+     * TODO: and concurrency issues fixed with MNG-7157
+     */
+    private static class ProjectLock implements AutoCloseable
+    {
+        final Lock acquiredAggregatorLock;
+        final Lock acquiredProjectLock;
+
+        ProjectLock( MavenSession session, MojoDescriptor mojoDescriptor, ReadWriteLock aggregatorLock )
+        {
+            if ( session.getRequest().getDegreeOfConcurrency() > 1 )
+            {
+                boolean aggregator = mojoDescriptor.isAggregator();
+                acquiredAggregatorLock = aggregator ? aggregatorLock.writeLock() : aggregatorLock.readLock();
+                acquiredProjectLock = getProjectLock( session );
+                acquiredAggregatorLock.lock();
+                acquiredProjectLock.lock();
+            }
+            else
+            {
+                acquiredAggregatorLock = null;
+                acquiredProjectLock = null;
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            // release the lock in the reverse order of the acquisition
+            if ( acquiredProjectLock != null )
+            {
+                acquiredProjectLock.unlock();
+            }
+            if ( acquiredAggregatorLock != null )
+            {
+                acquiredAggregatorLock.unlock();
+            }
+        }
+
+        @SuppressWarnings( { "unchecked", "rawtypes" } )
+        private Lock getProjectLock( MavenSession session )
+        {
+            final Lock acquiredProjectLock;
+            SessionData data = session.getRepositorySession().getData();
+            Map<MavenProject, Lock> locks = ( Map ) data.get( ProjectLock.class );
+            // initialize the value if not already done (in case of a concurrent access) to the method
+            if ( locks == null )
+            {
+                // the call to data.set(k, null, v) is effectively a call to data.putIfAbsent(k, v)
+                data.set( ProjectLock.class, null, new ConcurrentHashMap<>() );
+                locks = ( Map ) data.get( ProjectLock.class );
+            }
+            acquiredProjectLock = locks.computeIfAbsent( session.getCurrentProject(), p -> new ReentrantLock() );
+            return acquiredProjectLock;
+        }
+    }
+
+    private void doExecute( MavenSession session, MojoExecution mojoExecution, ProjectIndex projectIndex,
+                            DependencyContext dependencyContext )
+            throws LifecycleExecutionException
+    {
+        MojoDescriptor mojoDescriptor = mojoExecution.getMojoDescriptor();
 
         List<MavenProject> forkedProjects = executeForkedExecutions( mojoExecution, session, projectIndex );
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -78,7 +78,7 @@ public class MojoExecutor
     private final LifecycleDependencyResolver lifeCycleDependencyResolver;
     private final ExecutionEventCatapult eventCatapult;
 
-    private final ReadWriteLock aggregatorLock = new ReentrantReadWriteLock( true );
+    private final ReadWriteLock aggregatorLock = new ReentrantReadWriteLock();
 
     @Inject
     public MojoExecutor(

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.maven.AbstractCoreMavenComponentTestCase;
 import org.apache.maven.execution.MavenSession;
@@ -129,16 +130,16 @@ public class ProjectBuilderTest
         assertEquals( 1, mavenProject.getArtifacts().size() );
 
         final MavenProject project = mavenProject;
-        final int[] getArtifactsResultInAnotherThead = { 0 };
+        final AtomicInteger artifactsResultInAnotherThead = new AtomicInteger();
         Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
-                getArtifactsResultInAnotherThead[0] = project.getArtifacts().size();
+                artifactsResultInAnotherThead.set(project.getArtifacts().size());
             }
         });
         t.start();
         t.join();
-        assertEquals( project.getArtifacts().size(), getArtifactsResultInAnotherThead[0] );
+        assertEquals( project.getArtifacts().size(), artifactsResultInAnotherThead.get() );
     }
 
     @Test

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -127,6 +127,18 @@ public class ProjectBuilderTest
         assertEquals( 1, results.size() );
         MavenProject mavenProject = results.get( 0 ).getProject();
         assertEquals( 1, mavenProject.getArtifacts().size() );
+
+        final MavenProject project = mavenProject;
+        final int[] getArtifactsResultInAnotherThead = { 0 };
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                getArtifactsResultInAnotherThead[0] = project.getArtifacts().size();
+            }
+        });
+        t.start();
+        t.join();
+        assertEquals( project.getArtifacts().size(), getArtifactsResultInAnotherThead[0] );
     }
 
     @Test

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -130,16 +130,16 @@ public class ProjectBuilderTest
         assertEquals( 1, mavenProject.getArtifacts().size() );
 
         final MavenProject project = mavenProject;
-        final AtomicInteger artifactsResultInAnotherThead = new AtomicInteger();
+        final AtomicInteger artifactsResultInAnotherThread = new AtomicInteger();
         Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
-                artifactsResultInAnotherThead.set(project.getArtifacts().size());
+                artifactsResultInAnotherThread.set(project.getArtifacts().size());
             }
         });
         t.start();
         t.join();
-        assertEquals( project.getArtifacts().size(), artifactsResultInAnotherThead.get() );
+        assertEquals( project.getArtifacts().size(), artifactsResultInAnotherThread.get() );
     }
 
     @Test


### PR DESCRIPTION
Hopefully supersedes #476, #578, #625 in order to fix the threading problems in `MavenProject` during parallel builds.
This may need to be combined with #570  and https://github.com/apache/maven-integration-testing/pull/127
