### PR TITLE
Get rid of surefire warning, take 2

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -160,10 +160,7 @@ under the License.
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <property>
-              <name>basedir</name>
-              <value>${basedir}</value>
-            </property>
+            <basedir>${basedir}</basedir>
           </systemPropertyVariables>
         </configuration>
         <executions>


### PR DESCRIPTION
The commit 36f02c9de1792478538a171108048c8b86d5a5a1 is wrong, as new config property is a Map.