### PR TITLE
Example of Artifact Transform API change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ under the License.
     <cipherVersion>2.0</cipherVersion>
     <modelloVersion>1.11</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.7.2</resolverVersion>
+    <resolverVersion>1.8.0-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.32</slf4jVersion>
     <xmlunitVersion>2.6.4</xmlunitVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
Caller, here Maven, should prepare all, and hook onto close
to perform proper cleanup. The API does not allow use of
target directory, that would be even better, but this does
it as well, as tmp file really appears just before
install/deploy and dissapears immediately after.
