### PR TITLE
Added missing @Deprecated/@deprecated annotations

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/profiles/DefaultProfileManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/profiles/DefaultProfileManager.java
@@ -62,6 +62,7 @@ public class DefaultProfileManager implements ProfileManager {
      * @deprecated without passing in the system properties, the SystemPropertiesProfileActivator will not work
      *             correctly in embedded environments.
      */
+    @Deprecated
     public DefaultProfileManager(PlexusContainer container) {
         this(container, null);
     }

--- a/maven-compat/src/main/java/org/apache/maven/project/InvalidProjectModelException.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/InvalidProjectModelException.java
@@ -40,6 +40,7 @@ public class InvalidProjectModelException extends ProjectBuildingException {
      * @param validationResult
      * @deprecated use {@link File} constructor for pomLocation
      */
+    @Deprecated
     public InvalidProjectModelException(
             String projectId, String pomLocation, String message, ModelValidationResult validationResult) {
         this(projectId, message, new File(pomLocation), validationResult);
@@ -58,6 +59,7 @@ public class InvalidProjectModelException extends ProjectBuildingException {
      * @param message
      * @deprecated use {@link File} constructor for pomLocation
      */
+    @Deprecated
     public InvalidProjectModelException(String projectId, String pomLocation, String message) {
         this(projectId, message, new File(pomLocation));
     }

--- a/maven-compat/src/main/java/org/apache/maven/project/inheritance/ModelInheritanceAssembler.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/inheritance/ModelInheritanceAssembler.java
@@ -23,7 +23,6 @@ import org.apache.maven.model.Model;
 
 /**
  * @author Jason van Zyl
- * @deprecated
  */
 @Deprecated
 public interface ModelInheritanceAssembler {

--- a/maven-compat/src/main/java/org/apache/maven/project/interpolation/AbstractStringBasedModelInterpolator.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/interpolation/AbstractStringBasedModelInterpolator.java
@@ -117,6 +117,7 @@ public abstract class AbstractStringBasedModelInterpolator extends AbstractLogEn
      *
      * @deprecated Use {@link ModelInterpolator#interpolate(Model, File, ProjectBuilderConfiguration, boolean)} instead.
      */
+    @Deprecated
     public Model interpolate(Model model, Map<String, ?> context, boolean strict) throws ModelInterpolationException {
         Properties props = new Properties();
         props.putAll(context);

--- a/maven-compat/src/main/java/org/apache/maven/project/interpolation/ModelInterpolator.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/interpolation/ModelInterpolator.java
@@ -38,11 +38,13 @@ public interface ModelInterpolator {
     /**
      * @deprecated Use {@link ModelInterpolator#interpolate(Model, File, ProjectBuilderConfiguration, boolean)} instead.
      */
+    @Deprecated
     Model interpolate(Model project, Map<String, ?> context) throws ModelInterpolationException;
 
     /**
      * @deprecated Use {@link ModelInterpolator#interpolate(Model, File, ProjectBuilderConfiguration, boolean)} instead.
      */
+    @Deprecated
     Model interpolate(Model model, Map<String, ?> context, boolean strict) throws ModelInterpolationException;
 
     Model interpolate(Model model, File projectDir, ProjectBuilderConfiguration config, boolean debugEnabled)

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/DefaultLifecycleMapping.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/DefaultLifecycleMapping.java
@@ -36,6 +36,7 @@ public class DefaultLifecycleMapping implements LifecycleMapping {
     private Map<String, Lifecycle> lifecycleMap;
 
     /** @deprecated use lifecycles instead */
+    @Deprecated
     private Map<String, LifecyclePhase> phases;
 
     /**

--- a/maven-core/src/main/java/org/apache/maven/project/DuplicateProjectException.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DuplicateProjectException.java
@@ -35,6 +35,7 @@ public class DuplicateProjectException extends Exception {
     /**
      * @deprecated use {@link #DuplicateProjectException(String, File, File, String)}
      */
+    @Deprecated
     public DuplicateProjectException(String message) {
         this(null, null, null, message);
     }
@@ -42,6 +43,7 @@ public class DuplicateProjectException extends Exception {
     /**
      * @deprecated use {@link #DuplicateProjectException(String, File, File, String)}
      */
+    @Deprecated
     public DuplicateProjectException(String message, Exception e) {
         super(message, e);
         this.projectId = null;

--- a/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
@@ -72,6 +72,7 @@ public class ProjectBuildingException extends Exception {
     /**
      * @deprecated use {@link #getPomFile()}
      */
+    @Deprecated
     public String getPomLocation() {
         if (getPomFile() != null) {
             return getPomFile().getAbsolutePath();

--- a/maven-core/src/main/java/org/apache/maven/toolchain/java/DefaultJavaToolChain.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/java/DefaultJavaToolChain.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
  * @deprecated clients that do not require compatibility with Maven 3.2.3 and earlier should link to
  *             {@link JavaToolchainImpl} instead.
  */
+@Deprecated
 public class DefaultJavaToolChain extends JavaToolchainImpl {
     public static final String KEY_JAVAHOME = JavaToolchainImpl.KEY_JAVAHOME;
 


### PR DESCRIPTION
@Deprecated annotations helpfully to prevent usage of deprecated API. For example: developer can see crossed out method/field name if this item is deprecated.