### PR TITLE
[MNG-7583] Allow concurrent access to the MavenPluginManager

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginDescriptorCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginDescriptorCache.java
@@ -20,7 +20,6 @@ package org.apache.maven.plugin;
  */
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -74,10 +73,12 @@ public class DefaultPluginDescriptorCache
     }
 
     @Override
-    public PluginDescriptor get(Key key, PluginDescriptorSupplier supplier)
-            throws PluginDescriptorParsingException, PluginResolutionException, InvalidPluginDescriptorException {
-        try {
-            return clone( descriptors.computeIfAbsent(key, k ->
+    public PluginDescriptor get( Key key, PluginDescriptorSupplier supplier )
+            throws PluginDescriptorParsingException, PluginResolutionException, InvalidPluginDescriptorException
+    {
+        try
+        {
+            return clone( descriptors.computeIfAbsent( key, k ->
             {
                 try
                 {
@@ -86,7 +87,7 @@ public class DefaultPluginDescriptorCache
                 catch ( PluginDescriptorParsingException | PluginResolutionException
                         | InvalidPluginDescriptorException e )
                 {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException( e );
                 }
             } ) );
         }
@@ -108,7 +109,7 @@ public class DefaultPluginDescriptorCache
         }
     }
 
-    public void put(Key cacheKey, PluginDescriptor pluginDescriptor )
+    public void put( Key cacheKey, PluginDescriptor pluginDescriptor )
     {
         descriptors.put( cacheKey, clone( pluginDescriptor ) );
     }

--- a/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
@@ -163,8 +163,9 @@ public class DefaultPluginRealmCache
     public CacheRecord get( Key key, PluginRealmSupplier supplier )
             throws PluginResolutionException, PluginContainerException
     {
-        try {
-            return cache.computeIfAbsent(key, k ->
+        try
+        {
+            return cache.computeIfAbsent( key, k ->
             {
                 try
                 {
@@ -172,7 +173,7 @@ public class DefaultPluginRealmCache
                 }
                 catch ( PluginResolutionException | PluginContainerException e )
                 {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException( e );
                 }
             } );
         }
@@ -190,7 +191,7 @@ public class DefaultPluginRealmCache
         }
     }
 
-    public CacheRecord put(Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts )
+    public CacheRecord put( Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts )
     {
         Objects.requireNonNull( pluginRealm, "pluginRealm cannot be null" );
         Objects.requireNonNull( pluginArtifacts, "pluginArtifacts cannot be null" );

--- a/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
@@ -159,7 +159,38 @@ public class DefaultPluginRealmCache
         return cache.get( key );
     }
 
-    public CacheRecord put( Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts )
+    @Override
+    public CacheRecord get( Key key, PluginRealmSupplier supplier )
+            throws PluginResolutionException, PluginContainerException
+    {
+        try {
+            return cache.computeIfAbsent(key, k ->
+            {
+                try
+                {
+                    return supplier.load();
+                }
+                catch ( PluginResolutionException | PluginContainerException e )
+                {
+                    throw new RuntimeException(e);
+                }
+            } );
+        }
+        catch ( RuntimeException e )
+        {
+            if ( e.getCause() instanceof PluginResolutionException )
+            {
+                throw (PluginResolutionException) e.getCause();
+            }
+            if ( e.getCause() instanceof PluginContainerException )
+            {
+                throw (PluginContainerException) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    public CacheRecord put(Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts )
     {
         Objects.requireNonNull( pluginRealm, "pluginRealm cannot be null" );
         Objects.requireNonNull( pluginArtifacts, "pluginArtifacts cannot be null" );

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginDescriptorCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginDescriptorCache.java
@@ -47,11 +47,21 @@ public interface PluginDescriptorCache
         // marker interface for cache keys
     }
 
+    @FunctionalInterface
+    interface PluginDescriptorSupplier
+    {
+        PluginDescriptor load()
+                throws PluginResolutionException, PluginDescriptorParsingException, InvalidPluginDescriptorException;
+    }
+
     Key createKey( Plugin plugin, List<RemoteRepository> repositories, RepositorySystemSession session );
 
     void put( Key key, PluginDescriptor pluginDescriptor );
 
     PluginDescriptor get( Key key );
+
+    PluginDescriptor get( Key key, PluginDescriptorSupplier supplier )
+            throws PluginResolutionException, PluginDescriptorParsingException, InvalidPluginDescriptorException;
 
     void flush();
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
@@ -74,11 +74,20 @@ public interface PluginRealmCache
         // marker interface for cache keys
     }
 
+    @FunctionalInterface
+    interface PluginRealmSupplier
+    {
+        CacheRecord load() throws PluginResolutionException, PluginContainerException;
+    }
+
     Key createKey( Plugin plugin, ClassLoader parentRealm, Map<String, ClassLoader> foreignImports,
                    DependencyFilter dependencyFilter, List<RemoteRepository> repositories,
                    RepositorySystemSession session );
 
     CacheRecord get( Key key );
+
+    CacheRecord get( Key key, PluginRealmSupplier supplier )
+            throws PluginResolutionException, PluginContainerException;
 
     CacheRecord put( Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts );
 


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7583

This would allow a better integration with mvnd.

At the moment, `mvnd` has to rewrite the `MavenPluginManager` to work around this synchronisation bottleneck.
See https://github.com/apache/maven-mvnd/blob/master/daemon/src/main/java/org/mvndaemon/mvnd/plugin/CliMavenPluginManager.java

Having the additional `get` methods on the cache would allow `mvnd` to simply provide a different cache, without having to rewrite the `DefaultMavenPluginManager`.

This will ease mvnd maintenance and maven upgrades a lot !