### PR TITLE
Fix project versions not updated during release

### DIFF
--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -37,16 +37,22 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-model</artifactId>
-      <version>4.0.0-alpha-3-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-xml-impl</artifactId>
-      <version>4.0.0-alpha-3-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -64,7 +70,7 @@ under the License.
                 <artifactItem>
                   <groupId>org.apache.maven</groupId>
                   <artifactId>maven-api-model</artifactId>
-                  <version>4.0.0-alpha-1-SNAPSHOT</version>
+                  <version>${project.version}</version>
                   <type>mdo</type>
                   <outputDirectory>target/mdo/</outputDirectory>
                   <destFileName>maven.mdo</destFileName>

--- a/maven-model/src/test/resources/xml/pom.xml
+++ b/maven-model/src/test/resources/xml/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>4.0.0-alpha-1-SNAPSHOT</version>
+    <version>dummy-version</version>
   </parent>
 
   <artifactId>maven-model</artifactId>
@@ -37,12 +37,12 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-model</artifactId>
-      <version>4.0.0-alpha-1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-xml-impl</artifactId>
-      <version>4.0.0-alpha-1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 
@@ -64,7 +64,7 @@ under the License.
                 <artifactItem>
                   <groupId>org.apache.maven</groupId>
                   <artifactId>maven-api-model</artifactId>
-                  <version>4.0.0-alpha-1-SNAPSHOT</version>
+                  <version>${project.version}</version>
                   <type>mdo</type>
                   <outputDirectory>target/mdo/</outputDirectory>
                   <destFileName>maven.mdo</destFileName>
@@ -77,7 +77,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven</groupId>
         <artifactId>modello-plugin-velocity</artifactId>
-        <version>4.0.0-alpha-1-SNAPSHOT</version>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <id>velocity</id>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -37,12 +37,12 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-settings</artifactId>
-      <version>4.0.0-alpha-3-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-xml-impl</artifactId>
-      <version>4.0.0-alpha-3-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -68,7 +68,7 @@ under the License.
                 <artifactItem>
                   <groupId>org.apache.maven</groupId>
                   <artifactId>maven-api-settings</artifactId>
-                  <version>4.0.0-alpha-1-SNAPSHOT</version>
+                  <version>${project.version}</version>
                   <type>mdo</type>
                   <outputDirectory>target/mdo/</outputDirectory>
                   <destFileName>settings.mdo</destFileName>

--- a/maven-toolchain-model/pom.xml
+++ b/maven-toolchain-model/pom.xml
@@ -36,12 +36,12 @@ under the License.
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-api-toolchain</artifactId>
-            <version>4.0.0-alpha-3-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-xml-impl</artifactId>
-            <version>4.0.0-alpha-3-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -67,7 +67,7 @@ under the License.
                                 <artifactItem>
                                     <groupId>org.apache.maven</groupId>
                                     <artifactId>maven-api-toolchain</artifactId>
-                                    <version>4.0.0-alpha-1-SNAPSHOT</version>
+                                    <version>${project.version}</version>
                                     <type>mdo</type>
                                     <outputDirectory>target/mdo/</outputDirectory>
                                     <destFileName>toolchains.mdo</destFileName>


### PR DESCRIPTION
For an unknown reason the versions in the various modules were not updated correctly during the previous new snapshot version. 

This only fixes the current versions. It does not address the root cause at this point.

----

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
