### PR TITLE
[3.9.x][MNG-7583] Allow concurrent access to the MavenPluginManager

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
@@ -147,6 +147,28 @@ public class DefaultPluginRealmCache implements PluginRealmCache, Disposable {
         return cache.get(key);
     }
 
+    @Override
+    public CacheRecord get(Key key, PluginRealmSupplier supplier)
+            throws PluginResolutionException, PluginContainerException {
+        try {
+            return cache.computeIfAbsent(key, k -> {
+                try {
+                    return supplier.load();
+                } catch (PluginResolutionException | PluginContainerException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof PluginResolutionException) {
+                throw (PluginResolutionException) e.getCause();
+            }
+            if (e.getCause() instanceof PluginContainerException) {
+                throw (PluginContainerException) e.getCause();
+            }
+            throw e;
+        }
+    }
+
     public CacheRecord put(Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts) {
         Objects.requireNonNull(pluginRealm, "pluginRealm cannot be null");
         Objects.requireNonNull(pluginArtifacts, "pluginArtifacts cannot be null");

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginDescriptorCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginDescriptorCache.java
@@ -56,8 +56,15 @@ public interface PluginDescriptorCache {
 
     PluginDescriptor get(Key key);
 
-    PluginDescriptor get(Key key, PluginDescriptorSupplier supplier)
-            throws PluginResolutionException, PluginDescriptorParsingException, InvalidPluginDescriptorException;
+    default PluginDescriptor get(Key key, PluginDescriptorSupplier supplier)
+            throws PluginResolutionException, PluginDescriptorParsingException, InvalidPluginDescriptorException {
+        PluginDescriptor pd = get(key);
+        if (pd == null) {
+            pd = supplier.load();
+            put(key, pd);
+        }
+        return pd;
+    }
 
     void flush();
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginDescriptorCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginDescriptorCache.java
@@ -44,11 +44,20 @@ public interface PluginDescriptorCache {
         // marker interface for cache keys
     }
 
+    @FunctionalInterface
+    interface PluginDescriptorSupplier {
+        PluginDescriptor load()
+                throws PluginResolutionException, PluginDescriptorParsingException, InvalidPluginDescriptorException;
+    }
+
     Key createKey(Plugin plugin, List<RemoteRepository> repositories, RepositorySystemSession session);
 
     void put(Key key, PluginDescriptor pluginDescriptor);
 
     PluginDescriptor get(Key key);
+
+    PluginDescriptor get(Key key, PluginDescriptorSupplier supplier)
+            throws PluginResolutionException, PluginDescriptorParsingException, InvalidPluginDescriptorException;
 
     void flush();
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
@@ -82,7 +82,15 @@ public interface PluginRealmCache {
 
     CacheRecord get(Key key);
 
-    CacheRecord get(Key key, PluginRealmSupplier supplier) throws PluginResolutionException, PluginContainerException;
+    default CacheRecord get(Key key, PluginRealmSupplier supplier)
+            throws PluginResolutionException, PluginContainerException {
+        CacheRecord cr = get(key);
+        if (cr == null) {
+            CacheRecord tcr = supplier.load();
+            cr = put(key, tcr.getRealm(), tcr.getArtifacts());
+        }
+        return cr;
+    }
 
     CacheRecord put(Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts);
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
@@ -67,6 +67,11 @@ public interface PluginRealmCache {
         // marker interface for cache keys
     }
 
+    @FunctionalInterface
+    interface PluginRealmSupplier {
+        CacheRecord load() throws PluginResolutionException, PluginContainerException;
+    }
+
     Key createKey(
             Plugin plugin,
             ClassLoader parentRealm,
@@ -76,6 +81,8 @@ public interface PluginRealmCache {
             RepositorySystemSession session);
 
     CacheRecord get(Key key);
+
+    CacheRecord get(Key key, PluginRealmSupplier supplier) throws PluginResolutionException, PluginContainerException;
 
     CacheRecord put(Key key, ClassRealm pluginRealm, List<Artifact> pluginArtifacts);
 


### PR DESCRIPTION
Backport to 3.9.x branch.
Aligning both 3.9.x and 4.0.x branches would help reducing the maintenance in `mvnd`.