### PR TITLE
Implement some `toString`s

### DIFF
--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -43,8 +43,8 @@
   |   definition of these types
   |
 -->
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.8.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.8.0.xsd"
   xml.namespace="http://maven.apache.org/POM/${version}"
   xml.schemaLocation="https://maven.apache.org/xsd/maven-${version}.xsd">
   <id>maven</id>
@@ -1422,7 +1422,7 @@
         and maybe even a specific element for the user and scm mailing lists. Then leave the more
         lose structure for any other type of mailing list.</comment>
     </class>
-    <class java.clone="deep">
+    <class java.clone="deep" java.toString="true">
       <name>Organization</name>
       <description>Specifies the organization that produces this project.</description>
       <version>3.0.0+</version>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1253,6 +1253,20 @@
           <type>String</type>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "IssueManagement(system=%s, url=%s)", system, url );
+     }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class java.clone="deep">
       <name>DistributionManagement</name>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1312,11 +1312,13 @@
           <version>4.0.0+</version>
           <code>
             <![CDATA[
-     @Override
-     public String toString()
-     {
-         return String.format( "IssueManagement(system=%s, url=%s)", system, url );
-     }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "IssueManagement {system=" + system + ", url=" + url + "}";
+    }
             ]]>
           </code>
         </codeSegment>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1457,7 +1457,7 @@
         </codeSegment>
       </codeSegments>
     </class>
-    <class java.clone="deep" java.toString="true">
+    <class java.clone="deep">
       <name>MailingList</name>
       <version>3.0.0+</version>
       <description>This element describes all of the mailing lists associated with a project. The
@@ -1531,6 +1531,22 @@
       <comment>We could probably have a specific element for a dev mailing list for things like CI,
         and maybe even a specific element for the user and scm mailing lists. Then leave the more
         lose structure for any other type of mailing list.</comment>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "MailingList {name=" + name + ", archive=" + archive + "}";
+    }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class java.clone="deep">
       <name>Organization</name>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1388,6 +1388,20 @@
           <type>String</type>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "License(name=%s, url=%s)", name, url );
+     }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class java.clone="deep">
       <name>MailingList</name>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1403,7 +1403,7 @@
         </codeSegment>
       </codeSegments>
     </class>
-    <class java.clone="deep">
+    <class java.clone="deep" java.toString="true">
       <name>MailingList</name>
       <version>3.0.0+</version>
       <description>This element describes all of the mailing lists associated with a project. The

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1030,11 +1030,13 @@
           <version>4.0.0+</version>
           <code>
             <![CDATA[
-     @Override
-     public String toString()
-     {
-         return String.format( "Contributor(name=%s, email=%s)", name, email );
-     }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "Contributor {name=" + name + ", email=" + email + "}";
+    }
             ]]>
           </code>
         </codeSegment>
@@ -1252,11 +1254,13 @@
           <version>4.0.0+</version>
           <code>
             <![CDATA[
-     @Override
-     public String toString()
-     {
-         return String.format( "Developer(super=%s, id=%s)", super.toString(), id );
-     }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "Developer {id=" + id + ", " + super.toString() + "}";
+    }
             ]]>
           </code>
         </codeSegment>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -625,7 +625,7 @@
      @Override
      public String toString()
      {
-         return String.format( "PluginContainer()" );
+         return "PluginContainer {}";
      }
             ]]>
           </code>
@@ -658,11 +658,13 @@
           <version>4.0.0+</version>
           <code>
             <![CDATA[
-     @Override
-     public String toString()
-     {
-         return String.format( "PluginConfiguration(super=%s)", super.toString() );
-     }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "PluginConfiguration {" + super.toString() + "}";
+    }
             ]]>
           </code>
         </codeSegment>
@@ -746,11 +748,13 @@
           <version>4.0.0+</version>
           <code>
             <![CDATA[
-     @Override
-     public String toString()
-     {
-         return String.format( "BuildBase(super=%s)", super.toString() );
-     }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "BuildBase {" + super.toString() + "}";
+    }
             ]]>
           </code>
         </codeSegment>
