### PR TITLE
Restore compatibility with 3.x

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/MavenBuildTimestamp.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/MavenBuildTimestamp.java
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Map;
+import java.util.Properties;
 import java.util.TimeZone;
 
 /**
@@ -52,6 +53,11 @@ public class MavenBuildTimestamp
     public MavenBuildTimestamp( Date time, Map<String, String> properties )
     {
         this( time, properties != null ? properties.get( BUILD_TIMESTAMP_FORMAT_PROPERTY ) : null );
+    }
+
+    public MavenBuildTimestamp( Date time, Properties properties )
+    {
+        this( time, properties != null ? properties.getProperty( BUILD_TIMESTAMP_FORMAT_PROPERTY ) : null );
     }
 
     public MavenBuildTimestamp( Date time, String timestampFormat )

--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/MavenBuildTimestamp.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/MavenBuildTimestamp.java
@@ -55,6 +55,12 @@ public class MavenBuildTimestamp
         this( time, properties != null ? properties.get( BUILD_TIMESTAMP_FORMAT_PROPERTY ) : null );
     }
 
+    /**
+     *
+     * @deprecated Use {@link #MavenBuildTimestamp(Date, Map)} or extract the format and pass it
+     *             to {@link #MavenBuildTimestamp(Date, String)} instead.
+     */
+    @Deprecated
     public MavenBuildTimestamp( Date time, Properties properties )
     {
         this( time, properties != null ? properties.getProperty( BUILD_TIMESTAMP_FORMAT_PROPERTY ) : null );


### PR DESCRIPTION
Restore compatibility with maven 3.x.

This is causing some plugins to fail:
```
[ERROR] Failed to execute goal
org.codehaus.mojo:flatten-maven-plugin:1.3.0:flatten (flatten) on project maven-super: Execution flatten of goal org.codehaus.mojo:flatten-maven-plugin:1.3.0:flatten 
failed: An API incompatibility was encountered while executing org.codehaus.mojo:flatten-maven-plugin:1.3.0:flatten: java.lang.NoSuchMethodError: 'void 
org.apache.maven.model.interpolation.MavenBuildTimestamp.<init>(java.util.Date, java.util.Properties)'
```
