### PR TITLE
[MNG-7759] Maven2 plugins will not have even session

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -1000,6 +1000,10 @@ public class DefaultProjectBuilder implements ProjectBuilder {
     }
 
     private ModelCache createModelCache(RepositorySystemSession session) {
+        // MNG-7759: very old clients (Maven2 plugins) will not even have session, as setter was added in Maven 3
+        if (session == null) {
+            return null;
+        }
         // MNG-7693: for older clients (not injecting ModelCacheFactory), make this work OOTB w/ defaults
         return modelCacheFactory != null
                 ? modelCacheFactory.createCache(session)


### PR DESCRIPTION
As PBR session setter was added in Maven3. Still, this causes unexpected NPE during plugin execution, while Maven3 should support Maven2 plugins.

---

https://issues.apache.org/jira/browse/MNG-7759