### PR TITLE
[MNG-7624] Use groupId:artifactId instead of empty goal

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
@@ -420,6 +420,9 @@ public class ExecutionEventLogger extends AbstractExecutionListener {
 
     private void append(MessageBuilder buffer, MojoExecution me) {
         String prefix = me.getMojoDescriptor().getPluginDescriptor().getGoalPrefix();
+        if (StringUtils.isEmpty(prefix)) {
+            prefix = me.getGroupId() + ":" + me.getArtifactId();
+        }
         buffer.mojo(prefix + ':' + me.getVersion() + ':' + me.getGoal());
         if (me.getExecutionId() != null) {
             buffer.a(' ').strong('(' + me.getExecutionId() + ')');


### PR DESCRIPTION
JIRA issue : https://issues.apache.org/jira/browse/MNG-7624