### PR TITLE
[maven-3.9.x] [MNG-7666] Update default binding and lifecycle plugin versions

### DIFF
--- a/maven-core/src/main/resources/META-INF/plexus/components.xml
+++ b/maven-core/src/main/resources/META-INF/plexus/components.xml
@@ -78,7 +78,7 @@ under the License.
         </phases>
         <default-phases>
           <clean>
-            org.apache.maven.plugins:maven-clean-plugin:2.5:clean
+            org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean
           </clean>
         </default-phases>
         <!-- END SNIPPET: clean -->
@@ -101,10 +101,10 @@ under the License.
         </phases>
         <default-phases>
           <site>
-            org.apache.maven.plugins:maven-site-plugin:3.3:site
+            org.apache.maven.plugins:maven-site-plugin:3.12.1:site
           </site>
           <site-deploy>
-            org.apache.maven.plugins:maven-site-plugin:3.3:deploy
+            org.apache.maven.plugins:maven-site-plugin:3.12.1:deploy
           </site-deploy>
         </default-phases>
         <!-- END SNIPPET: site -->

--- a/maven-core/src/main/resources/META-INF/plexus/default-bindings.xml
+++ b/maven-core/src/main/resources/META-INF/plexus/default-bindings.xml
@@ -41,10 +41,10 @@ Mappings to default lifecycle, specific for each packaging.
             <!-- START SNIPPET: pom-lifecycle -->
             <phases>
               <install>
-                org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install
+                org.apache.maven.plugins:maven-install-plugin:3.1.0:install
               </install>
               <deploy>
-                org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+                org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy
               </deploy>
             </phases>
             <!-- END SNIPPET: pom-lifecycle -->
@@ -67,28 +67,28 @@ Mappings to default lifecycle, specific for each packaging.
             <!-- START SNIPPET: jar-lifecycle -->
             <phases>
               <process-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:resources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources
               </process-resources>
               <compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile
               </compile>
               <process-test-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:testResources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:testResources
               </process-test-resources>
               <test-compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile
               </test-compile>
               <test>
-                org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test
+                org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M8:test
               </test>
               <package>
-                org.apache.maven.plugins:maven-jar-plugin:2.4:jar
+                org.apache.maven.plugins:maven-jar-plugin:3.3.0:jar
               </package>
               <install>
-                org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install
+                org.apache.maven.plugins:maven-install-plugin:3.1.0:install
               </install>
               <deploy>
-                org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+                org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy
               </deploy>
             </phases>
             <!-- END SNIPPET: jar-lifecycle -->
@@ -111,28 +111,28 @@ Mappings to default lifecycle, specific for each packaging.
             <!-- START SNIPPET: ejb-lifecycle -->
             <phases>
               <process-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:resources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources
               </process-resources>
               <compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile
               </compile>
               <process-test-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:testResources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:testResources
               </process-test-resources>
               <test-compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile
               </test-compile>
               <test>
-                org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test
+                org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M8:test
               </test>
               <package>
-                org.apache.maven.plugins:maven-ejb-plugin:2.3:ejb
+                org.apache.maven.plugins:maven-ejb-plugin:3.2.1:ejb
               </package>
               <install>
-                org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install
+                org.apache.maven.plugins:maven-install-plugin:3.1.0:install
               </install>
               <deploy>
-                org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+                org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy
               </deploy>
             </phases>
             <!-- END SNIPPET: ejb-lifecycle -->
@@ -155,32 +155,32 @@ Mappings to default lifecycle, specific for each packaging.
             <!-- START SNIPPET: maven-plugin-lifecycle -->
             <phases>
               <process-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:resources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources
               </process-resources>
               <compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile
               </compile>
               <process-classes>
-                org.apache.maven.plugins:maven-plugin-plugin:3.2:descriptor
+                org.apache.maven.plugins:maven-plugin-plugin:3.7.0:descriptor
               </process-classes>
               <process-test-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:testResources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:testResources
               </process-test-resources>
               <test-compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile
               </test-compile>
               <test>
-                org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test
+                org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M8:test
               </test>
               <package>
-                org.apache.maven.plugins:maven-jar-plugin:2.4:jar,
-                org.apache.maven.plugins:maven-plugin-plugin:3.2:addPluginArtifactMetadata
+                org.apache.maven.plugins:maven-jar-plugin:3.3.0:jar,
+                org.apache.maven.plugins:maven-plugin-plugin:3.7.0:addPluginArtifactMetadata
               </package>
               <install>
