### PR TITLE
[MNG-6609] Profile activation based on packaging

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/ProfileActivationContext.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/ProfileActivationContext.java
@@ -30,6 +30,12 @@ import java.util.Map;
  */
 public interface ProfileActivationContext
 {
+    /**
+     * Key of the property containing the project's packaging.
+     * Available in {@link #getUserProperties()}.
+     * @since 3.9
+     */
+    String PROPERTY_NAME_PACKAGING = "packaging";
 
     /**
      * Gets the identifiers of those profiles that should be activated by explicit demand.


### PR DESCRIPTION
In short: do NOT set request.setRawModel as NOTHING sets it. The Maven4 vs Maven3 is different, in Maven 3 NOTHING calls request.setRawModel

Full explanation: as ModelBuildingRequest is REUSED, and nothing sets this value in Maven3, once you set it here (as in original PR https://github.com/apache/maven/pull/849 ) results in awkward situation in Maven3: it will not load any other model...

---

https://issues.apache.org/jira/browse/MNG-6609

