### PR TITLE
[MNG-6487] Add Sonatype dependency-check plugin to Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@ under the License.
     <resolverVersion>1.8.2</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.6.4</xmlunitVersion>
+    <sonatypeVersion>3.2.0</sonatypeVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <!-- Control the name of the distribution and information output by mvn -->
     <distributionId>apache-maven</distributionId>
@@ -678,6 +679,24 @@ under the License.
           <violationIgnore>JavadocVariable,JavadocMethod,HiddenField</violationIgnore>
 <!--          <suppressionsLocation>${maven.multiModuleProjectDirectory}/build/checkstyle-suppressions.xml</suppressionsLocation>-->
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.ossindex.maven</groupId>
+        <artifactId>ossindex-maven-plugin</artifactId>
+        <version>${sonatypeVersion}</version>
+        <configuration>
+          <scope>compile</scope>
+          <cvssScoreThreshold>7.0</cvssScoreThreshold>
+        </configuration>
+        <executions>
+          <execution>
+            <id>audit-dependencies</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>audit-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-6487

This plugin checks dependencies for CVE vulnerabilities using Sonatype's vulnerability database. The build will fail when CVSS scores of >7.0 (HIGH) are found in any of the sub-modules. As discussed in MPOM-210, the OSS plugin is chosen in favour of OWASP Dependency-Check because the latter reports a lot of false positives and produces noise.

Only compile-time dependencies are included, because these are risky for Maven users and should be resolved before releasing.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