@@ -837,11 +841,13 @@
           <version>4.0.0+</version>
           <code>
             <![CDATA[
-     @Override
-     public String toString()
-     {
-         return String.format( "Build(super=%s)", super.toString() );
-     }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "Build {" + super.toString() + "}";
+    }
             ]]>
           </code>
         </codeSegment>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -618,6 +618,18 @@
             ]]>
           </code>
         </codeSegment>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "PluginContainer()" );
+     }
+            ]]>
+          </code>
+        </codeSegment>
       </codeSegments>
     </class>
     <class>
@@ -641,6 +653,20 @@
           </association>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "PluginConfiguration(super=%s)", super.toString() );
+     }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class>
       <name>BuildBase</name>
@@ -715,6 +741,20 @@
           </association>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "BuildBase(super=%s)", super.toString() );
+     }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class>
       <name>Build</name>
@@ -792,6 +832,20 @@
           </association>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "Build(super=%s)", super.toString() );
+     }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class java.clone="deep">
       <name>CiManagement</name>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1652,7 +1652,7 @@
       </codeSegments>
 
     </class>
-    <class java.clone="deep">
+    <class java.clone="deep" java.toString="true">
       <name>Scm</name>
       <version>4.0.0+</version>
       <description>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1738,7 +1738,7 @@
       </codeSegments>
 
     </class>
-    <class java.clone="deep" java.toString="true">
+    <class java.clone="deep">
       <name>Scm</name>
       <version>4.0.0+</version>
       <description>
@@ -1876,6 +1876,20 @@
         this.childScmUrlInheritAppendPath = String.valueOf( childScmUrlInheritAppendPath );
     }
 
+            ]]>
+          </code>
+        </codeSegment>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "Scm {connection=" + connection + "}";
+    }
             ]]>
           </code>
         </codeSegment>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1532,7 +1532,7 @@
         and maybe even a specific element for the user and scm mailing lists. Then leave the more
         lose structure for any other type of mailing list.</comment>
     </class>
-    <class java.clone="deep" java.toString="true">
+    <class java.clone="deep">
       <name>Organization</name>
       <description>Specifies the organization that produces this project.</description>
       <version>3.0.0+</version>
@@ -1550,6 +1550,22 @@
           <type>String</type>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "Organization {name=" + name + ", url=" + url + "}";
+    }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class java.clone="deep">
       <name>PatternSet</name>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -971,6 +971,20 @@
           </association>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "Contributor(name=%s, email=%s)", name, email );
+     }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class java.clone="deep">
       <name>Dependency</name>
@@ -1179,6 +1193,20 @@
           <type>String</type>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.0.0+</version>
+          <code>
+            <![CDATA[
+     @Override
+     public String toString()
+     {
+         return String.format( "Developer(super=%s, id=%s)", super.toString(), id );
+     }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class java.clone="deep">
       <name>Exclusion</name>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1447,11 +1447,13 @@
           <version>4.0.0+</version>
           <code>
             <![CDATA[
-     @Override
-     public String toString()
-     {
-         return String.format( "License(name=%s, url=%s)", name, url );
-     }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "License {name=" + name + ", url=" + url + "}";
+    }
             ]]>
           </code>
         </codeSegment>

--- a/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
@@ -59,6 +59,6 @@ public class BuildTest
 
         String s = build.toString();
 
-        assert "Build(super=BuildBase(super=PluginConfiguration(super=PluginContainer())))".equals( s ) : s;
+        assert "Build {BuildBase {PluginConfiguration {PluginContainer {}}}}".equals( s ) : s;
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
@@ -53,4 +53,12 @@ public class BuildTest
         assertNotNull( new Build().toString() );
     }
 
+    public void testToStringNotNonsense()
+    {
+        Build build = new Build();
+
+        String s = build.toString();
+
+        assert "Build(super=BuildBase(super=PluginConfiguration(super=PluginContainer())))".equals( s ) : s;
+    }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
@@ -53,4 +53,15 @@ public class DeveloperTest
         assertNotNull( new Developer().toString() );
     }
 
