### PR TITLE
Add bin packages to SHA512 checksumming as well

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -281,7 +281,7 @@ under the License.
                   <goal>artifacts</goal>
                 </goals>
                 <configuration>
-                  <includeClassifiers>src</includeClassifiers>
+                  <includeClassifiers>bin,src</includeClassifiers>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Adding bin to SHA512 as well. Plugin now does
```
[INFO] --- checksum:1.11:artifacts (source-release-checksum) @ apache-maven ---
[INFO] apache-maven-3.9.1-SNAPSHOT-bin.tar.gz - SHA-512 : 9ee7e5282d8d2fb4990dc81a89ce132120fde38626e64922eb6f8999abcf516e6e969b2ef1a608e42a79c9fd406abadc72f57c7cde7e30a6bcb31faf25c82e28
[INFO] apache-maven-3.9.1-SNAPSHOT-bin.zip - SHA-512 : f57242ccca174df29d2570ef83648387648078fc9ead3443d7f772a5b9b50fd34fe5b213dcc128139b45469257e49ecc105fa05167962e63bd4536890a6ac9b4
[INFO] apache-maven-3.9.1-SNAPSHOT-src.tar.gz - SHA-512 : 6bd077f8478bb1c175aed4909aaa700e30c7e1b7beabe7b15606c4d01f8c1db94a1274a4c86e3c486a4f973579c54f0bde7043cc56b386c760c00061fb2b6bb0
[INFO] apache-maven-3.9.1-SNAPSHOT-src.zip - SHA-512 : ba1cffc3edeaaca814d55de217d97fb202ff54d7f57a9a1be86e6accfed8c74e010b4a31c815caed2606bbcf443b10332bde3ff0294b774232e25c8dc6d9704a
```