### PR TITLE
[MNG-7724] Don't log warnings when runtime is not broken (slf4j integrations)

### DIFF
--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -141,6 +141,12 @@ under the License.
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4jVersion}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <optional>true</optional>

--- a/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/JDKConfiguration.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/JDKConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.logging.impl;
+
+import java.util.logging.Logger;
+
+import org.apache.maven.cli.logging.BaseSlf4jConfiguration;
+
+/**
+ * Configuration for slf4j-jdk14.
+ */
+public class JDKConfiguration extends BaseSlf4jConfiguration {
+    @Override
+    public void setRootLoggerLevel(Level level) {
+        java.util.logging.Level value;
+        switch (level) {
+            case DEBUG:
+                value = java.util.logging.Level.FINEST;
+                break;
+
+            case INFO:
+                value = java.util.logging.Level.INFO;
+                break;
+
+            default:
+                value = java.util.logging.Level.SEVERE;
+                break;
+        }
+        Logger.getLogger("").setLevel(value);
+    }
+
+    @Override
+    public void activate() {
+        // no op
+    }
+}

--- a/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/NoopConfiguration.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/NoopConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.logging.impl;
+
+import org.apache.maven.cli.logging.BaseSlf4jConfiguration;
+
+/**
+ * Configuration available for users setting a custom binding and not using --fail-on-severity to avoid warnings.
+ * This is basically a no-op implementation not issuing any warning.
+ * To use it add to maven classpath (m2.conf) a folder/jar with a META-INF/maven/slf4j-configuration.properties
+ * containing {@code loggerClass = org.apache.maven.cli.logging.impl.NoopConfiguration}.
+ */
+public class NoopConfiguration extends BaseSlf4jConfiguration {
+    @Override
+    public void setRootLoggerLevel(Level level) {
+        // no-op
+    }
+
+    @Override
+    public void activate() {
+        // no-op
+    }
+}

--- a/maven-embedder/src/main/resources/META-INF/maven/slf4j-configuration.properties
+++ b/maven-embedder/src/main/resources/META-INF/maven/slf4j-configuration.properties
@@ -21,3 +21,4 @@ org.slf4j.impl.SimpleLoggerFactory org.apache.maven.cli.logging.impl.Slf4jSimple
 org.slf4j.impl.MavenLoggerFactory org.apache.maven.cli.logging.impl.Slf4jSimpleConfiguration
 org.apache.logging.slf4j.Log4jLoggerFactory org.apache.maven.cli.logging.impl.Log4j2Configuration
 ch.qos.logback.classic.LoggerContext org.apache.maven.cli.logging.impl.LogbackConfiguration
+org.slf4j.impl.JDK14LoggerFactory org.apache.maven.cli.logging.impl.JDKConfiguration

--- a/maven-embedder/src/test/java/org/apache/maven/cli/logging/Slf4jConfigurationFactoryTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/logging/Slf4jConfigurationFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.logging;
+
+import org.apache.maven.cli.logging.impl.JDKConfiguration;
+import org.junit.jupiter.api.Test;
+import org.slf4j.impl.JDK14LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class Slf4jConfigurationFactoryTest {
+    @Test
+    void jdk14() {
+        assertInstanceOf(JDKConfiguration.class, Slf4jConfigurationFactory.getConfiguration(new JDK14LoggerFactory()));
+    }
+}

--- a/maven-embedder/src/test/java/org/apache/maven/cli/logging/impl/JDKConfigurationTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/logging/impl/JDKConfigurationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.logging.impl;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.maven.cli.logging.Slf4jConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JDKConfigurationTest {
+    @Test
+    void checkLevel() {
+        final Logger rootLogger = Logger.getLogger("");
+        final Level level = rootLogger.getLevel();
+        rootLogger.setLevel(Level.INFO);
+        try {
+            new JDKConfiguration().setRootLoggerLevel(Slf4jConfiguration.Level.ERROR);
+            assertEquals(Level.SEVERE, rootLogger.getLevel());
+        } finally {
+            rootLogger.setLevel(level);
+        }
+    }
+}


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [X] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

[core-its]: https://maven.apache.org/core-its/core-it-suite/


The issue with current code is that using a SLF4J binding which is not known by maven will lead to WARNINGs.
There are several builds which intend to run without warning or consider warnings as error and therefore fail - not using maven CLI options but other mecanism - either log analyzis on CI, the old way with appenders/handlers or stdout/stderr check if the handlers support the redirection properly.
This behavior defeats a bit using a logger abstraction since the support is pretty limited.
The idea is to keep the message - we can refine it later if relevant - but log it at info level to not make the build failling when there is no issue loading the impl maven should use and keep warning when a loading failed (we can evaluate the move to error later too for this case).