+    public void testToStringNotNonsense()
+    {
+        Developer dev = new Developer();
+        dev.setName( "Maven Tester" );
+        dev.setEmail( "tester@acme.localdomain" );
+        dev.setId( "20220118" );
+
+        String s = dev.toString();
+
+        assert "Developer(super=Contributor(name=Maven Tester, email=tester@acme.localdomain), id=20220118)".equals( s ) : s;
+    }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
@@ -62,6 +62,6 @@ public class DeveloperTest
 
         String s = dev.toString();
 
-        assert "Developer(super=Contributor(name=Maven Tester, email=tester@acme.localdomain), id=20220118)".equals( s ) : s;
+        assert "Developer {id=20220118, Contributor {name=Maven Tester, email=tester@acme.localdomain}}".equals( s ) : s;
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
@@ -53,4 +53,14 @@ public class IssueManagementTest
         assertNotNull( new IssueManagement().toString() );
     }
 
+    public void testToStringNotNonsense()
+    {
+        IssueManagement im = new IssueManagement();
+        im.setSystem( "Velociraptor" );
+        im.setUrl( "https://velo.localdomain" );
+
+        String s = im.toString();
+
+        assert "IssueManagement(system=Velociraptor, url=https://velo.localdomain)".equals( s ) : s;
+    }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
@@ -61,6 +61,6 @@ public class IssueManagementTest
 
         String s = im.toString();
 
-        assert "IssueManagement(system=Velociraptor, url=https://velo.localdomain)".equals( s ) : s;
+        assert "IssueManagement {system=Velociraptor, url=https://velo.localdomain}".equals( s ) : s;
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
@@ -53,4 +53,14 @@ public class LicenseTest
         assertNotNull( new License().toString() );
     }
 
+    public void testToStringNotNonsense()
+    {
+        License license = new License();
+        license.setName( "Unlicense" );
+        license.setUrl( "http://lic.localdomain" );
+
+        String s = license.toString();
+
+        assert "License(name=Unlicense, url=http://lic.localdomain)".equals( s ) : s;
+    }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
@@ -61,6 +61,6 @@ public class LicenseTest
 
         String s = license.toString();
 
-        assert "License(name=Unlicense, url=http://lic.localdomain)".equals( s ) : s;
+        assert "License {name=Unlicense, url=http://lic.localdomain}".equals( s ) : s;
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
@@ -60,11 +60,6 @@ public class MailingListTest
 
         String s = list.toString();
 
-        assertEquals( "name = 'modello-dev'\n" +
-                      "subscribe = 'null'\n" +
-                      "unsubscribe = 'null'\n" +
-                      "post = 'null'\n" +
-                      "archive = 'null'\n" +
-                      "otherArchives = '[]'", s );
+        assertEquals( "MailingList {name=modello-dev, archive=null}", s );
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
@@ -53,4 +53,18 @@ public class MailingListTest
         assertNotNull( new MailingList().toString() );
     }
 
+    public void testToStringNotNonsense()
+    {
+        MailingList list = new MailingList();
+        list.setName( "modello-dev" );
+
+        String s = list.toString();
+
+        assertEquals( "name = 'modello-dev'\n" +
+                      "subscribe = 'null'\n" +
+                      "unsubscribe = 'null'\n" +
+                      "post = 'null'\n" +
+                      "archive = 'null'\n" +
+                      "otherArchives = '[]'", s );
+    }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
@@ -60,7 +60,7 @@ public class OrganizationTest
         org.setName( "Testing Maven Unit" );
         org.setUrl( "https://maven.localdomain" );
 
-        assertEquals( "name = 'Testing Maven Unit'\nurl = 'https://maven.localdomain'", org.toString() );
+        assertEquals( "Organization {name=Testing Maven Unit, url=https://maven.localdomain}", org.toString() );
     }
 
     public void testToStringNotNonsense10()
@@ -68,7 +68,7 @@ public class OrganizationTest
         Organization org = new Organization();
         org.setName( "Testing Maven Unit" );
 
-        assertEquals( "name = 'Testing Maven Unit'\nurl = 'null'", org.toString() );
+        assertEquals( "Organization {name=Testing Maven Unit, url=null}", org.toString() );
     }
 
     public void testToStringNotNonsense01()
