### PR TITLE
[MNG-7724] don't warn about unsupported SLF4J configs; no one cares

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/logging/Slf4jConfigurationFactory.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/logging/Slf4jConfigurationFactory.java
@@ -67,6 +67,6 @@ public class Slf4jConfigurationFactory {
             e.printStackTrace();
         }
 
-        return new UnsupportedSlf4jBindingConfiguration(slf4jBinding, supported);
+        return new UnsupportedSlf4jBindingConfiguration();
     }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/UnsupportedSlf4jBindingConfiguration.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/logging/impl/UnsupportedSlf4jBindingConfiguration.java
@@ -23,43 +23,23 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.cli.logging.BaseSlf4jConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Pseudo-configuration for unsupported slf4j binding.
+ * Pseudo-configuration for unsupported SLF4J binding.
  *
  * @author Hervé Boutemy
  * @since 3.2.4
  */
 public class UnsupportedSlf4jBindingConfiguration extends BaseSlf4jConfiguration {
-    private static final Logger LOGGER = LoggerFactory.getLogger(UnsupportedSlf4jBindingConfiguration.class);
 
-    private String slf4jBinding;
+    /**
+     * @deprecated the arguments are ignored. Use the no-args constructor.
+     */
+    @Deprecated
+    public UnsupportedSlf4jBindingConfiguration(String slf4jBinding, Map<URL, Set<Object>> supported) {}
 
-    private Map<URL, Set<Object>> supported;
-
-    public UnsupportedSlf4jBindingConfiguration(String slf4jBinding, Map<URL, Set<Object>> supported) {
-        this.slf4jBinding = slf4jBinding;
-        this.supported = supported;
-    }
+    public UnsupportedSlf4jBindingConfiguration() {}
 
     @Override
-    public void activate() {
-        LOGGER.warn("The SLF4J binding actually used is not supported by Maven: {}", slf4jBinding);
-        LOGGER.warn("Maven supported bindings are:");
-
-        String ls = System.lineSeparator();
-
-        for (Map.Entry<URL, Set<Object>> entry : supported.entrySet()) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("(from ").append(entry.getKey().toExternalForm()).append(')');
-
-            for (Object binding : entry.getValue()) {
-                sb.append(ls).append("- ").append(binding);
-            }
-
-            LOGGER.warn(sb.toString());
-        }
-    }
+    public void activate() {}
 }


### PR DESCRIPTION
This is a more direct approach to avoiding the warnings. Just take them out. They're not actionable and no one cares about this. 