### PR TITLE
[EXPERIMENT] Jetty transport

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -89,6 +89,10 @@ under the License.
       <artifactId>maven-resolver-transport-wagon</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-jetty</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-slf4j-provider</artifactId>
     </dependency>

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -232,25 +232,8 @@ public class DefaultRepositorySystemSessionFactory {
         session.setAuthenticationSelector(authSelector);
 
         Object transport = configProps.getOrDefault(MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_DEFAULT);
-        if (MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals(transport)) {
-            // The "default" mode (user did not set anything) needs to tweak resolver default priorities
-            // that are coded like this (default values):
-            //
-            // org.eclipse.aether.transport.http.HttpTransporterFactory.priority = 5.0f;
-            // org.eclipse.aether.transport.wagon.WagonTransporterFactory.priority = -1.0f;
-            //
-            // Hence, as both are present on classpath, HttpTransport would be selected, while
-            // we want to retain "default" behaviour of Maven and use Wagon. To achieve that,
-            // we set explicitly priority of WagonTransport to 6.0f (just above of HttpTransport),
-            // to make it "win" over HttpTransport. We do this to NOT interfere with possibly
-            // installed OTHER transports and their priorities, as unlike "wagon" or "native"
-            // transport setting, that sets priorities to MAX, hence prevents any 3rd party
-            // transport to get into play (inhibits them), in default mode we want to retain
-            // old behavior. Also, this "default" mode is different from "auto" setting,
-            // as it does not alter resolver priorities at all, and uses priorities as is.
-
-            configProps.put(WAGON_TRANSPORTER_PRIORITY_KEY, "6");
-        } else if (MAVEN_RESOLVER_TRANSPORT_NATIVE.equals(transport)) {
+        if (MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals(transport) || MAVEN_RESOLVER_TRANSPORT_NATIVE.equals(transport)) {
+            // The "default" mode (user did not set anything) from now on defaults to NATIVE
             // Make sure (whatever extra priority is set) that resolver native is selected
             configProps.put(NATIVE_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);
             configProps.put(NATIVE_HTTP_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -84,11 +84,15 @@ public class DefaultRepositorySystemSessionFactory {
 
     private static final String MAVEN_RESOLVER_TRANSPORT_DEFAULT = "default";
 
+    private static final String MAVEN_RESOLVER_TRANSPORT_JETTY = "jetty";
+
     private static final String MAVEN_RESOLVER_TRANSPORT_WAGON = "wagon";
 
     private static final String MAVEN_RESOLVER_TRANSPORT_NATIVE = "native";
 
     private static final String MAVEN_RESOLVER_TRANSPORT_AUTO = "auto";
+
+    private static final String JETTY_TRANSPORTER_PRIORITY_KEY = "aether.priority.JettyTransporterFactory";
 
     private static final String WAGON_TRANSPORTER_PRIORITY_KEY = "aether.priority.WagonTransporterFactory";
 
@@ -237,6 +241,9 @@ public class DefaultRepositorySystemSessionFactory {
             // Make sure (whatever extra priority is set) that resolver native is selected
             configProps.put(NATIVE_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);
             configProps.put(NATIVE_HTTP_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);
+        } else if (MAVEN_RESOLVER_TRANSPORT_JETTY.equals(transport)) {
+            // Make sure (whatever extra priority is set) that wagon is selected
+            configProps.put(JETTY_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);
         } else if (MAVEN_RESOLVER_TRANSPORT_WAGON.equals(transport)) {
             // Make sure (whatever extra priority is set) that wagon is selected
             configProps.put(WAGON_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,12 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>8</javaVersion>
+    <javaVersion>11</javaVersion>
+    <maven.compiler.release>${javaVersion}</maven.compiler.release>
+    <maven.compiler.source>${javaVersion}</maven.compiler.source>
+    <!-- JETTY TODO: used by enforcer, but Jetty brings in Java 17 dep -->
+    <maven.compiler.target>17</maven.compiler.target>
+
     <classWorldsVersion>2.6.0</classWorldsVersion>
     <commonsCliVersion>1.5.0</commonsCliVersion>
     <commonsIoVersion>2.11.0</commonsIoVersion>
@@ -165,7 +170,7 @@ under the License.
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
     <cipherVersion>2.0</cipherVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.9.2</resolverVersion>
+    <resolverVersion>1.9.3-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.6.4</xmlunitVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
@@ -394,6 +399,11 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-transport-wagon</artifactId>
+        <version>${resolverVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-jetty</artifactId>
         <version>${resolverVersion}</version>
       </dependency>
       <!--  Commons -->


### PR DESCRIPTION
Add Jetty transport from resolver and make it selectable.

To build this Java17 is must (and raises Maven as well to 11).

Depends on https://github.com/apache/maven-resolver/pull/225

To build this (some dependencies brings in new license):
```
mvn clean install -Dremoteresources.skip
```

You will end up with HUGE maven 4 snapshot that embed Jetty Client.

---

To use it: use this settings: https://gist.github.com/cstamas/492747108c6112cedf887a5394e52eb0

```
~/tmp/apache-maven-4.0.0-alpha-3-SNAPSHOT/bin/mvn -V -s settings.xml clean install -Drat.skip -Dmaven.test.skip -Dmaven.resolver.transport=jetty
```
(rat.skip needed to leave alone local repo within build, tests skip to make it shorter, not wait for UT runs)

Transport values:
* maven.resolver.transport=jetty
* maven.resolver.transport=native
* maven.resolver.transport=wagon

settings.xml will use $CWD/local as local repo, nuke it before runs (to force all being re-downloaded).