### PR TITLE
[MNG-7750] Ensure no unwanted interpolation in plugins from profiles.

### DIFF
--- a/maven-core/src/test/resources-project-builder/plugin-interpolation-build/pom.xml
+++ b/maven-core/src/test/resources-project-builder/plugin-interpolation-build/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.build.plugins</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <name>MNG-7750</name>
+  <description>
+    Test build plugin and execution interpolation.
+  </description>
+
+  <properties>
+    <prop-outside>||${project.basedir}||</prop-outside>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>plugin-all-profiles</artifactId>
+        <executions>
+          <execution>
+            <id>Outside ||${project.basedir}||</id>
+            <configuration>
+              <plugin-all-profiles-out>Outside ||${project.basedir}||</plugin-all-profiles-out>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>activeProfile</id>
+      <properties>
+        <prop-active>||${project.basedir}||</prop-active>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <executions>
+              <execution>
+                <id>Active all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-in>Active all ||${project.basedir}||</plugin-all-profiles-in>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>only-active-profile</artifactId>
+            <executions>
+              <execution>
+                <id>Active only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-active-profile-only>Active only ||${project.basedir}||</plugin-in-active-profile-only>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>inactiveProfile</id>
+      <properties>
+        <prop-inactive>||${project.basedir}||</prop-inactive>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <executions>
+              <execution>
+                <id>Inactive all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-ina>Inactive all ||${project.basedir}||</plugin-all-profiles-ina>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>only-inactive-profile</artifactId>
+            <executions>
+              <execution>
+                <id>Inactive only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-inactive-only>Inactive only ||${project.basedir}||</plugin-in-inactive-only>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
+</project>

--- a/maven-core/src/test/resources-project-builder/plugin-interpolation-reporting/pom.xml
+++ b/maven-core/src/test/resources-project-builder/plugin-interpolation-reporting/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.reporting.plugins</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <name>MNG-7750</name>
+  <description>
+    Test reporting plugin and reportSet interpolation.
+  </description>
+
+  <properties>
+    <prop-outside>||${project.basedir}||</prop-outside>
+  </properties>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <artifactId>plugin-all-profiles</artifactId>
+        <reportSets>
+          <reportSet>
+            <id>Outside ||${project.basedir}||</id>
+            <configuration>
+              <plugin-all-profiles-out>Outside ||${project.basedir}||</plugin-all-profiles-out>
+            </configuration>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <profiles>
+    <profile>
+      <id>activeProfile</id>
+      <properties>
+        <prop-active>||${project.basedir}||</prop-active>
+      </properties>
+      <reporting>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Active all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-in>Active all ||${project.basedir}||</plugin-all-profiles-in>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+          <plugin>
+            <artifactId>only-active-profile</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Active only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-active-profile-only>Active only ||${project.basedir}||</plugin-in-active-profile-only>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+
+    <profile>
+      <id>inactiveProfile</id>
+      <properties>
+        <prop-inactive>||${project.basedir}||</prop-inactive>
+      </properties>
+      <reporting>
+        <plugins>
+          <plugin>
+            <artifactId>plugin-all-profiles</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Inactive all ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-all-profiles-ina>Inactive all ||${project.basedir}||</plugin-all-profiles-ina>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+          <plugin>
+            <artifactId>only-inactive-profile</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>Inactive only ||${project.basedir}||</id>
+                <configuration>
+                  <plugin-in-inactive-only>Inactive only ||${project.basedir}||</plugin-in-inactive-only>
+                </configuration>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+
+  </profiles>
+
+</project>


### PR DESCRIPTION
This is the port of https://github.com/apache/maven/pull/1075 to the master branch.

The good thing is that this is ONLY the tests because the maven 4 does not have the problem of MNG-7750.

A few small changes in the tests were needed to handle the internal differences between maven 3.x and maven 4.x.


 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

