### PR TITLE
MNG-7400 - Allow more WorkspaceReader's to participate

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -266,28 +266,15 @@ public class DefaultMaven
             return addExceptionToResult( result, e );
         }
 
-        WorkspaceReader reactorWorkspace;
         try
         {
-            reactorWorkspace = container.lookup( WorkspaceReader.class, ReactorReader.HINT );
+            setupWorkspaceReader( session, repoSession );
         }
         catch ( ComponentLookupException e )
         {
             return addExceptionToResult( result, e );
         }
-
-        //
-        // Desired order of precedence for local artifact repositories
-        //
-        // Reactor
-        // Workspace
-        // User Local Repository
-        //
-        repoSession.setWorkspaceReader( ChainedWorkspaceReader.newInstance( reactorWorkspace,
-                                                                            repoSession.getWorkspaceReader() ) );
-
         repoSession.setReadOnly();
-
         try
         {
             afterProjectsRead( session );
@@ -367,11 +354,40 @@ public class DefaultMaven
         return result;
     }
 
+    private void setupWorkspaceReader( MavenSession session, DefaultRepositorySystemSession repoSession )
+        throws ComponentLookupException
+    {
+        // Desired order of precedence for workspace readers before querying the local artifact repositories
+        List<WorkspaceReader> workspaceReaders = new ArrayList<WorkspaceReader>();
+        // 1) Reactor workspace reader
+        workspaceReaders.add( container.lookup( WorkspaceReader.class, ReactorReader.HINT ) );
+        // 2) Repository system session-scoped workspace reader
+        WorkspaceReader repoWorkspaceReader = repoSession.getWorkspaceReader();
+        if ( repoWorkspaceReader != null )
+        {
+            workspaceReaders.add( repoWorkspaceReader );
+        }
+        // 3) .. n) Project-scoped workspace readers
+        for ( WorkspaceReader workspaceReader : getProjectScopedExtensionComponents( session.getProjects(),
+                                                                                     WorkspaceReader.class ) )
+        {
+            if ( workspaceReaders.contains( workspaceReader ) )
+            {
+                continue;
+            }
+            workspaceReaders.add( workspaceReader );
+        }
+        WorkspaceReader[] readers = workspaceReaders.toArray( new WorkspaceReader[0] );
+        repoSession.setWorkspaceReader( new ChainedWorkspaceReader( readers ) );
+
+    }
+
     private void afterSessionStart( MavenSession session )
         throws MavenExecutionException
     {
         // CHECKSTYLE_OFF: LineLength
-        for ( AbstractMavenLifecycleParticipant listener : getLifecycleParticipants( Collections.emptyList() ) )
+        for ( AbstractMavenLifecycleParticipant listener : getExtensionComponents( Collections.emptyList(),
+                                                                                   AbstractMavenLifecycleParticipant.class ) )
         // CHECKSTYLE_ON: LineLength
         {
             listener.afterSessionStart( session );
@@ -384,7 +400,10 @@ public class DefaultMaven
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try
         {
-            for ( AbstractMavenLifecycleParticipant listener : getLifecycleParticipants( session.getProjects() ) )
+            // CHECKSTYLE_OFF: LineLength
+            for ( AbstractMavenLifecycleParticipant listener : getExtensionComponents( session.getProjects(),
+                                                                                       AbstractMavenLifecycleParticipant.class ) )
+            // CHECKSTYLE_ON: LineLength
             {
                 Thread.currentThread().setContextClassLoader( listener.getClass().getClassLoader() );
 
@@ -403,7 +422,10 @@ public class DefaultMaven
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try
         {
-            for ( AbstractMavenLifecycleParticipant listener : getLifecycleParticipants( projects ) )
+            // CHECKSTYLE_OFF: LineLength
+            for ( AbstractMavenLifecycleParticipant listener : getExtensionComponents( projects,
+                                                                                       AbstractMavenLifecycleParticipant.class ) )
+            // CHECKSTYLE_ON: LineLength
             {
                 Thread.currentThread().setContextClassLoader( listener.getClass().getClassLoader() );
 
@@ -463,51 +485,60 @@ public class DefaultMaven
         }
     }
 
-    private Collection<AbstractMavenLifecycleParticipant> getLifecycleParticipants( Collection<MavenProject> projects )
+    private <T> Collection<T> getExtensionComponents( Collection<MavenProject> projects, Class<T> role )
     {
-        Collection<AbstractMavenLifecycleParticipant> lifecycleListeners = new LinkedHashSet<>();
+        Collection<T> foundComponents = new LinkedHashSet<>();
 
-        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try
         {
-            try
-            {
-                lifecycleListeners.addAll( container.lookupList( AbstractMavenLifecycleParticipant.class ) );
-            }
-            catch ( ComponentLookupException e )
-            {
-                // this is just silly, lookupList should return an empty list!
-                logger.warn( "Failed to lookup lifecycle participants: " + e.getMessage() );
-            }
+            foundComponents.addAll( container.lookupList( role ) );
+        }
+        catch ( ComponentLookupException e )
+        {
+            // this is just silly, lookupList should return an empty list!
+            logger.warn( "Failed to lookup " + role + ": " + e.getMessage() );
+        }
 
-            Collection<ClassLoader> scannedRealms = new HashSet<>();
+        foundComponents.addAll( getProjectScopedExtensionComponents( projects, role ) );
 
+        return foundComponents;
+    }
+
+    protected <T> Collection<T> getProjectScopedExtensionComponents( Collection<MavenProject> projects, Class<T> role )
+    {
+
+        Collection<T> foundComponents = new LinkedHashSet<>();
+        Collection<ClassLoader> scannedRealms = new HashSet<>();
+
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalContextClassLoader = currentThread.getContextClassLoader();
+        try
+        {
             for ( MavenProject project : projects )
             {
                 ClassLoader projectRealm = project.getClassRealm();
 
                 if ( projectRealm != null && scannedRealms.add( projectRealm ) )
                 {
-                    Thread.currentThread().setContextClassLoader( projectRealm );
+                    currentThread.setContextClassLoader( projectRealm );
 
                     try
                     {
-                        lifecycleListeners.addAll( container.lookupList( AbstractMavenLifecycleParticipant.class ) );
+                        foundComponents.addAll( container.lookupList( role ) );
                     }
                     catch ( ComponentLookupException e )
                     {
                         // this is just silly, lookupList should return an empty list!
-                        logger.warn( "Failed to lookup lifecycle participants: " + e.getMessage() );
+                        logger.warn( "Failed to lookup " + role + ": " + e.getMessage() );
                     }
                 }
             }
+            return foundComponents;
         }
         finally
         {
-            Thread.currentThread().setContextClassLoader( originalClassLoader );
+            currentThread.setContextClassLoader( originalContextClassLoader );
         }
-
-        return lifecycleListeners;
     }
 
     private MavenExecutionResult addExceptionToResult( MavenExecutionResult result, Throwable e )


### PR DESCRIPTION
We at [Tycho](https://github.com/eclipse/tycho/) have a high demand in integrating better with maven to reduce some workarounds that where used in the past to get custom dependency types into the maven dependency model (namely using system scoped absolute paths).

For that reason it would help if it where possible to register additional WorkspaceReader to participate.

I have created [a prototype](https://github.com/eclipse/tycho/pull/586/files) to show/test this new feature. 

FYI @mickaelistria @akurtakov 

This PR allows maven-extensions to supply `WorkspaceReader` as it is possible with `AbstractMavenLifecycleParticipant` currently it is only possible with some workarounds:

1. One needs to register a `AbstractMavenLifecycleParticipant` in a maven-core-extension
2. In the `afterSessionStart` cast the `RepositorySystemSession` to `DefaultRepositorySystemSession`
3. Call `setWorkspaceReader` and take care not to replace an already exiting one

With this change it is possible to simply register  WorkspaceReader component directly and Maven takes care of all the rest.

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] SUMMARY`, where you replace `MNG-XXX`
       and `SUMMARY` with the appropriate JIRA issue. Best practice is to use the JIRA issue
       title in the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