-                org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install
+                org.apache.maven.plugins:maven-install-plugin:3.1.0:install
               </install>
               <deploy>
-                org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+                org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy
               </deploy>
             </phases>
             <!-- END SNIPPET: maven-plugin-lifecycle -->
@@ -203,28 +203,28 @@ Mappings to default lifecycle, specific for each packaging.
             <!-- START SNIPPET: war-lifecycle -->
             <phases>
               <process-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:resources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources
               </process-resources>
               <compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile
               </compile>
               <process-test-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:testResources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:testResources
               </process-test-resources>
               <test-compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile
               </test-compile>
               <test>
-                org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test
+                org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M8:test
               </test>
               <package>
-                org.apache.maven.plugins:maven-war-plugin:2.2:war
+                org.apache.maven.plugins:maven-war-plugin:3.3.2:war
               </package>
               <install>
-                org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install
+                org.apache.maven.plugins:maven-install-plugin:3.1.0:install
               </install>
               <deploy>
-                org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+                org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy
               </deploy>
             </phases>
             <!-- END SNIPPET: war-lifecycle -->
@@ -247,19 +247,19 @@ Mappings to default lifecycle, specific for each packaging.
             <!-- START SNIPPET: ear-lifecycle -->
             <phases>
               <generate-resources>
-                org.apache.maven.plugins:maven-ear-plugin:2.8:generate-application-xml
+                org.apache.maven.plugins:maven-ear-plugin:3.3.0:generate-application-xml
               </generate-resources>
               <process-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:resources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources
               </process-resources>
               <package>
-                org.apache.maven.plugins:maven-ear-plugin:2.8:ear
+                org.apache.maven.plugins:maven-ear-plugin:3.3.0:ear
               </package>
               <install>
-                org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install
+                org.apache.maven.plugins:maven-install-plugin:3.1.0:install
               </install>
               <deploy>
-                org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+                org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy
               </deploy>
             </phases>
             <!-- END SNIPPET: ear-lifecycle -->
@@ -282,28 +282,28 @@ Mappings to default lifecycle, specific for each packaging.
             <!-- START SNIPPET: rar-lifecycle -->
             <phases>
               <process-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:resources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources
               </process-resources>
               <compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile
               </compile>
               <process-test-resources>
-                org.apache.maven.plugins:maven-resources-plugin:2.6:testResources
+                org.apache.maven.plugins:maven-resources-plugin:3.3.0:testResources
               </process-test-resources>
               <test-compile>
-                org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile
+                org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile
               </test-compile>
               <test>
-                org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test
+                org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M8:test
               </test>
               <package>
-                org.apache.maven.plugins:maven-rar-plugin:2.2:rar
+                org.apache.maven.plugins:maven-rar-plugin:3.0.0:rar
               </package>
               <install>
-                org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install
+                org.apache.maven.plugins:maven-install-plugin:3.1.0:install
               </install>
               <deploy>
-                org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+                org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy
               </deploy>
             </phases>
             <!-- END SNIPPET: rar-lifecycle -->

--- a/maven-core/src/main/resources/META-INF/plexus/default-bindings.xml
+++ b/maven-core/src/main/resources/META-INF/plexus/default-bindings.xml
@@ -161,7 +161,7 @@ Mappings to default lifecycle, specific for each packaging.
                 org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile
               </compile>
               <process-classes>
-                org.apache.maven.plugins:maven-plugin-plugin:3.7.0:descriptor
+                org.apache.maven.plugins:maven-plugin-plugin:3.7.1:descriptor
               </process-classes>
               <process-test-resources>
                 org.apache.maven.plugins:maven-resources-plugin:3.3.0:testResources
@@ -174,7 +174,7 @@ Mappings to default lifecycle, specific for each packaging.
               </test>
               <package>
                 org.apache.maven.plugins:maven-jar-plugin:3.3.0:jar,
-                org.apache.maven.plugins:maven-plugin-plugin:3.7.0:addPluginArtifactMetadata
+                org.apache.maven.plugins:maven-plugin-plugin:3.7.1:addPluginArtifactMetadata
               </package>
               <install>
                 org.apache.maven.plugins:maven-install-plugin:3.1.0:install


### PR DESCRIPTION
Finally use 3.x plugins for all.

---

https://issues.apache.org/jira/browse/MNG-7666