### PR TITLE
[MNG-7611] Change semantics of plugin descriptor's "requiredJavaVersion"

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteChecker.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteChecker.java
@@ -58,13 +58,13 @@ public class MavenPluginJavaPrerequisiteChecker implements MavenPluginPrerequisi
             constraint = versionScheme.parseVersionConstraint(requiredVersion);
         } catch (InvalidVersionSpecificationException e) {
             throw new IllegalArgumentException(
-                    "Invalid requiredJavaVersion given in plugin descriptor: " + e.getMessage(), e);
+                    "Invalid 'requiredJavaVersion' given in plugin descriptor", e);
         }
         Version current;
         try {
             current = versionScheme.parseVersion(currentVersion);
         } catch (InvalidVersionSpecificationException e) {
-            throw new IllegalStateException("Could not parse current Java version: " + e.getMessage(), e);
+            throw new IllegalStateException("Could not parse current Java version", e);
         }
         if (constraint.getRange() == null) {
             return constraint.getVersion().compareTo(current) <= 0;

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteChecker.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteChecker.java
@@ -57,8 +57,7 @@ public class MavenPluginJavaPrerequisiteChecker implements MavenPluginPrerequisi
         try {
             constraint = versionScheme.parseVersionConstraint(requiredVersion);
         } catch (InvalidVersionSpecificationException e) {
-            throw new IllegalArgumentException(
-                    "Invalid 'requiredJavaVersion' given in plugin descriptor", e);
+            throw new IllegalArgumentException("Invalid 'requiredJavaVersion' given in plugin descriptor", e);
         }
         Version current;
         try {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteChecker.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteChecker.java
@@ -18,26 +18,57 @@
  */
 package org.apache.maven.plugin.internal;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.apache.maven.model.profile.activation.JdkVersionProfileActivator;
 import org.apache.maven.plugin.MavenPluginPrerequisitesChecker;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionConstraint;
+import org.eclipse.aether.version.VersionScheme;
 
 @Named
 @Singleton
 public class MavenPluginJavaPrerequisiteChecker implements MavenPluginPrerequisitesChecker {
+
+    private final VersionScheme versionScheme;
+
+    @Inject
+    public MavenPluginJavaPrerequisiteChecker(final VersionScheme versionScheme) {
+        this.versionScheme = versionScheme;
+    }
 
     @Override
     public void accept(PluginDescriptor pluginDescriptor) {
         String requiredJavaVersion = pluginDescriptor.getRequiredJavaVersion();
         if (StringUtils.isNotBlank(requiredJavaVersion)) {
             String currentJavaVersion = System.getProperty("java.version");
-            if (!JdkVersionProfileActivator.isJavaVersionCompatible(requiredJavaVersion, currentJavaVersion)) {
+            if (!matchesVersion(requiredJavaVersion, currentJavaVersion)) {
                 throw new IllegalStateException("Required Java version " + requiredJavaVersion
                         + " is not met by current version: " + currentJavaVersion);
             }
         }
+    }
+
+    boolean matchesVersion(String requiredVersion, String currentVersion) {
+        VersionConstraint constraint;
+        try {
+            constraint = versionScheme.parseVersionConstraint(requiredVersion);
+        } catch (InvalidVersionSpecificationException e) {
+            throw new IllegalArgumentException(
+                    "Invalid requiredJavaVersion given in plugin descriptor: " + e.getMessage(), e);
+        }
+        Version current;
+        try {
+            current = versionScheme.parseVersion(currentVersion);
+        } catch (InvalidVersionSpecificationException e) {
+            throw new IllegalStateException("Could not parse current Java version: " + e.getMessage(), e);
+        }
+        if (constraint.getRange() == null) {
+            return constraint.getVersion().compareTo(current) <= 0;
+        }
+        return constraint.containsVersion(current);
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteCheckerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteCheckerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.junit.jupiter.api.Test;
+
+class MavenPluginJavaPrerequisiteCheckerTest {
+
+    @Test
+    void testMatchesVersion() {
+        MavenPluginJavaPrerequisiteChecker checker = new MavenPluginJavaPrerequisiteChecker(new GenericVersionScheme());
+        assertTrue(checker.matchesVersion("1.0", "8"));
+        assertFalse(checker.matchesVersion("[1.0,2],[3,4]", "2.1"));
+        assertThrows(IllegalArgumentException.class, () -> checker.matchesVersion("(1.0,0)", "11"));
+    }
+}

--- a/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteCheckerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteCheckerTest.java
@@ -28,8 +28,10 @@ class MavenPluginJavaPrerequisiteCheckerTest {
     @Test
     void testMatchesVersion() {
         MavenPluginJavaPrerequisiteChecker checker = new MavenPluginJavaPrerequisiteChecker(new GenericVersionScheme());
-        assertTrue(checker.matchesVersion("1.0", "8"));
+        assertTrue(checker.matchesVersion("1.0", "1.8"));
+        assertTrue(checker.matchesVersion("1.8", "9.0.1+11"));
         assertFalse(checker.matchesVersion("[1.0,2],[3,4]", "2.1"));
+        assertTrue(checker.matchesVersion("[1.0,2],[3,4]", "3.1"));
         assertThrows(IllegalArgumentException.class, () -> checker.matchesVersion("(1.0,0)", "11"));
     }
 }

--- a/maven-plugin-api/src/main/mdo/plugin.mdo
+++ b/maven-plugin-api/src/main/mdo/plugin.mdo
@@ -99,7 +99,7 @@ under the License.
         <field>
           <name>requiredJavaVersion</name>
           <version>1.1.0+</version>
-          <description>A version range which specifies the supported Java versions. The same values as for POM profile activation element 'jdk' are allowed, i.e. version ranges, version prefixes and negated version prefixes (starting with '!').</description>
+          <description>A version range which specifies the supported Java versions. A version range can either use the usual mathematical syntax "[2.0.10,2.1.0),[3.0,)" or use a single version "2.2.1". The latter is a short form for "[2.2.1,)", i.e. denotes the minimum version required.</description>
           <type>String</type>
         </field>
         <field>


### PR DESCRIPTION
Always assume version constraint (the same as in requiredMavenVersion)

