### PR TITLE
Fix site plugin warning

### DIFF
--- a/maven-core/src/site/apt/getting-to-container-configured-mojos.apt
+++ b/maven-core/src/site/apt/getting-to-container-configured-mojos.apt
@@ -20,7 +20,7 @@
   ---
   John Casey
   ---
-  29-April-2005
+  2005-04-29
 
 Abstract
 

--- a/maven-core/src/site/apt/offline-mode.apt
+++ b/maven-core/src/site/apt/offline-mode.apt
@@ -20,7 +20,7 @@
   ---
   John Casey
   ---
-  08-April-2005
+  2005-04-08
   ---
 
 Offline Mode Design


### PR DESCRIPTION
As date format in these two files were not parsed.
