### PR TITLE
[MNG-7455] Another attempt to fix the concurrency issue

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/SessionScoped.java
+++ b/maven-core/src/main/java/org/apache/maven/SessionScoped.java
@@ -31,6 +31,11 @@ import com.google.inject.ScopeAnnotation;
  * Indicates that annotated component should be instantiated before session execution starts
  * and discarded after session execution completes.
  *
+ * Note that components will be cached in the session scope and be injected with the root session.
+ * Derived sessions will reuse the same components than their root sessions, thus components
+ * should not rely on {@link org.apache.maven.execution.MavenSession#getCurrentProject()} which
+ * will always return the root project.
+ *
  * @author Jason van Zyl
  * @since 3.2.0
  */

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
@@ -88,14 +88,6 @@ public class LifecycleModuleBuilder
 
         long buildStartTime = System.currentTimeMillis();
 
-        // session may be different from rootSession seeded in DefaultMaven
-        // explicitly seed the right session here to make sure it is used by Guice
-        final boolean scoped = session != rootSession;
-        if ( scoped )
-        {
-            sessionScope.enter();
-            sessionScope.seed( MavenSession.class, session );
-        }
         try
         {
 
@@ -149,11 +141,6 @@ public class LifecycleModuleBuilder
         }
         finally
         {
-            if ( scoped )
-            {
-                sessionScope.exit();
-            }
-
             session.setCurrentProject( null );
 
             Thread.currentThread().setContextClassLoader( reactorContext.getOriginalContextClassLoader() );


### PR DESCRIPTION
This is another attempt to fix the concurrency issue with minimal changes and without introducing back a thread local storage.
The downside of this proposal is that components annotated with `@SessionScoped` will always be injected the root session, which imho, is not really a problem as all derived sessions are cloned from the root one, except for the value of the `MavenSession#getCurrentProject()` which changes from one session to another.

The current scope is flawed anyway, as components are clearly not cached for all derived sessions, which was the original point of MNG-7347.