### PR TITLE
Get rid of surefire warning

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -168,12 +168,12 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemProperties>
+          <systemPropertyVariables>
             <property>
               <name>basedir</name>
               <value>${basedir}</value>
             </property>
-          </systemProperties>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -169,10 +169,7 @@ under the License.
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <property>
-              <name>basedir</name>
-              <value>${basedir}</value>
-            </property>
+            <basedir>${basedir}</basedir>
           </systemPropertyVariables>
         </configuration>
         <executions>


### PR DESCRIPTION
As we use deprecated configuration.
