### PR TITLE
[MNG-7466] Align assembly XSD version with plugin used

### DIFF
--- a/apache-maven/src/assembly/bin.xml
+++ b/apache-maven/src/assembly/bin.xml
@@ -18,7 +18,7 @@ under the License.
 -->
 
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>bin</id>
   <formats>
     <format>zip</format>

--- a/apache-maven/src/assembly/bin.xml
+++ b/apache-maven/src/assembly/bin.xml
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>bin</id>
   <formats>
     <format>zip</format>

--- a/apache-maven/src/assembly/dir.xml
+++ b/apache-maven/src/assembly/dir.xml
@@ -18,7 +18,7 @@ under the License.
 -->
 
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>dir</id>
   <formats>
     <format>dir</format>

--- a/apache-maven/src/assembly/dir.xml
+++ b/apache-maven/src/assembly/dir.xml
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>dir</id>
   <formats>
     <format>dir</format>

--- a/apache-maven/src/assembly/src.xml
+++ b/apache-maven/src/assembly/src.xml
@@ -18,7 +18,7 @@ under the License.
 -->
 
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>src</id>
   <formats>
     <format>zip</format>

--- a/apache-maven/src/assembly/src.xml
+++ b/apache-maven/src/assembly/src.xml
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>src</id>
   <formats>
     <format>zip</format>


### PR DESCRIPTION
As title says, XSD is ancient old 2.0.0, while all
latest assembly plugins uses 2.1.0.

Not that this matters or changes anything at all,
this is more about correctness.

---

https://issues.apache.org/jira/browse/MNG-7466