### PR TITLE
[maven-3.9.x] [MNG-7713] Drop legacy-local-repository option

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -1025,7 +1025,7 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
 
     @Override
     public MavenExecutionRequest setUseLegacyLocalRepository(boolean useLegacyLocalRepositoryManager) {
-        this.useLegacyLocalRepositoryManager = useLegacyLocalRepositoryManager;
+        this.useLegacyLocalRepositoryManager = false;
         return this;
     }
 

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -373,12 +373,20 @@ public interface MavenExecutionRequest {
 
     /**
      * @since 3.1
+     * @deprecated Since 3.9 there is no direct Maven2 interop offered at LRM level. See
+     * <a href="https://maven.apache.org/resolver/configuration.html">Resolver Configuration</a> page option
+     * {@code aether.artifactResolver.simpleLrmInterop} that provides similar semantics.
      */
+    @Deprecated
     boolean isUseLegacyLocalRepository();
 
     /**
      * @since 3.1
+     * @deprecated Since 3.9 there is no direct Maven2 interop offered at LRM level. See
+     * <a href="https://maven.apache.org/resolver/configuration.html">Resolver Configuration</a> page option
+     * {@code aether.artifactResolver.simpleLrmInterop} that provides similar semantics.
      */
+    @Deprecated
     MavenExecutionRequest setUseLegacyLocalRepository(boolean useLegacyLocalRepository);
 
     /**

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -375,7 +375,8 @@ public interface MavenExecutionRequest {
      * @since 3.1
      * @deprecated Since 3.9 there is no direct Maven2 interop offered at LRM level. See
      * <a href="https://maven.apache.org/resolver/configuration.html">Resolver Configuration</a> page option
-     * {@code aether.artifactResolver.simpleLrmInterop} that provides similar semantics.
+     * {@code aether.artifactResolver.simpleLrmInterop} that provides similar semantics. This method should
+     * be never invoked, and always returns {@code false}.
      */
     @Deprecated
     boolean isUseLegacyLocalRepository();
@@ -384,8 +385,8 @@ public interface MavenExecutionRequest {
      * @since 3.1
      * @deprecated Since 3.9 there is no direct Maven2 interop offered at LRM level. See
      * <a href="https://maven.apache.org/resolver/configuration.html">Resolver Configuration</a> page option
-     * {@code aether.artifactResolver.simpleLrmInterop} that provides similar semantics.
-     */
+     * {@code aether.artifactResolver.simpleLrmInterop} that provides similar semantics. This method should
+     * be never invoked, and ignores parameter (value remains always {@code false}).     */
     @Deprecated
     MavenExecutionRequest setUseLegacyLocalRepository(boolean useLegacyLocalRepository);
 

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -53,11 +53,9 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
-import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
-import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.eclipse.aether.util.ConfigUtils;
 import org.eclipse.aether.util.listener.ChainedRepositoryListener;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
@@ -128,11 +126,6 @@ public class DefaultRepositorySystemSessionFactory {
 
     @Inject
     private RepositorySystem repoSystem;
-
-    @Inject
-    @Nullable
-    @Named("simple")
-    private LocalRepositoryManagerFactory simpleLocalRepoMgrFactory;
 
     @Inject
     @Nullable
@@ -371,33 +364,22 @@ public class DefaultRepositorySystemSessionFactory {
         LocalRepository localRepo =
                 new LocalRepository(request.getLocalRepository().getBasedir());
 
-        if (request.isUseLegacyLocalRepository()) {
-            try {
-                session.setLocalRepositoryManager(simpleLocalRepoMgrFactory.newInstance(session, localRepo));
-                logger.info("Disabling enhanced local repository: using legacy is strongly discouraged to ensure"
-                        + " build reproducibility.");
-            } catch (NoLocalRepositoryManagerException e) {
-                logger.error("Failed to configure legacy local repository: falling back to default");
-                session.setLocalRepositoryManager(repoSystem.newLocalRepositoryManager(session, localRepo));
-            }
-        } else {
-            LocalRepositoryManager lrm = repoSystem.newLocalRepositoryManager(session, localRepo);
+        LocalRepositoryManager lrm = repoSystem.newLocalRepositoryManager(session, localRepo);
 
-            String localRepoTail = ConfigUtils.getString(session, null, MAVEN_REPO_LOCAL_TAIL);
-            if (localRepoTail != null) {
-                boolean ignoreTailAvailability =
-                        ConfigUtils.getBoolean(session, true, MAVEN_REPO_LOCAL_TAIL_IGNORE_AVAILABILITY);
-                List<LocalRepositoryManager> tail = new ArrayList<>();
-                List<String> paths = Arrays.stream(localRepoTail.split(","))
-                        .filter(p -> p != null && !p.trim().isEmpty())
-                        .collect(toList());
-                for (String path : paths) {
-                    tail.add(repoSystem.newLocalRepositoryManager(session, new LocalRepository(path)));
-                }
-                session.setLocalRepositoryManager(new ChainedLocalRepositoryManager(lrm, tail, ignoreTailAvailability));
-            } else {
-                session.setLocalRepositoryManager(lrm);
+        String localRepoTail = ConfigUtils.getString(session, null, MAVEN_REPO_LOCAL_TAIL);
+        if (localRepoTail != null) {
+            boolean ignoreTailAvailability =
+                    ConfigUtils.getBoolean(session, true, MAVEN_REPO_LOCAL_TAIL_IGNORE_AVAILABILITY);
+            List<LocalRepositoryManager> tail = new ArrayList<>();
+            List<String> paths = Arrays.stream(localRepoTail.split(","))
+                    .filter(p -> p != null && !p.trim().isEmpty())
+                    .collect(toList());
+            for (String path : paths) {
+                tail.add(repoSystem.newLocalRepositoryManager(session, new LocalRepository(path)));
             }
+            session.setLocalRepositoryManager(new ChainedLocalRepositoryManager(lrm, tail, ignoreTailAvailability));
+        } else {
+            session.setLocalRepositoryManager(lrm);
         }
     }
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -101,8 +101,6 @@ public class CLIManager {
 
     public static final String THREADS = "T";
 
-    public static final String LEGACY_LOCAL_REPOSITORY = "llr";
-
     public static final String BUILDER = "b";
 
     public static final String NO_TRANSFER_PROGRESS = "ntp";
@@ -253,10 +251,6 @@ public class CLIManager {
                 .longOpt("threads")
                 .hasArg()
                 .desc("Thread count, for instance 4 (int) or 2C/2.5C (int/float) where C is core multiplied")
-                .build());
-        options.addOption(Option.builder(LEGACY_LOCAL_REPOSITORY)
-                .longOpt("legacy-local-repository")
-                .desc("Ineffective, only kept for backward compatibility.")
                 .build());
         options.addOption(Option.builder(BUILDER)
                 .longOpt("builder")

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -256,8 +256,7 @@ public class CLIManager {
                 .build());
         options.addOption(Option.builder(LEGACY_LOCAL_REPOSITORY)
                 .longOpt("legacy-local-repository")
-                .desc(
-                        "Use Maven 2 Legacy Local Repository behaviour, ie no use of _remote.repositories. Can also be activated by using -Dmaven.legacyLocalRepo=true")
+                .desc("Ineffective, only kept for backward compatibility.")
                 .build());
         options.addOption(Option.builder(BUILDER)
                 .longOpt("builder")

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -269,7 +269,6 @@ public class MavenCli {
             toolchains(cliRequest);
             populateRequest(cliRequest);
             encryption(cliRequest);
-            repository(cliRequest);
             return execute(cliRequest);
         } catch (ExitException e) {
             return e.exitCode;
@@ -806,13 +805,6 @@ public class MavenCli {
             System.out.println(cipher.encryptAndDecorate(passwd, masterPasswd));
 
             throw new ExitException(0);
-        }
-    }
-
-    private void repository(CliRequest cliRequest) throws Exception {
-        if (cliRequest.commandLine.hasOption(CLIManager.LEGACY_LOCAL_REPOSITORY)
-                || Boolean.getBoolean("maven.legacyLocalRepo")) {
-            cliRequest.request.setUseLegacyLocalRepository(true);
         }
     }
 


### PR DESCRIPTION
There is really no need for it, and there is a resolver option if really must (but really should not, local repo is and should be considered as transient).

---

https://issues.apache.org/jira/browse/MNG-7713