### PR TITLE
[MNG-7360] Fix xml transformation to ensure proper context

### DIFF
--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/BuildToRawPomXMLFilterFactory.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/BuildToRawPomXMLFilterFactory.java
@@ -53,7 +53,9 @@ public class BuildToRawPomXMLFilterFactory
     public final XmlPullParser get( XmlPullParser orgParser, Path projectFile )
 
     {
-        XmlPullParser parser = orgParser;
+        // Ensure that xs:any elements aren't touched by next filters
+        XmlPullParser parser = orgParser instanceof FastForwardFilter
+                ? orgParser : new FastForwardFilter( orgParser );
 
         if ( getDependencyKeyToVersionMapper() != null )
         {

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/FastForwardFilter.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/FastForwardFilter.java
@@ -63,17 +63,7 @@ class FastForwardFilter extends BufferingParser
     public int next() throws XmlPullParserException, IOException
     {
         int event = super.next();
-        if ( bypass && event == END_TAG )
-        {
-            if ( domDepth > 0 )
-            {
-                if ( --domDepth == 0 )
-                {
-                    bypass( false );
-                }
-            }
-            state.removeLast();
-        }
+        filter();
         return event;
     }
 
@@ -81,22 +71,11 @@ class FastForwardFilter extends BufferingParser
     public int nextToken() throws XmlPullParserException, IOException
     {
         int event = super.nextToken();
-        if ( bypass && event == END_TAG )
-        {
-            if ( domDepth > 0 )
-            {
-                if ( --domDepth == 0 )
-                {
-                    bypass( false );
-                }
-            }
-            state.removeLast();
-        }
+        filter();
         return event;
     }
 
-    @Override
-    protected boolean accept() throws XmlPullParserException, IOException
+    protected void filter() throws XmlPullParserException, IOException
     {
         if ( xmlPullParser.getEventType() == START_TAG )
         {
@@ -128,7 +107,17 @@ class FastForwardFilter extends BufferingParser
             }
             state.add( localName );
         }
-        return true;
+        else if ( xmlPullParser.getEventType() == END_TAG )
+        {
+            if ( domDepth > 0 )
+            {
+                if ( --domDepth == 0 )
+                {
+                    bypass( false );
+                }
+            }
+            state.removeLast();
+        }
     }
 
     @Override

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/FastForwardFilter.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/FastForwardFilter.java
@@ -60,6 +60,42 @@ class FastForwardFilter extends BufferingParser
     }
 
     @Override
+    public int next() throws XmlPullParserException, IOException
+    {
+        int event = super.next();
+        if ( bypass && event == END_TAG )
+        {
+            if ( domDepth > 0 )
+            {
+                if ( --domDepth == 0 )
+                {
+                    bypass( false );
+                }
+            }
+            state.removeLast();
+        }
+        return event;
+    }
+
+    @Override
+    public int nextToken() throws XmlPullParserException, IOException
+    {
+        int event = super.nextToken();
+        if ( bypass && event == END_TAG )
+        {
+            if ( domDepth > 0 )
+            {
+                if ( --domDepth == 0 )
+                {
+                    bypass( false );
+                }
+            }
+            state.removeLast();
+        }
+        return event;
+    }
+
+    @Override
     protected boolean accept() throws XmlPullParserException, IOException
     {
         if ( xmlPullParser.getEventType() == START_TAG )
@@ -92,26 +128,12 @@ class FastForwardFilter extends BufferingParser
             }
             state.add( localName );
         }
