### PR TITLE
MNG-7438 add execution id to "configuring mojo" debug message

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -515,7 +515,7 @@ public class DefaultMavenPluginManager
 
         if ( logger.isDebugEnabled() )
         {
-            logger.debug( "Configuring mojo " + mojoDescriptor.getId() + " from plugin realm " + pluginRealm );
+            logger.debug( "Loading mojo " + mojoDescriptor.getId() + " from plugin realm " + pluginRealm );
         }
 
         // We are forcing the use of the plugin realm for all lookups that might occur during
@@ -609,7 +609,8 @@ public class DefaultMavenPluginManager
 
             ExpressionEvaluator expressionEvaluator = new PluginParameterExpressionEvaluator( session, mojoExecution );
 
-            populatePluginFields( mojo, mojoDescriptor, pluginRealm, pomConfiguration, expressionEvaluator );
+            populateMojoExecutionFields( mojo, mojoExecution.getExecutionId(), mojoDescriptor, pluginRealm,
+                                         pomConfiguration, expressionEvaluator );
 
             return mojo;
         }
@@ -620,8 +621,9 @@ public class DefaultMavenPluginManager
         }
     }
 
-    private void populatePluginFields( Object mojo, MojoDescriptor mojoDescriptor, ClassRealm pluginRealm,
-                                       PlexusConfiguration configuration, ExpressionEvaluator expressionEvaluator )
+    private void populateMojoExecutionFields( Object mojo, String executionId, MojoDescriptor mojoDescriptor,
+                                              ClassRealm pluginRealm, PlexusConfiguration configuration,
+                                              ExpressionEvaluator expressionEvaluator )
         throws PluginConfigurationException
     {
         ComponentConfigurator configurator = null;
@@ -644,8 +646,8 @@ public class DefaultMavenPluginManager
             ValidatingConfigurationListener validator =
                 new ValidatingConfigurationListener( mojo, mojoDescriptor, listener, expressionEvaluator );
 
-            logger.debug(
-                "Configuring mojo '" + mojoDescriptor.getId() + "' with " + configuratorId + " configurator -->" );
+            logger.debug( "Configuring mojo execution '" + mojoDescriptor.getId() + ':' + executionId + "' with "
+                + configuratorId + " configurator -->" );
 
             configurator.configureComponent( mojo, configuration, expressionEvaluator, pluginRealm, validator );
 


### PR DESCRIPTION
```
[DEBUG] Loading mojo org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test from plugin realm ClassRealm[plugin>org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5, parent: sun.misc.Launcher$AppClassLoader@7852e922]
[DEBUG] Configuring mojo execution 'org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test:default-test' with basic configurator -->
```