### PR TITLE
[MNG-7726] Maven 3.9.0 resolves properties incorrectly

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/DefaultProfileActivationContext.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/DefaultProfileActivationContext.java
@@ -197,7 +197,7 @@ public class DefaultProfileActivationContext implements ProfileActivationContext
         if (projectProperties != null) {
             this.projectProperties = projectProperties.entrySet().stream()
                     .collect(collectingAndThen(
-                            toMap(k -> String.valueOf(k.getKey()), v -> String.valueOf(v)),
+                            toMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue())),
                             Collections::unmodifiableMap));
         } else {
             this.projectProperties = Collections.emptyMap();


### PR DESCRIPTION
There was a typo: the stream contains entries, so e.getKey and e.getValue is needed.

---

https://issues.apache.org/jira/browse/MNG-7726