### PR TITLE
Trasnport: use config properties instead user properties.

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -261,8 +261,7 @@ public class DefaultRepositorySystemSessionFactory
         }
         session.setAuthenticationSelector( authSelector );
 
-        String transport = request.getUserProperties()
-                .getProperty( MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_WAGON );
+        Object transport = configProps.getOrDefault( MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_WAGON );
         if ( MAVEN_RESOLVER_TRANSPORT_NATIVE.equals( transport ) )
         {
             // Make sure (whatever extra priority is set) that resolver native is selected


### PR DESCRIPTION
This setting should be possible to be set via MAVEN_OPTS (system wide) or in .mvn/maven.config etc, Currently it is possible only via `-Dxxx` AFTER mvn....