### PR TITLE
Switch version to 4.0.0 for @since tags

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
@@ -25,7 +25,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * An artifact points to a resource such as a jar file or war application.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
@@ -26,7 +26,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * The {@code Coordinate} object is used to point to an {@link Artifact}
  * but the version may be specified as a range instead of an exact version.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyCoordinate.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyCoordinate.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.annotations.Nullable;
 
 /**
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Event.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Event.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * Such events can be listened to using {@link Listener}s objects
  * registered in the {@link Session}.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface Event {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/EventType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/EventType.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The possible types of execution events.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public enum EventType {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Exclusion.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Exclusion.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.annotations.Nullable;
 /**
  * A dependency exlusion.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see DependencyCoordinate#getExclusions()
  */
 @Experimental

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaToolchain.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaToolchain.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * A specific {@link Toolchain} dedicated for Java.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface JavaToolchain extends Toolchain {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Listener.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Listener.java
@@ -26,7 +26,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * A listener for session events.
  * TODO: open this to other events like similar to {@code org.apache.maven.eventspy.EventSpy}
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @FunctionalInterface

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/LocalRepository.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/LocalRepository.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * The local repository is used to cache artifacts downloaded from {@link RemoteRepository}
  * and to hold artifacts that have been build locally.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/MetadataStorage.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/MetadataStorage.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Storage location for metadata
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public enum MetadataStorage {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Node.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Node.java
@@ -30,7 +30,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Represents a dependency node within a Maven project's dependency collector.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see org.apache.maven.api.services.DependencyCollectorResult#getRoot()
  */
 @Experimental

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/NodeVisitor.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/NodeVisitor.java
@@ -25,7 +25,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Defines a hierarchical visitor for collecting dependency node trees.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Consumer

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Project.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Project.java
@@ -31,7 +31,7 @@ import org.apache.maven.api.model.Model;
  * Interface representing a Maven project.
  * Projects can be built using the {@link org.apache.maven.api.services.ProjectBuilder} service.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface Project {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Repository.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Repository.java
@@ -25,7 +25,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * A repository holds artifacts.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see RemoteRepository
  * @see LocalRepository
  */

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ResolutionScope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ResolutionScope.java
@@ -36,7 +36,7 @@ import org.apache.maven.api.annotations.Experimental;
  * Important note: The {@code id} values of this enum correspond to constants of
  * {@code org.apache.maven.artifact.Artifact} class and MUST BE KEPT IN SYNC.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public enum ResolutionScope {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Scope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Scope.java
@@ -25,7 +25,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Scope for a dependency
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public enum Scope {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
@@ -36,7 +36,7 @@ import org.apache.maven.api.settings.Settings;
 /**
  * The session to install / deploy / resolve artifacts and dependencies.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @ThreadSafe

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SessionData.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SessionData.java
@@ -36,7 +36,7 @@ import org.apache.maven.api.annotations.ThreadSafe;
  * <strong>Note:</strong> Actual implementations must be thread-safe.
  *
  * @see Session#getData()
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @ThreadSafe

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Toolchain.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Toolchain.java
@@ -25,7 +25,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Toolchain interface.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface Toolchain {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
@@ -29,7 +29,7 @@ import org.apache.maven.api.annotations.Immutable;
  * It is also used to determine if a given dependency should be
  * included in the classpath or if its transitive dependencies should.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Version.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Version.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * A version usually parsed using the {@link org.apache.maven.api.services.VersionParser} service.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see org.apache.maven.api.services.VersionParser#parseVersion(String)
  * @see org.apache.maven.api.Session#parseVersion(String)
  */

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/VersionRange.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/VersionRange.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * A range of versions.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface VersionRange {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
  * convenience, to enable developers to pass things like <code>java.lang.StringBuffer</code> directly into the logger,
  * rather than formatting first by calling <code>toString()</code>.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 public interface Log {
     /**

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Mojo.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Mojo.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.annotations.Experimental;
  * It features an <code>execute()</code> method, which triggers the Mojo's build-process behavior, and can throw
  * a MojoException if error conditions occur.<br>
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @FunctionalInterface

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/MojoException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/MojoException.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.services.MavenException;
 /**
  * An exception occurring during the execution of a plugin.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class MojoException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Component.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Component.java
@@ -32,7 +32,7 @@ import org.apache.maven.api.annotations.Experimental;
  * <a href="/ref/current/maven-core/apidocs/org/apache/maven/plugin/MavenPluginManager.html">
  * <code>MavenPluginManager.getConfiguredMojo(...)</code></a>.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Execute.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Execute.java
@@ -30,7 +30,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Used if your Mojo needs to fork a <a href="/ref/3.0.4/maven-core/lifecycles.html">lifecycle</a>.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/InstantiationStrategy.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/InstantiationStrategy.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Component instantiation strategy.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public enum InstantiationStrategy {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/LifecyclePhase.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/LifecyclePhase.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * <a href="/ref/3.0.4/maven-core/lifecycles.html">Lifecycle phases</a>.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public enum LifecyclePhase {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Mojo.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Mojo.java
@@ -31,7 +31,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * This annotation will mark your class as a Mojo (ie. goal in a Maven plugin).
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Parameter.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Parameter.java
@@ -36,7 +36,7 @@ import org.apache.maven.api.annotations.Experimental;
  * container: this annotation is only effective on fields of the Mojo class itself, nested bean injection
  * requires Sisu or JSR330 annotations.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactCoordinateFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactCoordinateFactory.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Service used to create {@link ArtifactCoordinate} objects.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ArtifactCoordinateFactory extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactCoordinateFactoryRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactCoordinateFactoryRequest.java
@@ -30,7 +30,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
 /**
  * A request for creating a {@link ArtifactCoordinate} object.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployer.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployer.java
@@ -30,7 +30,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Deploys {@link Artifact}s to a {@link RemoteRepository}.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see Session#deployArtifact(RemoteRepository, Artifact...)
  */
 @Experimental

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployerException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployerException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * An artifact could not correctly being deployed.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class ArtifactDeployerException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployerRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployerRequest.java
@@ -32,7 +32,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
 /**
  * A request for deploying one or more artifacts to a remote repository.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactFactory.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Service used to create {@link Artifact} objects.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ArtifactFactory extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactFactoryRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactFactoryRequest.java
@@ -29,7 +29,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
 /**
  *
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstaller.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstaller.java
@@ -29,7 +29,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Installs {@link Artifact}s to the local repository.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see Session#withLocalRepository(org.apache.maven.api.LocalRepository)
  */
 @Experimental

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerException.java
@@ -21,7 +21,7 @@ package org.apache.maven.api.services;
 import org.apache.maven.api.annotations.Experimental;
 
 /**
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class ArtifactInstallerException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerRequest.java
@@ -34,7 +34,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
 /**
  * A request for installing one or more artifacts in the local repository.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactManager.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactManager.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Nonnull;
 
 /**
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ArtifactManager extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolver.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolver.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Resolves the artifact, i.e download the file when required and attach it to the artifact
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ArtifactResolver extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  *
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class ArtifactResolverException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverRequest.java
@@ -32,7 +32,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
 /**
  * A request for resolving an artifact.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverResult.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * The Artifact Result
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ArtifactResolverResult {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/BaseRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/BaseRequest.java
@@ -29,7 +29,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Base class for requests.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 abstract class BaseRequest {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/BuilderProblem.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/BuilderProblem.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.annotations.Nullable;
  * Describes a problem that was encountered during project building. A problem can either be an exception that was
  * thrown or a simple string message. In addition, a problem carries a hint about its source.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable
@@ -97,7 +97,7 @@ public interface BuilderProblem {
     /**
      * The different severity levels for a problem, in decreasing order.
      *
-     * @since 4.0
+     * @since 4.0.0
      */
     @Experimental
     enum Severity {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollector.java
@@ -32,7 +32,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * The dependencies collection mechanism will not download any artifacts,
  * and only the pom files will be downloaded.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface DependencyCollector extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollectorException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollectorException.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.annotations.Experimental;
  * Thrown in case of bad artifact descriptors, version ranges or other
  * issues encountered during calculation of the dependency graph.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class DependencyCollectorException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollectorRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollectorRequest.java
@@ -43,7 +43,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
  * retrieved from the artifact descriptor of the root dependency. And last, only direct dependencies can be specified in
  * which case the root node of the resulting graph has no associated dependency.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see DependencyCollector#collect(DependencyCollectorRequest)
  */
 @Experimental

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollectorResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCollectorResult.java
@@ -26,7 +26,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The result of a dependency collection request.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see DependencyCollector#collect(DependencyCollectorRequest)
  */
 @Experimental

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinateFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinateFactory.java
@@ -30,7 +30,7 @@ import org.apache.maven.api.model.ReportPlugin;
 
 /**
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface DependencyCoordinateFactory extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinateFactoryRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinateFactoryRequest.java
@@ -35,7 +35,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
 
 /**
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/LocalRepositoryManager.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/LocalRepositoryManager.java
@@ -29,7 +29,7 @@ import org.apache.maven.api.annotations.Experimental;
 
 /**
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface LocalRepositoryManager extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/LookupException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/LookupException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The Exception class throw by the {@link Lookup} service.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class LookupException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/MavenException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/MavenException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Base class for all maven exceptions.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class MavenException extends RuntimeException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilder.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilder.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Message builder that supports configurable styling.
  *
- * @since 4.0
+ * @since 4.0.0
  * @see MessageBuilderFactory
  */
 public interface MessageBuilder {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilderFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilderFactory.java
@@ -25,7 +25,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * A factory for {@link MessageBuilder}.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface MessageBuilderFactory extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilder.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilder.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ProjectBuilder extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilderException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilderException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The Exception class throw by the {@link ProjectBuilder} service.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class ProjectBuilderException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilderRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilderRequest.java
@@ -36,7 +36,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
  * Request used to build a {@link org.apache.maven.api.Project} using
  * the {@link ProjectBuilder} service.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilderResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectBuilderResult.java
@@ -29,7 +29,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Result of a project build call.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ProjectBuilderResult {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectManager.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProjectManager.java
@@ -36,7 +36,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Interface to manage the project during its lifecycle.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ProjectManager extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/Prompter.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/Prompter.java
@@ -26,7 +26,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * Service used to interact with the end user.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface Prompter extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PrompterException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PrompterException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The Exception class throw by the {@link Prompter} service.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class PrompterException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/RepositoryFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/RepositoryFactory.java
@@ -30,7 +30,7 @@ import org.apache.maven.api.model.Repository;
 /**
  * Factory service to create {@link LocalRepository} or {@link RemoteRepository} objects.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface RepositoryFactory extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/SettingsBuilderException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/SettingsBuilderException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The Exception class throw by the {@link SettingsBuilder}.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class SettingsBuilderException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/Source.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/Source.java
@@ -26,7 +26,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The source for a project's XML model.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface Source {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainFactory.java
@@ -22,7 +22,7 @@ import org.apache.maven.api.annotations.Consumer;
 import org.apache.maven.api.annotations.Experimental;
 
 /**
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Consumer

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainManager.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainManager.java
@@ -31,7 +31,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Service to manage {@link Toolchain}s.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ToolchainManager extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainManagerException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainManagerException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The Exception class throw by the {@link ToolchainManager}.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class ToolchainManagerException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainsBuilderException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainsBuilderException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The Exception class throw by the {@link ToolchainsBuilder}.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class ToolchainsBuilderException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/Transport.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/Transport.java
@@ -34,7 +34,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * Transport for specified remote repository (using provided remote repository base URI as root). Must be treated as a
  * resource, best in try-with-resource block.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Consumer

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/TransportProvider.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/TransportProvider.java
@@ -34,7 +34,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * This implementation is backed by Maven Resolver API, supported protocols and transport selection depends on it. If
  * resolver preference regarding transport is altered, it will affect this service as well.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Consumer

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/TransportProviderException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/TransportProviderException.java
@@ -22,7 +22,7 @@ import org.apache.maven.api.annotations.Consumer;
 import org.apache.maven.api.annotations.Experimental;
 
 /**
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Consumer

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/TypeRegistry.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/TypeRegistry.java
@@ -26,7 +26,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Access to {@link Type} registry.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface TypeRegistry extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionParser.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionParser.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.annotations.Nonnull;
 /**
  * Service interface to parse {@link Version} and {@link VersionRange}.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface VersionParser extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionParserException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionParserException.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * The Exception class thrown by {@link VersionParser}.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class VersionParserException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/ModelXmlFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/ModelXmlFactory.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.model.Model;
 /**
  * Reads or writes a {@link Model} using XML.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ModelXmlFactory extends XmlFactory<Model> {}

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/SettingsXmlFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/SettingsXmlFactory.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.settings.Settings;
 /**
  * Reads and writes a {@link Settings} object to/from XML.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface SettingsXmlFactory extends XmlFactory<Settings> {}

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/ToolchainsXmlFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/ToolchainsXmlFactory.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.toolchain.PersistedToolchains;
 /**
  * Reads and writes a {@link PersistedToolchains} object to/from XML.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface ToolchainsXmlFactory extends XmlFactory<PersistedToolchains> {}

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlFactory.java
@@ -34,7 +34,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * Generic interface to read/write objects to/from XML.
  *
  * @param <T> the object type to read/write
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public interface XmlFactory<T> extends Service {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlReaderException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlReaderException.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.services.MavenException;
 /**
  * An exception thrown during the reading of an xml file.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class XmlReaderException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlReaderRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlReaderRequest.java
@@ -31,7 +31,7 @@ import org.apache.maven.api.annotations.NotThreadSafe;
 /**
  * An XML reader request.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Immutable

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlWriterException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlWriterException.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.services.MavenException;
 /**
  * An exception thrown during the writing of an xml file.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 public class XmlWriterException extends MavenException {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlWriterRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/XmlWriterRequest.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.annotations.Experimental;
 /**
  * An XML writer request.
  *
- * @since 4.0
+ * @since 4.0.0
  * @param <T> the object type to read
  */
 @Experimental

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Consumer.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Consumer.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * to be a provider type regardless of whether they are marked {@link Consumer} or {@link Provider}.
  *
  * @see Provider
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Experimental.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Experimental.java
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
  * This annotation tags types that are part of an experimental API.
  * Classes or methods annotated with this annotation may be changed / removed without notice.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Generated.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Generated.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 /**
  * This annotation indicates that a type is automatically generated.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Immutable.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Immutable.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * {@link ThreadSafe}.
  *
  * @see ThreadSafe
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Nonnull.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Nonnull.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * When this annotation is applied to a method it applies to the method return value.
  *
  * @see Nullable
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/NotThreadSafe.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/NotThreadSafe.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * and should only be used by a single thread.
  *
  * @see ThreadSafe
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Nullable.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Nullable.java
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
  * The annotated element can be {@code null}.
  *
  * @see Nonnull
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Provider.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/Provider.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * to be a provider type regardless of whether they are marked {@link Consumer} or {@link Provider}.
  *
  * @see Consumer
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/ThreadSafe.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/ThreadSafe.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *
  * @see Immutable
  * @see NotThreadSafe
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @Documented

--- a/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/package-info.java
+++ b/api/maven-api-meta/src/main/java/org/apache/maven/api/annotations/package-info.java
@@ -4,7 +4,7 @@
  * used to tag various elements and help users understanding
  * how those types should be used.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 package org.apache.maven.api.annotations;

--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
@@ -30,7 +30,7 @@ import org.apache.maven.api.annotations.ThreadSafe;
 /**
  * An immutable xml node.
  *
- * @since 4.0
+ * @since 4.0.0
  */
 @Experimental
 @ThreadSafe

--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/ProfileActivationContext.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/ProfileActivationContext.java
@@ -31,7 +31,7 @@ public interface ProfileActivationContext {
     /**
      * Key of the property containing the project's packaging.
      * Available in {@link #getUserProperties()}.
-     * @since 4.0
+     * @since 4.0.0
      */
     String PROPERTY_NAME_PACKAGING = "packaging";
 


### PR DESCRIPTION
To make source code a bit coherent, all `@since 4.0` tags are switched to `@since 4.0.0`