### PR TITLE
[MNG-7677] Maven slowness improvement

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -88,6 +88,9 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
 
     private ModelCacheFactory modelCacheFactory;
 
+    private final ArtifactDescriptorReaderDelegate artifactDescriptorReaderDelegate =
+            new ArtifactDescriptorReaderDelegate();
+
     public DefaultArtifactDescriptorReader() {
         // enable no-arg constructor
     }
@@ -173,7 +176,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                     (ArtifactDescriptorReaderDelegate) config.get(ArtifactDescriptorReaderDelegate.class.getName());
 
             if (delegate == null) {
-                delegate = new ArtifactDescriptorReaderDelegate();
+                delegate = artifactDescriptorReaderDelegate;
             }
 
             delegate.populateResult(session, result, model);

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@ under the License.
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
     <cipherVersion>2.0</cipherVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.9.4</resolverVersion>
+    <resolverVersion>1.9.5-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.2.1</xmlunitVersion>
     <powermockVersion>1.7.4</powermockVersion>


### PR DESCRIPTION
The crux was  in resolver 1.9.5, but there are other "low hanging fruits" like delegate created on a "hot method".

---

https://issues.apache.org/jira/browse/MNG-7677
