### PR TITLE
[MNG-7646] Do not parse all projects in the reactor when building a subtree

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -351,9 +351,11 @@ public class DefaultGraphBuilder implements GraphBuilder {
         }
 
         // 2. Collect projects for all modules in the multi-module project.
-        List<MavenProject> projects = multiModuleCollectionStrategy.collectProjects(request);
-        if (!projects.isEmpty()) {
-            return projects;
+        if (request.getMakeBehavior() != null || !request.getProjectActivation().isEmpty()) {
+            List<MavenProject> projects = multiModuleCollectionStrategy.collectProjects(request);
+            if (!projects.isEmpty()) {
+                return projects;
+            }
         }
 
         // 3. Collect projects for explicitly requested POM.


### PR DESCRIPTION
Follow up to MNG-7629 and #954, the idea for this PR is to not parse all the reactor.

The idea of this PR is to parse all projects from the reactor only if the _makeBehavior_ is set (i.e. `-am` and/or `-amd` option has been used), or if a project activation has been set (i.e. `-pl`, `-r` or `-rf` is used).  Note that parents are always resolved from the file system, even if not included in the reactor.

The ITs only require a single modification: https://github.com/apache/maven-integration-testing/pull/239