### PR TITLE
[MNG-7432] Proposed UT for maven-3.9.x and 3.8.x

### DIFF
--- a/maven-core/src/test/projects/default-maven/simple/pom.xml
+++ b/maven-core/src/test/projects/default-maven/simple/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>simple</groupId>
+  <artifactId>simple</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+</project>


### PR DESCRIPTION
This UT makes sure that DefaultMaven sets up proper type
of WorkspaceReader in RepositorySystemSession.

For example, this UT fails with current maven-3.8.x and
maven-3.9.x branches due MNG-7432
