### PR TITLE
[MNG-7468] Check unsupported plugins parameters in configuration

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
@@ -20,6 +20,9 @@ package org.apache.maven.lifecycle.internal;
  */
 
 import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -28,9 +31,17 @@ import org.apache.maven.lifecycle.MojoExecutionConfigurator;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.utils.logging.MessageBuilder;
+import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Arrays.stream;
 
 /**
  * @since 3.3.1, MNG-5753
@@ -40,6 +51,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 public class DefaultMojoExecutionConfigurator
     implements MojoExecutionConfigurator
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Override
     public void configure( MavenProject project, MojoExecution mojoExecution, boolean allowPluginLevelConfig )
@@ -76,6 +88,8 @@ public class DefaultMojoExecutionConfigurator
             mojoConfiguration = Xpp3Dom.mergeXpp3Dom( mojoExecution.getConfiguration(), mojoConfiguration );
 
             mojoExecution.setConfiguration( mojoConfiguration );
+
+            checkUnknownMojoConfigurationParameters( mojoExecution );
         }
     }
 
@@ -106,6 +120,79 @@ public class DefaultMojoExecutionConfigurator
         }
 
         return null;
+    }
+
+    private void checkUnknownMojoConfigurationParameters( MojoExecution mojoExecution )
+    {
+        if ( mojoExecution.getConfiguration() == null || mojoExecution.getConfiguration().getChildCount() == 0 )
+        {
+            return;
+        }
+
+        MojoDescriptor mojoDescriptor = mojoExecution.getMojoDescriptor();
+
+        // in first step get parameter names of current goal
+        Set<String> parametersNamesGoal = mojoDescriptor.getParameters().stream()
+            .flatMap( this::getParameterNames )
+            .collect( Collectors.toSet() );
+
+        Set<String> unknownParameters = getUnknownParameters( mojoExecution, parametersNamesGoal );
+
+        if ( unknownParameters.isEmpty() )
+        {
+            return;
+        }
+
+        // second step get parameter names of all plugin goals
+        Set<String> parametersNamesAll = mojoDescriptor.getPluginDescriptor().getMojos().stream()
+            .flatMap( m -> m.getParameters().stream() )
+            .flatMap( this::getParameterNames )
+            .collect( Collectors.toSet() );
+
+        unknownParameters = getUnknownParameters( mojoExecution, parametersNamesAll );
+
+        unknownParameters.forEach(
+            name ->
+            {
+                MessageBuilder messageBuilder = MessageUtils.buffer()
+                    .warning( "Parameter '" )
+                    .warning( name )
+                    .warning( "' is unknown for plugin '" )
+                    .warning( mojoExecution.getArtifactId() ).warning( ":" )
+                    .warning( mojoExecution.getVersion() ).warning( ":" )
+                    .warning( mojoExecution.getGoal() );
+
+                if ( mojoExecution.getExecutionId() != null )
+                {
+                    messageBuilder.warning( " (" );
+                    messageBuilder.warning( mojoExecution.getExecutionId() );
+                    messageBuilder.warning( ")" );
+                }
+
+                messageBuilder.warning( "'" );
+
+                logger.warn( messageBuilder.toString() );
+            } );
+    }
+
+    private Stream<String> getParameterNames( Parameter parameter )
+    {
+        if ( parameter.getAlias() != null )
+        {
+            return Stream.of( parameter.getName(), parameter.getAlias() );
+        }
+        else
+        {
+            return Stream.of( parameter.getName() );
+        }
+    }
+
+    private Set<String> getUnknownParameters( MojoExecution mojoExecution, Set<String> parameters )
+    {
+        return stream( mojoExecution.getConfiguration().getChildren() )
+            .map( Xpp3Dom::getName )
+            .filter( name -> !parameters.contains( name ) )
+            .collect( Collectors.toSet() );
     }
 
 }


### PR DESCRIPTION

After `MojoExecution` was created and configured all configuration will only contains parameters listed in plugin.xml
  
---

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] SUMMARY`, where you replace `MNG-XXX`
       and `SUMMARY` with the appropriate JIRA issue. Best practice is to use the JIRA issue
       title in the pull request title and in the first line of the commit message.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
