### PR TITLE
[EXPERIMENT] Halve logging

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -88,6 +88,9 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
 
     private ModelCacheFactory modelCacheFactory;
 
+    private final ArtifactDescriptorReaderDelegate artifactDescriptorReaderDelegate =
+            new ArtifactDescriptorReaderDelegate();
+
     public DefaultArtifactDescriptorReader() {
         // enable no-arg constructor
     }
@@ -173,7 +176,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                     (ArtifactDescriptorReaderDelegate) config.get(ArtifactDescriptorReaderDelegate.class.getName());
 
             if (delegate == null) {
-                delegate = new ArtifactDescriptorReaderDelegate();
+                delegate = artifactDescriptorReaderDelegate;
             }
 
             delegate.populateResult(session, result, model);

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@ under the License.
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
     <cipherVersion>2.0</cipherVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.9.4</resolverVersion>
+    <resolverVersion>1.9.5-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.2.1</xmlunitVersion>
     <powermockVersion>1.7.4</powermockVersion>


### PR DESCRIPTION
Of the resolver (downloading vs downloaded), just report after
the fact it was downloaded (or failed to download), no need
for double lines for same resource/dependency.

This experiment includes https://github.com/apache/maven/pull/989
but does not affects it (just to create "closer" Maven to
upcoming release).

As one could expect, IT suite does fail with this change
as some ITs do assert against the build logs (but the build
itself did pass OK). Failing ITs:

[ERROR] Failures:
[ERROR]   MavenITmng6240PluginExtensionAetherProvider.testPluginExtensionDependingOnMavenAetherProvider:83->AbstractMavenIntegrationTestCase.assertEquals:668->AbstractMavenIntegrationTestCase.assertEquals:673 expected: <2> but was: <0>
[INFO]
[ERROR] Tests run: 885, Failures: 1, Errors: 0, Skipped: 80

As to be expected, the IT asserts there is log line without
progress (so DownloadING one, the one that is removed).