### PR TITLE
[MNG-7478] Transport selection should use config properties

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -80,6 +80,8 @@ public class DefaultRepositorySystemSessionFactory
 {
     private static final String MAVEN_RESOLVER_TRANSPORT_KEY = "maven.resolver.transport";
 
+    private static final String MAVEN_RESOLVER_TRANSPORT_DEFAULT = "default";
+
     private static final String MAVEN_RESOLVER_TRANSPORT_WAGON = "wagon";
 
     private static final String MAVEN_RESOLVER_TRANSPORT_NATIVE = "native";
@@ -261,9 +263,28 @@ public class DefaultRepositorySystemSessionFactory
         }
         session.setAuthenticationSelector( authSelector );
 
-        String transport = request.getUserProperties()
-                .getProperty( MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_WAGON );
-        if ( MAVEN_RESOLVER_TRANSPORT_NATIVE.equals( transport ) )
+        Object transport = configProps.getOrDefault( MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_DEFAULT );
+        if ( MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals( transport ) )
+        {
+            // The "default" mode (user did not set anything) needs to tweak resolver default priorities
+            // that are coded like this:
+            //
+            // org.eclipse.aether.transport.http.HttpTransporterFactory.priority = 5.0f;
+            // org.eclipse.aether.transport.wagon.WagonTransporterFactory.priority = -1.0f;
+            //
+            // Hence, as both are present on classpath, HttpTransport would be selected, while
+            // we want to retain "default" behaviour of Maven and use Wagon. To achieve that,
+            // we set explicitly priority of WagonTransport to 6.0f (just above of HttpTransport),
+            // to make it "win" over HttpTransport. We do this to NOT interfere with possibly
+            // installed OTHER transports and their priorities, as unlike "wagon" or "native"
+            // transport setting, that sets priorities to MAX, hence prevents any 3rd party
+            // transport to get into play (inhibits them), in default mode we want to retain
+            // old behavior. Also, this "default" mode is different from "auto" setting,
+            // as it does not alter resolver priorities at all, and uses priorities as is.
+
+            configProps.put( WAGON_TRANSPORTER_PRIORITY_KEY, "6" );
+        }
+        else if ( MAVEN_RESOLVER_TRANSPORT_NATIVE.equals( transport ) )
         {
             // Make sure (whatever extra priority is set) that resolver native is selected
             configProps.put( NATIVE_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY );

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -267,7 +267,7 @@ public class DefaultRepositorySystemSessionFactory
         if ( MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals( transport ) )
         {
             // The "default" mode (user did not set anything) needs to tweak resolver default priorities
-            // that are coded like this:
+            // that are coded like this (default values):
             //
             // org.eclipse.aether.transport.http.HttpTransporterFactory.priority = 5.0f;
             // org.eclipse.aether.transport.wagon.WagonTransporterFactory.priority = -1.0f;


### PR DESCRIPTION
Instead of user properties, as this allows making "permanent" the
selection by using MAVEN_OPTS and other places as well. Currently
only via command line works.

Also, do not modify existing Maven behavior, so introduce "default" branch
in selection. See comment in code.

---

https://issues.apache.org/jira/browse/MNG-7478
