### PR TITLE
[MNG-7339] Test if Maven can build itself on less OS'es & JDK's

### DIFF
--- a/.github/workflows/maven_build_itself.yml
+++ b/.github/workflows/maven_build_itself.yml
@@ -23,8 +23,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 11, 17]
+        os: [ubuntu-latest, windows-latest]
+        java: [8, 17]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Following this checklist to help us incorporate your contribution quickly and easily:

 - [X] Re-using the existing [Jira issue: MNG-7339](https://issues.apache.org/jira/browse/MNG-7339)
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MNG-XXX] SUMMARY`, where you replace `MNG-XXX`
       and `SUMMARY` with the appropriate JIRA issue. Best practice is to use the JIRA issue
       title in the pull request title and in the first line of the commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] ~~Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.~~
 - [ ] ~~You have run the [Core IT][core-its] successfully.~~

Follow-up on a quick chat that took place on the ASF Slack, this pull request removes the following entities from the build matrix that checks if Maven can build itself:
- macOS
- JDK 11

This brings the size of the build matrix from 9 down to 4.

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
