### PR TITLE
[MNG-7750] Executions for plugins from an active profile are interpolated in the originalModel.

### DIFF
--- a/maven-core/src/test/resources-project-builder/plugin-interpolation-build/pom.xml
+++ b/maven-core/src/test/resources-project-builder/plugin-interpolation-build/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.build.plugins</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <name>MNG-7750</name>
+  <description>
+    Test build plugin and execution interpolation.
+  </description>
+
+  <properties>
+    <prop-outside>||${project.basedir}||</prop-outside>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>plugin-all-profiles</artifactId>
+        <executions>
+          <execution>
+            <id>Outside ||${project.basedir}||</id>
+            <configuration>
+              <plugin-all-profiles-out>Outside ||${project.basedir}||</plugin-all-profiles-out>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>activeProfile</id>
+      <properties>
+        <prop-active>||${project.basedir}||</prop-active>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <executions>
+              <execution>
+                <id>Active all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-in>Active all ||${project.basedir}||</plugin-all-profiles-in>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>only-active-profile</artifactId>
+            <executions>
+              <execution>
+                <id>Active only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-active-profile-only>Active only ||${project.basedir}||</plugin-in-active-profile-only>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>inactiveProfile</id>
+      <properties>
+        <prop-inactive>||${project.basedir}||</prop-inactive>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <executions>
+              <execution>
+                <id>Inactive all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-ina>Inactive all ||${project.basedir}||</plugin-all-profiles-ina>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>only-inactive-profile</artifactId>
+            <executions>
+              <execution>
+                <id>Inactive only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-inactive-only>Inactive only ||${project.basedir}||</plugin-in-inactive-only>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
+</project>

--- a/maven-core/src/test/resources-project-builder/plugin-interpolation-reporting/pom.xml
+++ b/maven-core/src/test/resources-project-builder/plugin-interpolation-reporting/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.reporting.plugins</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <name>MNG-7750</name>
+  <description>
+    Test reporting plugin and reportSet interpolation.
+  </description>
+
+  <properties>
+    <prop-outside>||${project.basedir}||</prop-outside>
+  </properties>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <artifactId>plugin-all-profiles</artifactId>
+        <reportSets>
+          <reportSet>
+            <id>Outside ||${project.basedir}||</id>
+            <configuration>
+              <plugin-all-profiles-out>Outside ||${project.basedir}||</plugin-all-profiles-out>
+            </configuration>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <profiles>
+    <profile>
+      <id>activeProfile</id>
+      <properties>
+        <prop-active>||${project.basedir}||</prop-active>
+      </properties>
+      <reporting>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Active all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-in>Active all ||${project.basedir}||</plugin-all-profiles-in>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+          <plugin>
+            <artifactId>only-active-profile</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Active only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-active-profile-only>Active only ||${project.basedir}||</plugin-in-active-profile-only>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+
+    <profile>
+      <id>inactiveProfile</id>
+      <properties>
+        <prop-inactive>||${project.basedir}||</prop-inactive>
+      </properties>
+      <reporting>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Inactive all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-ina>Inactive all ||${project.basedir}||</plugin-all-profiles-ina>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+          <plugin>
+            <artifactId>only-inactive-profile</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Inactive only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-inactive-only>Inactive only ||${project.basedir}||</plugin-in-inactive-only>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+
+  </profiles>
+
+</project>

--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/DefaultProfileInjector.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/DefaultProfileInjector.java
@@ -108,7 +108,7 @@ public class DefaultProfileInjector implements ProfileInjector {
                             pending = new ArrayList<>();
                         }
                     } else {
-                        pending.add(element);
+                        pending.add(element.clone());
                     }
                 }
 
@@ -145,7 +145,7 @@ public class DefaultProfileInjector implements ProfileInjector {
                     if (existing != null) {
                         mergePluginExecution(existing, element, sourceDominant, context);
                     } else {
-                        merged.put(key, element);
+                        merged.put(key, element.clone());
                     }
                 }
 
@@ -170,7 +170,7 @@ public class DefaultProfileInjector implements ProfileInjector {
                     Object key = getReportPluginKey(element);
                     ReportPlugin existing = merged.get(key);
                     if (existing == null) {
-                        merged.put(key, element);
+                        merged.put(key, element.clone());
                     } else {
                         mergeReportPlugin(existing, element, sourceDominant, context);
                     }
@@ -199,7 +199,7 @@ public class DefaultProfileInjector implements ProfileInjector {
                     if (existing != null) {
                         mergeReportSet(existing, element, sourceDominant, context);
                     } else {
-                        merged.put(key, element);
+                        merged.put(key, element.clone());
                     }
                 }
 


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [x] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/




This is ONLY the reproduction of the problem I found.

If you disable the `activeProfile` (in buildPom and remove the assert) then all checks pass.

If you enable this profile (provided code) then in several places the `${project.basedir}` has been interpolated and shows the path of the build and the assertions fail the build.
