### PR TITLE
[MNG-7433] Warn if in parallel build aggregator Mojo found

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -229,13 +229,18 @@ public class MojoExecutor
             }
         }
 
-        if ( session.isParallel() && mojoDescriptor.isAggregator() )
-        {
-            LOGGER.warn( "Now what?" );
-        }
-
         try ( ProjectLock lock = new ProjectLock( session, mojoDescriptor, aggregatorLock ) )
         {
+            if ( session.isParallel() && mojoDescriptor.isAggregator() )
+            {
+                LOGGER.warn( "===" );
+                LOGGER.warn( "Executing aggregator Mojo in parallel build:" );
+                LOGGER.warn( "Aggregator Mojo requires exclusive access to reactor, " );
+                LOGGER.warn( "to prevent race conditions, an aggregating execution will block" );
+                LOGGER.warn( "all other executions until finished." );
+                LOGGER.warn( "===" );
+            }
+
             doExecute( session, mojoExecution, projectIndex, dependencyContext );
         }
     }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -59,6 +59,8 @@ import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.SessionData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -75,10 +77,14 @@ import org.eclipse.aether.SessionData;
 @Singleton
 public class MojoExecutor
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger( MojoExecutor.class );
 
     private final BuildPluginManager pluginManager;
+
     private final MavenPluginManager mavenPluginManager;
+
     private final LifecycleDependencyResolver lifeCycleDependencyResolver;
+
     private final ExecutionEventCatapult eventCatapult;
 
     private final ReadWriteLock aggregatorLock = new ReentrantReadWriteLock();
@@ -221,6 +227,11 @@ public class MojoExecutor
 
                 return;
             }
+        }
+
+        if ( session.isParallel() && mojoDescriptor.isAggregator() )
+        {
+            LOGGER.warn( "Now what?" );
         }
 
         try ( ProjectLock lock = new ProjectLock( session, mojoDescriptor, aggregatorLock ) )


### PR DESCRIPTION
As aggregator Mojos, as they have access to whole reactor,
are requiring unique access, hence, they block the parallel
build, while themselves are executing.
