### PR TITLE
Remove references to Xpp3DomBuilder and use XmlNodeBuilder instead

### DIFF
--- a/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorPathTest.java
+++ b/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorPathTest.java
@@ -25,8 +25,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.maven.configuration.internal.DefaultBeanConfigurator;
+import org.apache.maven.internal.xml.XmlNodeBuilder;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,7 +53,7 @@ public class DefaultBeanConfiguratorPathTest {
 
     private Xpp3Dom toConfig(String xml) {
         try {
-            return Xpp3DomBuilder.build(new StringReader("<configuration>" + xml + "</configuration>"));
+            return new Xpp3Dom(XmlNodeBuilder.build(new StringReader("<configuration>" + xml + "</configuration>")));
         } catch (XmlPullParserException | IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorTest.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.io.StringReader;
 
 import org.apache.maven.configuration.internal.DefaultBeanConfigurator;
+import org.apache.maven.internal.xml.XmlNodeBuilder;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +51,7 @@ public class DefaultBeanConfiguratorTest {
 
     private Xpp3Dom toConfig(String xml) {
         try {
-            return Xpp3DomBuilder.build(new StringReader("<configuration>" + xml + "</configuration>"));
+            return new Xpp3Dom(XmlNodeBuilder.build(new StringReader("<configuration>" + xml + "</configuration>")));
         } catch (XmlPullParserException | IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/maven-embedder/src/main/java/org/eclipse/sisu/plexus/PlexusXmlBeanConverter.java
+++ b/maven-embedder/src/main/java/org/eclipse/sisu/plexus/PlexusXmlBeanConverter.java
@@ -40,7 +40,6 @@ import com.google.inject.spi.TypeConverterBinding;
 import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.internal.xml.XmlNodeBuilder;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.MXParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -116,7 +115,7 @@ public final class PlexusXmlBeanConverter implements PlexusBeanConverter {
             return XmlNodeBuilder.build(parser);
         }
         if (Xpp3Dom.class.isAssignableFrom(rawType)) {
-            return parseXpp3Dom(parser);
+            return new Xpp3Dom(XmlNodeBuilder.build(parser));
         }
         if (Properties.class.isAssignableFrom(rawType)) {
             return parseProperties(parser);
@@ -131,16 +130,6 @@ public final class PlexusXmlBeanConverter implements PlexusBeanConverter {
             return parseArray(parser, TypeArguments.get(toType, 0));
         }
         return parseBean(parser, toType, rawType);
-    }
-
-    /**
-     * Parses an XML subtree and converts it to the {@link Xpp3Dom} type.
-     *
-     * @param parser The XML parser
-     * @return Converted Xpp3Dom instance
-     */
-    private static Xpp3Dom parseXpp3Dom(final XmlPullParser parser) throws Exception {
-        return Xpp3DomBuilder.build(parser);
     }
 
     /**

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/PluginsMetadataGenerator.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/PluginsMetadataGenerator.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.repository.internal;
 
-import java.io.Reader;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -30,10 +30,9 @@ import java.util.Map;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
+import org.apache.maven.api.xml.XmlNode;
+import org.apache.maven.internal.xml.XmlNodeBuilder;
 import org.apache.maven.repository.internal.PluginsMetadata.PluginInfo;
-import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.deployment.DeployRequest;
@@ -123,14 +122,13 @@ class PluginsMetadataGenerator implements MetadataGenerator {
                     ZipEntry pluginDescriptorEntry = artifactJar.getEntry(PLUGIN_DESCRIPTOR_LOCATION);
 
                     if (pluginDescriptorEntry != null) {
-                        try (Reader reader =
-                                ReaderFactory.newXmlReader(artifactJar.getInputStream(pluginDescriptorEntry))) {
+                        try (InputStream is = artifactJar.getInputStream(pluginDescriptorEntry)) {
                             // Note: using DOM instead of use of
                             // org.apache.maven.plugin.descriptor.PluginDescriptor
                             // as it would pull in dependency on:
                             // - maven-plugin-api (for model)
                             // - Plexus Container (for model supporting classes and exceptions)
-                            Xpp3Dom root = Xpp3DomBuilder.build(reader);
+                            XmlNode root = XmlNodeBuilder.build(is, null);
                             String groupId = root.getChild("groupId").getValue();
                             String artifactId = root.getChild("artifactId").getValue();
                             String goalPrefix = root.getChild("goalPrefix").getValue();


### PR DESCRIPTION
Remove remaining references to the plexus-utils Xpp3DomBuilder and favour the internal XmlNodeBuilder instead.
This also removes one reference to the plexus-utils ReaderFactory.