### PR TITLE
[MNG-7629] Improve resolution of modules within a multi-module build

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -20,40 +20,33 @@ package org.apache.maven;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.eventspy.EventSpy;
+import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.artifact.ProjectArtifact;
 import org.apache.maven.repository.internal.MavenWorkspaceReader;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.WorkspaceRepository;
-import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * An implementation of a workspace reader that knows how to search the Maven reactor for artifacts, either as packaged
@@ -66,30 +59,15 @@ import static java.util.stream.Collectors.toMap;
 class ReactorReader implements MavenWorkspaceReader {
     public static final String HINT = "reactor";
 
-    private static final Collection<String> COMPILE_PHASE_TYPES =
-            Arrays.asList("jar", "ejb-client", "war", "rar", "ejb3", "par", "sar", "wsr", "har", "app-client");
-
     private static final Logger LOGGER = LoggerFactory.getLogger(ReactorReader.class);
 
     private final MavenSession session;
-    private final Map<String, MavenProject> projectsByGAV;
-    private final Map<String, List<MavenProject>> projectsByGA;
     private final WorkspaceRepository repository;
-
-    private Function<MavenProject, String> projectIntoKey =
-            s -> ArtifactUtils.key(s.getGroupId(), s.getArtifactId(), s.getVersion());
-
-    private Function<MavenProject, String> projectIntoVersionlessKey =
-            s -> ArtifactUtils.versionlessKey(s.getGroupId(), s.getArtifactId());
 
     @Inject
     ReactorReader(MavenSession session) {
         this.session = session;
-        this.projectsByGAV = session.getAllProjects().stream().collect(toMap(projectIntoKey, identity()));
-
-        this.projectsByGA = projectsByGAV.values().stream().collect(groupingBy(projectIntoVersionlessKey));
-
-        repository = new WorkspaceRepository("reactor", new HashSet<>(projectsByGAV.keySet()));
+        this.repository = new WorkspaceRepository("reactor", null);
     }
 
     //
@@ -101,227 +79,146 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     public File findArtifact(Artifact artifact) {
-        String projectKey = ArtifactUtils.key(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
-
-        MavenProject project = projectsByGAV.get(projectKey);
-
-        if (project != null) {
-            File file = find(project, artifact);
-            if (file == null && project != project.getExecutionProject()) {
-                file = find(project.getExecutionProject(), artifact);
+        List<MavenProject> projects = session.getAllProjects();
+        if (projects != null) {
+            for (MavenProject p : projects) {
+                if (Objects.equals(artifact.getGroupId(), p.getGroupId())
+                        && Objects.equals(artifact.getArtifactId(), p.getArtifactId())
+                        && Objects.equals(artifact.getBaseVersion(), p.getVersion())
+                        && Objects.equals(artifact.getExtension(), "pom")
+                        && p.getFile() != null) {
+                    return p.getFile();
+                }
             }
-            return file;
         }
-
-        return null;
+        File file = find(artifact);
+        return file;
     }
 
     public List<String> findVersions(Artifact artifact) {
-        String key = ArtifactUtils.versionlessKey(artifact.getGroupId(), artifact.getArtifactId());
-
-        return Optional.ofNullable(projectsByGA.get(key)).orElse(Collections.emptyList()).stream()
-                .filter(s -> Objects.nonNull(find(s, artifact)))
-                .map(MavenProject::getVersion)
-                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+        List<String> versions = new ArrayList<>();
+        String artifactId = artifact.getArtifactId();
+        String groupId = artifact.getGroupId();
+        Path repo = getProjectLocalRepo().resolve(groupId).resolve(artifactId);
+        String classifier = artifact.getClassifier();
+        String extension = artifact.getExtension();
+        Pattern pattern = Pattern.compile("\\Q" + artifactId + "\\E-(.*)"
+                + (classifier != null ? "-\\Q" + classifier + "\\E" : "")
+                + (extension != null ? "." + extension : ""));
+        try (Stream<Path> paths = Files.list(repo)) {
+            paths.forEach(p -> {
+                String filename = p.getFileName().toString();
+                Matcher matcher = pattern.matcher(filename);
+                if (matcher.matches()) {
+                    versions.add(matcher.group(1));
+                }
+            });
+        } catch (IOException e) {
+            // ignore
+        }
+        return Collections.unmodifiableList(versions);
     }
 
     @Override
     public Model findModel(Artifact artifact) {
-        String projectKey = ArtifactUtils.key(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
-        MavenProject project = projectsByGAV.get(projectKey);
-        return project == null ? null : project.getModel();
+        List<MavenProject> projects = session.getAllProjects();
+        if (projects != null) {
+            for (MavenProject p : projects) {
+                if (Objects.equals(artifact.getGroupId(), p.getGroupId())
+                        && Objects.equals(artifact.getArtifactId(), p.getArtifactId())
+                        && Objects.equals(artifact.getBaseVersion(), p.getVersion())
+                        && Objects.equals(artifact.getExtension(), "pom")
+                        && p.getFile() != null) {
+                    return p.getModel();
+                }
+            }
+        }
+        return null;
     }
 
     //
     // Implementation
     //
 
-    private File find(MavenProject project, Artifact artifact) {
-        if ("pom".equals(artifact.getExtension())) {
-            return project.getFile();
-        }
-
-        Artifact projectArtifact = findMatchingArtifact(project, artifact);
-        File packagedArtifactFile = determinePreviouslyPackagedArtifactFile(project, projectArtifact);
-
-        if (hasArtifactFileFromPackagePhase(projectArtifact)) {
-            return projectArtifact.getFile();
-        }
-        // Check whether an earlier Maven run might have produced an artifact that is still on disk.
-        else if (packagedArtifactFile != null
-                && packagedArtifactFile.exists()
-                && isPackagedArtifactUpToDate(project, packagedArtifactFile, artifact)) {
-            return packagedArtifactFile;
-        } else if (!hasBeenPackagedDuringThisSession(project)) {
-            // fallback to loose class files only if artifacts haven't been packaged yet
-            // and only for plain old jars. Not war files, not ear files, not anything else.
-            return determineBuildOutputDirectoryForArtifact(project, artifact);
-        }
-
-        // The fall-through indicates that the artifact cannot be found;
-        // for instance if package produced nothing or classifier problems.
-        return null;
+    private File find(Artifact artifact) {
+        Path target = getArtifactPath(artifact);
+        return Files.isRegularFile(target) ? target.toFile() : null;
     }
 
-    private File determineBuildOutputDirectoryForArtifact(final MavenProject project, final Artifact artifact) {
-        if (isTestArtifact(artifact)) {
-            if (project.hasLifecyclePhase("test-compile")) {
-                return new File(project.getBuild().getTestOutputDirectory());
-            }
-        } else {
-            String type = artifact.getProperty("type", "");
-            File outputDirectory = new File(project.getBuild().getOutputDirectory());
+    public void processProject(MavenProject project) {
+        List<Artifact> artifacts = new ArrayList<>();
 
-            // Check if the project is being built during this session, and if we can expect any output.
-            // There is no need to check if the build has created any outputs, see MNG-2222.
-            boolean projectCompiledDuringThisSession =
-                    project.hasLifecyclePhase("compile") && COMPILE_PHASE_TYPES.contains(type);
-
-            // Check if the project is part of the session (not filtered by -pl, -rf, etc). If so, we check
-            // if a possible earlier Maven invocation produced some output for that project which we can use.
-            boolean projectHasOutputFromPreviousSession =
-                    !session.getProjects().contains(project) && outputDirectory.exists();
-
-            if (projectHasOutputFromPreviousSession || projectCompiledDuringThisSession) {
-                return outputDirectory;
-            }
+        artifacts.add(RepositoryUtils.toArtifact(new ProjectArtifact(project)));
+        if (!"pom".equals(project.getPackaging())) {
+            org.apache.maven.artifact.Artifact mavenMainArtifact = project.getArtifact();
+            artifacts.add(RepositoryUtils.toArtifact(mavenMainArtifact));
+        }
+        for (org.apache.maven.artifact.Artifact attached : project.getAttachedArtifacts()) {
+            artifacts.add(RepositoryUtils.toArtifact(attached));
         }
 
-        // The fall-through indicates that the artifact cannot be found;
-        // for instance if package produced nothing or classifier problems.
-        return null;
-    }
-
-    private File determinePreviouslyPackagedArtifactFile(MavenProject project, Artifact artifact) {
-        if (artifact == null) {
-            return null;
-        }
-
-        String fileName = String.format("%s.%s", project.getBuild().getFinalName(), artifact.getExtension());
-        return new File(project.getBuild().getDirectory(), fileName);
-    }
-
-    private boolean hasArtifactFileFromPackagePhase(Artifact projectArtifact) {
-        return projectArtifact != null
-                && projectArtifact.getFile() != null
-                && projectArtifact.getFile().exists();
-    }
-
-    private boolean isPackagedArtifactUpToDate(MavenProject project, File packagedArtifactFile, Artifact artifact) {
-        Path outputDirectory = Paths.get(project.getBuild().getOutputDirectory());
-        if (!outputDirectory.toFile().exists()) {
-            return true;
-        }
-
-        try (Stream<Path> outputFiles = Files.walk(outputDirectory)) {
-            // Not using File#lastModified() to avoid a Linux JDK8 milliseconds precision bug: JDK-8177809.
-            long artifactLastModified =
-                    Files.getLastModifiedTime(packagedArtifactFile.toPath()).toMillis();
-
-            if (session.getProjectBuildingRequest().getBuildStartTime() != null) {
-                long buildStartTime =
-                        session.getProjectBuildingRequest().getBuildStartTime().getTime();
-                if (artifactLastModified > buildStartTime) {
-                    return true;
+        for (Artifact artifact : artifacts) {
+            if (artifact.getFile() != null && artifact.getFile().isFile()) {
+                Path target = getArtifactPath(artifact);
+                try {
+                    LOGGER.debug("Copying {} to project local repository", artifact);
+                    Files.createDirectories(target.getParent());
+                    Files.copy(artifact.getFile().toPath(), target, StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    LOGGER.warn("Error while copying artifact to project local repository", e);
                 }
             }
+        }
+    }
 
-            Iterator<Path> iterator = outputFiles.iterator();
-            while (iterator.hasNext()) {
-                Path outputFile = iterator.next();
+    private Path getArtifactPath(Artifact artifact) {
+        String groupId = artifact.getGroupId();
+        String artifactId = artifact.getArtifactId();
+        String version = artifact.getBaseVersion();
+        String classifier = artifact.getClassifier();
+        String extension = artifact.getExtension();
+        Path repo = getProjectLocalRepo();
+        return repo.resolve(groupId)
+                .resolve(artifactId)
+                .resolve(artifactId
+                        + "-" + version
+                        + (classifier != null && !classifier.isEmpty() ? "-" + classifier : "")
+                        + (extension != null && !extension.isEmpty() ? "." + extension : ""));
+    }
 
-                if (Files.isDirectory(outputFile)) {
-                    continue;
-                }
+    private Path getProjectLocalRepo() {
+        Path root = session.getRequest().getMultiModuleProjectDirectory().toPath();
+        Path repo = root.resolve("target").resolve("project-local-repo");
+        return repo;
+    }
 
-                long outputFileLastModified =
-                        Files.getLastModifiedTime(outputFile).toMillis();
-                if (outputFileLastModified > artifactLastModified) {
-                    File alternative = determineBuildOutputDirectoryForArtifact(project, artifact);
-                    if (alternative != null) {
-                        LOGGER.warn(
-                                "File '{}' is more recent than the packaged artifact for '{}'; using '{}' instead",
-                                relativizeOutputFile(outputFile),
-                                project.getArtifactId(),
-                                relativizeOutputFile(alternative.toPath()));
-                    } else {
-                        LOGGER.warn(
-                                "File '{}' is more recent than the packaged artifact for '{}'; "
-                                        + "cannot use the build output directory for this type of artifact",
-                                relativizeOutputFile(outputFile),
-                                project.getArtifactId());
-                    }
-                    return false;
+    @Named
+    @Singleton
+    @SuppressWarnings("unused")
+    static class ReactorReaderSpy implements EventSpy {
+
+        final PlexusContainer container;
+
+        @Inject
+        ReactorReaderSpy(PlexusContainer container) {
+            this.container = container;
+        }
+
+        @Override
+        public void init(Context context) throws Exception {}
+
+        @Override
+        public void onEvent(Object event) throws Exception {
+            if (event instanceof ExecutionEvent) {
+                ExecutionEvent ee = (ExecutionEvent) event;
+                if (ee.getType() == ExecutionEvent.Type.ForkedProjectSucceeded
+                        || ee.getType() == ExecutionEvent.Type.ProjectSucceeded) {
+                    container.lookup(ReactorReader.class).processProject(ee.getProject());
                 }
             }
-
-            return true;
-        } catch (IOException e) {
-            LOGGER.warn(
-                    "An I/O error occurred while checking if the packaged artifact is up-to-date "
-                            + "against the build output directory. "
-                            + "Continuing with the assumption that it is up-to-date.",
-                    e);
-            return true;
-        }
-    }
-
-    private boolean hasBeenPackagedDuringThisSession(MavenProject project) {
-        return project.hasLifecyclePhase("package")
-                || project.hasLifecyclePhase("install")
-                || project.hasLifecyclePhase("deploy");
-    }
-
-    private Path relativizeOutputFile(final Path outputFile) {
-        Path projectBaseDirectory =
-                Paths.get(session.getRequest().getMultiModuleProjectDirectory().toURI());
-        return projectBaseDirectory.relativize(outputFile);
-    }
-
-    /**
-     * Tries to resolve the specified artifact from the artifacts of the given project.
-     *
-     * @param project The project to try to resolve the artifact from, must not be <code>null</code>.
-     * @param requestedArtifact The artifact to resolve, must not be <code>null</code>.
-     * @return The matching artifact from the project or <code>null</code> if not found. Note that this
-     */
-    private Artifact findMatchingArtifact(MavenProject project, Artifact requestedArtifact) {
-        String requestedRepositoryConflictId = ArtifactIdUtils.toVersionlessId(requestedArtifact);
-
-        Artifact mainArtifact = RepositoryUtils.toArtifact(project.getArtifact());
-        if (requestedRepositoryConflictId.equals(ArtifactIdUtils.toVersionlessId(mainArtifact))) {
-            return mainArtifact;
         }
 
-        return RepositoryUtils.toArtifacts(project.getAttachedArtifacts()).stream()
-                .filter(isRequestedArtifact(requestedArtifact))
-                .findFirst()
-                .orElse(null);
-    }
-
-    /**
-     * We are taking as much as we can from the DefaultArtifact.equals(). The requested artifact has no file, so we want
-     * to remove that from the comparison.
-     *
-     * @param requestArtifact checked against the given artifact.
-     * @return true if equals, false otherwise.
-     */
-    private Predicate<Artifact> isRequestedArtifact(Artifact requestArtifact) {
-        return s -> s.getArtifactId().equals(requestArtifact.getArtifactId())
-                && s.getGroupId().equals(requestArtifact.getGroupId())
-                && s.getVersion().equals(requestArtifact.getVersion())
-                && s.getExtension().equals(requestArtifact.getExtension())
-                && s.getClassifier().equals(requestArtifact.getClassifier());
-    }
-
-    /**
-     * Determines whether the specified artifact refers to test classes.
-     *
-     * @param artifact The artifact to check, must not be {@code null}.
-     * @return {@code true} if the artifact refers to test classes, {@code false} otherwise.
-     */
-    private static boolean isTestArtifact(Artifact artifact) {
-        return ("test-jar".equals(artifact.getProperty("type", "")))
-                || ("jar".equals(artifact.getExtension()) && "tests".equals(artifact.getClassifier()));
+        @Override
+        public void close() throws Exception {}
     }
 }


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7629

- Partial revert of MNG-6118
- [MNG-7629] Change reactor reader to copy packaged artifacts and reuse them across builds if needed

PR with IT at https://github.com/apache/maven-integration-testing/pull/219

================

As discussed in the JIRA, the fix for MNG-6118 has several problems:
  * it requires reading the whole reactor when building a subtree
  * it does not work with attached artifacts
This PR partially reverts MNG-6118 so that maven does not read the full reactor anymore and fixes the `ReactorReader` so that it keeps a copy of each artifact to be installed/deployed in the `${multiModuleProjectDirectory}/target/project-local-repo` directory and uses them to resolve artifacts during build.
