### PR TITLE
[MNG-7710] Downgrade plexus-utils to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ under the License.
     <mockitoVersion>2.21.0</mockitoVersion>
     <plexusVersion>2.1.0</plexusVersion>
     <plexusInterpolationVersion>1.26</plexusInterpolationVersion>
-    <plexusUtilsVersion>3.4.2</plexusUtilsVersion>
+    <plexusUtilsVersion>3.3.1</plexusUtilsVersion>
     <guiceVersion>5.1.0</guiceVersion>
     <guavaVersion>30.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@ under the License.
     <mockitoVersion>2.21.0</mockitoVersion>
     <plexusVersion>2.1.0</plexusVersion>
     <plexusInterpolationVersion>1.26</plexusInterpolationVersion>
+    <!-- Blocked by 3.4.0+ changes, see MNG-7710 -->
     <plexusUtilsVersion>3.3.1</plexusUtilsVersion>
     <guiceVersion>5.1.0</guiceVersion>
     <guavaVersion>30.1-jre</guavaVersion>


### PR DESCRIPTION
As version 3.4.0 and above introduced several issues related to XML parsing and merging.

---

https://issues.apache.org/jira/browse/MNG-7710