### PR TITLE
[MNG-7707] ${project.basedir} directory creation when running plugin

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
@@ -62,6 +62,11 @@ public final class ConsumerPomArtifactTransformer {
     private static final String CONSUMER_POM_CLASSIFIER = "consumer";
 
     public void injectTransformedArtifacts(MavenProject project, RepositorySystemSession session) throws IOException {
+        if (project.getFile() == null) {
+            // If there is no build POM there is no reason to inject artifacts for the consumer POM.
+            // https://issues.apache.org/jira/browse/MNG-7707
+            return;
+        }
         if (isActive(session)) {
             Path generatedFile;
             String buildDirectory =

--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
@@ -64,7 +64,6 @@ public final class ConsumerPomArtifactTransformer {
     public void injectTransformedArtifacts(MavenProject project, RepositorySystemSession session) throws IOException {
         if (project.getFile() == null) {
             // If there is no build POM there is no reason to inject artifacts for the consumer POM.
-            // https://issues.apache.org/jira/browse/MNG-7707
             return;
         }
         if (isActive(session)) {

--- a/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
@@ -37,9 +37,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-public class ConsumerPomArtifactTransformerTest {
+class ConsumerPomArtifactTransformerTest {
     @Test
-    public void transform() throws Exception {
+    void transform() throws Exception {
         Path beforePomFile =
                 Paths.get("src/test/resources/projects/transform/before.pom").toAbsolutePath();
         Path afterPomFile =
@@ -53,7 +53,7 @@ public class ConsumerPomArtifactTransformerTest {
     }
 
     @Test
-    public void injectTransformedArtifactsWithoutPomShouldNotInjectAnyArtifacts() throws IOException {
+    void injectTransformedArtifactsWithoutPomShouldNotInjectAnyArtifacts() throws IOException {
         MavenProject emptyProject = new MavenProject();
 
         RepositorySystemSession systemSessionMock = Mockito.mock(RepositorySystemSession.class);

--- a/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.internal.transformation;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,8 +26,16 @@ import java.nio.file.Paths;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.TransformerContext;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.SessionData;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.xmlunit.assertj.XmlAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 public class ConsumerPomArtifactTransformerTest {
     @Test
@@ -41,6 +50,20 @@ public class ConsumerPomArtifactTransformerTest {
                         ConsumerPomArtifactTransformer.transform(beforePomFile, new NoTransformerContext())) {
             XmlAssert.assertThat(result).and(expected).areIdentical();
         }
+    }
+
+    @Test
+    public void injectTransformedArtifactsWithoutPomShouldNotInjectAnyArtifacts() throws IOException {
+        MavenProject emptyProject = new MavenProject();
+
+        RepositorySystemSession systemSessionMock = Mockito.mock(RepositorySystemSession.class);
+        SessionData sessionDataMock = Mockito.mock(SessionData.class);
+        when(systemSessionMock.getData()).thenReturn(sessionDataMock);
+        when(sessionDataMock.get(any())).thenReturn(new NoTransformerContext());
+
+        new ConsumerPomArtifactTransformer().injectTransformedArtifacts(emptyProject, systemSessionMock);
+
+        assertThat(emptyProject.getAttachedArtifacts()).isEmpty();
     }
 
     private static class NoTransformerContext implements TransformerContext {


### PR DESCRIPTION
When running `mvn archetype:generate` without providing a valid POM a directory named `${project.basedir}` is created at the location where you invoke the command from. This is done in the `ConsumerPomArtifactTransformer`. 

If there is no (build) POM present at all there is no need to transform artifacts for a consumer POM and thus the side effect of creating the directory.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [MNG-7707](https://issues.apache.org/jira/browse/MNG-7707) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [x] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
