### PR TITLE
[MNG-7455] Use a single session object during the whole build

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -52,7 +52,7 @@ public class MavenSession
 
     private RepositorySystemSession repositorySession;
 
-    private Properties executionProperties;
+    private final Properties executionProperties;
 
     private InheritableThreadLocal<MavenProject> currentProject = new InheritableThreadLocal<>();
 
@@ -306,6 +306,9 @@ public class MavenSession
         this.result = result;
         this.settings = new SettingsAdapter( request );
         this.repositorySession = repositorySession;
+        this.executionProperties = new Properties();
+        this.executionProperties.putAll( request.getSystemProperties() );
+        this.executionProperties.putAll( request.getUserProperties() );
     }
     
     @Deprecated
@@ -351,6 +354,9 @@ public class MavenSession
         this.request = request;
         this.result = result;
         this.settings = new SettingsAdapter( request );
+        this.executionProperties = new Properties();
+        this.executionProperties.putAll( request.getSystemProperties() );
+        this.executionProperties.putAll( request.getUserProperties() );
         setProjects( projects );
     }
 
@@ -388,13 +394,6 @@ public class MavenSession
     @Deprecated
     public Properties getExecutionProperties()
     {
-        if ( executionProperties == null )
-        {
-            executionProperties = new Properties();
-            executionProperties.putAll( request.getSystemProperties() );
-            executionProperties.putAll( request.getUserProperties() );
-        }
-
         return executionProperties;
     }
     

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -54,7 +54,7 @@ public class MavenSession
 
     private Properties executionProperties;
 
-    private MavenProject currentProject;
+    private InheritableThreadLocal<MavenProject> currentProject = new InheritableThreadLocal<>();
 
     /**
      * These projects have already been topologically sorted in the {@link org.apache.maven.Maven} component before
@@ -83,14 +83,14 @@ public class MavenSession
     {
         if ( !projects.isEmpty() )
         {
-            this.currentProject = projects.get( 0 );
-            this.topLevelProject =
-                    projects.stream().filter( project -> project.isExecutionRoot() ).findFirst()
-                            .orElse( currentProject );
+            MavenProject prj = projects.get( 0 );
+            this.currentProject.set( prj );
+            this.topLevelProject = projects.stream().filter( project -> project.isExecutionRoot() ).findFirst()
+                            .orElse( prj );
         }
         else
         {
-            this.currentProject = null;
+            this.currentProject.set( null );
             this.topLevelProject = null;
         }
         this.projects = projects;
@@ -151,12 +151,12 @@ public class MavenSession
 
     public void setCurrentProject( MavenProject currentProject )
     {
-        this.currentProject = currentProject;
+        this.currentProject.set( currentProject );
     }
 
     public MavenProject getCurrentProject()
     {
-        return currentProject;
+        return currentProject.get();
     }
 
     public ProjectBuildingRequest getProjectBuildingRequest()

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildListCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildListCalculator.java
@@ -61,9 +61,7 @@ public class BuildListCalculator
                 try
                 {
                     BuilderCommon.attachToThread( project ); // Not totally sure if this is needed for anything
-                    MavenSession copiedSession = session.clone();
-                    copiedSession.setCurrentProject( project );
-                    projectBuilds.add( new ProjectSegment( project, taskSegment, copiedSession ) );
+                    projectBuilds.add( new ProjectSegment( project, taskSegment, session ) );
                 }
                 finally
                 {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
@@ -88,13 +88,10 @@ public class LifecycleModuleBuilder
 
         long buildStartTime = System.currentTimeMillis();
 
-        // session may be different from rootSession seeded in DefaultMaven
-        // explicitly seed the right session here to make sure it is used by Guice
-        final boolean scoped = session != rootSession;
-        if ( scoped )
+        if ( session != rootSession )
         {
-            sessionScope.enter();
-            sessionScope.seed( MavenSession.class, session );
+            // a single session is reused during the whole build
+            throw new UnsupportedOperationException();
         }
         try
         {
@@ -149,11 +146,6 @@ public class LifecycleModuleBuilder
         }
         finally
         {
-            if ( scoped )
-            {
-                sessionScope.exit();
-            }
-
             session.setCurrentProject( null );
 
             Thread.currentThread().setContextClassLoader( reactorContext.getOriginalContextClassLoader() );


### PR DESCRIPTION
Attempt to fix https://issues.apache.org/jira/browse/MNG-7455 without reverting https://issues.apache.org/jira/browse/MNG-7347.