### PR TITLE
[MNG-5659] Provide project-specific settings located in ${session.rootdir}/.mvn/settings.xml by default

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/SettingsBuilder.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/SettingsBuilder.java
@@ -48,7 +48,7 @@ public interface SettingsBuilder extends Service {
     @Nonnull
     default SettingsBuilderResult build(
             @Nonnull Session session, @Nonnull Source globalSettingsSource, @Nonnull Source userSettingsSource) {
-        return build(SettingsBuilderRequest.build(session, globalSettingsSource, userSettingsSource));
+        return build(session, globalSettingsSource, null, userSettingsSource);
     }
 
     /**
@@ -60,6 +60,37 @@ public interface SettingsBuilder extends Service {
     @Nonnull
     default SettingsBuilderResult build(
             @Nonnull Session session, @Nonnull Path globalSettingsPath, @Nonnull Path userSettingsPath) {
-        return build(SettingsBuilderRequest.build(session, globalSettingsPath, userSettingsPath));
+        return build(session, globalSettingsPath, null, userSettingsPath);
+    }
+
+    /**
+     * Builds the effective settings of the specified settings sources.
+     *
+     * @return the result of the settings building, never {@code null}
+     * @throws SettingsBuilderException if the effective settings could not be built
+     */
+    @Nonnull
+    default SettingsBuilderResult build(
+            @Nonnull Session session,
+            @Nonnull Source globalSettingsSource,
+            @Nonnull Source projectSettingsSource,
+            @Nonnull Source userSettingsSource) {
+        return build(
+                SettingsBuilderRequest.build(session, globalSettingsSource, projectSettingsSource, userSettingsSource));
+    }
+
+    /**
+     * Builds the effective settings of the specified settings paths.
+     *
+     * @return the result of the settings building, never {@code null}
+     * @throws SettingsBuilderException if the effective settings could not be built
+     */
+    @Nonnull
+    default SettingsBuilderResult build(
+            @Nonnull Session session,
+            @Nonnull Path globalSettingsPath,
+            @Nonnull Path projectSettingsPath,
+            @Nonnull Path userSettingsPath) {
+        return build(SettingsBuilderRequest.build(session, globalSettingsPath, projectSettingsPath, userSettingsPath));
     }
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/SettingsBuilderRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/SettingsBuilderRequest.java
@@ -57,6 +57,22 @@ public interface SettingsBuilderRequest {
     Optional<Source> getGlobalSettingsSource();
 
     /**
+     * Gets the project settings source.
+     *
+     * @return the project settings source or {@code null} if none
+     */
+    @Nonnull
+    Optional<Source> getProjectSettingsSource();
+
+    /**
+     * Gets the project settings path.
+     *
+     * @return the project settings path or {@code null} if none
+     */
+    @Nonnull
+    Optional<Path> getProjectSettingsPath();
+
+    /**
      * Gets the user settings path.
      *
      * @return the user settings path or {@code null} if none
@@ -75,19 +91,39 @@ public interface SettingsBuilderRequest {
     @Nonnull
     static SettingsBuilderRequest build(
             @Nonnull Session session, @Nonnull Source globalSettingsSource, @Nonnull Source userSettingsSource) {
+        return build(session, globalSettingsSource, null, userSettingsSource);
+    }
+
+    @Nonnull
+    static SettingsBuilderRequest build(
+            @Nonnull Session session, @Nonnull Path globalSettingsPath, @Nonnull Path userSettingsPath) {
+        return build(session, globalSettingsPath, null, userSettingsPath);
+    }
+
+    @Nonnull
+    static SettingsBuilderRequest build(
+            @Nonnull Session session,
+            @Nonnull Source globalSettingsSource,
+            @Nonnull Source projectSettingsSource,
+            @Nonnull Source userSettingsSource) {
         return builder()
                 .session(nonNull(session, "session cannot be null"))
                 .globalSettingsSource(nonNull(globalSettingsSource, "globalSettingsSource cannot be null"))
+                .projectSettingsSource(nonNull(projectSettingsSource, "projectSettingsSource cannot be null"))
                 .userSettingsSource(nonNull(userSettingsSource, "userSettingsSource cannot be null"))
                 .build();
     }
 
     @Nonnull
     static SettingsBuilderRequest build(
-            @Nonnull Session session, @Nonnull Path globalSettingsPath, @Nonnull Path userSettingsPath) {
+            @Nonnull Session session,
+            @Nonnull Path globalSettingsPath,
+            @Nonnull Path projectSettingsPath,
+            @Nonnull Path userSettingsPath) {
         return builder()
                 .session(nonNull(session, "session cannot be null"))
                 .globalSettingsPath(nonNull(globalSettingsPath, "globalSettingsPath cannot be null"))
+                .projectSettingsPath(nonNull(projectSettingsPath, "projectSettingsPath cannot be null"))
                 .userSettingsPath(nonNull(userSettingsPath, "userSettingsPath cannot be null"))
                 .build();
     }
@@ -102,6 +138,8 @@ public interface SettingsBuilderRequest {
         Session session;
         Path globalSettingsPath;
         Source globalSettingsSource;
+        Path projectSettingsPath;
+        Source projectSettingsSource;
         Path userSettingsPath;
         Source userSettingsSource;
 
@@ -120,6 +158,16 @@ public interface SettingsBuilderRequest {
             return this;
         }
 
+        public SettingsBuilderRequestBuilder projectSettingsPath(Path projectSettingsPath) {
+            this.projectSettingsPath = projectSettingsPath;
+            return this;
+        }
+
+        public SettingsBuilderRequestBuilder projectSettingsSource(Source projectSettingsSource) {
+            this.projectSettingsSource = projectSettingsSource;
+            return this;
+        }
+
         public SettingsBuilderRequestBuilder userSettingsPath(Path userSettingsPath) {
             this.userSettingsPath = userSettingsPath;
             return this;
@@ -132,12 +180,20 @@ public interface SettingsBuilderRequest {
 
         public SettingsBuilderRequest build() {
             return new DefaultSettingsBuilderRequest(
-                    session, globalSettingsPath, globalSettingsSource, userSettingsPath, userSettingsSource);
+                    session,
+                    globalSettingsPath,
+                    globalSettingsSource,
+                    projectSettingsPath,
+                    projectSettingsSource,
+                    userSettingsPath,
+                    userSettingsSource);
         }
 
         private static class DefaultSettingsBuilderRequest extends BaseRequest implements SettingsBuilderRequest {
             private final Path globalSettingsPath;
             private final Source globalSettingsSource;
+            private final Path projectSettingsPath;
+            private final Source projectSettingsSource;
             private final Path userSettingsPath;
             private final Source userSettingsSource;
 
@@ -146,11 +202,15 @@ public interface SettingsBuilderRequest {
                     @Nonnull Session session,
                     @Nullable Path globalSettingsPath,
                     @Nullable Source globalSettingsSource,
+                    @Nullable Path projectSettingsPath,
+                    @Nullable Source projectSettingsSource,
                     @Nullable Path userSettingsPath,
                     @Nullable Source userSettingsSource) {
                 super(session);
                 this.globalSettingsPath = globalSettingsPath;
                 this.globalSettingsSource = globalSettingsSource;
+                this.projectSettingsPath = projectSettingsPath;
+                this.projectSettingsSource = projectSettingsSource;
                 this.userSettingsPath = userSettingsPath;
                 this.userSettingsSource = userSettingsSource;
             }
@@ -165,6 +225,18 @@ public interface SettingsBuilderRequest {
             @Override
             public Optional<Source> getGlobalSettingsSource() {
                 return Optional.ofNullable(globalSettingsSource);
+            }
+
+            @Nonnull
+            @Override
+            public Optional<Path> getProjectSettingsPath() {
+                return Optional.ofNullable(projectSettingsPath);
+            }
+
+            @Nonnull
+            @Override
+            public Optional<Source> getProjectSettingsSource() {
+                return Optional.ofNullable(projectSettingsSource);
             }
 
             @Nonnull

--- a/api/maven-api-settings/src/main/mdo/settings.mdo
+++ b/api/maven-api-settings/src/main/mdo/settings.mdo
@@ -53,6 +53,7 @@
           <code>
             <![CDATA[
     public static final String USER_LEVEL = "user-level";
+    public static final String PROJECT_LEVEL = "project-level";
     public static final String GLOBAL_LEVEL = "global-level";
 
     private String sourceLevel = USER_LEVEL;
@@ -64,9 +65,9 @@
         {
             throw new IllegalStateException( "Cannot reset sourceLevel attribute; it is already set to: " + sourceLevel );
         }
-        else if ( !( USER_LEVEL.equals( sourceLevel ) || GLOBAL_LEVEL.equals( sourceLevel ) ) )
+        else if ( !( USER_LEVEL.equals( sourceLevel ) || PROJECT_LEVEL.equals( sourceLevel )  || GLOBAL_LEVEL.equals( sourceLevel ) ) )
         {
-            throw new IllegalArgumentException( "sourceLevel must be one of: {" + USER_LEVEL + "," + GLOBAL_LEVEL + "}" );
+            throw new IllegalArgumentException( "sourceLevel must be one of: {" + USER_LEVEL + "," + PROJECT_LEVEL + "," + GLOBAL_LEVEL + "}" );
         }
         else
         {

--- a/maven-compat/src/main/java/org/apache/maven/settings/DefaultMavenSettingsBuilder.java
+++ b/maven-compat/src/main/java/org/apache/maven/settings/DefaultMavenSettingsBuilder.java
@@ -87,6 +87,7 @@ public class DefaultMavenSettingsBuilder extends AbstractLogEnabled implements M
     public Settings buildSettings(MavenExecutionRequest request) throws IOException, XmlPullParserException {
         SettingsBuildingRequest settingsRequest = new DefaultSettingsBuildingRequest();
         settingsRequest.setUserSettingsFile(request.getUserSettingsFile());
+        settingsRequest.setProjectSettingsFile(request.getProjectSettingsFile());
         settingsRequest.setGlobalSettingsFile(request.getGlobalSettingsFile());
         settingsRequest.setUserProperties(request.getUserProperties());
         settingsRequest.setSystemProperties(request.getSystemProperties());

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -90,6 +90,8 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
 
     private File userSettingsFile;
 
+    private File projectSettingsFile;
+
     private File globalSettingsFile;
 
     private File userToolchainsFile;
@@ -838,6 +840,18 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
     @Override
     public MavenExecutionRequest setUserSettingsFile(File userSettingsFile) {
         this.userSettingsFile = userSettingsFile;
+
+        return this;
+    }
+
+    @Override
+    public File getProjectSettingsFile() {
+        return projectSettingsFile;
+    }
+
+    @Override
+    public MavenExecutionRequest setProjectSettingsFile(File projectSettingsFile) {
+        this.projectSettingsFile = projectSettingsFile;
 
         return this;
     }

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -393,6 +393,10 @@ public interface MavenExecutionRequest {
 
     MavenExecutionRequest setUserSettingsFile(File userSettingsFile);
 
+    File getProjectSettingsFile();
+
+    MavenExecutionRequest setProjectSettingsFile(File projectSettingsFile);
+
     File getGlobalSettingsFile();
 
     MavenExecutionRequest setGlobalSettingsFile(File globalSettingsFile);

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -78,6 +78,8 @@ public class CLIManager {
 
     public static final char ALTERNATE_USER_SETTINGS = 's';
 
+    public static final String ALTERNATE_PROJECT_SETTINGS = "ps";
+
     public static final String ALTERNATE_GLOBAL_SETTINGS = "gs";
 
     public static final char ALTERNATE_USER_TOOLCHAINS = 't';
@@ -203,6 +205,11 @@ public class CLIManager {
         options.addOption(Option.builder(Character.toString(ALTERNATE_USER_SETTINGS))
                 .longOpt("settings")
                 .desc("Alternate path for the user settings file")
+                .hasArg()
+                .build());
+        options.addOption(Option.builder(ALTERNATE_PROJECT_SETTINGS)
+                .longOpt("project-settings")
+                .desc("Alternate path for the project settings file")
                 .hasArg()
                 .build());
         options.addOption(Option.builder(ALTERNATE_GLOBAL_SETTINGS)

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
@@ -110,4 +110,12 @@ public class CliRequest {
     public void setUserProperties(Properties properties) {
         this.userProperties.putAll(properties);
     }
+
+    public Path getRootDirectory() {
+        return rootDirectory;
+    }
+
+    public Path getTopDirectory() {
+        return topDirectory;
+    }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -25,6 +25,7 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.maven.artifact.InvalidRepositoryException;
@@ -66,6 +67,8 @@ public class SettingsXmlConfigurationProcessor implements ConfigurationProcessor
 
     public static final File DEFAULT_USER_SETTINGS_FILE = new File(USER_MAVEN_CONFIGURATION_HOME, "settings.xml");
 
+    public static final File DEFAULT_PROJECT_SETTINGS_FILE = new File(".mvn", "settings.xml");
+
     public static final File DEFAULT_GLOBAL_SETTINGS_FILE = new File(System.getProperty("maven.conf"), "settings.xml");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SettingsXmlConfigurationProcessor.class);
@@ -98,6 +101,24 @@ public class SettingsXmlConfigurationProcessor implements ConfigurationProcessor
             userSettingsFile = DEFAULT_USER_SETTINGS_FILE;
         }
 
+        File projectSettingsFile;
+
+        if (commandLine.hasOption(CLIManager.ALTERNATE_PROJECT_SETTINGS)) {
+            projectSettingsFile = new File(commandLine.getOptionValue(CLIManager.ALTERNATE_PROJECT_SETTINGS));
+            projectSettingsFile = resolveFile(projectSettingsFile, workingDirectory);
+
+            if (!projectSettingsFile.isFile()) {
+                throw new FileNotFoundException(
+                        "The specified project settings file does not exist: " + projectSettingsFile);
+            }
+        } else if (cliRequest.getRootDirectory() != null) {
+            projectSettingsFile = DEFAULT_PROJECT_SETTINGS_FILE;
+            projectSettingsFile = resolveFile(
+                    projectSettingsFile, cliRequest.getRootDirectory().toString());
+        } else {
+            projectSettingsFile = null;
+        }
+
         File globalSettingsFile;
 
         if (commandLine.hasOption(CLIManager.ALTERNATE_GLOBAL_SETTINGS)) {
@@ -113,13 +134,21 @@ public class SettingsXmlConfigurationProcessor implements ConfigurationProcessor
         }
 
         request.setGlobalSettingsFile(globalSettingsFile);
+        request.setProjectSettingsFile(projectSettingsFile);
         request.setUserSettingsFile(userSettingsFile);
 
         SettingsBuildingRequest settingsRequest = new DefaultSettingsBuildingRequest();
         settingsRequest.setGlobalSettingsFile(globalSettingsFile);
+        settingsRequest.setProjectSettingsFile(projectSettingsFile);
         settingsRequest.setUserSettingsFile(userSettingsFile);
         settingsRequest.setSystemProperties(cliRequest.getSystemProperties());
-        settingsRequest.setUserProperties(cliRequest.getUserProperties());
+        Properties props = cliRequest.getUserProperties();
+        if (cliRequest.getRootDirectory() != null) {
+            props = new Properties();
+            props.putAll(cliRequest.getUserProperties());
+            props.put("session.rootDirectory", cliRequest.getRootDirectory().toString());
+        }
+        settingsRequest.setUserProperties(props);
 
         if (request.getEventSpyDispatcher() != null) {
             request.getEventSpyDispatcher().onEvent(settingsRequest);
@@ -128,6 +157,9 @@ public class SettingsXmlConfigurationProcessor implements ConfigurationProcessor
         LOGGER.debug(
                 "Reading global settings from '{}'",
                 getLocation(settingsRequest.getGlobalSettingsSource(), settingsRequest.getGlobalSettingsFile()));
+        LOGGER.debug(
+                "Reading project settings from '{}'",
+                getLocation(settingsRequest.getProjectSettingsSource(), settingsRequest.getProjectSettingsFile()));
         LOGGER.debug(
                 "Reading user settings from '{}'",
                 getLocation(settingsRequest.getUserSettingsSource(), settingsRequest.getUserSettingsFile()));

--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -78,7 +78,13 @@ under the License.
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <configuration />
+        <configuration>
+          <parameter>
+            <excludes>
+              <exclude>org.apache.maven.settings.validation.SettingsValidator#validate(org.apache.maven.settings.Settings,boolean,org.apache.maven.settings.building.SettingsProblemCollector):METHOD_NEW_DEFAULT</exclude>
+            </excludes>
+          </parameter>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-settings-builder/src/main/java/org/apache/maven/settings/building/DefaultSettingsBuildingRequest.java
+++ b/maven-settings-builder/src/main/java/org/apache/maven/settings/building/DefaultSettingsBuildingRequest.java
@@ -30,9 +30,13 @@ public class DefaultSettingsBuildingRequest implements SettingsBuildingRequest {
 
     private File globalSettingsFile;
 
+    private File projectSettingsFile;
+
     private File userSettingsFile;
 
     private SettingsSource globalSettingsSource;
+
+    private SettingsSource projectSettingsSource;
 
     private SettingsSource userSettingsSource;
 
@@ -60,6 +64,30 @@ public class DefaultSettingsBuildingRequest implements SettingsBuildingRequest {
     @Override
     public DefaultSettingsBuildingRequest setGlobalSettingsSource(SettingsSource globalSettingsSource) {
         this.globalSettingsSource = globalSettingsSource;
+
+        return this;
+    }
+
+    @Override
+    public File getProjectSettingsFile() {
+        return projectSettingsFile;
+    }
+
+    @Override
+    public DefaultSettingsBuildingRequest setProjectSettingsFile(File projectSettingsFile) {
+        this.projectSettingsFile = projectSettingsFile;
+
+        return this;
+    }
+
+    @Override
+    public SettingsSource getProjectSettingsSource() {
+        return projectSettingsSource;
+    }
+
+    @Override
+    public DefaultSettingsBuildingRequest setProjectSettingsSource(SettingsSource projectSettingsSource) {
+        this.projectSettingsSource = projectSettingsSource;
 
         return this;
     }

--- a/maven-settings-builder/src/main/java/org/apache/maven/settings/building/SettingsBuilder.java
+++ b/maven-settings-builder/src/main/java/org/apache/maven/settings/building/SettingsBuilder.java
@@ -19,7 +19,8 @@
 package org.apache.maven.settings.building;
 
 /**
- * Builds the effective settings from a user settings file and/or a global settings file.
+ * Builds the effective settings from a user settings file, a project settings file
+ * and/or a global settings file.
  *
  * @author Benjamin Bentmann
  */

--- a/maven-settings-builder/src/main/java/org/apache/maven/settings/building/SettingsBuildingRequest.java
+++ b/maven-settings-builder/src/main/java/org/apache/maven/settings/building/SettingsBuildingRequest.java
@@ -61,6 +61,40 @@ public interface SettingsBuildingRequest {
     SettingsBuildingRequest setGlobalSettingsSource(SettingsSource globalSettingsSource);
 
     /**
+     * Gets the project settings file.
+     *
+     * @return The project settings file or {@code null} if none.
+     * @since 4.0.0
+     */
+    File getProjectSettingsFile();
+
+    /**
+     * Sets the project settings file. A non-existent settings file is equivalent to empty settings.
+     *
+     * @param projectSettingsFile The project settings file, may be {@code null} to disable project settings.
+     * @return This request, never {@code null}.
+     * @since 4.0.0
+     */
+    DefaultSettingsBuildingRequest setProjectSettingsFile(File projectSettingsFile);
+
+    /**
+     * Gets the project settings source.
+     *
+     * @return The project settings source or {@code null} if none.
+     * @since 4.0.0
+     */
+    SettingsSource getProjectSettingsSource();
+
+    /**
+     * Sets the project settings source.
+     *
+     * @param projectSettingsSource The project settings source, may be {@code null} to disable global settings.
+     * @return This request, never {@code null}.
+     * @since 4.0.0
+     */
+    SettingsBuildingRequest setProjectSettingsSource(SettingsSource projectSettingsSource);
+
+    /**
      * Gets the user settings file.
      *
      * @return The user settings file or {@code null} if none.

--- a/maven-settings-builder/src/main/java/org/apache/maven/settings/validation/SettingsValidator.java
+++ b/maven-settings-builder/src/main/java/org/apache/maven/settings/validation/SettingsValidator.java
@@ -35,4 +35,15 @@ public interface SettingsValidator {
      * @param problems The container used to collect problems that were encountered, must not be {@code null}.
      */
     void validate(Settings settings, SettingsProblemCollector problems);
+
+    /**
+     * Validate the specified settings.
+     *
+     * @param settings The settings to validate, must not be {@code null}.
+     * @param isProjectSettings Boolean indicating if the validation is for project settings or user / global settings.
+     * @param problems The container used to collect problems that were encountered, must not be {@code null}.
+     */
+    default void validate(Settings settings, boolean isProjectSettings, SettingsProblemCollector problems) {
+        validate(settings, problems);
+    }
 }


### PR DESCRIPTION
This add support for project specific settings using:
  * a default location of `${session.rootDirectory}/.mvn/settings.xml`
  * an alternate location specified by `-ps` or `--project-settings` and resolved against the current dir if provided with a relative path

Note that project settings have some limitations:
  * no `localRepository`
  * no `interactiveMode`
  * no `offline`
  * no `proxies`
  * no `server[x].username`, `server[x].password`, `server[x].privateKey`, `server[x].passphrase`, `server[x].filePermissions`, `server[x].directoryPermissions`
  * no `usePluginRegistry`

Simple IT provided with https://github.com/apache/maven-integration-testing/pull/265

===
Related discussions to be considered (but note that this PR does not depend on the following):

* [MNG-6762](https://issues.apache.org/jira/browse/MNG-6762) suggests to also modify other file resolution, but there was a strong opposition to modify the existing behaviour.  This PR is coherent with the current code where relative files are resolved against the current directory.  

