### PR TITLE
[MNG-7754] Improvement and extension of plugin validation

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
@@ -30,7 +30,7 @@ import org.eclipse.aether.artifact.Artifact;
  */
 public interface PluginValidationManager {
     /**
-     * Reports plugin issues applicable to the plugin as whole.
+     * Reports plugin issues applicable to the plugin as a whole.
      * <p>
      * This method should be used in "early" phase of plugin execution, possibly even when plugin or mojo descriptor
      * does not exist yet. In turn, this method will not record extra information like plugin occurrence or declaration
@@ -39,7 +39,7 @@ public interface PluginValidationManager {
     void reportPluginValidationIssue(RepositorySystemSession session, Artifact pluginArtifact, String issue);
 
     /**
-     * Reports plugin issues applicable to the plugin as whole.
+     * Reports plugin issues applicable to the plugin as a whole.
      * <p>
      * This method will record extra information as well, like plugin occurrence or declaration location.
      */

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
@@ -19,9 +19,9 @@
 package org.apache.maven.plugin;
 
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
 
 /**
  * Component collecting plugin validation issues and reporting them.
@@ -29,17 +29,27 @@ import org.eclipse.aether.RepositorySystemSession;
  * @since 3.9.2
  */
 public interface PluginValidationManager {
+    /**
+     * Reports plugin issues applicable to the plugin as whole.
+     * <p>
+     * This method should be used in "early" phase of plugin execution, possibly even when plugin or mojo descriptor
+     * does not exist yet. In turn, this method will not record extra information like plugin occurrence or declaration
+     * location as those are not yet available.
+     */
+    void reportPluginValidationIssue(RepositorySystemSession session, Artifact pluginArtifact, String issue);
 
-    String pluginKey(String groupId, String artifactId, String version);
-
-    String pluginKey(Plugin plugin);
-
-    String pluginKey(MojoDescriptor mojoDescriptor);
-
-    void reportPluginValidationIssue(RepositorySystemSession session, String pluginKey, String issue);
-
+    /**
+     * Reports plugin issues applicable to the plugin as whole.
+     * <p>
+     * This method will record extra information as well, like plugin occurrence or declaration location.
+     */
     void reportPluginValidationIssue(MavenSession mavenSession, MojoDescriptor mojoDescriptor, String issue);
 
+    /**
+     * Reports plugin Mojo issues applicable to the Mojo itself.
+     * <p>
+     * This method will record extra information as well, like plugin occurrence or declaration location.
+     */
     void reportPluginMojoValidationIssue(
             MavenSession mavenSession, MojoDescriptor mojoDescriptor, Class<?> mojoClass, String issue);
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Component collecting plugin validation issues and reporting them.
+ *
+ * @since 3.9.2
+ */
+public interface PluginValidationManager {
+
+    String pluginKey(String groupId, String artifactId, String version);
+
+    String pluginKey(Plugin plugin);
+
+    String pluginKey(MojoDescriptor mojoDescriptor);
+
+    void reportPluginValidationIssue(RepositorySystemSession session, String pluginKey, String issue);
+
+    void reportPluginValidationIssue(MavenSession mavenSession, MojoDescriptor mojoDescriptor, String issue);
+
+    void reportPluginMojoValidationIssue(
+            MavenSession mavenSession, MojoDescriptor mojoDescriptor, Class<?> mojoClass, String issue);
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.plugin.internal;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -30,6 +33,9 @@ import static java.util.Objects.requireNonNull;
  * @since 3.9.2
  */
 abstract class AbstractMavenPluginDependenciesValidator implements MavenPluginDependenciesValidator {
+
+    protected final List<String> expectedProvidedScopeExclusions = Arrays.asList(
+            "org.apache.maven:maven-archiver", "org.apache.maven:maven-jxr", "org.apache.maven:plexus-utils");
 
     protected final PluginValidationManager pluginValidationManager;
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
@@ -19,6 +19,7 @@
 package org.apache.maven.plugin.internal;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
 import static java.util.Objects.requireNonNull;

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
@@ -20,22 +20,29 @@ package org.apache.maven.plugin.internal;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
-import org.codehaus.plexus.configuration.PlexusConfiguration;
+
+import static java.util.Objects.requireNonNull;
 
 /**
- * Service responsible for validating plugin configuration.
+ * Service responsible for validating plugin dependencies.
  *
- * @author Slawomir Jaranowski
+ * @since 3.9.2
  */
-interface MavenPluginConfigurationValidator {
-    /**
-     * Returns mojo configuration issues.
-     */
-    void validate(
-            MavenSession mavenSession,
-            MojoDescriptor mojoDescriptor,
-            Class<?> mojoClass,
-            PlexusConfiguration pomConfiguration,
-            ExpressionEvaluator expressionEvaluator);
+abstract class AbstractMavenPluginDependenciesValidator implements MavenPluginDependenciesValidator {
+
+    protected final PluginValidationManager pluginValidationManager;
+
+    protected AbstractMavenPluginDependenciesValidator(PluginValidationManager pluginValidationManager) {
+        this.pluginValidationManager = requireNonNull(pluginValidationManager);
+    }
+
+    @Override
+    public void validate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
+        if (mojoDescriptor.getPluginDescriptor() != null
+                && mojoDescriptor.getPluginDescriptor().getDependencies() != null) {
+            doValidate(mavenSession, mojoDescriptor);
+        }
+    }
+
+    protected abstract void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor);
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator.java
@@ -48,6 +48,10 @@ abstract class AbstractMavenPluginDescriptorSourcedParametersValidator extends A
     private static final List<String> IGNORED_PROPERTY_PREFIX =
             Arrays.asList("mojo.", "pom.", "plugin.", "project.", "session.", "settings.");
 
+    protected AbstractMavenPluginDescriptorSourcedParametersValidator(PluginValidationManager pluginValidationManager) {
+        super(pluginValidationManager);
+    }
+
     @Override
     protected boolean isIgnoredProperty(String strValue) {
         if (!strValue.startsWith("${")) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator.java
@@ -21,6 +21,8 @@ package org.apache.maven.plugin.internal;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.maven.plugin.PluginValidationManager;
+
 /**
  * Common implementations for plugin parameters configuration validation that relies on Mojo descriptor (leaves out
  * core parameters by default).

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
@@ -19,6 +19,7 @@
 package org.apache.maven.plugin.internal;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
@@ -99,18 +99,18 @@ abstract class AbstractMavenPluginParametersValidator implements MavenPluginConf
     protected abstract String getParameterLogReason(Parameter parameter);
 
     protected String formatParameter(Parameter parameter) {
-        StringBuilder messageBuilder = new StringBuilder()
+        StringBuilder stringBuilder = new StringBuilder()
                 .append("Parameter '")
                 .append(parameter.getName())
                 .append('\'');
 
         if (parameter.getExpression() != null) {
             String userProperty = parameter.getExpression().replace("${", "'").replace('}', '\'');
-            messageBuilder.append(" (user property ").append(userProperty).append(")");
+            stringBuilder.append(" (user property ").append(userProperty).append(")");
         }
 
-        messageBuilder.append(" ").append(getParameterLogReason(parameter));
+        stringBuilder.append(" ").append(getParameterLogReason(parameter));
 
-        return messageBuilder.toString();
+        return stringBuilder.toString();
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
@@ -96,7 +96,7 @@ abstract class AbstractMavenPluginParametersValidator implements MavenPluginConf
 
     protected void logParameter(Parameter parameter) {
         MessageBuilder messageBuilder = MessageUtils.buffer()
-                .warning("Parameter '")
+                .warning("Mojo parameter '")
                 .warning(parameter.getName())
                 .warning('\'');
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -553,7 +553,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                         session,
                         mojoDescriptor,
                         mojo.getClass(),
-                        "Implements `Contextualizable` interface from Plexus Container, that is EOL.");
+                        "Implements `Contextualizable` interface from Plexus Container, which is EOL.");
             }
 
             for (MavenPluginDependenciesValidator validator : dependenciesValidators) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -552,9 +552,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                         session,
                         mojoDescriptor,
                         mojo.getClass(),
-                        "Mojo `"
-                                + mojo.getClass().getSimpleName()
-                                + "` implements `Contextualizable` interface from Plexus Container that is EOL.");
+                        "Implements `Contextualizable` interface from Plexus Container, that is EOL.");
             }
 
             for (MavenPluginDependenciesValidator validator : dependenciesValidators) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -64,6 +64,7 @@ import org.apache.maven.plugin.PluginParameterException;
 import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
 import org.apache.maven.plugin.PluginRealmCache;
 import org.apache.maven.plugin.PluginResolutionException;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -28,6 +28,7 @@ import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.PluginResolutionException;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -78,6 +79,9 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
     @Requirement
     private RepositorySystem repoSystem;
 
+    @Requirement
+    private PluginValidationManager pluginValidationManager;
+
     private Artifact toArtifact(Plugin plugin, RepositorySystemSession session) {
         return new DefaultArtifact(
                 plugin.getGroupId(),
@@ -102,6 +106,18 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                     new ArtifactDescriptorRequest(pluginArtifact, repositories, REPOSITORY_CONTEXT);
             request.setTrace(trace);
             ArtifactDescriptorResult result = repoSystem.readArtifactDescriptor(pluginSession, request);
+
+            if (result.getDependencies() != null) {
+                for (org.eclipse.aether.graph.Dependency dependency : result.getDependencies()) {
+                    if ("org.apache.maven".equals(dependency.getArtifact().getGroupId())
+                            && "maven-compat".equals(dependency.getArtifact().getArtifactId())) {
+                        pluginValidationManager.reportPluginValidationIssue(
+                                session,
+                                pluginValidationManager.pluginKey(plugin),
+                                "Plugin depends on Maven 2.x compatibility layer, will be not supported in Maven 4.x");
+                    }
+                }
+            }
 
             pluginArtifact = result.getArtifact();
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -110,7 +110,8 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             if (result.getDependencies() != null) {
                 for (org.eclipse.aether.graph.Dependency dependency : result.getDependencies()) {
                     if ("org.apache.maven".equals(dependency.getArtifact().getGroupId())
-                            && "maven-compat".equals(dependency.getArtifact().getArtifactId())) {
+                            && "maven-compat".equals(dependency.getArtifact().getArtifactId())
+                            && !JavaScopes.TEST.equals(dependency.getScope())) {
                         pluginValidationManager.reportPluginValidationIssue(
                                 session,
                                 pluginValidationManager.pluginKey(plugin),

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -115,7 +115,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                         pluginValidationManager.reportPluginValidationIssue(
                                 session,
                                 pluginValidationManager.pluginKey(plugin),
-                                "Plugin depends on Maven 2.x compatibility layer, will be not supported in Maven 4.x");
+                                "Plugin depends on the deprecated Maven 2.x compatibility layer, which may not be supported in Maven 4.x");
                     }
                 }
             }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -114,7 +114,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                             && !JavaScopes.TEST.equals(dependency.getScope())) {
                         pluginValidationManager.reportPluginValidationIssue(
                                 session,
-                                pluginValidationManager.pluginKey(plugin),
+                                pluginArtifact,
                                 "Plugin depends on the deprecated Maven 2.x compatibility layer, which may not be supported in Maven 4.x");
                     }
                 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -73,7 +73,7 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
             return ValidationLevel.valueOf(level.toUpperCase(Locale.ENGLISH));
         } catch (IllegalArgumentException e) {
             logger.warn(
-                    "Invalid value specified for property '{}': '{}'. Supported values are (case insensitive): {}",
+                    "Invalid value specified for property {}: '{}'. Supported values are (case insensitive): {}",
                     MAVEN_PLUGIN_VALIDATION_KEY,
                     level,
                     Arrays.toString(ValidationLevel.values()));

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -221,7 +221,7 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
     }
 
     private String mojoInfo(MojoDescriptor mojoDescriptor, Class<?> mojoClass) {
-        return mojoDescriptor.getFullGoalName() + " (class: " + mojoClass.getName() + ")";
+        return mojoDescriptor.getFullGoalName() + " (" + mojoClass.getName() + ")";
     }
 
     @SuppressWarnings("unchecked")

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -64,10 +64,15 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
 
     private ValidationLevel validationLevel(RepositorySystemSession session) {
         String level = ConfigUtils.getString(session, null, MAVEN_PLUGIN_VALIDATION_KEY);
-        if (level == null) {
+        if (level == null || level.isEmpty()) {
             return ValidationLevel.DEFAULT;
         }
-        return ValidationLevel.valueOf(level.toUpperCase(Locale.ENGLISH));
+        try {
+            return ValidationLevel.valueOf(level.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Invalid value specified for property " + MAVEN_PLUGIN_VALIDATION_KEY + ": '" + level + "'", e);
+        }
     }
 
     private String pluginKey(String groupId, String artifactId, String version) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -156,20 +156,6 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
                     "To fix these issues, please upgrade listed plugins, or notify their maintainers about these issues.");
             logger.warn("");
         }
-        // - plugin
-        //   - used in
-        //     - issues
-        //     - mojo
-        //       - issues
-        //        if (!validationIssues.isEmpty()) {
-        //            logger.warn("Mojo validation issues:");
-        //            for (String validationIssue : validationIssues) {
-        //                logger.warn("  * " + validationIssue);
-        //            }
-        //            logger.warn("");
-        //            logger.warn("Please upgrade this plugin, or, contact plugin developers to fix the reported
-        // issue(s).");
-        //            logger.warn("");
     }
 
     private String pluginDeclaration(MojoDescriptor mojoDescriptor) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -49,8 +49,6 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
 
     private static final String MAVEN_PLUGIN_VALIDATION_KEY = "maven.plugin.validation";
 
-    private static final String MAVEN_PLUGIN_VALIDATION_DEFAULT = "default";
-
     private enum ValidationLevel {
         DISABLED,
         DEFAULT,
@@ -65,12 +63,11 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
     }
 
     private ValidationLevel validationLevel(RepositorySystemSession session) {
-        String level = ConfigUtils.getString(session, MAVEN_PLUGIN_VALIDATION_DEFAULT, MAVEN_PLUGIN_VALIDATION_KEY);
-        try {
-            return ValidationLevel.valueOf(level.toUpperCase(Locale.ENGLISH));
-        } catch (IllegalArgumentException e) {
+        String level = ConfigUtils.getString(session, null, MAVEN_PLUGIN_VALIDATION_KEY);
+        if (level == null) {
             return ValidationLevel.DEFAULT;
         }
+        return ValidationLevel.valueOf(level.toUpperCase(Locale.ENGLISH));
     }
 
     private String pluginKey(String groupId, String artifactId, String version) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -53,7 +53,7 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
 
     private enum ValidationLevel {
         DISABLED,
-        DEFAULT,
+        ENABLED,
         VERBOSE
     }
 
@@ -67,7 +67,7 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
     private ValidationLevel validationLevel(RepositorySystemSession session) {
         String level = ConfigUtils.getString(session, null, MAVEN_PLUGIN_VALIDATION_KEY);
         if (level == null || level.isEmpty()) {
-            return ValidationLevel.DEFAULT;
+            return ValidationLevel.ENABLED;
         }
         try {
             return ValidationLevel.valueOf(level.toUpperCase(Locale.ENGLISH));
@@ -77,7 +77,7 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
                     MAVEN_PLUGIN_VALIDATION_KEY,
                     level,
                     Arrays.toString(ValidationLevel.values()));
-            return ValidationLevel.DEFAULT;
+            return ValidationLevel.ENABLED;
         }
     }
 
@@ -172,7 +172,8 @@ public final class DefaultPluginValidationManager extends AbstractMavenLifecycle
                     "To fix these issues, please upgrade above listed plugins, or, notify their maintainers about reported issues.");
             logger.warn("");
             logger.warn(
-                    "For more or less details in this report, use 'maven.plugin.validation' user property with one of the values: 'disabled', 'verbose' or (implied) 'default'");
+                    "For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): {}",
+                    Arrays.toString(ValidationLevel.values()));
             logger.warn("");
         }
     }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
@@ -59,7 +59,8 @@ class DeprecatedCoreExpressionValidator extends AbstractMavenPluginParametersVal
 
     @Override
     protected String getParameterLogReason(Parameter parameter) {
-        return "uses deprecated parameter expression '" + parameter.getDefaultValue() + "': " + DEPRECATED_CORE_PARAMETERS.get(parameter.getDefaultValue());
+        return "uses deprecated parameter expression '" + parameter.getDefaultValue() + "': "
+                + DEPRECATED_CORE_PARAMETERS.get(parameter.getDefaultValue());
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
@@ -40,7 +40,7 @@ class DeprecatedCoreExpressionValidator extends AbstractMavenPluginParametersVal
     private static final HashMap<String, String> DEPRECATED_CORE_PARAMETERS;
 
     private static final String ARTIFACT_REPOSITORY_REASON =
-            "Avoid use of ArtifactRepository type. If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead.";
+            "Use of ArtifactRepository type in Mojos is deprecated and should be avoided. Upgrade this plugin, or if it does not help, notify plugin developers about this warning.";
 
     static {
         HashMap<String, String> deprecatedCoreParameters = new HashMap<>();

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Objects;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
@@ -59,7 +59,7 @@ class DeprecatedCoreExpressionValidator extends AbstractMavenPluginParametersVal
 
     @Override
     protected String getParameterLogReason(Parameter parameter) {
-        return "uses deprecated parameter expression; " + DEPRECATED_CORE_PARAMETERS.get(parameter.getDefaultValue());
+        return "uses deprecated parameter expression '" + parameter.getDefaultValue() + "': " + DEPRECATED_CORE_PARAMETERS.get(parameter.getDefaultValue());
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
@@ -43,7 +43,7 @@ class DeprecatedCoreExpressionValidator extends AbstractMavenPluginParametersVal
     private static final HashMap<String, String> DEPRECATED_CORE_PARAMETERS;
 
     private static final String ARTIFACT_REPOSITORY_REASON =
-            "ArtifactRepository type is deprecated and it's use in Mojos should be avoided.";
+            "ArtifactRepository type is deprecated and its use in Mojos should be avoided.";
 
     static {
         HashMap<String, String> deprecatedCoreParameters = new HashMap<>();

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.shared.utils.logging.MessageUtils;

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
@@ -18,9 +18,11 @@
  */
 package org.apache.maven.plugin.internal;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.shared.utils.logging.MessageUtils;
@@ -35,6 +37,12 @@ import org.codehaus.plexus.configuration.PlexusConfiguration;
 @Singleton
 @Named
 class DeprecatedPluginValidator extends AbstractMavenPluginDescriptorSourcedParametersValidator {
+
+    @Inject
+    DeprecatedPluginValidator(PluginValidationManager pluginValidationManager) {
+        super(pluginValidationManager);
+    }
+
     @Override
     protected String getParameterLogReason(Parameter parameter) {
         return "is deprecated: " + parameter.getDeprecated();
@@ -42,40 +50,46 @@ class DeprecatedPluginValidator extends AbstractMavenPluginDescriptorSourcedPara
 
     @Override
     protected void doValidate(
+            MavenSession mavenSession,
             MojoDescriptor mojoDescriptor,
+            Class<?> mojoClass,
             PlexusConfiguration pomConfiguration,
             ExpressionEvaluator expressionEvaluator) {
         if (mojoDescriptor.getDeprecated() != null) {
-            logDeprecatedMojo(mojoDescriptor);
+            pluginValidationManager.reportPluginMojoValidationIssue(
+                    mavenSession, mojoDescriptor, mojoClass, logDeprecatedMojo(mojoDescriptor));
         }
 
-        if (mojoDescriptor.getParameters() == null) {
-            return;
+        if (mojoDescriptor.getParameters() != null) {
+            mojoDescriptor.getParameters().stream()
+                    .filter(parameter -> parameter.getDeprecated() != null)
+                    .filter(Parameter::isEditable)
+                    .forEach(parameter -> checkParameter(
+                            mavenSession, mojoDescriptor, mojoClass, parameter, pomConfiguration, expressionEvaluator));
         }
-
-        mojoDescriptor.getParameters().stream()
-                .filter(parameter -> parameter.getDeprecated() != null)
-                .filter(Parameter::isEditable)
-                .forEach(parameter -> checkParameter(parameter, pomConfiguration, expressionEvaluator));
     }
 
     private void checkParameter(
-            Parameter parameter, PlexusConfiguration pomConfiguration, ExpressionEvaluator expressionEvaluator) {
+            MavenSession mavenSession,
+            MojoDescriptor mojoDescriptor,
+            Class<?> mojoClass,
+            Parameter parameter,
+            PlexusConfiguration pomConfiguration,
+            ExpressionEvaluator expressionEvaluator) {
         PlexusConfiguration config = pomConfiguration.getChild(parameter.getName(), false);
 
         if (isValueSet(config, expressionEvaluator)) {
-            logParameter(parameter);
+            pluginValidationManager.reportPluginMojoValidationIssue(
+                    mavenSession, mojoDescriptor, mojoClass, formatParameter(parameter));
         }
     }
 
-    private void logDeprecatedMojo(MojoDescriptor mojoDescriptor) {
-        String message = MessageUtils.buffer()
+    private String logDeprecatedMojo(MojoDescriptor mojoDescriptor) {
+        return MessageUtils.buffer()
                 .warning("Goal '")
                 .warning(mojoDescriptor.getGoal())
                 .warning("' is deprecated: ")
                 .warning(mojoDescriptor.getDeprecated())
                 .toString();
-
-        logger.warn(message);
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.codehaus.plexus.component.repository.ComponentDependency;
+
+/**
+ * Detects Maven2 plugins.
+ *
+ * @since 3.9.2
+ */
+@Singleton
+@Named
+class Maven2DependenciesValidator extends AbstractMavenPluginDependenciesValidator {
+
+    @Inject
+    Maven2DependenciesValidator(PluginValidationManager pluginValidationManager) {
+        super(pluginValidationManager);
+    }
+
+    @Override
+    protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
+        Set<String> maven2Versions = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
+                .filter(d -> "org.apache.maven".equals(d.getGroupId()))
+                .filter(d -> !"maven-archiver".equals(d.getArtifactId()))
+                .map(ComponentDependency::getVersion)
+                .filter(v -> v.startsWith("2."))
+                .collect(Collectors.toSet());
+
+        if (!maven2Versions.isEmpty()) {
+            pluginValidationManager.reportPluginValidationIssue(
+                    mavenSession, mojoDescriptor, "Plugin is a Maven 2.x plugin, will be not supported in Maven 4.x");
+        }
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
@@ -48,14 +48,16 @@ class Maven2DependenciesValidator extends AbstractMavenPluginDependenciesValidat
     protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
         Set<String> maven2Versions = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
                 .filter(d -> "org.apache.maven".equals(d.getGroupId()))
-                .filter(d -> !"maven-archiver".equals(d.getArtifactId()))
+                .filter(d -> !expectedProvidedScopeExclusions.contains(d.getGroupId() + ":" + d.getArtifactId()))
                 .map(ComponentDependency::getVersion)
                 .filter(v -> v.startsWith("2."))
                 .collect(Collectors.toSet());
 
         if (!maven2Versions.isEmpty()) {
             pluginValidationManager.reportPluginValidationIssue(
-                    mavenSession, mojoDescriptor, "Plugin is a Maven 2.x plugin, will be not supported in Maven 4.x");
+                    mavenSession,
+                    mojoDescriptor,
+                    "Plugin is a Maven 2.x plugin, which will be not supported in Maven 4.x");
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.codehaus.plexus.component.repository.ComponentDependency;
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.codehaus.plexus.component.repository.ComponentDependency;
+
+/**
+ * Detects mixed Maven versions in plugins.
+ *
+ * @since 3.9.2
+ */
+@Singleton
+@Named
+class MavenMixedDependenciesValidator extends AbstractMavenPluginDependenciesValidator {
+
+    @Inject
+    MavenMixedDependenciesValidator(PluginValidationManager pluginValidationManager) {
+        super(pluginValidationManager);
+    }
+
+    @Override
+    protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
+        Set<String> mavenVersions = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
+                .filter(d -> "org.apache.maven".equals(d.getGroupId()))
+                .filter(d -> !"maven-archiver".equals(d.getArtifactId()))
+                .map(ComponentDependency::getVersion)
+                .collect(Collectors.toSet());
+
+        if (mavenVersions.size() > 1) {
+            pluginValidationManager.reportPluginValidationIssue(
+                    mavenSession, mojoDescriptor, "Plugin mixes multiple Maven versions: " + mavenVersions);
+        }
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
@@ -48,7 +48,7 @@ class MavenMixedDependenciesValidator extends AbstractMavenPluginDependenciesVal
     protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
         Set<String> mavenVersions = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
                 .filter(d -> "org.apache.maven".equals(d.getGroupId()))
-                .filter(d -> !"maven-archiver".equals(d.getArtifactId()))
+                .filter(d -> !expectedProvidedScopeExclusions.contains(d.getGroupId() + ":" + d.getArtifactId()))
                 .map(ComponentDependency::getVersion)
                 .collect(Collectors.toSet());
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.codehaus.plexus.component.repository.ComponentDependency;
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginConfigurationValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginConfigurationValidator.java
@@ -30,7 +30,7 @@ import org.codehaus.plexus.configuration.PlexusConfiguration;
  */
 interface MavenPluginConfigurationValidator {
     /**
-     * Returns mojo configuration issues.
+     * Checks mojo configuration issues.
      */
     void validate(
             MavenSession mavenSession,

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
@@ -28,7 +28,7 @@ import org.apache.maven.plugin.descriptor.MojoDescriptor;
  */
 interface MavenPluginDependenciesValidator {
     /**
-     * Returns mojo dependency issues.
+     * Checks mojo dependency issues.
      */
     void validate(MavenSession mavenSession, MojoDescriptor mojoDescriptor);
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
@@ -20,22 +20,15 @@ package org.apache.maven.plugin.internal;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
-import org.codehaus.plexus.configuration.PlexusConfiguration;
 
 /**
- * Service responsible for validating plugin configuration.
+ * Service responsible for validating plugin dependencies.
  *
- * @author Slawomir Jaranowski
+ * @since 3.9.2
  */
-interface MavenPluginConfigurationValidator {
+interface MavenPluginDependenciesValidator {
     /**
-     * Returns mojo configuration issues.
+     * Returns mojo dependency issues.
      */
-    void validate(
-            MavenSession mavenSession,
-            MojoDescriptor mojoDescriptor,
-            Class<?> mojoClass,
-            PlexusConfiguration pomConfiguration,
-            ExpressionEvaluator expressionEvaluator);
+    void validate(MavenSession mavenSession, MojoDescriptor mojoDescriptor);
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
@@ -47,7 +47,7 @@ class MavenScopeDependenciesValidator extends AbstractMavenPluginDependenciesVal
     protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
         Set<String> mavenArtifacts = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
                 .filter(d -> "org.apache.maven".equals(d.getGroupId()))
-                .filter(d -> !"maven-archiver".equals(d.getArtifactId()))
+                .filter(d -> !expectedProvidedScopeExclusions.contains(d.getGroupId() + ":" + d.getArtifactId()))
                 .filter(d -> d.getVersion().startsWith("3."))
                 .map(d -> d.getGroupId() + ":" + d.getArtifactId() + ":" + d.getVersion())
                 .collect(Collectors.toSet());

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
 /**

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+
+/**
+ * Detects Maven3 artifacts in bad scope in plugins.
+ *
+ * @since 3.9.2
+ */
+@Singleton
+@Named
+class MavenScopeDependenciesValidator extends AbstractMavenPluginDependenciesValidator {
+
+    @Inject
+    MavenScopeDependenciesValidator(PluginValidationManager pluginValidationManager) {
+        super(pluginValidationManager);
+    }
+
+    @Override
+    protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
+        Set<String> mavenArtifacts = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
+                .filter(d -> "org.apache.maven".equals(d.getGroupId()))
+                .filter(d -> !"maven-archiver".equals(d.getArtifactId()))
+                .filter(d -> d.getVersion().startsWith("3."))
+                .map(d -> d.getGroupId() + ":" + d.getArtifactId() + ":" + d.getVersion())
+                .collect(Collectors.toSet());
+
+        if (!mavenArtifacts.isEmpty()) {
+            pluginValidationManager.reportPluginValidationIssue(
+                    mavenSession,
+                    mojoDescriptor,
+                    "Plugin should declare these Maven artifacts in `provided` scope: " + mavenArtifacts);
+        }
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
@@ -46,7 +46,7 @@ class PlexusContainerDefaultDependenciesValidator extends AbstractMavenPluginDep
 
         if (pcdPresent) {
             pluginValidationManager.reportPluginValidationIssue(
-                    mavenSession, mojoDescriptor, "Plugin depends on plexus-container-default that is EOL");
+                    mavenSession, mojoDescriptor, "Plugin depends on plexus-container-default, that is EOL");
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
 /**

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+
+/**
+ * Detects Plexus Container Default in plugins.
+ *
+ * @since 3.9.2
+ */
+@Singleton
+@Named
+class PlexusContainerDefaultDependenciesValidator extends AbstractMavenPluginDependenciesValidator {
+
+    @Inject
+    PlexusContainerDefaultDependenciesValidator(PluginValidationManager pluginValidationManager) {
+        super(pluginValidationManager);
+    }
+
+    protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
+        boolean pcdPresent = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
+                .filter(d -> "org.codehaus.plexus".equals(d.getGroupId()))
+                .anyMatch(d -> "plexus-container-default".equals(d.getArtifactId()));
+
+        if (pcdPresent) {
+            pluginValidationManager.reportPluginValidationIssue(
+                    mavenSession, mojoDescriptor, "Plugin depends on plexus-container-default that is EOL");
+        }
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
@@ -47,7 +47,7 @@ class PlexusContainerDefaultDependenciesValidator extends AbstractMavenPluginDep
 
         if (pcdPresent) {
             pluginValidationManager.reportPluginValidationIssue(
-                    mavenSession, mojoDescriptor, "Plugin depends on plexus-container-default, that is EOL");
+                    mavenSession, mojoDescriptor, "Plugin depends on plexus-container-default, which is EOL");
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginValidationManager.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.InputLocation;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Component collecting plugin validation issues and reporting them.
+ *
+ * @since 3.9.2
+ */
+@Singleton
+@Named
+public class PluginValidationManager extends AbstractMavenLifecycleParticipant {
+
+    private static final String ISSUES_KEY = PluginValidationManager.class.getName() + ".issues";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void afterSessionEnd(MavenSession session) {
+        reportSessionCollectedValidationIssues(session);
+    }
+
+    public void reportPluginValidationIssue(MavenSession mavenSession, MojoDescriptor mojoDescriptor, String issue) {
+        String pluginKey = mojoDescriptor.getPluginDescriptor().getId();
+        PluginDescriptor pluginDescriptor = mojoDescriptor.getPluginDescriptor();
+        PluginValidationIssues pluginIssues = pluginIssues(mavenSession)
+                .computeIfAbsent(
+                        pluginKey,
+                        k -> new PluginValidationIssues(
+                                pluginDescriptor.getGroupId(),
+                                pluginDescriptor.getArtifactId(),
+                                pluginDescriptor.getVersion()));
+        pluginIssues.reportPluginIssue(pluginDeclaration(mojoDescriptor), pluginOccurence(mavenSession), issue);
+    }
+
+    public void reportPluginMojoValidationIssue(
+            MavenSession mavenSession, MojoDescriptor mojoDescriptor, Class<?> mojoClass, String issue) {
+        String pluginKey = mojoDescriptor.getPluginDescriptor().getId();
+        PluginDescriptor pluginDescriptor = mojoDescriptor.getPluginDescriptor();
+        PluginValidationIssues pluginIssues = pluginIssues(mavenSession)
+                .computeIfAbsent(
+                        pluginKey,
+                        k -> new PluginValidationIssues(
+                                pluginDescriptor.getGroupId(),
+                                pluginDescriptor.getArtifactId(),
+                                pluginDescriptor.getVersion()));
+        pluginIssues.reportPluginMojoIssue(
+                pluginDeclaration(mojoDescriptor),
+                pluginOccurence(mavenSession),
+                mojoInfo(mojoDescriptor, mojoClass),
+                issue);
+    }
+
+    public void reportSessionCollectedValidationIssues(MavenSession session) {
+        ConcurrentHashMap<String, PluginValidationIssues> issuesMap = pluginIssues(session);
+        if (!issuesMap.isEmpty()) {
+            logger.warn("");
+            logger.warn("Plugin issues were detected in build:");
+            logger.warn("");
+            for (PluginValidationIssues issues : issuesMap.values()) {
+                logger.warn("Plugin {}:{}:{}", issues.groupId, issues.artifactId, issues.version);
+                if (!issues.pluginDeclarations.isEmpty()) {
+                    logger.warn("  Declared at location(s):");
+                    for (String pluginDeclaration : issues.pluginDeclarations) {
+                        logger.warn("   * {}", pluginDeclaration);
+                    }
+                }
+                if (!issues.pluginOccurences.isEmpty()) {
+                    logger.warn("  Used in module(s):");
+                    for (String pluginOccurence : issues.pluginOccurences) {
+                        logger.warn("   * {}", pluginOccurence);
+                    }
+                }
+                if (!issues.pluginIssues.isEmpty()) {
+                    logger.warn("  Plugin issue(s):");
+                    for (String pluginIssue : issues.pluginIssues) {
+                        logger.warn("   * {}", pluginIssue);
+                    }
+                }
+                if (!issues.mojoIssues.isEmpty()) {
+                    logger.warn("  Mojo issue(s):");
+                    for (String mojoInfo : issues.mojoIssues.keySet()) {
+                        logger.warn("   * Mojo {}", mojoInfo);
+                        for (String mojoIssue : issues.mojoIssues.get(mojoInfo)) {
+                            logger.warn("     - {}", mojoIssue);
+                        }
+                    }
+                }
+                logger.warn("");
+            }
+            logger.warn("");
+            logger.warn(
+                    "To fix these issues, please upgrade listed plugins, or notify their maintainers about these issues.");
+            logger.warn("");
+        }
+        // - plugin
+        //   - used in
+        //     - issues
+        //     - mojo
+        //       - issues
+        //        if (!validationIssues.isEmpty()) {
+        //            logger.warn("Mojo validation issues:");
+        //            for (String validationIssue : validationIssues) {
+        //                logger.warn("  * " + validationIssue);
+        //            }
+        //            logger.warn("");
+        //            logger.warn("Please upgrade this plugin, or, contact plugin developers to fix the reported
+        // issue(s).");
+        //            logger.warn("");
+    }
+
+    private String pluginDeclaration(MojoDescriptor mojoDescriptor) {
+
+        InputLocation inputLocation =
+                mojoDescriptor.getPluginDescriptor().getPlugin().getLocation("");
+        if (inputLocation != null) {
+            return inputLocation.toString();
+        } else {
+            return "unknown";
+        }
+    }
+
+    private String pluginOccurence(MavenSession mavenSession) {
+        MavenProject prj = mavenSession.getCurrentProject();
+        String result = prj.getName() + " " + prj.getVersion();
+        File currentPom = prj.getFile();
+        if (currentPom != null) {
+            File rootBasedir = mavenSession.getTopLevelProject().getBasedir();
+            result += " (from " + rootBasedir.toPath().relativize(currentPom.toPath()) + ")";
+        }
+        return result;
+    }
+
+    private String mojoInfo(MojoDescriptor mojoDescriptor, Class<?> mojoClass) {
+        return mojoDescriptor.getFullGoalName() + " (class: " + mojoClass.getName() + ")";
+    }
+
+    @SuppressWarnings("unchecked")
+    private ConcurrentHashMap<String, PluginValidationIssues> pluginIssues(MavenSession mavenSession) {
+        return (ConcurrentHashMap<String, PluginValidationIssues>)
+                mavenSession.getRepositorySession().getData().computeIfAbsent(ISSUES_KEY, ConcurrentHashMap::new);
+    }
+
+    private static class PluginValidationIssues {
+        private final String groupId;
+
+        private final String artifactId;
+
+        private final String version;
+
+        private final LinkedHashSet<String> pluginDeclarations;
+
+        private final LinkedHashSet<String> pluginOccurences;
+
+        private final LinkedHashSet<String> pluginIssues;
+
+        private final LinkedHashMap<String, LinkedHashSet<String>> mojoIssues;
+
+        private PluginValidationIssues(String groupId, String artifactId, String version) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.version = version;
+            this.pluginDeclarations = new LinkedHashSet<>();
+            this.pluginOccurences = new LinkedHashSet<>();
+            this.pluginIssues = new LinkedHashSet<>();
+            this.mojoIssues = new LinkedHashMap<>();
+        }
+
+        private synchronized void reportPluginIssue(String pluginDeclaration, String pluginOccurence, String issue) {
+            pluginDeclarations.add(pluginDeclaration);
+            pluginOccurences.add(pluginOccurence);
+            pluginIssues.add(issue);
+        }
+
+        private synchronized void reportPluginMojoIssue(
+                String pluginDeclaration, String pluginOccurence, String mojoInfo, String issue) {
+            pluginDeclarations.add(pluginDeclaration);
+            pluginOccurences.add(pluginOccurence);
+            mojoIssues.computeIfAbsent(mojoInfo, k -> new LinkedHashSet<>()).add(issue);
+        }
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginValidationManager.java
@@ -85,6 +85,9 @@ public class PluginValidationManager extends AbstractMavenLifecycleParticipant {
     }
 
     public void reportSessionCollectedValidationIssues(MavenSession session) {
+        if (!logger.isWarnEnabled()) {
+            return;
+        }
         ConcurrentHashMap<String, PluginValidationIssues> issuesMap = pluginIssues(session);
         if (!issuesMap.isEmpty()) {
             logger.warn("");

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator.java
@@ -18,9 +18,11 @@
  */
 package org.apache.maven.plugin.internal;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
@@ -34,6 +36,12 @@ import org.codehaus.plexus.configuration.PlexusConfiguration;
 @Named
 @Singleton
 class ReadOnlyPluginParametersValidator extends AbstractMavenPluginDescriptorSourcedParametersValidator {
+
+    @Inject
+    ReadOnlyPluginParametersValidator(PluginValidationManager pluginValidationManager) {
+        super(pluginValidationManager);
+    }
+
     @Override
     protected String getParameterLogReason(Parameter parameter) {
         return "is read-only, must not be used in configuration";
@@ -41,7 +49,9 @@ class ReadOnlyPluginParametersValidator extends AbstractMavenPluginDescriptorSou
 
     @Override
     protected void doValidate(
+            MavenSession mavenSession,
             MojoDescriptor mojoDescriptor,
+            Class<?> mojoClass,
             PlexusConfiguration pomConfiguration,
             ExpressionEvaluator expressionEvaluator) {
         if (mojoDescriptor.getParameters() == null) {
@@ -50,15 +60,22 @@ class ReadOnlyPluginParametersValidator extends AbstractMavenPluginDescriptorSou
 
         mojoDescriptor.getParameters().stream()
                 .filter(parameter -> !parameter.isEditable())
-                .forEach(parameter -> checkParameter(parameter, pomConfiguration, expressionEvaluator));
+                .forEach(parameter -> checkParameter(
+                        mavenSession, mojoDescriptor, mojoClass, parameter, pomConfiguration, expressionEvaluator));
     }
 
     private void checkParameter(
-            Parameter parameter, PlexusConfiguration pomConfiguration, ExpressionEvaluator expressionEvaluator) {
+            MavenSession mavenSession,
+            MojoDescriptor mojoDescriptor,
+            Class<?> mojoClass,
+            Parameter parameter,
+            PlexusConfiguration pomConfiguration,
+            ExpressionEvaluator expressionEvaluator) {
         PlexusConfiguration config = pomConfiguration.getChild(parameter.getName(), false);
 
         if (isValueSet(config, expressionEvaluator)) {
-            logParameter(parameter);
+            pluginValidationManager.reportPluginMojoValidationIssue(
+                    mavenSession, mojoDescriptor, mojoClass, formatParameter(parameter));
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;


### PR DESCRIPTION
This is general rework of current Maven 3.9.x line how it handles plugin and mojo validations.

Changes:
* added plugin validations for dependencies
* introduced pluginValidationManager that gathers violations
* manager creates a report at build end, with dense and non repeating data
* this is in spirit to lessen already too verbose logging, as current solution would report violations as many times plugin is used in reactor, and that can be many (ie. a plugin from parent for each module)


Example report of Maven 3.9.x build: https://gist.github.com/cstamas/b62fdcd53eaf316123cf183f5a24e6a5

---

https://issues.apache.org/jira/browse/MNG-7754
