### PR TITLE
Make sure RAT plugin ignores files in the target folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-target/
+**/target/**
 .project
 .classpath
 .settings/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .checkstyle
 .factorypath
 .vscode/
+repo/

--- a/maven-bom/pom.xml
+++ b/maven-bom/pom.xml
@@ -160,6 +160,16 @@ under the License.
           <topSiteURL>${project.distributionManagement.site.url}/..</topSiteURL>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>rat-check</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -573,28 +573,6 @@ under the License.
           <artifactId>buildnumber-maven-plugin</artifactId>
           <version>1.4</version>
         </plugin>
-        <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <configuration>
-            <excludes>
-              <exclude>**/.gitattributes</exclude>
-              <exclude>src/test/resources*/**</exclude>
-              <exclude>src/test/projects/**</exclude>
-              <exclude>src/test/remote-repo/**</exclude>
-              <exclude>**/*.odg</exclude>
-              <!--
-                ! Excluded the license files itself cause they do not have have a license of themselves.
-              -->
-              <exclude>src/main/appended-resources/licenses/MIT-slf4j-api-1.7.30.txt</exclude>
-              <exclude>src/main/appended-resources/licenses/EPL-1.0.txt</exclude>
-              <exclude>src/main/appended-resources/licenses/unrecognized-aopalliance-1.0.txt</exclude>
-              <exclude>src/main/appended-resources/licenses/unrecognized-javax.annotation-api-1.3.2.txt</exclude>
-              <!-- exclude all files in the target folder -->
-              <exclude>**/target/**</exclude>
-            </excludes>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -636,14 +614,29 @@ under the License.
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes combine.children="append">
-            <exclude>bootstrap/**</exclude>
-            <exclude>README.bootstrap.txt</exclude>
-            <exclude>README.md</exclude>
-            <exclude>**/.factorypath</exclude>
-          </excludes>
-        </configuration>
+        <executions>
+          <execution>
+            <id>rat-check</id>
+            <inherited>false</inherited>
+            <configuration>
+              <excludes>
+                <exclude>**/.gitattributes</exclude>
+                <exclude>src/test/resources*/**</exclude>
+                <exclude>src/test/projects/**</exclude>
+                <exclude>src/test/remote-repo/**</exclude>
+                <exclude>**/*.odg</exclude>
+                <!--
+                  ! Excluded the license files itself cause they do not have have a license of themselves.
+                -->
+                <exclude>src/main/appended-resources/licenses/MIT-slf4j-api-1.7.30.txt</exclude>
+                <exclude>src/main/appended-resources/licenses/EPL-1.0.txt</exclude>
+                <exclude>src/main/appended-resources/licenses/unrecognized-aopalliance-1.0.txt</exclude>
+                <exclude>src/main/appended-resources/licenses/unrecognized-javax.annotation-api-1.3.2.txt</exclude>
+              </excludes>
+              <excludesFile>.gitignore</excludesFile>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -590,7 +590,8 @@ under the License.
               <exclude>src/main/appended-resources/licenses/EPL-1.0.txt</exclude>
               <exclude>src/main/appended-resources/licenses/unrecognized-aopalliance-1.0.txt</exclude>
               <exclude>src/main/appended-resources/licenses/unrecognized-javax.annotation-api-1.3.2.txt</exclude>
-              <exclude>plexus-utils/target/**</exclude>
+              <!-- exclude all files in the target folder -->
+              <exclude>**/target/**</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -625,6 +625,7 @@ under the License.
                 <exclude>src/test/projects/**</exclude>
                 <exclude>src/test/remote-repo/**</exclude>
                 <exclude>**/*.odg</exclude>
+                <exclude>.asf.yaml</exclude>
                 <!--
                   ! Excluded the license files itself cause they do not have have a license of themselves.
                 -->
@@ -633,7 +634,6 @@ under the License.
                 <exclude>src/main/appended-resources/licenses/unrecognized-aopalliance-1.0.txt</exclude>
                 <exclude>src/main/appended-resources/licenses/unrecognized-javax.annotation-api-1.3.2.txt</exclude>
               </excludes>
-              <excludesFile>.gitignore</excludesFile>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
When switching branches, left-over `target` folder *often* causes issues with the `rat-maven-plugin`.
Ignoring those folders does help from a day-to-day pov.

See #814 and #815 