### PR TITLE
[MNG-7713] Make Maven fail if option present

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -283,7 +283,7 @@ public class CLIManager {
         // Adding this back to make Maven fail if used
         options.addOption(Option.builder("llr")
                 .longOpt("legacy-local-repository")
-                .desc("Ineffective, use of this option will make Maven invocation fail.")
+                .desc("UNSUPPORTED: Use of this option will make Maven invocation fail.")
                 .build());
 
         options.addOption(Option.builder()

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -280,6 +280,12 @@ public class CLIManager {
                 .desc("Ineffective, only kept for backward compatibility")
                 .build());
 
+        // Adding this back to make Maven fail if used
+        options.addOption(Option.builder("llr")
+                .longOpt("legacy-local-repository")
+                .desc("Ineffective, use of this option will make Maven invocation fail.")
+                .build());
+
         options.addOption(Option.builder()
                 .longOpt(COLOR)
                 .hasArg()

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -362,6 +362,17 @@ public class MavenCli {
             cliManager.displayHelp(System.out);
             throw e;
         }
+
+        // check for presence of unsupported command line options
+        try {
+            if (cliRequest.commandLine.hasOption("llr")) {
+                throw new UnrecognizedOptionException("Option '-llr' is not supported starting with Maven 3.9.1");
+            }
+        } catch (ParseException e) {
+            System.err.println("Unsupported options: " + e.getMessage());
+            cliManager.displayHelp(System.out);
+            throw e;
+        }
     }
 
     private void informativeCommands(CliRequest cliRequest) throws ExitException {


### PR DESCRIPTION
As with previous PR (simple removal) the `-llr` got interpreted as `-l lr`, it logged all output to `lr` file. This would maean that use of `-llr` would still sneakily 'work' and probably cause surprise down the road to users.

Returned the option, and expicitly checking for it's presence to be able to fail with meaningful message.

---

https://issues.apache.org/jira/browse/MNG-7713