### PR TITLE
[MNG-7475] Restore binary compat for FileProfileActivator

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileProfileActivator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileProfileActivator.java
@@ -138,7 +138,7 @@ public class FileProfileActivator
                     {
                         /*
                          * NOTE: We intentionally only support ${basedir} and not ${project.basedir} as the latter form
-                         * would suggest that other project.* expressions can be used which is however beyond the design.
+                         * would suggest that other project.* expressions can be used which is however beyond the design
                          */
                         if ( "basedir".equals( expression ) )
                         {


### PR DESCRIPTION
When manually constructed in legacy code.

This COMPONENT should be injected instead, or if no container,
then created by subclassing DefaultModelBuilderFactory helper
class meant for exactly these cases.
