### PR TITLE
[MNG-7455] Use a single session object during the whole build

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -52,7 +52,7 @@ public class MavenSession
 
     private RepositorySystemSession repositorySession;
 
-    private Properties executionProperties;
+    private volatile Properties executionProperties;
 
     private InheritableThreadLocal<MavenProject> currentProject = new InheritableThreadLocal<>();
 
@@ -397,9 +397,15 @@ public class MavenSession
     {
         if ( executionProperties == null )
         {
-            executionProperties = new Properties();
-            executionProperties.putAll( request.getSystemProperties() );
-            executionProperties.putAll( request.getUserProperties() );
+            synchronized ( this )
+            {
+                if ( executionProperties == null )
+                {
+                    executionProperties = new Properties();
+                    executionProperties.putAll( request.getSystemProperties() );
+                    executionProperties.putAll( request.getUserProperties() );
+                }
+            }
         }
 
         return executionProperties;

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -54,7 +54,7 @@ public class MavenSession
 
     private Properties executionProperties;
 
-    private MavenProject currentProject;
+    private InheritableThreadLocal<MavenProject> currentProject = new InheritableThreadLocal<>();
 
     /**
      * These projects have already been topologically sorted in the {@link org.apache.maven.Maven} component before
@@ -83,8 +83,9 @@ public class MavenSession
     {
         if ( !projects.isEmpty() )
         {
-            this.currentProject = projects.get( 0 );
-            this.topLevelProject = currentProject;
+            MavenProject prj = projects.get( 0 );
+            this.currentProject.set( prj );
+            this.topLevelProject = prj;
             for ( MavenProject project : projects )
             {
                 if ( project.isExecutionRoot() )
@@ -96,7 +97,7 @@ public class MavenSession
         }
         else
         {
-            this.currentProject = null;
+            this.currentProject.set( null );
             this.topLevelProject = null;
         }
         this.projects = projects;
@@ -157,12 +158,12 @@ public class MavenSession
 
     public void setCurrentProject( MavenProject currentProject )
     {
-        this.currentProject = currentProject;
+        this.currentProject.set( currentProject );
     }
 
     public MavenProject getCurrentProject()
     {
-        return currentProject;
+        return currentProject.get();
     }
 
     public ProjectBuildingRequest getProjectBuildingRequest()

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildListCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildListCalculator.java
@@ -61,9 +61,7 @@ public class BuildListCalculator
                 try
                 {
                     BuilderCommon.attachToThread( project ); // Not totally sure if this is needed for anything
-                    MavenSession copiedSession = session.clone();
-                    copiedSession.setCurrentProject( project );
-                    projectBuilds.add( new ProjectSegment( project, taskSegment, copiedSession ) );
+                    projectBuilds.add( new ProjectSegment( project, taskSegment, session ) );
                 }
                 finally
                 {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
@@ -88,13 +88,10 @@ public class LifecycleModuleBuilder
 
         long buildStartTime = System.currentTimeMillis();
 
-        // session may be different from rootSession seeded in DefaultMaven
-        // explicitly seed the right session here to make sure it is used by Guice
-        final boolean scoped = session != rootSession;
-        if ( scoped )
+        if ( session != rootSession )
         {
-            sessionScope.enter();
-            sessionScope.seed( MavenSession.class, session );
+            // a single session is reused during the whole build
+            throw new UnsupportedOperationException();
         }
         try
         {
@@ -149,11 +146,6 @@ public class LifecycleModuleBuilder
         }
         finally
         {
-            if ( scoped )
-            {
-                sessionScope.exit();
-            }
-
             session.setCurrentProject( null );
 
             Thread.currentThread().setContextClassLoader( reactorContext.getOriginalContextClassLoader() );


### PR DESCRIPTION
Attempt to fix https://issues.apache.org/jira/browse/MNG-7455 without reverting https://issues.apache.org/jira/browse/MNG-7347 (SessionScoped beans should be singletons for a given session).
https://github.com/apache/maven/pull/714 is the same targeted at `maven-3.9.x` branch.
This is also similar to https://github.com/apache/maven/pull/666 (fix http://issues.apache.org/jira/browse/MNG-7401).

If we want to fix the original problem which is that components annotated with `@SessionScoped` should be shared in a given session, we need to get rid of the thread local in the `SessionScope`, which has been done in #621.  There will be no concurrency issue as the enter/exit methods will only be called once for the session.

But we have 2 conflicting facts: `@SessionScoped` beans should be shared during  the execution of the reactor, and we have cloned sessions.  I think cloned sessions was just a way to fix some problems with the MT build, so i’d rather get rid of that one.  Also I think projects embedding maven such as the eclipse stuff and mvnd do reuse the container for multiple sessions and will leverage the `@SessionScoped` more that what we have now if that’s possible.

Because the session scope provides a clear boundary between stateless objects (or at least those that can be reused across builds) and those that needs to be discarded.  Caches, depending on what they cache, may belong to one or the other category.
