### PR TITLE
[MNG-7676] Fix checksum plugin configuration

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -282,7 +282,6 @@ under the License.
                 </goals>
                 <configuration>
                   <includeClassifiers>src</includeClassifiers>
-                  <attachChecksums>true</attachChecksums>
                 </configuration>
               </execution>
             </executions>

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -274,26 +274,16 @@ under the License.
           <plugin>
             <groupId>net.nicoulaj.maven.plugins</groupId>
             <artifactId>checksum-maven-plugin</artifactId>
-            <configuration>
-              <fileSets>
-                <fileSet>
-                  <directory>${project.build.directory}</directory>
-                  <includes>
-                    <include>${project.artifactId}-${project.version}-src.zip</include>
-                    <include>${project.artifactId}-${project.version}-src.tar.gz</include>
-                    <include>${project.artifactId}-${project.version}-bin.zip</include>
-                    <include>${project.artifactId}-${project.version}-bin.tar.gz</include>
-                  </includes>
-                </fileSet>
-              </fileSets>
-              <failIfNoFiles>true</failIfNoFiles>
-            </configuration>
             <executions>
               <execution>
                 <id>source-release-checksum</id>
                 <goals>
-                  <goal>files</goal>
+                  <goal>artifacts</goal>
                 </goals>
+                <configuration>
+                  <includeClassifiers>src</includeClassifiers>
+                  <attachChecksums>true</attachChecksums>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Wrong goal is being used that does not honor classifiers. Also, have to reshuffle the config, move it inside execution otherwise ASF parent pom execution is NOT overridden.

---

https://issues.apache.org/jira/browse/MNG-7676