-        else if ( xmlPullParser.getEventType() == END_TAG )
-        {
-            if ( domDepth > 0 )
-            {
-                if ( --domDepth == 0 )
-                {
-                    bypass( false );
-                }
-            }
-            state.pop();
-        }
         return true;
     }
 
     @Override
     public void bypass( boolean bypass )
     {
-        if ( xmlPullParser instanceof BufferingParser )
-        {
-            ( ( BufferingParser ) xmlPullParser ).bypass( bypass );
-        }
+        this.bypass = bypass;
     }
 }

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/FastForwardFilter.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/FastForwardFilter.java
@@ -70,7 +70,7 @@ class FastForwardFilter extends BufferingParser
             }
             else
             {
-                final String key = state.peek() + '/' + localName;
+                final String key = state.peekLast() + '/' + localName;
                 switch ( key )
                 {
                     case "execution/configuration":

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/RawToConsumerPomXMLFilterFactory.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/RawToConsumerPomXMLFilterFactory.java
@@ -39,12 +39,11 @@ public class RawToConsumerPomXMLFilterFactory
 
     public final XmlPullParser get( XmlPullParser orgParser, Path projectPath )
     {
-        XmlPullParser parser = orgParser;
+        // Ensure that xs:any elements aren't touched by next filters
+        XmlPullParser parser = orgParser instanceof FastForwardFilter
+                ? orgParser : new FastForwardFilter( orgParser );
 
         parser = buildPomXMLFilterFactory.get( parser, projectPath );
-
-        // Ensure that xs:any elements aren't touched by next filters
-        parser = new FastForwardFilter( parser );
 
         // Strip modules
         parser = new ModulesXMLFilter( parser );

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
@@ -41,7 +41,7 @@ public class BufferingParser implements XmlPullParser
     protected XmlPullParser xmlPullParser;
     protected Deque<Event> events;
     protected Event current;
-    protected boolean disabled;
+    protected boolean bypass;
 
     @SuppressWarnings( "checkstyle:VisibilityModifier" )
     public static class Event
@@ -404,7 +404,7 @@ public class BufferingParser implements XmlPullParser
                 throw new XmlPullParserException( "already reached end of XML input", this, null );
             }
             int currentEvent = xmlPullParser.next();
-            if ( disabled || accept() )
+            if ( bypass || accept() )
             {
                 return currentEvent;
             }
@@ -430,7 +430,7 @@ public class BufferingParser implements XmlPullParser
                 throw new XmlPullParserException( "already reached end of XML input", this, null );
             }
             int currentEvent = xmlPullParser.nextToken();
-            if ( disabled || accept() )
+            if ( bypass || accept() )
             {
                 return currentEvent;
             }
@@ -531,22 +531,13 @@ public class BufferingParser implements XmlPullParser
         return true;
     }
 
-    protected void enable()
+    public void bypass( boolean bypass )
     {
-        disabled = false;
-    }
-
-    protected void disable()
-    {
-        if ( events != null && !events.isEmpty() )
+        if ( bypass && events != null && !events.isEmpty() )
         {
             throw new IllegalStateException( "Can not disable filter while processing" );
         }
-        disabled = true;
-        if ( xmlPullParser instanceof BufferingParser )
-        {
-            ( ( BufferingParser ) xmlPullParser ).disable();
-        }
+        this.bypass = bypass;
     }
 
     protected static String nullSafeAppend( String originalValue, String charSegment )

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
@@ -430,7 +430,7 @@ public class BufferingParser implements XmlPullParser
                 throw new XmlPullParserException( "already reached end of XML input", this, null );
             }
             int currentEvent = xmlPullParser.nextToken();
-            if ( accept() )
+            if ( disabled || accept() )
             {
                 return currentEvent;
             }

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
@@ -404,7 +404,7 @@ public class BufferingParser implements XmlPullParser
                 throw new XmlPullParserException( "already reached end of XML input", this, null );
             }
             int currentEvent = xmlPullParser.next();
-            if ( bypass || accept() )
+            if ( bypass() || accept() )
             {
                 return currentEvent;
             }
@@ -430,7 +430,7 @@ public class BufferingParser implements XmlPullParser
                 throw new XmlPullParserException( "already reached end of XML input", this, null );
             }
             int currentEvent = xmlPullParser.nextToken();
-            if ( bypass || accept() )
+            if ( bypass() || accept() )
             {
                 return currentEvent;
             }
@@ -538,6 +538,13 @@ public class BufferingParser implements XmlPullParser
             throw new IllegalStateException( "Can not disable filter while processing" );
         }
         this.bypass = bypass;
+    }
+
+    public boolean bypass()
+    {
+        return bypass
+                || ( xmlPullParser instanceof BufferingParser
+                        && ( (BufferingParser) xmlPullParser ).bypass() );
     }
 
     protected static String nullSafeAppend( String originalValue, String charSegment )

--- a/maven-model-transform/src/test/java/org/apache/maven/model/transform/ParentXMLFilterTest.java
+++ b/maven-model-transform/src/test/java/org/apache/maven/model/transform/ParentXMLFilterTest.java
@@ -85,6 +85,53 @@ public class ParentXMLFilterTest
     }
 
     @Test
