### PR TITLE
[MNG-7697] Fix assembly which should not include plexus-utils-3.5.0

### DIFF
--- a/apache-maven/src/assembly/component.xml
+++ b/apache-maven/src/assembly/component.xml
@@ -31,6 +31,7 @@ under the License.
       <outputDirectory>lib</outputDirectory>
       <excludes>
         <exclude>org.codehaus.plexus:plexus-classworlds</exclude>
+        <exclude>org.codehaus.plexus:plexus-utils</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
Additional fix for [MNG-7697](http://issues.apache.org/jira/browse/MNG-7697)