### PR TITLE
[MNG-7608] Make native resolver transport the m4 default.

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -232,25 +232,8 @@ public class DefaultRepositorySystemSessionFactory {
         session.setAuthenticationSelector(authSelector);
 
         Object transport = configProps.getOrDefault(MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_DEFAULT);
-        if (MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals(transport)) {
-            // The "default" mode (user did not set anything) needs to tweak resolver default priorities
-            // that are coded like this (default values):
-            //
-            // org.eclipse.aether.transport.http.HttpTransporterFactory.priority = 5.0f;
-            // org.eclipse.aether.transport.wagon.WagonTransporterFactory.priority = -1.0f;
-            //
-            // Hence, as both are present on classpath, HttpTransport would be selected, while
-            // we want to retain "default" behaviour of Maven and use Wagon. To achieve that,
-            // we set explicitly priority of WagonTransport to 6.0f (just above of HttpTransport),
-            // to make it "win" over HttpTransport. We do this to NOT interfere with possibly
-            // installed OTHER transports and their priorities, as unlike "wagon" or "native"
-            // transport setting, that sets priorities to MAX, hence prevents any 3rd party
-            // transport to get into play (inhibits them), in default mode we want to retain
-            // old behavior. Also, this "default" mode is different from "auto" setting,
-            // as it does not alter resolver priorities at all, and uses priorities as is.
-
-            configProps.put(WAGON_TRANSPORTER_PRIORITY_KEY, "6");
-        } else if (MAVEN_RESOLVER_TRANSPORT_NATIVE.equals(transport)) {
+        if (MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals(transport) || MAVEN_RESOLVER_TRANSPORT_NATIVE.equals(transport)) {
+            // The "default" mode (user did not set anything) from now on defaults to NATIVE
             // Make sure (whatever extra priority is set) that resolver native is selected
             configProps.put(NATIVE_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);
             configProps.put(NATIVE_HTTP_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -232,8 +232,9 @@ public class DefaultRepositorySystemSessionFactory {
         session.setAuthenticationSelector(authSelector);
 
         Object transport = configProps.getOrDefault(MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_DEFAULT);
-        if (MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals(transport) || MAVEN_RESOLVER_TRANSPORT_NATIVE.equals(transport)) {
-            // The "default" mode (user did not set anything) from now on defaults to NATIVE
+        if (MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals(transport)) {
+            // The "default" mode (user did not set anything) from now on defaults to AUTO
+        } else if (MAVEN_RESOLVER_TRANSPORT_NATIVE.equals(transport)) {
             // Make sure (whatever extra priority is set) that resolver native is selected
             configProps.put(NATIVE_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);
             configProps.put(NATIVE_HTTP_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);


### PR DESCRIPTION
This immediately cuts in "half" the count of HTTP requests against Maven Central or any major MRM.

Altering the meaning of "default": is now same as NATIVE, still leaving it in place for future, as "default" at some point may again become something different than "native".

Depends on https://github.com/apache/maven-integration-testing/pull/215

---

https://issues.apache.org/jira/browse/MNG-7608