### PR TITLE
[MNG-7618] Use goalPrefix instead of artifactId to display mojos being executed

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
@@ -419,7 +419,8 @@ public class ExecutionEventLogger extends AbstractExecutionListener {
     }
 
     private void append(MessageBuilder buffer, MojoExecution me) {
-        buffer.mojo(me.getArtifactId() + ':' + me.getVersion() + ':' + me.getGoal());
+        String prefix = me.getMojoDescriptor().getPluginDescriptor().getGoalPrefix();
+        buffer.mojo(prefix + ':' + me.getVersion() + ':' + me.getGoal());
         if (me.getExecutionId() != null) {
             buffer.a(' ').strong('(' + me.getExecutionId() + ')');
         }


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7618
Related to https://github.com/apache/maven-mvnd/issues/745