### PR TITLE
[EXPERIMENT] Expose depMgr to use with Maven

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -59,6 +59,9 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
+import org.eclipse.aether.util.graph.manager.DefaultDependencyManager;
+import org.eclipse.aether.util.graph.manager.TransitiveDependencyManager;
 import org.eclipse.aether.util.listener.ChainedRepositoryListener;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.eclipse.aether.util.repository.ChainedLocalRepositoryManager;
@@ -361,6 +364,20 @@ public class DefaultRepositorySystemSessionFactory {
         mavenRepositorySystem.injectMirror(request.getPluginArtifactRepositories(), request.getMirrors());
         mavenRepositorySystem.injectProxy(session, request.getPluginArtifactRepositories());
         mavenRepositorySystem.injectAuthentication(session, request.getPluginArtifactRepositories());
+
+        Object resolverDependencyManager = configProps.get("maven.resolver.dependencyManager");
+        if (resolverDependencyManager != null) {
+            if ("classic".equals(resolverDependencyManager)) {
+                session.setDependencyManager(new ClassicDependencyManager());
+            } else if ("default".equals(resolverDependencyManager)) {
+                session.setDependencyManager(new DefaultDependencyManager());
+            } else if ("transitive".equals(resolverDependencyManager)) {
+                session.setDependencyManager(new TransitiveDependencyManager());
+            } else {
+                throw new IllegalArgumentException("Unknown resolver dependency manager '" + resolverDependencyManager
+                        + "'. Supported managers are: classic, default, transitive");
+            }
+        }
 
         setUpLocalRepositoryManager(request, session);
 

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -365,18 +365,16 @@ public class DefaultRepositorySystemSessionFactory {
         mavenRepositorySystem.injectProxy(session, request.getPluginArtifactRepositories());
         mavenRepositorySystem.injectAuthentication(session, request.getPluginArtifactRepositories());
 
-        Object resolverDependencyManager = configProps.get("maven.resolver.dependencyManager");
-        if (resolverDependencyManager != null) {
-            if ("classic".equals(resolverDependencyManager)) {
-                session.setDependencyManager(new ClassicDependencyManager());
-            } else if ("default".equals(resolverDependencyManager)) {
-                session.setDependencyManager(new DefaultDependencyManager());
-            } else if ("transitive".equals(resolverDependencyManager)) {
-                session.setDependencyManager(new TransitiveDependencyManager());
-            } else {
-                throw new IllegalArgumentException("Unknown resolver dependency manager '" + resolverDependencyManager
-                        + "'. Supported managers are: classic, default, transitive");
-            }
+        Object resolverDependencyManager = configProps.getOrDefault("maven.resolver.dependencyManager", "default");
+        if ("classic".equals(resolverDependencyManager)) {
+            session.setDependencyManager(new ClassicDependencyManager());
+        } else if ("default".equals(resolverDependencyManager)) {
+            session.setDependencyManager(new DefaultDependencyManager());
+        } else if ("transitive".equals(resolverDependencyManager)) {
+            session.setDependencyManager(new TransitiveDependencyManager());
+        } else {
+            throw new IllegalArgumentException("Unknown resolver dependency manager '" + resolverDependencyManager
+                    + "'. Supported managers are: classic, default, transitive");
         }
 
         setUpLocalRepositoryManager(request, session);

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -365,7 +365,7 @@ public class DefaultRepositorySystemSessionFactory {
         mavenRepositorySystem.injectProxy(session, request.getPluginArtifactRepositories());
         mavenRepositorySystem.injectAuthentication(session, request.getPluginArtifactRepositories());
 
-        Object resolverDependencyManager = configProps.getOrDefault("maven.resolver.dependencyManager", "default");
+        Object resolverDependencyManager = configProps.getOrDefault("maven.resolver.dependencyManager", "transitive");
         if ("classic".equals(resolverDependencyManager)) {
             session.setDependencyManager(new ClassicDependencyManager());
         } else if ("default".equals(resolverDependencyManager)) {


### PR DESCRIPTION
We have 3 of them, but we use always "classic" that behaves like Maven2 (with all it's shortocomings!).

Changes:
* change default depMgr Maven uses from "classic" to "default"
* expose config for all 3 of them

This is just an experiment for issues like:
* https://issues.apache.org/jira/browse/MRESOLVER-235
* https://issues.apache.org/jira/browse/MNG-7003 (using reproducer from it)

Adds `-Dmaven.resolver.dependencyManager` param with accepted values "classic" (the default every Maven3 used so far), "default" and "transitive".

Values are:
* "classic" (default in all Maven 3.x releases so far) org.eclipse.aether.util.graph.manager.ClassicDependencyManager
* "default" (never used) org.eclipse.aether.util.graph.manager.DefaultDependencyManager
* "transitive" (never used) org.eclipse.aether.util.graph.manager.TransitiveDependencyManager

Reproducer output with 3 of them:
```
[cstamas@urnebes usage]$ mvn dependency:tree -Dmaven.resolver.dependencyManager=transitive
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< arcomp.maven_example:usage >---------------------
[INFO] Building usage 1
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:2.8:tree (default-cli) @ usage ---
[INFO] arcomp.maven_example:usage:jar:1
[INFO] \- arcomp.maven_example:module:jar:1:compile
[INFO]    \- org.apache.logging.log4j:log4j-slf4j18-impl:jar:2.13.3:compile
[INFO]       +- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO]       +- org.apache.logging.log4j:log4j-api:jar:2.13.3:compile
[INFO]       \- org.apache.logging.log4j:log4j-core:jar:2.13.3:runtime
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.764 s
[INFO] Finished at: 2023-02-16T12:58:22+01:00
[INFO] ------------------------------------------------------------------------
[cstamas@urnebes usage]$ mvn dependency:tree -Dmaven.resolver.dependencyManager=default
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< arcomp.maven_example:usage >---------------------
[INFO] Building usage 1
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:2.8:tree (default-cli) @ usage ---
[INFO] arcomp.maven_example:usage:jar:1
[INFO] \- arcomp.maven_example:module:jar:1:compile
[INFO]    \- org.apache.logging.log4j:log4j-slf4j18-impl:jar:2.13.3:compile
[INFO]       +- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO]       +- org.apache.logging.log4j:log4j-api:jar:2.13.3:compile
[INFO]       \- org.apache.logging.log4j:log4j-core:jar:2.13.3:runtime
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.643 s
[INFO] Finished at: 2023-02-16T12:58:27+01:00
[INFO] ------------------------------------------------------------------------
[cstamas@urnebes usage]$ mvn dependency:tree -Dmaven.resolver.dependencyManager=classic
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< arcomp.maven_example:usage >---------------------
[INFO] Building usage 1
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:2.8:tree (default-cli) @ usage ---
[INFO] arcomp.maven_example:usage:jar:1
[INFO] \- arcomp.maven_example:module:jar:1:compile
[INFO]    \- org.apache.logging.log4j:log4j-slf4j18-impl:jar:2.13.3:compile
[INFO]       +- org.slf4j:slf4j-api:jar:1.8.0-beta4:compile                  <!-- BAD
[INFO]       +- org.apache.logging.log4j:log4j-api:jar:2.13.3:compile
[INFO]       \- org.apache.logging.log4j:log4j-core:jar:2.13.3:runtime
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.671 s
[INFO] Finished at: 2023-02-16T12:58:32+01:00
[INFO] ------------------------------------------------------------------------
[cstamas@urnebes usage]$ mvn dependency:tree                       <---- this PR changes to "transitive"
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< arcomp.maven_example:usage >---------------------
[INFO] Building usage 1
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:2.8:tree (default-cli) @ usage ---
[INFO] arcomp.maven_example:usage:jar:1
[INFO] \- arcomp.maven_example:module:jar:1:compile
[INFO]    \- org.apache.logging.log4j:log4j-slf4j18-impl:jar:2.13.3:compile
[INFO]       +- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO]       +- org.apache.logging.log4j:log4j-api:jar:2.13.3:compile
[INFO]       \- org.apache.logging.log4j:log4j-core:jar:2.13.3:runtime
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.662 s
[INFO] Finished at: 2023-02-16T12:58:39+01:00
[INFO] ------------------------------------------------------------------------
[cstamas@urnebes usage]$ 
```
