### PR TITLE
[MNG-7629] Change reactor reader to copy packaged artifacts and reuse them across builds if needed

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -242,13 +242,6 @@ public class DefaultMaven implements Maven {
             return addExceptionToResult(result, e);
         }
 
-        try {
-            WorkspaceReader reactorReader = container.lookup(WorkspaceReader.class, ReactorReader.HINT);
-            repoSession.setWorkspaceReader(reactorReader);
-        } catch (ComponentLookupException e) {
-            return addExceptionToResult(result, e);
-        }
-
         eventCatapult.fire(ExecutionEvent.Type.ProjectDiscoveryStarted, session, null);
 
         Result<? extends ProjectDependencyGraph> graphResult = buildGraph(session);
@@ -339,13 +332,12 @@ public class DefaultMaven implements Maven {
     private void setupWorkspaceReader(MavenSession session, DefaultRepositorySystemSession repoSession)
             throws ComponentLookupException {
         // Desired order of precedence for workspace readers before querying the local artifact repositories
-        List<WorkspaceReader> workspaceReaders = new ArrayList<>();
+        List<WorkspaceReader> workspaceReaders = new ArrayList<WorkspaceReader>();
         // 1) Reactor workspace reader
-        WorkspaceReader reactorReader = container.lookup(WorkspaceReader.class, ReactorReader.HINT);
-        workspaceReaders.add(reactorReader);
+        workspaceReaders.add(container.lookup(WorkspaceReader.class, ReactorReader.HINT));
         // 2) Repository system session-scoped workspace reader
         WorkspaceReader repoWorkspaceReader = repoSession.getWorkspaceReader();
-        if (repoWorkspaceReader != null && repoWorkspaceReader != reactorReader) {
+        if (repoWorkspaceReader != null) {
             workspaceReaders.add(repoWorkspaceReader);
         }
         // 3) .. n) Project-scoped workspace readers

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -135,8 +135,15 @@ class ReactorReader implements MavenWorkspaceReader {
             return project.getFile();
         }
 
+        File packagedArtifactFile = find(artifact);
+        if (packagedArtifactFile != null
+                && packagedArtifactFile.exists()
+                && isPackagedArtifactUpToDate(project, packagedArtifactFile, artifact)) {
+            return packagedArtifactFile;
+        }
+
         Artifact projectArtifact = findMatchingArtifact(project, artifact);
-        File packagedArtifactFile = determinePreviouslyPackagedArtifactFile(project, projectArtifact);
+        packagedArtifactFile = determinePreviouslyPackagedArtifactFile(project, projectArtifact);
 
         if (hasArtifactFileFromPackagePhase(projectArtifact)) {
             return projectArtifact.getFile();
@@ -190,11 +197,6 @@ class ReactorReader implements MavenWorkspaceReader {
         if (artifact == null) {
             return null;
         }
-        File file = find(artifact);
-        if (file != null) {
-            return file;
-        }
-
         String fileName = String.format("%s.%s", project.getBuild().getFinalName(), artifact.getExtension());
         return new File(project.getBuild().getDirectory(), fileName);
     }

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -204,8 +204,9 @@ class ReactorReader implements MavenWorkspaceReader {
             long artifactLastModified =
                     Files.getLastModifiedTime(packagedArtifactFile.toPath()).toMillis();
 
+            long buildStartTime = 0;
             if (session.getProjectBuildingRequest().getBuildStartTime() != null) {
-                long buildStartTime =
+                buildStartTime =
                         session.getProjectBuildingRequest().getBuildStartTime().getTime();
                 if (artifactLastModified > buildStartTime) {
                     return true;
@@ -222,7 +223,7 @@ class ReactorReader implements MavenWorkspaceReader {
 
                 long outputFileLastModified =
                         Files.getLastModifiedTime(outputFile).toMillis();
-                if (outputFileLastModified > artifactLastModified) {
+                if (outputFileLastModified > buildStartTime && outputFileLastModified > artifactLastModified) {
                     File alternative = determineBuildOutputDirectoryForArtifact(project, artifact);
                     if (alternative != null) {
                         LOGGER.warn(

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -204,9 +204,8 @@ class ReactorReader implements MavenWorkspaceReader {
             long artifactLastModified =
                     Files.getLastModifiedTime(packagedArtifactFile.toPath()).toMillis();
 
-            long buildStartTime = 0;
             if (session.getProjectBuildingRequest().getBuildStartTime() != null) {
-                buildStartTime =
+                long buildStartTime =
                         session.getProjectBuildingRequest().getBuildStartTime().getTime();
                 if (artifactLastModified > buildStartTime) {
                     return true;
@@ -223,7 +222,7 @@ class ReactorReader implements MavenWorkspaceReader {
 
                 long outputFileLastModified =
                         Files.getLastModifiedTime(outputFile).toMillis();
-                if (outputFileLastModified > buildStartTime && outputFileLastModified > artifactLastModified) {
+                if (outputFileLastModified > artifactLastModified) {
                     LOGGER.warn(
                             "File '{}' is more recent than the packaged artifact for '{}', please run a full `mvn verify` build",
                             relativizeOutputFile(outputFile),

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -146,14 +146,6 @@ class ReactorReader implements MavenWorkspaceReader {
             if (packagedArtifactFile != null && packagedArtifactFile.exists()) {
                 return packagedArtifactFile;
             }
-
-            // Check whether an earlier Maven run might have produced an artifact that is still on disk.
-            packagedArtifactFile = determinePreviouslyPackagedArtifactFile(project, projectArtifact);
-            if (packagedArtifactFile != null
-                    && packagedArtifactFile.exists()
-                    && isPackagedArtifactUpToDate(project, packagedArtifactFile, artifact)) {
-                return packagedArtifactFile;
-            }
         }
 
         if (!hasBeenPackagedDuringThisSession(project)) {
@@ -194,14 +186,6 @@ class ReactorReader implements MavenWorkspaceReader {
         // The fall-through indicates that the artifact cannot be found;
         // for instance if package produced nothing or classifier problems.
         return null;
-    }
-
-    private File determinePreviouslyPackagedArtifactFile(MavenProject project, Artifact artifact) {
-        if (artifact == null) {
-            return null;
-        }
-        String fileName = String.format("%s.%s", project.getBuild().getFinalName(), artifact.getExtension());
-        return new File(project.getBuild().getDirectory(), fileName);
     }
 
     private boolean isPackagedArtifactUpToDate(MavenProject project, File packagedArtifactFile, Artifact artifact) {

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -237,6 +237,11 @@ class ReactorReader implements MavenWorkspaceReader {
                                 relativizeOutputFile(outputFile),
                                 project.getArtifactId());
                     }
+                    // TODO: remove the following log
+                    LOGGER.warn(
+                            "{} > {}",
+                            Files.getLastModifiedTime(outputFile),
+                            Files.getLastModifiedTime(packagedArtifactFile.toPath()));
                     return false;
                 }
             }
@@ -334,7 +339,11 @@ class ReactorReader implements MavenWorkspaceReader {
                 try {
                     LOGGER.debug("Copying {} to project local repository", artifact);
                     Files.createDirectories(target.getParent());
-                    Files.copy(artifact.getFile().toPath(), target, StandardCopyOption.REPLACE_EXISTING);
+                    Files.copy(
+                            artifact.getFile().toPath(),
+                            target,
+                            StandardCopyOption.REPLACE_EXISTING,
+                            StandardCopyOption.COPY_ATTRIBUTES);
                 } catch (IOException e) {
                     LOGGER.warn("Error while copying artifact to project local repository", e);
                 }

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -318,10 +318,10 @@ class ReactorReader implements MavenWorkspaceReader {
     /**
      * Copy packaged and attached artifacts from this project to the
      * project local repository.
-     * This allow a subsequent build to resume while still being able
+     * This allows a subsequent build to resume while still being able
      * to locate attached artifacts.
      *
-     * @param project the project to copy artifacts
+     * @param project the project to copy artifacts from
      */
     private void installIntoProjectLocalRepository(MavenProject project) {
         if (!hasBeenPackagedDuringThisSession(project)) {

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -224,26 +224,11 @@ class ReactorReader implements MavenWorkspaceReader {
                 long outputFileLastModified =
                         Files.getLastModifiedTime(outputFile).toMillis();
                 if (outputFileLastModified > buildStartTime && outputFileLastModified > artifactLastModified) {
-                    File alternative = determineBuildOutputDirectoryForArtifact(project, artifact);
-                    if (alternative != null) {
-                        LOGGER.warn(
-                                "File '{}' is more recent than the packaged artifact for '{}'; using '{}' instead",
-                                relativizeOutputFile(outputFile),
-                                project.getArtifactId(),
-                                relativizeOutputFile(alternative.toPath()));
-                    } else {
-                        LOGGER.warn(
-                                "File '{}' is more recent than the packaged artifact for '{}'; "
-                                        + "cannot use the build output directory for this type of artifact",
-                                relativizeOutputFile(outputFile),
-                                project.getArtifactId());
-                    }
-                    // TODO: remove the following log
                     LOGGER.warn(
-                            "{} > {}",
-                            Files.getLastModifiedTime(outputFile),
-                            Files.getLastModifiedTime(packagedArtifactFile.toPath()));
-                    return false;
+                            "File '{}' is more recent than the packaged artifact for '{}', please run a full `mvn verify` build",
+                            relativizeOutputFile(outputFile),
+                            project.getArtifactId());
+                    return true;
                 }
             }
 

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -324,6 +324,9 @@ class ReactorReader implements MavenWorkspaceReader {
      * @param project the project to copy artifacts
      */
     private void installIntoProjectLocalRepository(MavenProject project) {
+        if (!hasBeenPackagedDuringThisSession(project)) {
+            return;
+        }
         List<Artifact> artifacts = new ArrayList<>();
 
         artifacts.add(RepositoryUtils.toArtifact(new ProjectArtifact(project)));

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -233,7 +233,7 @@ class ReactorReader implements MavenWorkspaceReader {
                         Files.getLastModifiedTime(outputFile).toMillis();
                 if (outputFileLastModified > artifactLastModified) {
                     LOGGER.warn(
-                            "File '{}' is more recent than the packaged artifact for '{}', please run a full `mvn verify` build",
+                            "File '{}' is more recent than the packaged artifact for '{}', please run a full `mvn package` build",
                             relativizeOutputFile(outputFile),
                             project.getArtifactId());
                     return true;


### PR DESCRIPTION
Similar to #912 but without removing the best effort artifact resolution to keep `mvn test` working _if possible_.

This require a few ITs to be modified:
  https://github.com/apache/maven-integration-testing/pull/234/
