### PR TITLE
[MNG-7751] Provide a way to inject XmlNode into plugins

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedConverterLookup.java
+++ b/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedConverterLookup.java
@@ -29,6 +29,7 @@ class EnhancedConverterLookup implements ConverterLookup {
 
     EnhancedConverterLookup() {
         registerConverter(new DefaultBeanConfigurator.PathConverter());
+        registerConverter(new DefaultBeanConfigurator.XmlConverter());
     }
 
     @Override


### PR DESCRIPTION
JIRA issue [MNG-7751](https://issues.apache.org/jira/browse/MNG-7751)

This PR provides the ability to inject an `XmlNode` object into a plugin.  This can be currently done by injecting a `PlexusConfiguration`, but injecting an `XmlNode` ensures there's no dependency on the internal plexus configuration bits and limits the plugin exposure to the maven v4 api.