### PR TITLE
[MNG-7728] Fix mutable api in PluginContainer

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -624,7 +624,7 @@
       </fields>
       <codeSegments>
         <codeSegment>
-          <version>4.0.0+</version>
+          <version>4.0.0/4.1.0</version>
           <code>
             <![CDATA[
     Map<String, Plugin> pluginMap;
@@ -656,6 +656,31 @@
             }
         }
 
+        return pluginMap;
+    }
+            ]]>
+          </code>
+        </codeSegment>
+        <codeSegment>
+          <version>4.2.0+</version>
+          <code>
+            <![CDATA[
+    volatile Map<String, Plugin> pluginMap;
+
+    /**
+     * @return a Map of plugins field with {@code Plugins#getKey()} as key
+     * @see Plugin#getKey()
+     */
+    public Map<String, Plugin> getPluginsAsMap() {
+        if (pluginMap == null) {
+            synchronized (this) {
+                if (pluginMap == null) {
+                    pluginMap = ImmutableCollections.copy(plugins.stream().collect(
+                            java.util.stream.Collectors.toMap(
+                                Plugin::getKey, java.util.function.Function.identity())));
+                }
+            }
+        }
         return pluginMap;
     }
             ]]>


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7728

The PluginContainer from the v4 api uses the same additional code block than the v3 api and thus offers a `getPluginsAsMap()` method along with a `flushPluginMap()` which makes the whole class non immutable.
Given additional constructor arguments are not supported by the generator, using a lazy computed field should be enough to ensure that the content of the class never changes, even though the field itself can change, the value returned by `getPluginsAsMap()` cannot.