### PR TITLE
[MNG-7453] Upgrade Maven Resolver to 1.8.0 in maven-4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,19 @@ under the License.
   <url>https://maven.apache.org/ref/${project.version}/</url>
   <inceptionYear>2001</inceptionYear>
 
+  <repositories>
+    <repository>
+      <id>repository.apache.org</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -65,7 +78,7 @@ under the License.
     <cipherVersion>2.0</cipherVersion>
     <modelloVersion>2.0.0</modelloVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.7.3</resolverVersion>
+    <resolverVersion>1.8.0-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.32</slf4jVersion>
     <xmlunitVersion>2.6.4</xmlunitVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
Note: current repository change in POM is ONLY to
make CI run ITs. This PR is placeholder until
maven-resolver 1.8.0 is released, but until then
let's see ITs at least.

---

https://issues.apache.org/jira/browse/MNG-7453