### PR TITLE
[3.9.x] [MNG-7477] Adapt the maven output to the width of the terminal

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/MessageHelper.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/MessageHelper.java
@@ -1,0 +1,91 @@
+package org.apache.maven.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class to format warning messages to the console
+ */
+public class MessageHelper
+{
+
+    private static final int DEFAULT_MAX_SIZE = 65;
+    private static final char BOX_CHAR = '*';
+
+    public static String separatorLine()
+    {
+        StringBuilder sb = new StringBuilder( DEFAULT_MAX_SIZE );
+        repeat( sb, '*', DEFAULT_MAX_SIZE );
+        return sb.toString();
+    }
+
+    public static List<String> formatWarning( String... lines )
+    {
+        int size = DEFAULT_MAX_SIZE;
+        int rem = size - 4;
+        List<String> result = new ArrayList<>();
+        StringBuilder sb = new StringBuilder( size );
+        // first line
+        sb.setLength( 0 );
+        repeat( sb, BOX_CHAR, size );
+        result.add( sb.toString() );
+        // lines
+        for ( String line : lines )
+        {
+            sb.setLength( 0 );
+            String[] words = line.split( " " );
+            for ( String word : words )
+            {
+                if ( sb.length() >= rem - word.length() - ( sb.length() > 0 ? 1 : 0 ) )
+                {
+                    repeat( sb, ' ', rem - sb.length() );
+                    result.add( BOX_CHAR + " " + sb + " " + BOX_CHAR );
+                    sb.setLength( 0 );
+                }
+                if ( sb.length() > 0 )
+                {
+                    sb.append( ' ' );
+                }
+                sb.append( word );
+            }
+
+            while ( sb.length() < rem )
+            {
+                sb.append( ' ' );
+            }
+            result.add( BOX_CHAR + " " + sb + " " + BOX_CHAR );
+        }
+        // last line
+        sb.setLength( 0 );
+        repeat( sb, BOX_CHAR, size );
+        result.add( sb.toString() );
+        return result;
+    }
+
+    private static void repeat( StringBuilder sb, char c, int nb )
+    {
+        for ( int i = 0; i < nb; i++ )
+        {
+            sb.append( c );
+        }
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/internal/MessageHelper.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/MessageHelper.java
@@ -28,19 +28,58 @@ import java.util.List;
 public class MessageHelper
 {
 
-    private static final int DEFAULT_MAX_SIZE = 65;
+    public static final int DEFAULT_TERMINAL_WIDTH = 80;
+
+    public static final int DEFAULT_MAX_SIZE = 65;
+
+    public static final String LINE_LENGTH_PROPERTY = "maven.console.lineLength";
+
     private static final char BOX_CHAR = '*';
+
+    public static int getConsoleLineLength()
+    {
+        try
+        {
+            int length;
+            String prop = System.getProperty( LINE_LENGTH_PROPERTY );
+            if ( prop != null )
+            {
+                length = Integer.parseInt( prop );
+            }
+            else
+            {
+                Class<?> ansiConsoleClass = Class.forName( "org.fusesource.jansi.AnsiConsole" );
+                Object out = ansiConsoleClass.getMethod( "out" ).invoke( null );
+                length = (Integer) out.getClass().getMethod( "getTerminalWidth" ).invoke( out );
+            }
+            return Math.max( length, DEFAULT_TERMINAL_WIDTH );
+        }
+        catch ( Throwable t )
+        {
+            // ignore exceptions
+            return DEFAULT_TERMINAL_WIDTH;
+        }
+    }
 
     public static String separatorLine()
     {
-        StringBuilder sb = new StringBuilder( DEFAULT_MAX_SIZE );
-        repeat( sb, '*', DEFAULT_MAX_SIZE );
+        return separatorLine( DEFAULT_MAX_SIZE );
+    }
+
+    public static String separatorLine( int length )
+    {
+        StringBuilder sb = new StringBuilder( length );
+        repeat( sb, '*', length );
         return sb.toString();
     }
 
-    public static List<String> formatWarning( String... lines )
+    public static List<String> messageBox( String... lines )
     {
-        int size = DEFAULT_MAX_SIZE;
+        return messageBox( DEFAULT_MAX_SIZE, lines );
+    }
+
+    public static List<String> messageBox( int size, String... lines )
+    {
         int rem = size - 4;
         List<String> result = new ArrayList<>();
         StringBuilder sb = new StringBuilder( size );

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -261,7 +261,9 @@ public class MojoExecutor
                 acquiredProjectLock = getProjectLock( session );
                 if ( !acquiredAggregatorLock.tryLock() )
                 {
-                    for ( String s : MessageHelper.formatWarning(
+                    int size = Math.max( MessageHelper.getConsoleLineLength() - "[WARNING] ".length() - 1,
+                                         MessageHelper.DEFAULT_MAX_SIZE );
+                    for ( String s : MessageHelper.messageBox( size,
                             "An aggregator Mojo is already executing in parallel build, but aggregator "
                                     + "Mojos require exclusive access to reactor to prevent race conditions. This "
                                     + "mojo execution will be blocked until the aggregator work is done." ) )

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/BuilderCommon.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/BuilderCommon.java
@@ -104,7 +104,9 @@ public class BuilderCommon
             final Set<Plugin> unsafePlugins = executionPlan.getNonThreadSafePlugins();
             if ( !unsafePlugins.isEmpty() )
             {
-                for ( String s : MessageHelper.formatWarning(
+                int size = Math.max( MessageHelper.getConsoleLineLength() - "[WARNING] ".length() - 1,
+                                     MessageHelper.DEFAULT_MAX_SIZE );
+                for ( String s : MessageHelper.messageBox( size,
                         "Your build is requesting parallel execution, but project contains the following "
                                 + "plugin(s) that have goals not marked as @threadSafe to support parallel building.",
                         "While this /may/ work fine, please look for plugin updates and/or "
@@ -119,7 +121,7 @@ public class BuilderCommon
                     logger.warn( "The following goals are not marked @threadSafe in " + project.getName() + ":" );
                     for ( MojoDescriptor unsafeGoal : unsafeGoals )
                     {
-                        logger.warn( unsafeGoal.getId() );
+                        logger.warn( "  - " + unsafeGoal.getId() );
                     }
                 }
                 else
@@ -127,11 +129,11 @@ public class BuilderCommon
                     logger.warn( "The following plugins are not marked @threadSafe in " + project.getName() + ":" );
                     for ( Plugin unsafePlugin : unsafePlugins )
                     {
-                        logger.warn( unsafePlugin.getId() );
+                        logger.warn( "  - " + unsafePlugin.getId() );
                     }
                     logger.warn( "Enable debug to see more precisely which goals are not marked @threadSafe." );
                 }
-                logger.warn( MessageHelper.separatorLine() );
+                logger.warn( MessageHelper.separatorLine( size ) );
             }
         }
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/BuilderCommon.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/BuilderCommon.java
@@ -24,6 +24,7 @@ import org.apache.maven.execution.BuildFailure;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.internal.MessageHelper;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.lifecycle.LifecycleNotFoundException;
 import org.apache.maven.lifecycle.LifecyclePhaseNotFoundException;
@@ -103,15 +104,15 @@ public class BuilderCommon
             final Set<Plugin> unsafePlugins = executionPlan.getNonThreadSafePlugins();
             if ( !unsafePlugins.isEmpty() )
             {
-                logger.warn( "*****************************************************************" );
-                logger.warn( "* Your build is requesting parallel execution, but project      *" );
-                logger.warn( "* contains the following plugin(s) that have goals not marked   *" );
-                logger.warn( "* as @threadSafe to support parallel building.                  *" );
-                logger.warn( "* While this /may/ work fine, please look for plugin updates    *" );
-                logger.warn( "* and/or request plugins be made thread-safe.                   *" );
-                logger.warn( "* If reporting an issue, report it against the plugin in        *" );
-                logger.warn( "* question, not against maven-core                              *" );
-                logger.warn( "*****************************************************************" );
+                for ( String s : MessageHelper.formatWarning(
+                        "Your build is requesting parallel execution, but project contains the following "
+                                + "plugin(s) that have goals not marked as @threadSafe to support parallel building.",
+                        "While this /may/ work fine, please look for plugin updates and/or "
+                                + "request plugins be made thread-safe.",
+                        "If reporting an issue, report it against the plugin in question, not against maven-core." ) )
+                {
+                    logger.warn( s );
+                }
                 if ( logger.isDebugEnabled() )
                 {
                     final Set<MojoDescriptor> unsafeGoals = executionPlan.getNonThreadSafeMojos();
@@ -130,7 +131,7 @@ public class BuilderCommon
                     }
                     logger.warn( "Enable debug to see more precisely which goals are not marked @threadSafe." );
                 }
-                logger.warn( "*****************************************************************" );
+                logger.warn( MessageHelper.separatorLine() );
             }
         }
 

--- a/maven-core/src/test/java/org/apache/maven/internal/MessageHelperTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/MessageHelperTest.java
@@ -43,7 +43,7 @@ public class MessageHelperTest
         msgs.add( "* question, not against maven-core                              *" );
         msgs.add( "*****************************************************************" );
 
-        assertEquals( msgs, MessageHelper.formatWarning(
+        assertEquals( msgs, MessageHelper.messageBox(
                 "Your build is requesting parallel execution, but project contains the following "
                         + "plugin(s) that have goals not marked as @threadSafe to support parallel building.",
                 "While this /may/ work fine, please look for plugin updates and/or "
@@ -63,7 +63,7 @@ public class MessageHelperTest
         msgs.add( "* until the aggregator work is done.                            *" );
         msgs.add( "*****************************************************************" );
 
-        assertEquals( msgs, MessageHelper.formatWarning(
+        assertEquals( msgs, MessageHelper.messageBox(
                 "An aggregator Mojo is already executing in parallel build, but aggregator "
                         + "Mojos require exclusive access to reactor to prevent race conditions. This "
                         + "mojo execution will be blocked until the aggregator work is done." ) );

--- a/maven-core/src/test/java/org/apache/maven/internal/MessageHelperTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/MessageHelperTest.java
@@ -1,0 +1,71 @@
+package org.apache.maven.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessageHelperTest
+{
+
+    @Test
+    public void testBuilderCommon()
+    {
+        List<String> msgs = new ArrayList<>();
+        msgs.add( "*****************************************************************" );
+        msgs.add( "* Your build is requesting parallel execution, but project      *" );
+        msgs.add( "* contains the following plugin(s) that have goals not marked   *" );
+        msgs.add( "* as @threadSafe to support parallel building.                  *" );
+        msgs.add( "* While this /may/ work fine, please look for plugin updates    *" );
+        msgs.add( "* and/or request plugins be made thread-safe.                   *" );
+        msgs.add( "* If reporting an issue, report it against the plugin in        *" );
+        msgs.add( "* question, not against maven-core                              *" );
+        msgs.add( "*****************************************************************" );
+
+        assertEquals( msgs, MessageHelper.formatWarning(
+                "Your build is requesting parallel execution, but project contains the following "
+                        + "plugin(s) that have goals not marked as @threadSafe to support parallel building.",
+                "While this /may/ work fine, please look for plugin updates and/or "
+                        + "request plugins be made thread-safe.",
+                "If reporting an issue, report it against the plugin in question, not against maven-core"
+        ) );
+    }
+
+    @Test
+    public void testMojoExecutor()
+    {
+        List<String> msgs = new ArrayList<>();
+        msgs.add( "*****************************************************************" );
+        msgs.add( "* An aggregator Mojo is already executing in parallel build,    *" );
+        msgs.add( "* but aggregator Mojos require exclusive access to reactor to   *" );
+        msgs.add( "* prevent race conditions. This mojo execution will be blocked  *" );
+        msgs.add( "* until the aggregator work is done.                            *" );
+        msgs.add( "*****************************************************************" );
+
+        assertEquals( msgs, MessageHelper.formatWarning(
+                "An aggregator Mojo is already executing in parallel build, but aggregator "
+                        + "Mojos require exclusive access to reactor to prevent race conditions. This "
+                        + "mojo execution will be blocked until the aggregator work is done." ) );
+    }
+}

--- a/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
@@ -183,7 +183,7 @@ public class ExecutionEventLogger
 
         List<MavenProject> projects = session.getProjects();
 
-        final int lineLength = MessageHelper.getConsoleLineLength();
+        final int lineLength = MessageHelper.getConsoleLineLength() - 8;
         int maxProjectNameLength = lineLength - ( LINE_LENGTH - MAX_PROJECT_NAME_LENGTH );
         for ( MavenProject project : projects )
         {
@@ -306,7 +306,7 @@ public class ExecutionEventLogger
             final String postHeader = " >--";
 
             final int headerLen = preHeader.length() + projectKey.length() + postHeader.length();
-            final int lineLength = MessageHelper.getConsoleLineLength();
+            final int lineLength = MessageHelper.getConsoleLineLength() - 8;
 
             String prefix = chars( '-', Math.max( 0, ( lineLength - headerLen ) / 2 ) ) + preHeader;
 

--- a/maven-embedder/src/test/java/org/apache/maven/cli/event/ExecutionEventLoggerTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/event/ExecutionEventLoggerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.internal.MessageHelper;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.junit.AfterClass;
@@ -40,12 +41,14 @@ public class ExecutionEventLoggerTest
     public static void setUp() 
     {
         MessageUtils.setColorEnabled( false );
+        System.setProperty( MessageHelper.LINE_LENGTH_PROPERTY, "80" );
     }
 
     @AfterClass
     public static void tearDown()
     {
         MessageUtils.setColorEnabled( true );
+        System.clearProperty( MessageHelper.LINE_LENGTH_PROPERTY );
     }
 
     @Test


### PR DESCRIPTION
PR for testing.
A few things:
  * I had to redefine the `getTerminalWidth()` method to take into account the fact that the output can be redirected, in which case the previous `getTerminalWidth()` returns the width of the console using the err stream.
  *  the exact behavior when the output is redirected needs to be chosen: the behavior could depend if the output is actually padded or not, or the output could be padded only in the case the output is actually displayed on the console.  The behavior with this PR is to consider a default width of 80, thereby using the previous behavior
  *  the terminal width can be overridden by using the `maven.console.lineLength` system property