@@ -76,13 +76,13 @@ public class OrganizationTest
         Organization org = new Organization();
         org.setUrl( "https://maven.localdomain" );
 
-        assertEquals( "name = 'null'\nurl = 'https://maven.localdomain'", org.toString() );
+        assertEquals( "Organization {name=null, url=https://maven.localdomain}", org.toString() );
     }
 
     public void testToStringNotNonsense00()
     {
         Organization org = new Organization();
 
-        assertEquals( "name = 'null'\nurl = 'null'", org.toString() );
+        assertEquals( "Organization {name=null, url=null}", org.toString() );
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
@@ -53,4 +53,36 @@ public class OrganizationTest
         assertNotNull( new Organization().toString() );
     }
 
+
+    public void testToStringNotNonsense11()
+    {
+        Organization org = new Organization();
+        org.setName( "Testing Maven Unit" );
+        org.setUrl( "https://maven.localdomain" );
+
+        assertEquals( "name = 'Testing Maven Unit'\nurl = 'https://maven.localdomain'", org.toString() );
+    }
+
+    public void testToStringNotNonsense10()
+    {
+        Organization org = new Organization();
+        org.setName( "Testing Maven Unit" );
+
+        assertEquals( "name = 'Testing Maven Unit'\nurl = 'null'", org.toString() );
+    }
+
+    public void testToStringNotNonsense01()
+    {
+        Organization org = new Organization();
+        org.setUrl( "https://maven.localdomain" );
+
+        assertEquals( "name = 'null'\nurl = 'https://maven.localdomain'", org.toString() );
+    }
+
+    public void testToStringNotNonsense00()
+    {
+        Organization org = new Organization();
+
+        assertEquals( "name = 'null'\nurl = 'null'", org.toString() );
+    }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
@@ -60,12 +60,6 @@ public class ScmTest
 
         String s = scm.toString();
 
-        assertEquals( "connection = 'scm:git:git://git.localdomain/model'\n" +
-                      "developerConnection = 'null'\n" +
-                      "tag = 'HEAD'\n" +
-                      "url = 'null'\n" +
-                      "childScmConnectionInheritAppendPath = 'null'\n" +
-                      "childScmDeveloperConnectionInheritAppendPath = 'null'\n" +
-                      "childScmUrlInheritAppendPath = 'null'", s );
+        assertEquals( "Scm {connection=scm:git:git://git.localdomain/model}", s );
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
@@ -53,4 +53,19 @@ public class ScmTest
         assertNotNull( new Scm().toString() );
     }
 
+    public void testToStringNotNonsense()
+    {
+        Scm scm = new Scm();
+        scm.setConnection( "scm:git:git://git.localdomain/model" );
+
+        String s = scm.toString();
+
+        assertEquals( "connection = 'scm:git:git://git.localdomain/model'\n" +
+                      "developerConnection = 'null'\n" +
+                      "tag = 'HEAD'\n" +
+                      "url = 'null'\n" +
+                      "childScmConnectionInheritAppendPath = 'null'\n" +
+                      "childScmDeveloperConnectionInheritAppendPath = 'null'\n" +
+                      "childScmUrlInheritAppendPath = 'null'", s );
+    }
 }


### PR DESCRIPTION

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

----

If something decides to dump some build/session details, like `maven-bundle-plugin` with `--debug` does, currently it produces:
```
[DEBUG] BND Instructions:
project.build.mailingLists=[org.apache.maven.model.MailingList@16e91d6f, org.apache.maven.model.MailingList@57104caa]
project.licenses=[org.apache.maven.model.License@416855dc, org.apache.maven.model.License@1f342afb]
project.build.scm=org.apache.maven.model.Scm@5d4369c5
```

I propose to change that to something more useful, like
```
[DEBUG] BND Instructions:
project.build.mailingLists=[name \= '...']
project.licenses=[License(name\=Eclipse Public License v. 2.0, url\=https\://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt), License(name\=GNU General Public License, version 2 with the GNU Classpath Exception, url\=https\://www.gnu.org/software/classpath/license.html)]
project.build.scm=connection \= '...'
```
