### PR TITLE
[MNG-7713] Make Maven fail if option present (#1021)

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -290,6 +290,12 @@ public class CLIManager {
                 .desc("Defines the color mode of the output. Supported are 'auto', 'always', 'never'.")
                 .build());
 
+        // Adding this back to make Maven fail if used
+        options.addOption(Option.builder("llr")
+                .longOpt("legacy-local-repository")
+                .desc("UNSUPPORTED: Use of this option will make Maven invocation fail.")
+                .build());
+
         // Deprecated
         options.addOption(Option.builder()
                 .longOpt(DEBUG)

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -374,6 +374,17 @@ public class MavenCli {
             cliManager.displayHelp(System.out);
             throw e;
         }
+
+        // check for presence of unsupported command line options
+        try {
+            if (cliRequest.commandLine.hasOption("llr")) {
+                throw new UnrecognizedOptionException("Option '-llr' is not supported starting with Maven 3.9.1");
+            }
+        } catch (ParseException e) {
+            System.err.println("Unsupported options: " + e.getMessage());
+            cliManager.displayHelp(System.out);
+            throw e;
+        }
     }
 
     private void informativeCommands(CliRequest cliRequest) throws ExitException {


### PR DESCRIPTION
As with previous PR (simple removal) the `-llr` got interpreted as `-l lr`, it logged all output to `lr` file. This would maean that use of `-llr` would still sneakily 'work' and probably cause surprise down the road to users.

Returned the option, and expicitly checking for it's presence to be able to fail with meaningful message.

---

https://issues.apache.org/jira/browse/MNG-7713
