### PR TITLE
Add bin packages to SHA512 checksumming as well

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -290,7 +290,7 @@ under the License.
                   <goal>artifacts</goal>
                 </goals>
                 <configuration>
-                  <includeClassifiers>src</includeClassifiers>
+                  <includeClassifiers>bin,src</includeClassifiers>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Not only src but bin needs SHA512 as well. Plugin now does:
```
[INFO] --- checksum:1.11:artifacts (source-release-checksum) @ apache-maven ---
[INFO] apache-maven-4.0.0-alpha-5-SNAPSHOT-bin.tar.gz - SHA-512 : 2ee4c27ff611852caffab6543582918c06d900da184cdd389e64bae05fb8a2ac959edf27a946c60c9129c87baa6ec593a64d25edf3739339dd3f8d3d7942c7db
[INFO] apache-maven-4.0.0-alpha-5-SNAPSHOT-bin.zip - SHA-512 : 078667f3aad060163cad692eab7ced00fa377ba3a89f43431b23bd5248fc1603d3668cd68a7f096abcbc460ef4fbb47981b6bf5acc236a522e40fd700bb415c6
[INFO] apache-maven-4.0.0-alpha-5-SNAPSHOT-src.tar.gz - SHA-512 : ad2ca325ef138389fa967bde5e176a2447b5dd9e7edfa5cd1bf3f586fd39b93a1d415b55bb41b29e996104a4e14d4ef5fcc0e2c2eff65609121595f2695c96d4
[INFO] apache-maven-4.0.0-alpha-5-SNAPSHOT-src.zip - SHA-512 : 060de415118365954918079c73bf0ecc5d1ea8989b1864b32e3ebccd94306263878805c6d997d6c4a69700ebedd6fe42485a3692570c6466deb5e1be136e3e3e
```