### PR TITLE
[MNG-7608] Make native transport the default

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -227,9 +227,8 @@ public class DefaultRepositorySystemSessionFactory {
                 configProps.put("aether.connector.wagon.config." + server.getId(), config);
 
                 // Translate to proper resolver configuration properties as well (as Plexus XML above is Wagon specific
-                // only)
-                // but support only configuration/httpConfiguration/all, not the per-method nonsense
-                // https://maven.apache.org/guides/mini/guide-http-settings.html#support-for-general-wagon-configuration-standards
+                // only) but support only configuration/httpConfiguration/all, see
+                // https://maven.apache.org/guides/mini/guide-http-settings.html
                 Map<String, String> headers = null;
                 Integer connectTimeout = null;
                 Integer requestTimeout = null;

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -226,7 +226,9 @@ public class DefaultRepositorySystemSessionFactory {
                 PlexusConfiguration config = XmlPlexusConfiguration.toPlexusConfiguration(dom);
                 configProps.put("aether.connector.wagon.config." + server.getId(), config);
 
-                // translate to proper Resolver configuration properties as well, support all of "standards" as on page
+                // Translate to proper resolver configuration properties as well (as Plexus XML above is Wagon specific
+                // only)
+                // but support only configuration/httpConfiguration/all, not the per-method nonsense
                 // https://maven.apache.org/guides/mini/guide-http-settings.html#support-for-general-wagon-configuration-standards
                 Map<String, String> headers = null;
                 Integer connectTimeout = null;
@@ -250,9 +252,16 @@ public class DefaultRepositorySystemSessionFactory {
                     connectTimeout = Integer.parseInt(connectTimeoutXml.getValue());
                 } else {
                     // fallback configuration name
-                    connectTimeoutXml = config.getChild("connectionTimeout", false);
-                    if (connectTimeoutXml != null) {
-                        connectTimeout = Integer.parseInt(connectTimeoutXml.getValue());
+                    PlexusConfiguration httpConfiguration = config.getChild("httpConfiguration", false);
+                    if (httpConfiguration != null) {
+                        PlexusConfiguration httpConfigurationAll = httpConfiguration.getChild("all", false);
+                        if (httpConfigurationAll != null) {
+                            connectTimeoutXml = httpConfigurationAll.getChild("connectionTimeout", false);
+                            if (connectTimeoutXml != null) {
+                                connectTimeout = Integer.parseInt(connectTimeoutXml.getValue());
+                                logger.warn("Settings for server {} uses legacy format", server.getId());
+                            }
+                        }
                     }
                 }
 
@@ -261,9 +270,16 @@ public class DefaultRepositorySystemSessionFactory {
                     requestTimeout = Integer.parseInt(requestTimeoutXml.getValue());
                 } else {
                     // fallback configuration name
-                    requestTimeoutXml = config.getChild("readTimeout", false);
-                    if (requestTimeoutXml != null) {
-                        requestTimeout = Integer.parseInt(requestTimeoutXml.getValue());
+                    PlexusConfiguration httpConfiguration = config.getChild("httpConfiguration", false);
+                    if (httpConfiguration != null) {
+                        PlexusConfiguration httpConfigurationAll = httpConfiguration.getChild("all", false);
+                        if (httpConfigurationAll != null) {
+                            requestTimeoutXml = httpConfigurationAll.getChild("readTimeout", false);
+                            if (requestTimeoutXml != null) {
+                                requestTimeout = Integer.parseInt(requestTimeoutXml.getValue());
+                                logger.warn("Settings for server {} uses legacy format", server.getId());
+                            }
+                        }
                     }
                 }
 

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -233,23 +233,7 @@ public class DefaultRepositorySystemSessionFactory {
 
         Object transport = configProps.getOrDefault(MAVEN_RESOLVER_TRANSPORT_KEY, MAVEN_RESOLVER_TRANSPORT_DEFAULT);
         if (MAVEN_RESOLVER_TRANSPORT_DEFAULT.equals(transport)) {
-            // The "default" mode (user did not set anything) needs to tweak resolver default priorities
-            // that are coded like this (default values):
-            //
-            // org.eclipse.aether.transport.http.HttpTransporterFactory.priority = 5.0f;
-            // org.eclipse.aether.transport.wagon.WagonTransporterFactory.priority = -1.0f;
-            //
-            // Hence, as both are present on classpath, HttpTransport would be selected, while
-            // we want to retain "default" behaviour of Maven and use Wagon. To achieve that,
-            // we set explicitly priority of WagonTransport to 6.0f (just above of HttpTransport),
-            // to make it "win" over HttpTransport. We do this to NOT interfere with possibly
-            // installed OTHER transports and their priorities, as unlike "wagon" or "native"
-            // transport setting, that sets priorities to MAX, hence prevents any 3rd party
-            // transport to get into play (inhibits them), in default mode we want to retain
-            // old behavior. Also, this "default" mode is different from "auto" setting,
-            // as it does not alter resolver priorities at all, and uses priorities as is.
-
-            configProps.put(WAGON_TRANSPORTER_PRIORITY_KEY, "6");
+            // The "default" mode (user did not set anything) from now on defaults to AUTO
         } else if (MAVEN_RESOLVER_TRANSPORT_NATIVE.equals(transport)) {
             // Make sure (whatever extra priority is set) that resolver native is selected
             configProps.put(NATIVE_FILE_TRANSPORTER_PRIORITY_KEY, RESOLVER_MAX_PRIORITY);


### PR DESCRIPTION
This immediately cuts in "half" the count of HTTP requests against Maven Central or any major MRM.

Altering the meaning of "default": is now same as "auto", but still leaving it in place for future, as "default" at some point may again become something different than "native".

---

https://issues.apache.org/jira/browse/MNG-7608