+    public void testWithFastForwardAfterByPass()
+            throws Exception
+    {
+        String input = "<project>"
+                        + "<build>"
+                            + "<plugins>"
+                                + "<plugin>"
+                                    + "<configuration>"
+                                        + "<parent>"
+                                            + "<groupId>GROUPID</groupId>"
+                                            + "<artifactId>ARTIFACTID</artifactId>"
+                                        + "</parent>"
+                                    + "</configuration>"
+                                + "</plugin>"
+                            + "</plugins>"
+                        + "</build>"
+                        + "<parent>"
+                            + "<groupId>GROUPID</groupId>"
+                            + "<artifactId>ARTIFACTID</artifactId>"
+                        + "</parent>"
+                    + "</project>";
+        String expected = "<project>"
+                            + "<build>"
+                                + "<plugins>"
+                                    + "<plugin>"
+                                        + "<configuration>"
+                                            + "<parent>"
+                                                + "<groupId>GROUPID</groupId>"
+                                                + "<artifactId>ARTIFACTID</artifactId>"
+                                            + "</parent>"
+                                        + "</configuration>"
+                                    + "</plugin>"
+                                + "</plugins>"
+                            + "</build>"
+                            + "<parent>"
+                                + "<groupId>GROUPID</groupId>"
+                                + "<artifactId>ARTIFACTID</artifactId>"
+                                + "<version>1.0.0</version>"
+                            + "</parent>"
+                        + "</project>";
+
+        String actual = transform( input );
+
+        assertEquals( expected, actual );
+    }
+
+    @Test
     public void testMinimum()
         throws Exception
     {

--- a/maven-model-transform/src/test/java/org/apache/maven/model/transform/ParentXMLFilterTest.java
+++ b/maven-model-transform/src/test/java/org/apache/maven/model/transform/ParentXMLFilterTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ParentXMLFilterTest
     extends AbstractXMLFilterTests
 {
-    private Function<XmlPullParser, ParentXMLFilter> filterCreator;
+    private Function<XmlPullParser, XmlPullParser> filterCreator;
 
     @BeforeEach
     void reset() {
@@ -41,22 +41,47 @@ public class ParentXMLFilterTest
     }
 
     @Override
-    protected ParentXMLFilter getFilter( XmlPullParser parser )
+    protected XmlPullParser getFilter( XmlPullParser parser )
     {
-        Function<XmlPullParser, ParentXMLFilter> filterCreator =
+        Function<XmlPullParser, XmlPullParser> filterCreator =
             (this.filterCreator != null ? this.filterCreator : this::createFilter);
         return filterCreator.apply(parser);
     }
 
-    protected ParentXMLFilter createFilter( XmlPullParser parser ) {
+    protected XmlPullParser createFilter( XmlPullParser parser ) {
         return createFilter( parser,
                 x -> Optional.of(new RelativeProject("GROUPID", "ARTIFACTID", "1.0.0")),
                 Paths.get( "pom.xml").toAbsolutePath() );
     }
 
-    protected ParentXMLFilter createFilter( XmlPullParser parser, Function<Path, Optional<RelativeProject>> pathMapper, Path projectPath ) {
+    protected XmlPullParser createFilter( XmlPullParser parser, Function<Path, Optional<RelativeProject>> pathMapper, Path projectPath ) {
         ParentXMLFilter filter = new ParentXMLFilter( parser, pathMapper, projectPath );
-        return filter;
+        return new FastForwardFilter( filter );
+    }
+
+    @Test
+    public void testWithFastForward()
+        throws Exception
+    {
+        String input = "<project>"
+                        + "<build>"
+                            + "<plugins>"
+                                + "<plugin>"
+                                    + "<configuration>"
+                                        + "<parent>"
+                                            + "<groupId>GROUPID</groupId>"
+                                            + "<artifactId>ARTIFACTID</artifactId>"
+                                        + "</parent>"
+                                    + "</configuration>"
+                                + "</plugin>"
+                            + "</plugins>"
+                        + "</build>"
+                    + "</project>";
+        String expected = input;
+
+        String actual = transform( input );
+
+        assertEquals( expected, actual );
     }
 
     @Test

--- a/maven-model-transform/src/test/java/org/apache/maven/model/transform/ParentXMLFilterTest.java
+++ b/maven-model-transform/src/test/java/org/apache/maven/model/transform/ParentXMLFilterTest.java
@@ -55,8 +55,7 @@ public class ParentXMLFilterTest
     }
 
     protected XmlPullParser createFilter( XmlPullParser parser, Function<Path, Optional<RelativeProject>> pathMapper, Path projectPath ) {
-        ParentXMLFilter filter = new ParentXMLFilter( parser, pathMapper, projectPath );
-        return new FastForwardFilter( filter );
+        return new ParentXMLFilter( new FastForwardFilter( parser ), pathMapper, projectPath );
     }
 
     @Test


### PR DESCRIPTION
As hinted by @rfscholte , the `FastForwardFilter` is supposed to handle those problems by disabling the filters when parsing  xml config nodes.  I've added a unit test and investigated in that direction, which leads to this new PR.  It looks much simpler than #697, so I think it's better to keep that one.
