### PR TITLE
[MNG-7618][MNG-7624] Backport to Maven 3.9.x

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
@@ -380,7 +380,11 @@ public class ExecutionEventLogger extends AbstractExecutionListener {
     }
 
     private void append(MessageBuilder buffer, MojoExecution me) {
-        buffer.mojo(me.getArtifactId() + ':' + me.getVersion() + ':' + me.getGoal());
+        String prefix = me.getMojoDescriptor().getPluginDescriptor().getGoalPrefix();
+        if (StringUtils.isEmpty(prefix)) {
+            prefix = me.getGroupId() + ":" + me.getArtifactId();
+        }
+        buffer.mojo(prefix + ':' + me.getVersion() + ':' + me.getGoal());
         if (me.getExecutionId() != null) {
             buffer.a(' ').strong('(' + me.getExecutionId() + ')');
         }


### PR DESCRIPTION
Lack of these changes are making IT suite to fail with maven-3.9.x branch.

OTOH, the change is nearly trivial, while value is high, so let's backport them.

---

https://issues.apache.org/jira/browse/MNG-7618
https://issues.apache.org/jira/browse/MNG-7624
