### PR TITLE
[MNG-7648] Fix locationTracking in DefaultModelBuildingRequest copy constructor.

### DIFF
--- a/maven-core/src/test/projects/project-builder/MNG-7648/pom.xml
+++ b/maven-core/src/test/projects/project-builder/MNG-7648/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.its</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.1</version>
+    </parent>
+
+    <artifactId>location-tracking</artifactId>
+    <packaging>jar</packaging>
+
+    <repositories>
+        <repository>
+            <id>remote-repo</id>
+            <url>file://${basedir}/../../src/test/remote-repo</url>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.its</groupId>
+                <artifactId>bom</artifactId>
+                <version>0.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.its</groupId>
+            <artifactId>a</artifactId>
+            <!-- version from BOM -->
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <!-- version from parent -->
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-core/src/test/remote-repo/org/apache/maven/its/bom/0.1/bom-0.1.pom
+++ b/maven-core/src/test/remote-repo/org/apache/maven/its/bom/0.1/bom-0.1.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.its</groupId>
+    <artifactId>bom</artifactId>
+    <version>0.1</version>
+    <packaging>pom</packaging>
+
+    <name>Maven Integration Test :: Dummy BOM</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.its</groupId>
+                <artifactId>a</artifactId>
+                <version>0.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/maven-core/src/test/remote-repo/org/apache/maven/its/bom/maven-metadata.xml
+++ b/maven-core/src/test/remote-repo/org/apache/maven/its/bom/maven-metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>bom</artifactId>
+  <version>0.1</version>
+  <versioning>
+    <versions>
+      <version>0.1</version>
+    </versions>
+  </versioning>
+</metadata>

--- a/maven-core/src/test/remote-repo/org/apache/maven/its/parent/0.1/parent-0.1.pom
+++ b/maven-core/src/test/remote-repo/org/apache/maven/its/parent/0.1/parent-0.1.pom
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.its</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+    <packaging>pom</packaging>
+
+    <name>Maven Integration Test :: Dummy Parent</name>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>0.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/maven-core/src/test/remote-repo/org/apache/maven/its/parent/maven-metadata.xml
+++ b/maven-core/src/test/remote-repo/org/apache/maven/its/parent/maven-metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>parent</artifactId>
+  <version>0.1</version>
+  <versioning>
+    <versions>
+      <version>0.1</version>
+    </versions>
+  </versioning>
+</metadata>

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuildingRequest.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuildingRequest.java
@@ -87,6 +87,7 @@ public class DefaultModelBuildingRequest implements ModelBuildingRequest {
         setValidationLevel(request.getValidationLevel());
         setProcessPlugins(request.isProcessPlugins());
         setTwoPhaseBuilding(request.isTwoPhaseBuilding());
+        setLocationTracking(request.isLocationTracking());
         setProfiles(request.getProfiles());
         setActiveProfileIds(request.getActiveProfileIds());
         setInactiveProfileIds(request.getInactiveProfileIds());


### PR DESCRIPTION
This fixes missing `locationTracking` in project model.

Missing `locationTracking` was causing issues down the line in enforcer plugin that was not able to verify source of the model configuration.

--

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [x] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

[core-its]: https://maven.apache.org/core-its/core-it-suite/
