### PR TITLE
Pull out lifecycle plugin versions

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
@@ -43,11 +43,23 @@ public abstract class AbstractLifecycleMappingProvider
 
     protected static final String SUREFIRE_PLUGIN_VERSION = "3.0.0-M5";
 
-    protected static final String JAR_PLUGIN_VERSION = "3.2.0";
-
     protected static final String INSTALL_PLUGIN_VERSION = "3.0.0-M1";
 
     protected static final String DEPLOY_PLUGIN_VERSION = "3.0.0-M2";
+
+    // packaging
+
+    protected static final String JAR_PLUGIN_VERSION = "3.2.0";
+
+    protected static final String EAR_PLUGIN_VERSION = "3.1.2";
+
+    protected static final String EJB_PLUGIN_VERSION = "3.1.0";
+
+    protected static final String PLUGIN_PLUGIN_VERSION = "3.6.0";
+
+    protected static final String RAR_PLUGIN_VERSION = "2.4"; // TODO: Update!!!
+
+    protected static final String WAR_PLUGIN_VERSION = "3.3.1";
 
     private final LifecycleMapping lifecycleMapping;
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
@@ -37,6 +37,18 @@ import static java.util.Objects.requireNonNull;
 public abstract class AbstractLifecycleMappingProvider
     implements Provider<LifecycleMapping>
 {
+    protected static final String RESOURCES_PLUGIN_VERSION = "3.2.0";
+
+    protected static final String COMPILER_PLUGIN_VERSION = "3.8.1";
+
+    protected static final String SUREFIRE_PLUGIN_VERSION = "3.0.0-M5";
+
+    protected static final String JAR_PLUGIN_VERSION = "3.2.0";
+
+    protected static final String INSTALL_PLUGIN_VERSION = "3.0.0-M1";
+
+    protected static final String DEPLOY_PLUGIN_VERSION = "3.0.0-M2";
+
     private final LifecycleMapping lifecycleMapping;
 
     protected AbstractLifecycleMappingProvider( String[] pluginBindings )

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EarLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EarLifecycleMappingProvider.java
@@ -31,8 +31,6 @@ import javax.inject.Singleton;
 public final class EarLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
-    private static final String EAR_PLUGIN_VERSION = "3.1.2";
-
     // START SNIPPET: ear
     @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EarLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EarLifecycleMappingProvider.java
@@ -31,14 +31,17 @@ import javax.inject.Singleton;
 public final class EarLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
+    private static final String EAR_PLUGIN_VERSION = "3.1.2";
+
     // START SNIPPET: ear
+    @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =
     {
-        "generate-resources", "org.apache.maven.plugins:maven-ear-plugin:3.1.2:generate-application-xml",
-        "process-resources",  "org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources",
-        "package",            "org.apache.maven.plugins:maven-ear-plugin:3.1.2:ear",
-        "install",            "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install",
-        "deploy",             "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy"
+        "generate-resources", "org.apache.maven.plugins:maven-ear-plugin:" + EAR_PLUGIN_VERSION + ":generate-application-xml",
+        "process-resources",  "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":resources",
+        "package",            "org.apache.maven.plugins:maven-ear-plugin:" + EAR_PLUGIN_VERSION + ":ear",
+        "install",            "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy",             "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
     };
     // END SNIPPET: ear
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EjbLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EjbLifecycleMappingProvider.java
@@ -31,8 +31,6 @@ import javax.inject.Singleton;
 public final class EjbLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
-    private static final String EJB_PLUGIN_VERSION = "3.1.0";
-
     // START SNIPPET: ejb
     @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EjbLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/EjbLifecycleMappingProvider.java
@@ -31,17 +31,20 @@ import javax.inject.Singleton;
 public final class EjbLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
+    private static final String EJB_PLUGIN_VERSION = "3.1.0";
+
     // START SNIPPET: ejb
+    @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =
     {
-        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources",
-        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile",
-        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:3.2.0:testResources",
-        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile",
-        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test",
-        "package",                "org.apache.maven.plugins:maven-ejb-plugin:3.1.0:ejb",
-        "install",                "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install",
-        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy"
+        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":resources",
+        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":compile",
+        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":testResources",
+        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":testCompile",
+        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:" + SUREFIRE_PLUGIN_VERSION + ":test",
+        "package",                "org.apache.maven.plugins:maven-ejb-plugin:" + EJB_PLUGIN_VERSION + ":ejb",
+        "install",                "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
     };
     // END SNIPPET: ejb
     

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/JarLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/JarLifecycleMappingProvider.java
@@ -32,16 +32,17 @@ public final class JarLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
     // START SNIPPET: jar
+    @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =
     {
-        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources",
-        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile",
-        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:3.2.0:testResources",
-        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile",
-        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test",
-        "package",                "org.apache.maven.plugins:maven-jar-plugin:3.2.0:jar",
-        "install",                "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install",
-        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy"
+        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":resources",
+        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":compile",
+        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":testResources",
+        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":testCompile",
+        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:" + SUREFIRE_PLUGIN_VERSION + ":test",
+        "package",                "org.apache.maven.plugins:maven-jar-plugin:" + JAR_PLUGIN_VERSION + ":jar",
+        "install",                "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
     };
     // END SNIPPET: jar
     

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/MavenPluginLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/MavenPluginLifecycleMappingProvider.java
@@ -31,8 +31,6 @@ import javax.inject.Singleton;
 public final class MavenPluginLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
-    private static final String PLUGIN_PLUGIN_VERSION = "3.6.0";
-
     // START SNIPPET: maven-plugin
     @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/MavenPluginLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/MavenPluginLifecycleMappingProvider.java
@@ -31,19 +31,22 @@ import javax.inject.Singleton;
 public final class MavenPluginLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
+    private static final String PLUGIN_PLUGIN_VERSION = "3.6.0";
+
     // START SNIPPET: maven-plugin
+    @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =
     {
-        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources",
-        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile",
-        "process-classes",        "org.apache.maven.plugins:maven-plugin-plugin:3.6.0:descriptor",
-        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:3.2.0:testResources",
-        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile",
-        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test",
-        "package",                "org.apache.maven.plugins:maven-jar-plugin:3.2.0:jar,"
-                                + "org.apache.maven.plugins:maven-plugin-plugin:3.6.0:addPluginArtifactMetadata",
-        "install",                "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install",
-        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy"
+        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":resources",
+        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":compile",
+        "process-classes",        "org.apache.maven.plugins:maven-plugin-plugin:" + PLUGIN_PLUGIN_VERSION + ":descriptor",
+        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":testResources",
+        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":testCompile",
+        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:" + SUREFIRE_PLUGIN_VERSION + ":test",
+        "package",                "org.apache.maven.plugins:maven-jar-plugin:" + JAR_PLUGIN_VERSION + ":jar,"
+                                + "org.apache.maven.plugins:maven-plugin-plugin:" + PLUGIN_PLUGIN_VERSION + ":addPluginArtifactMetadata",
+        "install",                "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
     };
     // END SNIPPET: maven-plugin
     

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/PomLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/PomLifecycleMappingProvider.java
@@ -32,10 +32,11 @@ public final class PomLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
     // START SNIPPET: pom
+    @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =
     {
-        "install", "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install",
-        "deploy",  "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy"
+        "install", "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy",  "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
     };
     // END SNIPPET: pom
     

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/RarLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/RarLifecycleMappingProvider.java
@@ -31,17 +31,20 @@ import javax.inject.Singleton;
 public final class RarLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
+    private static final String RAR_PLUGIN_VERSION = "2.4";
+
     // START SNIPPET: rar
+    @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =
     {
-        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources",
-        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile",
-        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:3.2.0:testResources",
-        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile",
-        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test",
-        "package",                "org.apache.maven.plugins:maven-rar-plugin:2.4:rar",
-        "install",                "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install",
-        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy"
+        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":resources",
+        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":compile",
+        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":testResources",
+        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":testCompile",
+        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:" + SUREFIRE_PLUGIN_VERSION + ":test",
+        "package",                "org.apache.maven.plugins:maven-rar-plugin:" + RAR_PLUGIN_VERSION + ":rar",
+        "install",                "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
     };
     // END SNIPPET: rar
     

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/RarLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/RarLifecycleMappingProvider.java
@@ -31,8 +31,6 @@ import javax.inject.Singleton;
 public final class RarLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
-    private static final String RAR_PLUGIN_VERSION = "2.4";
-
     // START SNIPPET: rar
     @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/WarLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/WarLifecycleMappingProvider.java
@@ -31,17 +31,20 @@ import javax.inject.Singleton;
 public final class WarLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
+    private static final String WAR_PLUGIN_VERSION = "3.3.1";
+
     // START SNIPPET: war
+    @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =
     {
-        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources",
-        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile",
-        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:3.2.0:testResources",
-        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile",
-        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test",
-        "package",                "org.apache.maven.plugins:maven-war-plugin:3.3.1:war",
-        "install",                "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install",
-        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy"
+        "process-resources",      "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":resources",
+        "compile",                "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":compile",
+        "process-test-resources", "org.apache.maven.plugins:maven-resources-plugin:" + RESOURCES_PLUGIN_VERSION + ":testResources",
+        "test-compile",           "org.apache.maven.plugins:maven-compiler-plugin:" + COMPILER_PLUGIN_VERSION + ":testCompile",
+        "test",                   "org.apache.maven.plugins:maven-surefire-plugin:" + SUREFIRE_PLUGIN_VERSION + ":test",
+        "package",                "org.apache.maven.plugins:maven-war-plugin:" + WAR_PLUGIN_VERSION + ":war",
+        "install",                "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy",                 "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
     };
     // END SNIPPET: war
     

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/WarLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/WarLifecycleMappingProvider.java
@@ -31,8 +31,6 @@ import javax.inject.Singleton;
 public final class WarLifecycleMappingProvider
     extends AbstractLifecycleMappingProvider
 {
-    private static final String WAR_PLUGIN_VERSION = "3.3.1";
-
     // START SNIPPET: war
     @SuppressWarnings( "checkstyle:linelength" )
     private static final String[] BINDINGS =


### PR DESCRIPTION
To lessen mistake (copy-paste vs forgotten update) but also just to
make things less redundant. This also makes possible "experimenting"
much more easier.

This is merely a refactoring that does not takes or gives anything, just tidies up.