### PR TITLE
[MNG-7454] Include resolver-transport-http in Maven 3.9.x

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -63,21 +63,10 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http</artifactId>
-      <classifier>shaded</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpcore</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.maven.wagon</groupId>
-          <artifactId>wagon-http-shared</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.wagon</groupId>
+      <artifactId>wagon-file</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -86,12 +75,16 @@ under the License.
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-file</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-connector-basic</artifactId>
+      <artifactId>maven-resolver-transport-file</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -63,6 +63,20 @@ import java.util.Map;
 @Named
 public class DefaultRepositorySystemSessionFactory
 {
+    private static final String MAVEN_TRANSPORT_KEY = "maven.transport";
+
+    private static final String MAVEN_TRANSPORT_WAGON = "wagon";
+
+    private static final String MAVEN_TRANSPORT_RESOLVER = "resolver";
+
+    private static final String MAVEN_TRANSPORT_AUTO = "auto";
+
+    private static final String WAGON_TRANSPORTER_KEY_PRIORITY_KEY = "aether.priority.WagonTransporterFactory";
+
+    private static final String RESOLVER_HTTP_TRANSPORTER_PRIORITY_KEY = "aether.priority.HttpTransporterFactory";
+
+    private static final String RESOLVER_FILE_TRANSPORTER_PRIORITY_KEY = "aether.priority.FileTransporterFactory";
+
     @Inject
     private Logger logger;
 
@@ -94,6 +108,7 @@ public class DefaultRepositorySystemSessionFactory
     @Inject
     private RuntimeInformation runtimeInformation;
 
+    @SuppressWarnings( "checkstyle:methodlength" )
     public DefaultRepositorySystemSession newRepositorySession( MavenExecutionRequest request )
     {
         DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
@@ -223,6 +238,25 @@ public class DefaultRepositorySystemSessionFactory
             configProps.put( "aether.connector.perms.dirMode." + server.getId(), server.getDirectoryPermissions() );
         }
         session.setAuthenticationSelector( authSelector );
+
+        String transport = request.getUserProperties().getProperty( MAVEN_TRANSPORT_KEY, MAVEN_TRANSPORT_WAGON );
+        if ( MAVEN_TRANSPORT_RESOLVER.equals( transport ) )
+        {
+            // Is not needed, as resolver prefers native transport if both present
+            configProps.put( RESOLVER_FILE_TRANSPORTER_PRIORITY_KEY, "100" );
+            configProps.put( RESOLVER_HTTP_TRANSPORTER_PRIORITY_KEY, "100" );
+        }
+        else if ( MAVEN_TRANSPORT_WAGON.equals( transport ) )
+        {
+            // is needed, as resolver prefers native transport if both present
+            configProps.put( WAGON_TRANSPORTER_KEY_PRIORITY_KEY, "100" );
+        }
+        else if ( !MAVEN_TRANSPORT_AUTO.equals( transport ) )
+        {
+            throw new IllegalArgumentException( "Unknown maven.transport=" + transport
+                    + ". Supported ones are: " + MAVEN_TRANSPORT_WAGON + ", "
+                    + MAVEN_TRANSPORT_RESOLVER + " and " + MAVEN_TRANSPORT_AUTO );
+        }
 
         session.setTransferListener( request.getTransferListener() );
 

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -244,13 +244,13 @@ public class DefaultRepositorySystemSessionFactory
         String transport = request.getUserProperties().getProperty( MAVEN_TRANSPORT_KEY, MAVEN_TRANSPORT_WAGON );
         if ( MAVEN_TRANSPORT_RESOLVER.equals( transport ) )
         {
-            // Is not needed, as resolver prefers native transport if both present
+            // Make sure (whatever extra priority is set) that resolver native is selected
             configProps.put( RESOLVER_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY );
             configProps.put( RESOLVER_HTTP_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY );
         }
         else if ( MAVEN_TRANSPORT_WAGON.equals( transport ) )
         {
-            // is needed, as resolver prefers native transport if both present
+            // Make sure (whatever extra priority is set) that wagon is selected
             configProps.put( WAGON_TRANSPORTER_KEY_PRIORITY_KEY, RESOLVER_MAX_PRIORITY );
         }
         else if ( !MAVEN_TRANSPORT_AUTO.equals( transport ) )

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -77,6 +77,8 @@ public class DefaultRepositorySystemSessionFactory
 
     private static final String RESOLVER_FILE_TRANSPORTER_PRIORITY_KEY = "aether.priority.FileTransporterFactory";
 
+    private static final String RESOLVER_MAX_PRIORITY = String.valueOf( Float.MAX_VALUE );
+
     @Inject
     private Logger logger;
 
@@ -243,13 +245,13 @@ public class DefaultRepositorySystemSessionFactory
         if ( MAVEN_TRANSPORT_RESOLVER.equals( transport ) )
         {
             // Is not needed, as resolver prefers native transport if both present
-            configProps.put( RESOLVER_FILE_TRANSPORTER_PRIORITY_KEY, "100" );
-            configProps.put( RESOLVER_HTTP_TRANSPORTER_PRIORITY_KEY, "100" );
+            configProps.put( RESOLVER_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY );
+            configProps.put( RESOLVER_HTTP_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY );
         }
         else if ( MAVEN_TRANSPORT_WAGON.equals( transport ) )
         {
             // is needed, as resolver prefers native transport if both present
-            configProps.put( WAGON_TRANSPORTER_KEY_PRIORITY_KEY, "100" );
+            configProps.put( WAGON_TRANSPORTER_KEY_PRIORITY_KEY, RESOLVER_MAX_PRIORITY );
         }
         else if ( !MAVEN_TRANSPORT_AUTO.equals( transport ) )
         {

--- a/maven-resolver-provider/pom.xml
+++ b/maven-resolver-provider/pom.xml
@@ -104,12 +104,12 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <artifactId>maven-resolver-transport-file</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-file</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ under the License.
     <cipherVersion>2.0</cipherVersion>
     <modelloVersion>2.0.0</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.8.0-SNAPSHOT</resolverVersion>
+    <resolverVersion>1.7.3</resolverVersion>
     <slf4jVersion>1.7.32</slf4jVersion>
     <xmlunitVersion>2.2.1</xmlunitVersion>
     <powermockVersion>1.7.4</powermockVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ under the License.
     <cipherVersion>2.0</cipherVersion>
     <modelloVersion>2.0.0</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.7.2</resolverVersion>
+    <resolverVersion>1.8.0-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.32</slf4jVersion>
     <xmlunitVersion>2.2.1</xmlunitVersion>
     <powermockVersion>1.7.4</powermockVersion>
@@ -379,13 +379,6 @@ under the License.
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-http</artifactId>
         <version>${wagonVersion}</version>
-        <classifier>shaded</classifier>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <!--  Repository -->
       <dependency>
@@ -411,6 +404,16 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-connector-basic</artifactId>
+        <version>${resolverVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-file</artifactId>
+        <version>${resolverVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-http</artifactId>
         <version>${resolverVersion}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
But keep Wagon as default transport. This PR merely includes
resolver http and file transport and switches wagon-http
to non-shaded one.

Changes:
* switch to non-shaded wagon-http (as httpClient is now shared)
* include resolver http and file transport
* override resolver default behaviour (native transport preferred over wagon, when both on classpath)
* provide simplistic means to choose transport

The chosen transport can be seen in debug (-X) output on line
`[DEBUG] Using transporter XXX...`

The `-Dmaven.transport` simplistic switch can be used to choose transport:
* not set: default, that is Wagon
* `wagon`: explicitly sets Wagon
* `resolver`: explicitly sets resolver native transports (file and http)
* `auto`: relies on resolver "auto discovery" (priorities, etc). This is MUST to keep transport pluggable with 3rd party transports. In fact, this was the default so far in Maven, along with the fact that native resolver transports were not included (as resolver prefers native ones over Wagon).

Note: resolver by default, if both wagon and native transports are present on classpath,
would prefer native ones. Hence, to retain "wagon as default" this extra config
bit is a must in Maven.

