### PR TITLE
run clean before building maven and integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn verify -e -B -V -DdistributionFileName=apache-maven
+        run: mvn clean verify -e -B -V -DdistributionFileName=apache-maven
 
       - name: Upload built Maven
         uses: actions/upload-artifact@v2
@@ -118,4 +118,4 @@ jobs:
 
       - name: Running integration tests
         shell: bash
-        run: mvn install -e -B -V -Prun-its,embedded -Dmaven.repo.local="$HOME/.m2/repository" -DmavenDistro="$GITHUB_WORKSPACE/built-maven/apache-maven-bin.zip" -f maven-integration-testing/pom.xml
+        run: mvn clean install -e -B -V -Prun-its,embedded -Dmaven.repo.local="$HOME/.m2/repository" -DmavenDistro="$GITHUB_WORKSPACE/built-maven/apache-maven-bin.zip" -f maven-integration-testing/pom.xml

--- a/.github/workflows/maven_build_itself.yml
+++ b/.github/workflows/maven_build_itself.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn verify -e -B -V -DdistributionFileName=apache-maven
+        run: mvn clean verify -e -B -V -DdistributionFileName=apache-maven
 
       - name: Extract tarball
         shell: bash


### PR DESCRIPTION
Explicitly run clean before (re-)building the maven distribution
and integration tests. Currently the tests seem to be a bit unstable
for 3.9.x and master; I can reproduce this locally and the errors
go away when explicitly cleaning the workspace before building.

This is a non-code, build only change.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
