### PR TITLE
[3.8.x][MNG-7160] Ability to customize core extensions classloaders (#616)

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultArtifactFilterManager.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultArtifactFilterManager.java
@@ -29,7 +29,7 @@ import javax.inject.Singleton;
 
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.ExclusionSetFilter;
-import org.apache.maven.extension.internal.CoreExportsProvider;
+import org.apache.maven.extension.internal.CoreExports;
 
 /**
  * @author Jason van Zyl
@@ -50,10 +50,10 @@ public class DefaultArtifactFilterManager
 
     @Inject
     public DefaultArtifactFilterManager( List<ArtifactFilterManagerDelegate> delegates,
-                                         CoreExportsProvider coreExports )
+                                         CoreExports coreExports )
     {
         this.delegates = delegates;
-        this.coreArtifacts = coreExports.get().getExportedArtifacts();
+        this.coreArtifacts = coreExports.getExportedArtifacts();
     }
 
     private synchronized Set<String> getExcludedArtifacts()

--- a/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
+++ b/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
@@ -37,7 +37,7 @@ import javax.inject.Singleton;
 
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.classrealm.ClassRealmRequest.RealmType;
-import org.apache.maven.extension.internal.CoreExportsProvider;
+import org.apache.maven.extension.internal.CoreExports;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.MutablePlexusContainer;
@@ -92,20 +92,20 @@ public class DefaultClassRealmManager
 
     @Inject
     public DefaultClassRealmManager( Logger logger, PlexusContainer container,
-                                     List<ClassRealmManagerDelegate> delegates, CoreExportsProvider exports )
+                                     List<ClassRealmManagerDelegate> delegates, CoreExports exports )
     {
         this.logger = logger;
         this.world = ( (MutablePlexusContainer) container ).getClassWorld();
         this.containerRealm = container.getContainerRealm();
         this.delegates = delegates;
 
-        Map<String, ClassLoader> foreignImports = exports.get().getExportedPackages();
+        Map<String, ClassLoader> foreignImports = exports.getExportedPackages();
 
         this.mavenApiRealm =
             createRealm( API_REALMID, RealmType.Core, null /* parent */, null /* parentImports */,
                          foreignImports, null /* artifacts */ );
 
-        this.providedArtifacts = exports.get().getExportedArtifacts();
+        this.providedArtifacts = exports.getExportedArtifacts();
     }
 
     private ClassRealm newRealm( String id )

--- a/maven-core/src/main/java/org/apache/maven/extension/internal/CoreExportsProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/extension/internal/CoreExportsProvider.java
@@ -19,34 +19,34 @@ package org.apache.maven.extension.internal;
  * under the License.
  */
 
+import java.util.Objects;
+
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.codehaus.plexus.PlexusContainer;
-import org.eclipse.sisu.Nullable;
 
 /**
  * CoreExportsProvider
  */
 @Named
 @Singleton
-public class CoreExportsProvider
+public class CoreExportsProvider implements Provider<CoreExports>
 {
 
     private final CoreExports exports;
 
     @Inject
-    public CoreExportsProvider( PlexusContainer container, @Nullable CoreExports exports )
+    public CoreExportsProvider( PlexusContainer container )
     {
-        if ( exports == null )
-        {
-            this.exports = new CoreExports( CoreExtensionEntry.discoverFrom( container.getContainerRealm() ) );
-        }
-        else
-        {
-            this.exports = exports;
-        }
+        this( new CoreExports( CoreExtensionEntry.discoverFrom( container.getContainerRealm() ) ) );
+    }
+
+    public CoreExportsProvider( CoreExports exports )
+    {
+        this.exports = Objects.requireNonNull( exports );
     }
 
     public CoreExports get()

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -204,7 +204,7 @@ under the License.
         <groupId>org.codehaus.modello</groupId>
         <artifactId>modello-maven-plugin</artifactId>
         <configuration>
-          <version>1.0.0</version>
+          <version>1.1.0</version>
           <models>
             <model>src/main/mdo/core-extensions.mdo</model>
           </models>

--- a/maven-embedder/src/main/mdo/core-extensions.mdo
+++ b/maven-embedder/src/main/mdo/core-extensions.mdo
@@ -82,6 +82,14 @@
           <required>true</required>
           <type>String</type>
         </field>
+        <field>
+          <name>classLoadingStrategy</name>
+          <description>The class loading strategy: 'self-first' (the default), 'parent-first' (loads classes from the parent, then from the extension) or 'plugin' (follows the rules from extensions defined as plugins).</description>
+          <version>1.1.0+</version>
+          <defaultValue>self-first</defaultValue>
+          <required>false</required>
+          <type>String</type>
+        </field>
       </fields>
       <codeSegments>
         <codeSegment>


### PR DESCRIPTION
Backport of https://github.com/apache/maven/commit/115febf29b9520eed6e94a65212e00e88806a860 (from 3.9.0) with minimal Java 7 adjustments.
As discussed here: https://lists.apache.org/thread/wcbz8nsrrrdx8s8byoqpj99ksv73scqy (cc @michael-o)