### PR TITLE
[MNG-7706] Deprecate 'localRepository' parameter expression

### DIFF
--- a/maven-artifact/src/main/java/org/apache/maven/artifact/repository/ArtifactRepository.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/repository/ArtifactRepository.java
@@ -28,7 +28,10 @@ import org.apache.maven.repository.Proxy;
 /**
  * Abstraction of an artifact repository. Artifact repositories can be remote, local, or even build reactor or
  * IDE workspace.
+ *
+ * @deprecated Avoid use of this type, if you need access to local repository use repository system classes instead.
  */
+@Deprecated
 public interface ArtifactRepository {
     String pathOf(Artifact artifact);
 

--- a/maven-artifact/src/main/java/org/apache/maven/artifact/repository/ArtifactRepositoryPolicy.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/repository/ArtifactRepositoryPolicy.java
@@ -25,7 +25,9 @@ import java.util.Date;
  * Describes a set of policies for a repository to use under certain conditions.
  *
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
+ * @deprecated Avoid use of this type, if you need access to local repository use repository system session instead.
  */
+@Deprecated
 public class ArtifactRepositoryPolicy {
     public static final String UPDATE_POLICY_NEVER = "never";
 

--- a/maven-artifact/src/main/java/org/apache/maven/artifact/repository/layout/ArtifactRepositoryLayout.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/repository/layout/ArtifactRepositoryLayout.java
@@ -22,7 +22,13 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 
-/** @author jdcasey */
+/**
+ * Repository layout.
+ *
+ * @author jdcasey
+ * @deprecated Avoid use of this type, if you need access to local repository use repository system session instead.
+ */
+@Deprecated
 public interface ArtifactRepositoryLayout {
     String ROLE = ArtifactRepositoryLayout.class.getName();
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluator.java
@@ -40,7 +40,7 @@ import org.codehaus.plexus.util.introspection.ReflectionValueExtractor;
  * <tr><td><code>session</code></td>           <td></td>               <td>the actual {@link MavenSession}</td></tr>
  * <tr><td><code>session.*</code></td>         <td>(since Maven 3)</td><td></td></tr>
  * <tr><td><code>localRepository</code></td>   <td></td>
- *                                             <td>{@link MavenSession#getLocalRepository()}</td></tr>
+ *                                             <td>{@link MavenSession#getLocalRepository()} DEPRECATED: Avoid use of {@link org.apache.maven.artifact.repository.ArtifactRepository} type. If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead. See <a href="https://issues.apache.org/jira/browse/MNG-7706">MNG-7706</a></td></tr>
  * <tr><td><code>reactorProjects</code></td>   <td></td>               <td>{@link MavenSession#getProjects()}</td></tr>
  * <tr><td><code>repositorySystemSession</code></td><td> (since Maven 3)</td>
  *                                             <td>{@link MavenSession#getRepositorySession()}</td></tr>

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Common implementations for plugin parameters configuration validation that relies on Mojo descriptor (leaves out
+ * core parameters by default).
+ *
+ * @author Slawomir Jaranowski
+ */
+abstract class AbstractMavenPluginDescriptorSourcedParametersValidator extends AbstractMavenPluginParametersValidator {
+
+    // plugin author can provide @Parameter( property = "session" ) in this case property will always evaluate
+    // so, we need ignore those
+
+    // source org.apache.maven.plugin.PluginParameterExpressionEvaluator
+    private static final List<String> IGNORED_PROPERTY_VALUES = Arrays.asList(
+            "basedir",
+            "executedProject",
+            "localRepository",
+            "mojo",
+            "mojoExecution",
+            "plugin",
+            "project",
+            "reactorProjects",
+            "session",
+            "settings");
+
+    private static final List<String> IGNORED_PROPERTY_PREFIX =
+            Arrays.asList("mojo.", "pom.", "plugin.", "project.", "session.", "settings.");
+
+    @Override
+    protected boolean isIgnoredProperty(String strValue) {
+        if (!strValue.startsWith("${")) {
+            return false;
+        }
+
+        String propertyName = strValue.replace("${", "").replace("}", "");
+
+        if (IGNORED_PROPERTY_VALUES.contains(propertyName)) {
+            return true;
+        }
+
+        return IGNORED_PROPERTY_PREFIX.stream().anyMatch(propertyName::startsWith);
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
@@ -21,22 +21,36 @@ package org.apache.maven.plugin.internal;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import java.util.HashMap;
+
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 
 /**
- * Print warnings if read-only parameters of a plugin are used in configuration.
+ * Print warnings if deprecated core parameters are used in mojo.
  *
- * @author Slawomir Jaranowski
+ * @since 3.9.1
  */
-@Named
 @Singleton
-class ReadOnlyPluginParametersValidator extends AbstractMavenPluginDescriptorSourcedParametersValidator {
+@Named
+class DeprecatedCoreExpressionValidator extends AbstractMavenPluginParametersValidator {
+    private static final HashMap<String, String> DEPRECATED_CORE_PARAMETERS;
+
+    private static final String ARTIFACT_REPOSITORY_REASON =
+            "Avoid use of ArtifactRepository type. If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead.";
+
+    static {
+        HashMap<String, String> deprecatedCoreParameters = new HashMap<>();
+        deprecatedCoreParameters.put("localRepository", ARTIFACT_REPOSITORY_REASON);
+        deprecatedCoreParameters.put("session.localRepository", ARTIFACT_REPOSITORY_REASON);
+        DEPRECATED_CORE_PARAMETERS = deprecatedCoreParameters;
+    }
+
     @Override
     protected String getParameterLogReason(Parameter parameter) {
-        return "is read-only, must not be used in configuration";
+        return "is deprecated core expression; " + DEPRECATED_CORE_PARAMETERS.get(parameter.getName());
     }
 
     @Override
@@ -49,16 +63,7 @@ class ReadOnlyPluginParametersValidator extends AbstractMavenPluginDescriptorSou
         }
 
         mojoDescriptor.getParameters().stream()
-                .filter(parameter -> !parameter.isEditable())
-                .forEach(parameter -> checkParameter(parameter, pomConfiguration, expressionEvaluator));
-    }
-
-    private void checkParameter(
-            Parameter parameter, PlexusConfiguration pomConfiguration, ExpressionEvaluator expressionEvaluator) {
-        PlexusConfiguration config = pomConfiguration.getChild(parameter.getName(), false);
-
-        if (isValueSet(config, expressionEvaluator)) {
-            logParameter(parameter);
-        }
+                .filter(parameter -> DEPRECATED_CORE_PARAMETERS.containsKey(parameter.getName()))
+                .forEach(this::logParameter);
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
@@ -18,43 +18,33 @@
  */
 package org.apache.maven.plugin.internal;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.shared.utils.logging.MessageUtils;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Print warnings if deprecated mojo or parameters of plugin are used in configuration.
  *
  * @author Slawomir Jaranowski
  */
-@Component(role = MavenPluginConfigurationValidator.class)
-class DeprecatedPluginValidator extends AbstractMavenPluginParametersValidator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeprecatedPluginValidator.class);
-
-    @Override
-    protected Logger getLogger() {
-        return LOGGER;
-    }
-
+@Singleton
+@Named
+class DeprecatedPluginValidator extends AbstractMavenPluginDescriptorSourcedParametersValidator {
     @Override
     protected String getParameterLogReason(Parameter parameter) {
         return "is deprecated: " + parameter.getDeprecated();
     }
 
     @Override
-    public void validate(
+    protected void doValidate(
             MojoDescriptor mojoDescriptor,
             PlexusConfiguration pomConfiguration,
             ExpressionEvaluator expressionEvaluator) {
-        if (!LOGGER.isWarnEnabled()) {
-            return;
-        }
-
         if (mojoDescriptor.getDeprecated() != null) {
             logDeprecatedMojo(mojoDescriptor);
         }
@@ -86,6 +76,6 @@ class DeprecatedPluginValidator extends AbstractMavenPluginParametersValidator {
                 .warning(mojoDescriptor.getDeprecated())
                 .toString();
 
-        LOGGER.warn(message);
+        logger.warn(message);
     }
 }


### PR DESCRIPTION
This PR deprecates the 'localRepository' mojo parameter expression, and Core will emit warning if used by any Mojo.

---

https://issues.apache.org/jira/browse/MNG-7706