### PR TITLE
[MNG-7447] Fix ReactorReader unintended change

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -80,7 +80,7 @@ class ReactorReader
     {
         this.session = session;
         this.projectsByGAV =
-                session.getAllProjects().stream()
+                session.getProjects().stream()
                         .collect( toMap( projectIntoKey, identity() ) );
 
         this.projectsByGA = projectsByGAV.values().stream()


### PR DESCRIPTION
The commit c604db3c3a103e2212f4628d8e2a997017fe579e
changed ReactorReader to use MavenSession#getAllProjects()
instead of deprecated MavenSession#getProjectMap() that
is equivalent of MavenSession#getProjects().

This undoes this unintended change.
