### PR TITLE
[MNG-7038] Introduce public property to point to a root directory of (multi-module) project

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Project.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Project.java
@@ -86,7 +86,44 @@ public interface Project {
         return getModel().getId();
     }
 
+    /**
+     * @deprecated use {@link #isTopProject()} instead
+     */
+    @Deprecated
     boolean isExecutionRoot();
+
+    /**
+     * Returns a boolean indicating if the project is the top level project for
+     * this reactor build.  The top level project may be different from the
+     * {@code rootDirectory}, especially if a subtree of the project is being
+     * built, either because Maven has been launched in a subdirectory or using
+     * a {@code -f} option.
+     *
+     * @return {@code true} if the project is the top level project for this build
+     */
+    boolean isTopProject();
+
+    /**
+     * Returns a boolean indicating if the project is a root project,
+     * meaning that the {@link #getRootDirectory()} and {@link #getBasedir()}
+     * points to the same directory, and that either {@link Model#isRoot()}
+     * is {@code true} or that {@code basedir} contains a {@code .mvn} child
+     * directory.
+     *
+     * @return {@code true} if the project is the root project
+     * @see Model#isRoot()
+     */
+    boolean isRootProject();
+
+    /**
+     * Gets the root directory of the project, which is the parent directory
+     * containing the {@code .mvn} directory or flagged with {@code root="true"}.
+     *
+     * @throws IllegalStateException if the root directory could not be found
+     * @see Session#getRootDirectory()
+     */
+    @Nonnull
+    Path getRootDirectory();
 
     @Nonnull
     Optional<Project> getParent();

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
@@ -84,9 +84,34 @@ public interface Session {
     @Nonnull
     Instant getStartTime();
 
+    /**
+     * Gets the directory of the topmost project being built, usually the current directory or the
+     * directory pointed at by the {@code -f/--file} command line argument.
+     */
     @Nonnull
+    Path getTopDirectory();
+
+    /**
+     * Gets the root directory of the session, which is the root directory for the top directory project.
+     *
+     * @throws IllegalStateException if the root directory could not be found
+     * @see #getTopDirectory()
+     * @see Project#getRootDirectory()
+     */
+    @Nonnull
+    Path getRootDirectory();
+
+    /**
+     * @deprecated use {@link #getRootDirectory()} instead
+     */
+    @Nonnull
+    @Deprecated
     Path getMultiModuleProjectDirectory();
 
+    /**
+     * @deprecated use {@link #getTopDirectory()} instead
+     */
+    @Deprecated
     @Nonnull
     Path getExecutionRootDirectory();
 
@@ -97,8 +122,8 @@ public interface Session {
      * Returns the plugin context for mojo being executed and the specified
      * {@link Project}, never returns {@code null} as if context not present, creates it.
      *
-     * <strong>Implementation note:</strong> while this method return type is {@link Map}, the returned map instance
-     * implements {@link java.util.concurrent.ConcurrentMap} as well.
+     * <strong>Implementation note:</strong> while this method return type is {@link Map}, the
+     * returned map instance implements {@link java.util.concurrent.ConcurrentMap} as well.
      *
      * @throws org.apache.maven.api.services.MavenException if not called from the within a mojo execution
      */

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -212,6 +212,19 @@
           </description>
           <type>String</type>
         </field>
+        <field xml.attribute="true" xml.tagName="root">
+          <name>root</name>
+          <version>4.0.0+</version>
+          <description>
+            <![CDATA[
+            Indicates that this project is the root project, located in the upper directory of the source tree.
+            This is the directory which may contain the .mvn directory.
+            <br><b>Since</b>: Maven 4.0.0
+            ]]>
+          </description>
+          <type>boolean</type>
+          <defaultValue>false</defaultValue>
+        </field>
         <field>
           <name>inceptionYear</name>
           <version>3.0.0+</version>

--- a/maven-compat/src/test/java/org/apache/maven/project/TestProjectBuilder.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/TestProjectBuilder.java
@@ -29,6 +29,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.bridge.MavenRepositorySystem;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelProcessor;
+import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.repository.internal.ModelCacheFactory;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -45,7 +46,8 @@ public class TestProjectBuilder extends DefaultProjectBuilder {
             RepositorySystem repoSystem,
             RemoteRepositoryManager repositoryManager,
             ProjectDependenciesResolver dependencyResolver,
-            ModelCacheFactory modelCacheFactory) {
+            ModelCacheFactory modelCacheFactory,
+            RootLocator rootLocator) {
         super(
                 modelBuilder,
                 modelProcessor,
@@ -54,7 +56,8 @@ public class TestProjectBuilder extends DefaultProjectBuilder {
                 repoSystem,
                 repositoryManager,
                 dependencyResolver,
-                modelCacheFactory);
+                modelCacheFactory,
+                rootLocator);
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.execution;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Properties;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.eventspy.internal.EventSpyDispatcher;
 import org.apache.maven.model.Profile;
+import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.properties.internal.SystemProperties;
@@ -101,6 +103,10 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
     private File multiModuleProjectDirectory;
 
     private File basedir;
+
+    private Path rootDirectory;
+
+    private Path topDirectory;
 
     private List<String> goals;
 
@@ -1051,14 +1057,41 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
         return this;
     }
 
+    @Deprecated
     @Override
     public void setMultiModuleProjectDirectory(File directory) {
         this.multiModuleProjectDirectory = directory;
     }
 
+    @Deprecated
     @Override
     public File getMultiModuleProjectDirectory() {
         return multiModuleProjectDirectory;
+    }
+
+    @Override
+    public Path getRootDirectory() {
+        if (rootDirectory == null) {
+            throw new IllegalStateException(RootLocator.UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE);
+        }
+        return rootDirectory;
+    }
+
+    @Override
+    public MavenExecutionRequest setRootDirectory(Path rootDirectory) {
+        this.rootDirectory = rootDirectory;
+        return this;
+    }
+
+    @Override
+    public Path getTopDirectory() {
+        return topDirectory;
+    }
+
+    @Override
+    public MavenExecutionRequest setTopDirectory(Path topDirectory) {
+        this.topDirectory = topDirectory;
+        return this;
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.execution;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -91,8 +92,17 @@ public interface MavenExecutionRequest {
     // ----------------------------------------------------------------------
 
     // Base directory
+
+    /**
+     * @deprecated use {@link #setTopDirectory(Path)} instead
+     */
+    @Deprecated
     MavenExecutionRequest setBaseDirectory(File basedir);
 
+    /**
+     * @deprecated use {@link #getTopDirectory()} instead
+     */
+    @Deprecated
     String getBaseDirectory();
 
     // Timing (remove this)
@@ -494,13 +504,50 @@ public interface MavenExecutionRequest {
 
     /**
      * @since 3.3.0
+     * @deprecated use {@link #setRootDirectory(Path)} instead
      */
+    @Deprecated
     void setMultiModuleProjectDirectory(File file);
 
     /**
      * @since 3.3.0
+     * @deprecated use {@link #getRootDirectory()} instead
      */
+    @Deprecated
     File getMultiModuleProjectDirectory();
+
+    /**
+     * Sets the top directory of the project.
+     *
+     * @since 4.0.0
+     */
+    MavenExecutionRequest setTopDirectory(Path topDirectory);
+
+    /**
+     * Gets the directory of the topmost project being built, usually the current directory or the
+     * directory pointed at by the {@code -f/--file} command line argument.
+     *
+     * @since 4.0.0
+     */
+    Path getTopDirectory();
+
+    /**
+     * Sets the root directory of the project.
+     *
+     * @since 4.0.0
+     */
+    MavenExecutionRequest setRootDirectory(Path rootDirectory);
+
+    /**
+     * Gets the root directory of the top project, which is the parent directory containing the {@code .mvn}
+     * directory or a {@code pom.xml} file with the {@code root="true"} attribute.
+     * If there's no such directory, an {@code IllegalStateException} will be thrown.
+     *
+     * @throws IllegalStateException if the root directory could not be found
+     * @see #getTopDirectory()
+     * @since 4.0.0
+     */
+    Path getRootDirectory();
 
     /**
      * @since 3.3.0

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -19,6 +19,7 @@
 package org.apache.maven.execution;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -141,8 +142,28 @@ public class MavenSession implements Cloneable {
         return projects;
     }
 
+    /**
+     * @deprecated use {@link #getTopDirectory()} ()}
+     */
+    @Deprecated
     public String getExecutionRootDirectory() {
         return request.getBaseDirectory();
+    }
+
+    /**
+     * @see MavenExecutionRequest#getTopDirectory()
+     * @since 4.0.0
+     */
+    public Path getTopDirectory() {
+        return request.getTopDirectory();
+    }
+
+    /**
+     * @see MavenExecutionRequest#getRootDirectory()
+     * @since 4.0.0
+     */
+    public Path getRootDirectory() {
+        return request.getRootDirectory();
     }
 
     public MavenExecutionRequest getRequest() {

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
@@ -130,6 +130,22 @@ public class DefaultProject implements Project {
     }
 
     @Override
+    public boolean isTopProject() {
+        return getBasedir().isPresent()
+                && getBasedir().get().equals(getSession().getTopDirectory());
+    }
+
+    @Override
+    public boolean isRootProject() {
+        return getBasedir().isPresent() && getBasedir().get().equals(getRootDirectory());
+    }
+
+    @Override
+    public Path getRootDirectory() {
+        return project.getRootDirectory();
+    }
+
+    @Override
     public Optional<Project> getParent() {
         MavenProject parent = project.getParent();
         return parent != null ? Optional.of(session.getProject(parent)) : Optional.empty();

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
@@ -19,7 +19,6 @@
 package org.apache.maven.internal.impl;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -150,7 +149,17 @@ public class DefaultSession extends AbstractSession {
     @Nonnull
     @Override
     public Path getExecutionRootDirectory() {
-        return Paths.get(mavenSession.getRequest().getBaseDirectory());
+        return getTopDirectory();
+    }
+
+    @Override
+    public Path getRootDirectory() {
+        return mavenSession.getRequest().getRootDirectory();
+    }
+
+    @Override
+    public Path getTopDirectory() {
+        return mavenSession.getRequest().getTopDirectory();
     }
 
     @Nonnull

--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
@@ -74,6 +74,9 @@ public final class ConsumerPomArtifactTransformer {
                 generatedFile = Files.createTempFile(buildDir, CONSUMER_POM_CLASSIFIER, "pom");
             }
             project.addAttachedArtifact(new ConsumerPomArtifact(project, generatedFile, session));
+        } else if (project.getModel().isRoot()) {
+            throw new IllegalStateException(
+                    "The use of the root attribute on the model requires the buildconsumer feature to be active");
         }
     }
 

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -69,6 +69,7 @@ import org.apache.maven.model.building.StringModelSource;
 import org.apache.maven.model.building.TransformerContext;
 import org.apache.maven.model.building.TransformerContextBuilder;
 import org.apache.maven.model.resolution.ModelResolver;
+import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.repository.internal.ArtifactDescriptorUtils;
 import org.apache.maven.repository.internal.ModelCacheFactory;
 import org.codehaus.plexus.util.Os;
@@ -101,6 +102,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
     private final ProjectDependenciesResolver dependencyResolver;
     private final ModelCacheFactory modelCacheFactory;
 
+    private final RootLocator rootLocator;
+
     @SuppressWarnings("checkstyle:ParameterNumber")
     @Inject
     public DefaultProjectBuilder(
@@ -111,7 +114,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             RepositorySystem repoSystem,
             RemoteRepositoryManager repositoryManager,
             ProjectDependenciesResolver dependencyResolver,
-            ModelCacheFactory modelCacheFactory) {
+            ModelCacheFactory modelCacheFactory,
+            RootLocator rootLocator) {
         this.modelBuilder = modelBuilder;
         this.modelProcessor = modelProcessor;
         this.projectBuildingHelper = projectBuildingHelper;
@@ -120,6 +124,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
         this.repositoryManager = repositoryManager;
         this.dependencyResolver = dependencyResolver;
         this.modelCacheFactory = modelCacheFactory;
+        this.rootLocator = rootLocator;
     }
     // ----------------------------------------------------------------------
     // MavenProjectBuilder Implementation
@@ -161,6 +166,11 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 request.setPomFile(pomFile);
                 request.setModelSource(modelSource);
                 request.setLocationTracking(true);
+
+                if (pomFile != null) {
+                    project.setRootDirectory(
+                            rootLocator.findRoot(pomFile.getParentFile().toPath()));
+                }
 
                 ModelBuildingResult result;
                 try {
@@ -444,6 +454,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
 
         MavenProject project = new MavenProject();
         project.setFile(pomFile);
+
+        project.setRootDirectory(rootLocator.findRoot(pomFile.getParentFile().toPath()));
 
         ModelBuildingRequest request = getModelBuildingRequest(config)
                 .setPomFile(pomFile)

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -21,6 +21,7 @@ package org.apache.maven.project;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,6 +65,7 @@ import org.apache.maven.model.Repository;
 import org.apache.maven.model.Resource;
 import org.apache.maven.model.Scm;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.project.artifact.InvalidDependencyVersionException;
 import org.apache.maven.project.artifact.MavenMetadataSource;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
@@ -104,6 +106,8 @@ public class MavenProject implements Cloneable {
     private File file;
 
     private File basedir;
+
+    private Path rootDirectory;
 
     private Set<Artifact> resolvedArtifacts;
 
@@ -1678,5 +1682,21 @@ public class MavenProject implements Cloneable {
     @Deprecated
     public void setProjectBuildingRequest(ProjectBuildingRequest projectBuildingRequest) {
         this.projectBuilderConfiguration = projectBuildingRequest;
+    }
+
+    /**
+     * @since 4.0.0
+     * @return the rootDirectory for this project
+     * @throws IllegalStateException if the rootDirectory cannot be found
+     */
+    public Path getRootDirectory() {
+        if (rootDirectory == null) {
+            throw new IllegalStateException(RootLocator.UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE);
+        }
+        return rootDirectory;
+    }
+
+    public void setRootDirectory(Path rootDirectory) {
+        this.rootDirectory = rootDirectory;
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.internal.impl;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.root.RootLocator;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DefaultSessionTest {
+
+    @Test
+    void testRootDirectoryWithNull() {
+        RepositorySystemSession rss = MavenRepositorySystemUtils.newSession();
+        DefaultMavenExecutionRequest mer = new DefaultMavenExecutionRequest();
+        MavenSession ms = new MavenSession(null, rss, mer, null);
+        DefaultSession session =
+                new DefaultSession(ms, new DefaultRepositorySystem(), Collections.emptyList(), null, null, null);
+
+        assertEquals(
+                RootLocator.UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE,
+                assertThrows(IllegalStateException.class, session::getRootDirectory)
+                        .getMessage());
+    }
+
+    @Test
+    void testRootDirectory() {
+        RepositorySystemSession rss = MavenRepositorySystemUtils.newSession();
+        DefaultMavenExecutionRequest mer = new DefaultMavenExecutionRequest();
+        MavenSession ms = new MavenSession(null, rss, mer, null);
+        ms.getRequest().setRootDirectory(Paths.get("myRootDirectory"));
+        DefaultSession session =
+                new DefaultSession(ms, new DefaultRepositorySystem(), Collections.emptyList(), null, null, null);
+
+        assertEquals(Paths.get("myRootDirectory"), session.getRootDirectory());
+    }
+}

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
@@ -135,6 +135,13 @@ public final class CLIReportingUtils {
     }
 
     public static void showError(Logger logger, String message, Throwable e, boolean showStackTrace) {
+        if (logger == null) {
+            System.err.println(message);
+            if (showStackTrace && e != null) {
+                e.printStackTrace(System.err);
+            }
+            return;
+        }
         if (showStackTrace) {
             logger.error(message, e);
         } else {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.cli;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.commons.cli.CommandLine;
@@ -39,6 +40,10 @@ public class CliRequest {
     String workingDirectory;
 
     File multiModuleProjectDirectory;
+
+    Path rootDirectory;
+
+    Path topDirectory;
 
     boolean verbose;
 

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -22,6 +22,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
@@ -36,6 +38,7 @@ import org.apache.maven.eventspy.internal.EventSpyDispatcher;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.ProfileActivation;
 import org.apache.maven.execution.ProjectActivation;
+import org.apache.maven.model.root.DefaultRootLocator;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.apache.maven.toolchain.building.ToolchainsBuildingRequest;
@@ -541,6 +544,12 @@ class MavenCliTest {
 
         // Assert
         assertThat(request.getUserProperties().getProperty("x"), is("false"));
+    }
+
+    @Test
+    public void findRootProjectWithAttribute() {
+        Path test = Paths.get("src/test/projects/root-attribute");
+        assertEquals(test, new DefaultRootLocator().findRoot(test.resolve("child")));
     }
 
     private MavenProject createMavenProject(String groupId, String artifactId) {

--- a/maven-embedder/src/test/projects/root-attribute/child/pom.xml
+++ b/maven-embedder/src/test/projects/root-attribute/child/pom.xml
@@ -1,0 +1,3 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+
+</project>

--- a/maven-embedder/src/test/projects/root-attribute/pom.xml
+++ b/maven-embedder/src/test/projects/root-attribute/pom.xml
@@ -1,0 +1,3 @@
+<project root="true" xmlns="http://maven.apache.org/POM/4.0.0">
+
+</project>

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
@@ -64,6 +64,8 @@ import org.apache.maven.model.profile.activation.JdkVersionProfileActivator;
 import org.apache.maven.model.profile.activation.OperatingSystemProfileActivator;
 import org.apache.maven.model.profile.activation.ProfileActivator;
 import org.apache.maven.model.profile.activation.PropertyProfileActivator;
+import org.apache.maven.model.root.DefaultRootLocator;
+import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.model.superpom.DefaultSuperPomProvider;
 import org.apache.maven.model.superpom.SuperPomProvider;
 import org.apache.maven.model.validation.DefaultModelValidator;
@@ -99,6 +101,8 @@ public class DefaultModelBuilderFactory {
     private ReportConfigurationExpander reportConfigurationExpander;
     private ProfileActivationFilePathInterpolator profileActivationFilePathInterpolator;
     private ModelVersionProcessor versionProcessor;
+
+    private RootLocator rootLocator;
 
     public DefaultModelBuilderFactory setModelProcessor(ModelProcessor modelProcessor) {
         this.modelProcessor = modelProcessor;
@@ -201,6 +205,11 @@ public class DefaultModelBuilderFactory {
         return this;
     }
 
+    public DefaultModelBuilderFactory setRootLocator(RootLocator rootLocator) {
+        this.rootLocator = rootLocator;
+        return this;
+    }
+
     protected ModelProcessor newModelProcessor() {
         return new DefaultModelProcessor(newModelLocator(), newModelReader());
     }
@@ -227,7 +236,7 @@ public class DefaultModelBuilderFactory {
     }
 
     protected ProfileActivationFilePathInterpolator newProfileActivationFilePathInterpolator() {
-        return new ProfileActivationFilePathInterpolator(newPathTranslator());
+        return new ProfileActivationFilePathInterpolator(newPathTranslator(), newRootLocator());
     }
 
     protected UrlNormalizer newUrlNormalizer() {
@@ -238,10 +247,15 @@ public class DefaultModelBuilderFactory {
         return new DefaultPathTranslator();
     }
 
+    protected RootLocator newRootLocator() {
+        return new DefaultRootLocator();
+    }
+
     protected ModelInterpolator newModelInterpolator() {
         UrlNormalizer normalizer = newUrlNormalizer();
         PathTranslator pathTranslator = newPathTranslator();
-        return new StringVisitorModelInterpolator(pathTranslator, normalizer);
+        RootLocator rootLocator = newRootLocator();
+        return new StringVisitorModelInterpolator(pathTranslator, normalizer, rootLocator);
     }
 
     protected ModelVersionProcessor newModelVersionPropertiesProcessor() {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
@@ -35,6 +35,7 @@ import org.apache.maven.model.building.ModelProblemCollector;
 import org.apache.maven.model.building.ModelProblemCollectorRequest;
 import org.apache.maven.model.path.PathTranslator;
 import org.apache.maven.model.path.UrlNormalizer;
+import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.model.v4.MavenTransformer;
 import org.codehaus.plexus.interpolation.InterpolationException;
 import org.codehaus.plexus.interpolation.InterpolationPostProcessor;
@@ -51,8 +52,9 @@ import org.codehaus.plexus.interpolation.ValueSource;
 @Singleton
 public class StringVisitorModelInterpolator extends AbstractStringBasedModelInterpolator {
     @Inject
-    public StringVisitorModelInterpolator(PathTranslator pathTranslator, UrlNormalizer urlNormalizer) {
-        super(pathTranslator, urlNormalizer);
+    public StringVisitorModelInterpolator(
+            PathTranslator pathTranslator, UrlNormalizer urlNormalizer, RootLocator rootLocator) {
+        super(pathTranslator, urlNormalizer, rootLocator);
     }
 
     interface InnerInterpolator {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/root/DefaultRootLocator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/root/DefaultRootLocator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.root;
+
+import javax.inject.Named;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.codehaus.plexus.util.xml.pull.MXParser;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+@Named
+public class DefaultRootLocator implements RootLocator {
+
+    public boolean isRootDirectory(Path dir) {
+        if (Files.isDirectory(dir.resolve(".mvn"))) {
+            return true;
+        }
+        // we're too early to use the modelProcessor ...
+        Path pom = dir.resolve("pom.xml");
+        try (InputStream is = Files.newInputStream(pom)) {
+            MXParser parser = new MXParser();
+            parser.setInput(is, null);
+            if (parser.nextTag() == MXParser.START_TAG && parser.getName().equals("project")) {
+                for (int i = 0; i < parser.getAttributeCount(); i++) {
+                    if ("root".equals(parser.getAttributeName(i))) {
+                        return Boolean.parseBoolean(parser.getAttributeValue(i));
+                    }
+                }
+            }
+        } catch (IOException | XmlPullParserException e) {
+            // The root locator can be used very early during the setup of Maven,
+            // even before the arguments from the command line are parsed.  Any exception
+            // that would happen here should cause the build to fail at a later stage
+            // (when actually parsing the POM) and will lead to a better exception being
+            // displayed to the user, so just bail out and return false.
+        }
+        return false;
+    }
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/root/RootLocator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/root/RootLocator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.root;
+
+import java.nio.file.Path;
+
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
+
+/**
+ * Interface used to locate the root directory for a given project.
+ *
+ * The root locator is usually looked up from the plexus container.
+ * One notable exception is the computation of the early {@code session.rootDirectory}
+ * property which happens very early.  The implementation used in this case
+ * will be discovered using the JDK service mechanism.
+ *
+ * The default implementation will look for a {@code .mvn} child directory
+ * or a {@code pom.xml} containing the {@code root="true"} attribute.
+ *
+ * @see DefaultRootLocator
+ */
+public interface RootLocator {
+
+    String UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE = "Unable to find the root directory. "
+            + "Create a .mvn directory in the root directory or add the root=\"true\""
+            + " attribute on the root project's model to identify it.";
+
+    @Nonnull
+    default Path findMandatoryRoot(Path basedir) {
+        Path rootDirectory = findRoot(basedir);
+        if (rootDirectory == null) {
+            throw new IllegalStateException(getNoRootMessage());
+        }
+        return rootDirectory;
+    }
+
+    @Nullable
+    default Path findRoot(Path basedir) {
+        Path rootDirectory = basedir;
+        while (rootDirectory != null && !isRootDirectory(rootDirectory)) {
+            rootDirectory = rootDirectory.getParent();
+        }
+        return rootDirectory;
+    }
+
+    @Nonnull
+    default String getNoRootMessage() {
+        return UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE;
+    }
+
+    boolean isRootDirectory(Path dir);
+}

--- a/maven-model-builder/src/main/resources/META-INF/services/org.apache.maven.model.root.RootLocator
+++ b/maven-model-builder/src/main/resources/META-INF/services/org.apache.maven.model.root.RootLocator
@@ -1,0 +1,1 @@
+org.apache.maven.model.root.DefaultRootLocator

--- a/maven-model-builder/src/site/apt/index.apt
+++ b/maven-model-builder/src/site/apt/index.apt
@@ -41,7 +41,7 @@ Maven Model Builder
 
    ** profile activation: see {{{./apidocs/org/apache/maven/model/profile/activation/package-summary.html}available activators}}.
    Notice that model interpolation hasn't happened yet, then interpolation for file-based activation is limited to
-   <<<$\{basedir}>>> (since Maven 3), system properties and user properties
+   <<<$\{basedir}>>> (since Maven 3), <<<$\{rootDirectory}>>> (since Maven 4), system properties and user properties
 
    ** file model validation: <<<ModelValidator>>> ({{{./apidocs/org/apache/maven/model/validation/ModelValidator.html}javadoc}}),
    with its <<<DefaultModelValidator>>> implementation
@@ -51,7 +51,7 @@ Maven Model Builder
 
  * phase 2, with optional plugin processing
 
-   ** Build up a raw model by re-reading the file and enrich it based on information available in the reactor. Some features:
+   ** Build up a raw model by re-reading the file and enriching it based on information available in the reactor. Some features:
 
       *** Resolve version of versionless parents based on relativePath (including ci-friendly versions)
 
@@ -156,13 +156,13 @@ Maven Model Builder
 
 * Model Interpolation
 
-  Model Interpolation consists in replacing <<<$\{...\}>>> with calculated value. It is done in <<<StringSearchModelInterpolator>>>
-  ({{{./apidocs/org/apache/maven/model/interpolation/StringSearchModelInterpolator.html}javadoc}},
-  {{{./xref/org/apache/maven/model/interpolation/StringSearchModelInterpolator.html}source}}).
+  Model Interpolation consists in replacing <<<$\{...\}>>> with calculated value. It is done in <<<StringVisitorModelInterpolator>>>
+  ({{{./apidocs/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.html}javadoc}},
+  {{{./xref/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.html}source}}).
 
-  Notice that model interpolation happens <after> profile activation, then profile activation doesn't benefit from every values:
+  Notice that model interpolation happens <after> profile activation, and that profile activation doesn't benefit from every values:
   interpolation for file-based activation is limited to <<<$\{basedir}>>> (which was introduced in Maven 3 and is not deprecated
-  in this context), system properties and user properties.
+  in this context) and <<<$\{rootDirectory}>>> (introduced in Maven 4), system properties and user properties.
 
   Values are evaluated in sequence from different syntaxes:
 
@@ -182,6 +182,8 @@ Maven Model Builder
 *----+------+------+
 | <<<project.baseUri>>>\
 <<<pom.baseUri>>> (<deprecated>) | the directory containing the <<<pom.xml>>> file as URI | <<<$\{project.baseUri\}>>> |
+*----+------+------+
+| <<<project.rootDirectory>>> | the project's root directory (containing a <<<.mvn>>> directory or with the <<<root="true">>> xml attribute) | <<<$\{project.rootDirectory\}>>> |
 *----+------+------+
 | <<<build.timestamp>>>\
 <<<maven.build.timestamp>>> | the UTC timestamp of build start, in <<<yyyy-MM-dd'T'HH:mm:ss'Z'>>> default format, which can be overridden with <<<maven.build.timestamp.format>>> POM property | <<<$\{maven.build.timestamp\}>>> |

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
@@ -19,6 +19,8 @@
 package org.apache.maven.model.interpolation;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -41,11 +43,13 @@ import org.apache.maven.api.model.Scm;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.SimpleProblemCollector;
+import org.apache.maven.model.root.RootLocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -307,8 +311,49 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
+    void testRootDirectory() throws Exception {
+        Path rootDirectory = Paths.get("myRootDirectory");
+
+        Model model = Model.newBuilder()
+                .version("3.8.1")
+                .artifactId("foo")
+                .repositories(Collections.singletonList(Repository.newBuilder()
+                        .url("file:${project.rootDirectory}/temp-repo")
+                        .build()))
+                .build();
+
+        ModelInterpolator interpolator = createInterpolator();
+
+        final SimpleProblemCollector collector = new SimpleProblemCollector();
+        Model out = interpolator.interpolateModel(
+                model, rootDirectory.toFile(), createModelBuildingRequest(context), collector);
+        assertProblemFree(collector);
+
+        assertEquals("file:myRootDirectory/temp-repo", (out.getRepositories().get(0)).getUrl());
+    }
+
+    @Test
+    void testRootDirectoryWithNull() throws Exception {
+        Model model = Model.newBuilder()
+                .version("3.8.1")
+                .artifactId("foo")
+                .repositories(Collections.singletonList(Repository.newBuilder()
+                        .url("file:///${project.rootDirectory}/temp-repo")
+                        .build()))
+                .build();
+
+        ModelInterpolator interpolator = createInterpolator();
+
+        final SimpleProblemCollector collector = new SimpleProblemCollector();
+        IllegalStateException e = assertThrows(
+                IllegalStateException.class,
+                () -> interpolator.interpolateModel(model, null, createModelBuildingRequest(context), collector));
+
+        assertEquals(RootLocator.UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE, e.getMessage());
+    }
+
+    @Test
     public void testEnvars() throws Exception {
-        Properties context = new Properties();
         context.put("env.HOME", "/path/to/home");
 
         Map<String, String> modelProperties = new HashMap<>();

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolatorTest.java
@@ -20,6 +20,6 @@ package org.apache.maven.model.interpolation;
 
 public class StringVisitorModelInterpolatorTest extends AbstractModelInterpolatorTest {
     protected ModelInterpolator createInterpolator() {
-        return new StringVisitorModelInterpolator(null, null);
+        return new StringVisitorModelInterpolator(null, null, bd -> true);
     }
 }

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/BufferingParser.java
@@ -395,6 +395,16 @@ public class BufferingParser implements XmlPullParser {
                 event.prefix = pp.getPrefix();
                 event.empty = pp.isEmptyElementTag();
                 event.text = pp.getText();
+                event.attributes = new Attribute[pp.getAttributeCount()];
+                for (int i = 0; i < pp.getAttributeCount(); i++) {
+                    Attribute attr = new Attribute();
+                    attr.name = pp.getAttributeName(i);
+                    attr.namespace = pp.getAttributeNamespace(i);
+                    attr.value = pp.getAttributeValue(i);
+                    attr.type = pp.getAttributeType(i);
+                    attr.isDefault = pp.isAttributeDefault(i);
+                    event.attributes[i] = attr;
+                }
                 break;
             case END_TAG:
                 event.name = pp.getName();

--- a/src/mdo/reader-ex.vm
+++ b/src/mdo/reader-ex.vm
@@ -207,7 +207,7 @@ public class ${className}
       #if ( $field.type == "String" )
                 ${classLcapName}.${field.name}( interpolatedTrimmed( value, "$fieldTagName" ) );
       #elseif ( $field.type == "boolean" || $field.type == "Boolean" )
-                ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( value, "$fieldTagName" ), "$fieldTagName", parser, strict, "${field.defaultValue}" ) );
+                ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( value, "$fieldTagName" ), "$fieldTagName", parser, ${field.defaultValue} ) );
       #else
                 // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end

--- a/src/mdo/reader-modified.vm
+++ b/src/mdo/reader-modified.vm
@@ -236,7 +236,7 @@ public class ${className}
       #if ( $field.type == "String" )
                 ${classLcapName}.${field.name}( interpolatedTrimmed( value, "$fieldTagName" ) );
       #elseif ( $field.type == "boolean" || $field.type == "Boolean" )
-                ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( value, "$fieldTagName" ), "$fieldTagName", parser, "${field.defaultValue}" ) );
+                ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( value, "$fieldTagName" ), "$fieldTagName", parser, ${field.defaultValue} ) );
       #else
                 // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end

--- a/src/mdo/reader.vm
+++ b/src/mdo/reader.vm
@@ -175,7 +175,7 @@ public class ${className}
     private boolean getBooleanValue( String s, String attribute, XmlPullParser parser )
         throws XmlPullParserException
     {
-        return getBooleanValue( s, attribute, parser, null );
+        return getBooleanValue( s, attribute, parser, false );
     } //-- boolean getBooleanValue( String, String, XmlPullParser )
 
     /**
@@ -189,18 +189,14 @@ public class ${className}
      * any.
      * @return boolean
      */
-    private boolean getBooleanValue( String s, String attribute, XmlPullParser parser, String defaultValue )
+    private boolean getBooleanValue( String s, String attribute, XmlPullParser parser, boolean defaultValue )
         throws XmlPullParserException
     {
         if ( s != null && s.length() != 0 )
         {
             return Boolean.valueOf( s ).booleanValue();
         }
-        if ( defaultValue != null )
-        {
-            return Boolean.valueOf( defaultValue ).booleanValue();
-        }
-        return false;
+        return defaultValue;
     } //-- boolean getBooleanValue( String, String, XmlPullParser, String )
 
     /**
@@ -709,7 +705,7 @@ public class ${className}
       #if ( $field.type == "String" )
                 ${classLcapName}.${field.name}( interpolatedTrimmed( value, "$fieldTagName" ) );
       #elseif ( $field.type == "boolean" || $field.type == "Boolean" )
-                ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( value, "$fieldTagName" ), "$fieldTagName", parser, "${field.defaultValue}" ) );
+                ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( value, "$fieldTagName" ), "$fieldTagName", parser, ${field.defaultValue} ) );
       #else
                 // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end
@@ -749,7 +745,7 @@ public class ${className}
                     ${classLcapName}.${field.name}( interpolatedTrimmed( parser.nextText(), "${fieldTagName}" ) );
                     break;
       #elseif ( $field.type == "boolean" || $field.type == "Boolean" )
-                    ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( parser.nextText(), "${fieldTagName}" ), "${fieldTagName}", parser, "${field.defaultValue}" ) );
+                    ${classLcapName}.${field.name}( getBooleanValue( interpolatedTrimmed( parser.nextText(), "${fieldTagName}" ), "${fieldTagName}", parser, ${field.defaultValue} ) );
                     break;
       #elseif ( $field.type == "int" )
                     ${classLcapName}.${field.name}( getIntegerValue( interpolatedTrimmed( parser.nextText(), "${fieldTagName}" ), "${fieldTagName}", parser, strict, ${field.defaultValue} ) );

--- a/src/mdo/writer-ex.vm
+++ b/src/mdo/writer-ex.vm
@@ -210,8 +210,15 @@ public class ${className}
       #set ( $fieldCapName = $Helper.capitalise( $field.name ) )
       #if ( $field.type == "String" )
             writeAttr( "$fieldTagName", ${classLcapName}.get${fieldCapName}(), serializer );
+      #elseif ( $field.type == "boolean" )
+        #set ( $def = ${field.defaultValue} )
+        #if ( ${def} == "true" )
+            writeAttr( "$fieldTagName", ${classLcapName}.is${fieldCapName}() ? null : "false", serializer );
+        #else
+            writeAttr( "$fieldTagName", ${classLcapName}.is${fieldCapName}() ? "true" : null, serializer );
+        #end
       #else
-        // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
+            // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end
     #end
   #end

--- a/src/mdo/writer.vm
+++ b/src/mdo/writer.vm
@@ -192,8 +192,15 @@ public class ${className}
       #set ( $fieldCapName = $Helper.capitalise( $field.name ) )
       #if ( $field.type == "String" )
             writeAttr( "$fieldTagName", ${classLcapName}.get${fieldCapName}(), serializer );
+      #elseif ( $field.type == "boolean" )
+        #set ( $def = ${field.defaultValue} )
+        #if ( ${def} == "true" )
+            writeAttr( "$fieldTagName", ${classLcapName}.is${fieldCapName}() ? null : "false", serializer );
+        #else
+            writeAttr( "$fieldTagName", ${classLcapName}.is${fieldCapName}() ? "true" : null, serializer );
+        #end
       #else
-        // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
+            // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end
     #end
   #end


### PR DESCRIPTION
JIRA issue: [MNG-7038] Introduce public property to point to a root directory of (multi-module) project

This PR introduces three properties:
  * `project.rootDirectory`: _the project's directory or parent directory containing a `.mvn` subdirectory or a `pom.xml` flagged with the `root="true"` attribute_. If no such directory can be found, accessing the rootDirectory property will throw an `IllegalStateException`.

  * `session.topDirectory` : _the directory of the topmost project being built, usually the current directory or the directory pointed at by the `-f`/`--file` command line argument_. The `topDirectory` is similar to the `executionRootDirectory` property available on the session, but renamed to make it coherent with the new `rootDirectory` and to avoid using _root_ in its name.  The `topDirectory` property is computed by the CLI as the directory pointed at by the `-f`/`--file` command line argument, or the current directory if there's no such argument. 

  * `session.rootDirectory` : _the rootDirectory for the topDirectory project_.

The `topDirectory` and `rootDirectory` properties are made available on the `MavenSession` / `Session` and deprecate the `executionRootDirectory` and `multiModuleProjectDirectory` properties.  The `rootDirectory` should never change for a given project and is thus made available for profile activation and model interpolation (without the `project.` prefix, similar to `basedir`).   The goal is also to make the `rootDirectory` property also available during [command line arguments interpolation](https://github.com/apache/maven/pull/1062).

A `root` boolean attribute is also added to the model to indicate that the project is the root project. This attribute is only supported if the _buildconsumer_ feature is active and removed before the pom is installed or deployed.  It can be used as an alternative mechanism to the `.mvn` directory.