### PR TITLE
Get rid of surefire warning

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -159,12 +159,12 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemProperties>
+          <systemPropertyVariables>
             <property>
               <name>basedir</name>
               <value>${basedir}</value>
             </property>
-          </systemProperties>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
As POM uses deprecated configuration.
