### PR TITLE
[3.8.x] [MNG-6889] Deprecate llr option

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -242,10 +242,10 @@ public class DefaultRepositorySystemSessionFactory
                 logger.info( "Disabling enhanced local repository: using legacy is strongly discouraged to ensure"
                                  + " build reproducibility." );
                 logger.warn( "" );
-                logger.warn( "WARNING: due issues listed above, but also due fact that with using this option" );
-                logger.warn( "Maven cannot provide the latest local repository features, this option is being DEPRECATED." );
-                logger.warn( "Moreover, this option is being DROPPED starting with Maven 3.9.1, and use of this option" );
-                logger.warn( "will prevent Maven execution." );
+                logger.warn( "WARNING: due issues listed above, but also due fact that with this option" );
+                logger.warn( "Maven cannot provide the latest local repository features, it is being " );
+                logger.warn( "DEPRECATED. Moreover, this option is being DROPPED starting with Maven 3.9.1, and use" );
+                logger.warn( "of this option will prevent Maven execution." );
                 logger.warn( "" );
             }
             catch ( NoLocalRepositoryManagerException e )

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -241,6 +241,12 @@ public class DefaultRepositorySystemSessionFactory
                 session.setLocalRepositoryManager( simpleLocalRepoMgrFactory.newInstance( session, localRepo ) );
                 logger.info( "Disabling enhanced local repository: using legacy is strongly discouraged to ensure"
                                  + " build reproducibility." );
+                logger.warn( "" );
+                logger.warn( "WARNING: due issues listed above, but also due fact that with using this option" );
+                logger.warn( "Maven cannot provide the latest local repository features, this option is being DEPRECATED." );
+                logger.warn( "Moreover, this option is being DROPPED starting with Maven 3.9.1, and use of this option" );
+                logger.warn( "will prevent Maven execution." );
+                logger.warn( "" );
             }
             catch ( NoLocalRepositoryManagerException e )
             {

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -242,9 +242,9 @@ public class DefaultRepositorySystemSessionFactory
                 logger.info( "Disabling enhanced local repository: using legacy is strongly discouraged to ensure"
                                  + " build reproducibility." );
                 logger.warn( "" );
-                logger.warn( "WARNING: due issues listed above, but also due fact that with this option" );
-                logger.warn( "Maven cannot provide the latest local repository features, it is being " );
-                logger.warn( "DEPRECATED. Moreover, this option is being DROPPED starting with Maven 3.9.1, and use" );
+                logger.warn( "Due issues listed above, but also due fact that with this option Maven" );
+                logger.warn( "cannot provide the latest local repository features, it is being DEPRECATED." );
+                logger.warn( "Moreover, this option is being DROPPED starting with Maven 3.9.1, and use" );
                 logger.warn( "of this option will prevent Maven execution." );
                 logger.warn( "" );
             }


### PR DESCRIPTION
This option promotes "Maven2" in latest Maven 3 versions that is insane. Also, this option was really meant to bridge transition from Maven2 to Maven3, when both were sharing same local repository. Hopefully, in 2023 nobody does that anymore.

---

https://issues.apache.org/jira/browse/MNG-6889