### PR TITLE
[EXPERIMENT] Resolver locking mode

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -81,6 +81,20 @@ public class DefaultRepositorySystemSessionFactory
 
     private static final String RESOLVER_MAX_PRIORITY = String.valueOf( Float.MAX_VALUE );
 
+    private static final String MAVEN_RESOLVER_LOCKING_KEY = "maven.resolver.locking";
+
+    private static final String MAVEN_RESOLVER_LOCKING_DEFAULT = "default";
+
+    private static final String MAVEN_RESOLVER_LOCKING_LOCAL = "local";
+
+    private static final String MAVEN_RESOLVER_LOCKING_FILE = "file";
+
+    private static final String MAVEN_RESOLVER_LOCKING_AUTO = "auto";
+
+    private static final String MAVEN_RESOLVER_LOCKING_LOCK_FACTORY_KEY = "aether.syncContext.named.factory";
+
+    private static final String MAVEN_RESOLVER_LOCKING_NAME_MAPPER_KEY = "aether.syncContext.named.nameMapper";
+
     @Inject
     private Logger logger;
 
@@ -280,6 +294,25 @@ public class DefaultRepositorySystemSessionFactory
             throw new IllegalArgumentException( "Unknown resolver transport '" + transport
                     + "'. Supported transports are: " + MAVEN_RESOLVER_TRANSPORT_WAGON + ", "
                     + MAVEN_RESOLVER_TRANSPORT_NATIVE + ", " + MAVEN_RESOLVER_TRANSPORT_AUTO );
+        }
+
+        Object locking = configProps.getOrDefault( MAVEN_RESOLVER_LOCKING_KEY, MAVEN_RESOLVER_LOCKING_DEFAULT );
+        if ( MAVEN_RESOLVER_LOCKING_DEFAULT.equals( locking ) || MAVEN_RESOLVER_LOCKING_FILE.equals( locking ) )
+        {
+            // The "default" mode (user did not set anything) is same as "file" mode
+            configProps.put( MAVEN_RESOLVER_LOCKING_LOCK_FACTORY_KEY, "file-lock" );
+            configProps.put( MAVEN_RESOLVER_LOCKING_NAME_MAPPER_KEY, "file-gav" );
+        }
+        else if ( MAVEN_RESOLVER_LOCKING_LOCAL.equals( locking ) )
+        {
+            configProps.put( MAVEN_RESOLVER_LOCKING_LOCK_FACTORY_KEY, "rwlock-local" );
+            configProps.put( MAVEN_RESOLVER_LOCKING_NAME_MAPPER_KEY, "gav" );
+        }
+        else if ( !MAVEN_RESOLVER_LOCKING_AUTO.equals( locking ) )
+        {
+            throw new IllegalArgumentException( "Unknown resolver locking mode '" + transport
+                    + "'. Supported locking modes are: " + MAVEN_RESOLVER_LOCKING_FILE + ", "
+                    + MAVEN_RESOLVER_LOCKING_LOCAL + ", " + MAVEN_RESOLVER_LOCKING_AUTO );
         }
 
         session.setTransferListener( request.getTransferListener() );

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -89,6 +89,10 @@ public class DefaultRepositorySystemSessionFactory
 
     private static final String MAVEN_RESOLVER_LOCKING_FILE = "file";
 
+    private static final String MAVEN_RESOLVER_LOCKING_HAZELCAST = "hazelcast";
+
+    private static final String MAVEN_RESOLVER_LOCKING_REDISSON = "redisson";
+
     private static final String MAVEN_RESOLVER_LOCKING_AUTO = "auto";
 
     private static final String MAVEN_RESOLVER_LOCKING_LOCK_FACTORY_KEY = "aether.syncContext.named.factory";
@@ -307,6 +311,16 @@ public class DefaultRepositorySystemSessionFactory
         {
             configProps.put( MAVEN_RESOLVER_LOCKING_LOCK_FACTORY_KEY, "rwlock-local" );
             configProps.put( MAVEN_RESOLVER_LOCKING_NAME_MAPPER_KEY, "gav" );
+        }
+        else if ( MAVEN_RESOLVER_LOCKING_HAZELCAST.equals( locking ) )
+        {
+            configProps.put( MAVEN_RESOLVER_LOCKING_LOCK_FACTORY_KEY, "semaphore-hazelcast-client" );
+            configProps.put( MAVEN_RESOLVER_LOCKING_NAME_MAPPER_KEY, "discriminating" );
+        }
+        else if ( MAVEN_RESOLVER_LOCKING_REDISSON.equals( locking ) )
+        {
+            configProps.put( MAVEN_RESOLVER_LOCKING_LOCK_FACTORY_KEY, "rwlock-redisson" );
+            configProps.put( MAVEN_RESOLVER_LOCKING_NAME_MAPPER_KEY, "discriminating" );
         }
         else if ( !MAVEN_RESOLVER_LOCKING_AUTO.equals( locking ) )
         {


### PR DESCRIPTION
Requires https://github.com/apache/maven-resolver/pull/188

The idea is similar as with resolver transport: add simple(er) switches to maven to control resolver locking aspect. Just as with transport (setting priority), setting proper locking may be cumbersome, as it requires lock factory but also name mapper settings, and there are even pairings that are must (like for file). Instead of relying directly on https://maven.apache.org/resolver/configuration.html here, again as in case of transport, offer a "higher" level settings from Maven itself:
* file
* local
* hazelcast
* redisson

That provides OOTB "experience" to end users (naturally  in case of latter two needed configuration and remote services are assumed but not checked for!).

Hence, `mvn -Dmaven.resolver.locking=file ...` would make Maven use file locking. 
