### PR TITLE
[3.9.x] [MNG-7720] Wrong build order of forked projects

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -103,7 +103,10 @@ public class LifecycleDependencyResolver {
     private static Stream<MavenProject> getProjectAndSubModules(MavenProject project) {
         return Stream.concat(
                 Stream.of(project),
-                project.getCollectedProjects().stream().flatMap(LifecycleDependencyResolver::getProjectAndSubModules));
+                project.getCollectedProjects() == null
+                        ? Stream.empty()
+                        : project.getCollectedProjects().stream()
+                                .flatMap(LifecycleDependencyResolver::getProjectAndSubModules));
     }
 
     public void resolveProjectDependencies(

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -90,8 +91,9 @@ public class LifecycleDependencyResolver {
 
     public static List<MavenProject> getProjects(MavenProject project, MavenSession session, boolean aggregator) {
         if (aggregator && project.getCollectedProjects() != null) {
-            List<MavenProject> downstreamProjects = session.getProjectDependencyGraph()
-                    .getDownstreamProjects(project, true); // sorted but more than needed
+            List<MavenProject> downstreamProjects = new ArrayList<>(session.getProjectDependencyGraph()
+                    .getDownstreamProjects(project, true)); // sorted but more than needed
+            downstreamProjects.add(0, project); // add this project as first
             List<MavenProject> projectAndSubmodules =
                     getProjectAndSubModules(project).collect(Collectors.toList()); // not sorted but what we need
             return downstreamProjects.stream()

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -91,14 +90,11 @@ public class LifecycleDependencyResolver {
 
     public static List<MavenProject> getProjects(MavenProject project, MavenSession session, boolean aggregator) {
         if (aggregator && project.getCollectedProjects() != null) {
-            List<MavenProject> downstreamProjects = new ArrayList<>(session.getProjectDependencyGraph()
-                    .getDownstreamProjects(project, true)); // sorted but more than needed
-            downstreamProjects.add(0, project); // add this project as first
             List<MavenProject> projectAndSubmodules =
                     getProjectAndSubModules(project).collect(Collectors.toList()); // not sorted but what we need
-            return downstreamProjects.stream()
+            return session.getProjects().stream() // sorted all
                     .filter(projectAndSubmodules::contains)
-                    .collect(Collectors.toList()); // sorted what we need
+                    .collect(Collectors.toList()); // sorted and filtered to what we need
         } else {
             return Collections.singletonList(project);
         }


### PR DESCRIPTION
The original fix MNG-7672 matched the "scope" but missed the "order". `project.collectedProjects` are in order as loaded (POM order), is not topologically sorted.

Fix is to use DAG of projects, ask for downstream projects (will return more then we need but sorted) and narrow that list to only contain collected projects.

Related commit: 48cac1c003fdc409e8c455c21fcba07050393b0c

---

https://issues.apache.org/jira/browse/MNG-7720
