### PR TITLE
[MNG-7691] Lifecycle filter

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -82,6 +82,9 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
     @Requirement
     private LifecyclePluginResolver lifecyclePluginResolver;
 
+    @Requirement
+    private LifecyclePluginSkipper lifecyclePluginSkipper;
+
     @Requirement(hint = DefaultLifecycleMappingDelegate.HINT)
     private LifecycleMappingDelegate standardDelegate;
 
@@ -99,11 +102,13 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             BuildPluginManager pluginManager,
             DefaultLifecycles defaultLifeCycles,
             MojoDescriptorCreator mojoDescriptorCreator,
-            LifecyclePluginResolver lifecyclePluginResolver) {
+            LifecyclePluginResolver lifecyclePluginResolver,
+            LifecyclePluginSkipper lifecyclePluginSkipper) {
         this.pluginManager = pluginManager;
         this.defaultLifeCycles = defaultLifeCycles;
         this.mojoDescriptorCreator = mojoDescriptorCreator;
         this.lifecyclePluginResolver = lifecyclePluginResolver;
+        this.lifecyclePluginSkipper = lifecyclePluginSkipper;
         this.mojoExecutionConfigurators =
                 Collections.singletonMap("default", (MojoExecutionConfigurator) new DefaultMojoExecutionConfigurator());
     }
@@ -121,6 +126,8 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         if (setup) {
             setupMojoExecutions(session, project, executions);
         }
+
+        lifecyclePluginSkipper.processMojoExecutions(session, executions);
 
         final List<ExecutionPlanItem> planItem = ExecutionPlanItem.createExecutionPlanItems(project, executions);
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecyclePluginSkipper.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecyclePluginSkipper.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.internal;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.aether.util.ConfigUtils;
+
+/**
+ * Lifecycle plugin skipper.
+ *
+ * @since TBD
+ */
+@Component(role = LifecyclePluginSkipper.class)
+public class LifecyclePluginSkipper {
+    private static final String PARSED_FILTER_KEY = LifecyclePluginSkipper.class.getName() + ".filter";
+    private static final String MAVEN_LIFECYCLE_FILTER = "maven.lifecycle.filter";
+    private static final Predicate<MojoExecution> NO_FILTER = t -> true;
+    private static final Predicate<String> TRUE = t -> true;
+
+    void processMojoExecutions(MavenSession session, List<MojoExecution> executions) {
+        Predicate<MojoExecution> filter = getFilter(session);
+        if (filter == NO_FILTER) {
+            return;
+        }
+        executions.removeIf(filter);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Predicate<MojoExecution> getFilter(MavenSession mavenSession) {
+        return (Predicate<MojoExecution>) mavenSession
+                .getRepositorySession()
+                .getData()
+                .computeIfAbsent(PARSED_FILTER_KEY, () -> createFilter(mavenSession));
+    }
+
+    private Predicate<MojoExecution> createFilter(MavenSession mavenSession) {
+        String filterString = ConfigUtils.getString(mavenSession.getRepositorySession(), null, MAVEN_LIFECYCLE_FILTER);
+        if (filterString == null) {
+            return NO_FILTER;
+        }
+
+        Predicate<MojoExecution> result = null;
+        String[] filterExpressions = filterString.split(",");
+        for (String filterExpression : filterExpressions) {
+            if (result == null) {
+                result = parseFilterExpression(mavenSession.getPluginGroups(), filterExpression);
+            } else {
+                result = result.or(parseFilterExpression(mavenSession.getPluginGroups(), filterExpression));
+            }
+        }
+        return result;
+    }
+
+    private Predicate<MojoExecution> parseFilterExpression(List<String> pluginGroups, String filterExpression) {
+        // G:A:Goal:ExecId
+        //
+        // G values
+        // "" - default plugins (org.apache org codehaus)
+        // "*" - any
+        // "foo.bar" - exact G match
+        //
+        // A values
+        // "*" - any
+        // "foo-maven-plugin" - exact A match
+        //
+        // Goal values
+        // "*" - any
+        // "foo" - exact match
+        //
+        // ExecId values
+        // "*" - any
+        // "foo" - exact match
+
+        Predicate<String> groupIdPredicate;
+        Predicate<String> artifactIdPredicate = TRUE;
+        Predicate<String> goalPredicate = TRUE;
+        Predicate<String> executionIdPredicate = TRUE;
+
+        String[] elements = filterExpression.split(":");
+        if (elements.length == 0 || elements.length > 4) {
+            throw new IllegalArgumentException("Unsupported lifecycle filter expression: " + filterExpression);
+        }
+        String groupId = elements[0];
+        if (Objects.equals(groupId, "")) {
+            groupIdPredicate = pluginGroups::contains;
+        } else if (Objects.equals(groupId, "*")) {
+            groupIdPredicate = TRUE;
+        } else {
+            groupIdPredicate = t -> Objects.equals(groupId, t);
+        }
+
+        if (elements.length > 1) {
+            String artifactId = elements[1];
+            if (!Objects.equals(artifactId, "*")) {
+                artifactIdPredicate = t -> Objects.equals(artifactId, t);
+            }
+
+            if (elements.length > 2) {
+                String goal = elements[2];
+                if (!Objects.equals(goal, "*")) {
+                    goalPredicate = t -> Objects.equals(goal, t);
+                }
+
+                if (elements.length > 3) {
+                    String executionId = elements[3];
+                    if (!Objects.equals(executionId, "*")) {
+                        executionIdPredicate = t -> Objects.equals(executionId, t);
+                    }
+                }
+            }
+        }
+
+        return new ExecutionMatcher(groupIdPredicate, artifactIdPredicate, goalPredicate, executionIdPredicate);
+    }
+
+    private static class ExecutionMatcher implements Predicate<MojoExecution> {
+        private final Predicate<String> groupIdPredicate;
+        private final Predicate<String> artifactIdPredicate;
+        private final Predicate<String> goalPredicate;
+        private final Predicate<String> executionIdPredicate;
+
+        private ExecutionMatcher(
+                Predicate<String> groupIdPredicate,
+                Predicate<String> artifactIdPredicate,
+                Predicate<String> goalPredicate,
+                Predicate<String> executionIdPredicate) {
+            this.groupIdPredicate = groupIdPredicate;
+            this.artifactIdPredicate = artifactIdPredicate;
+            this.goalPredicate = goalPredicate;
+            this.executionIdPredicate = executionIdPredicate;
+        }
+
+        @Override
+        public boolean test(MojoExecution mojoExecution) {
+            return groupIdPredicate.test(mojoExecution
+                            .getMojoDescriptor()
+                            .getPluginDescriptor()
+                            .getGroupId())
+                    && artifactIdPredicate.test(mojoExecution
+                            .getMojoDescriptor()
+                            .getPluginDescriptor()
+                            .getArtifactId())
+                    && goalPredicate.test(mojoExecution.getMojoDescriptor().getGoal())
+                    && executionIdPredicate.test(mojoExecution.getExecutionId());
+        }
+    }
+}

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
@@ -62,7 +62,8 @@ public class LifecycleExecutionPlanCalculatorTest extends AbstractCoreMavenCompo
                 new BuildPluginManagerStub(),
                 DefaultLifecyclesStub.createDefaultLifecycles(),
                 mojoDescriptorCreator,
-                lifecyclePluginResolver);
+                lifecyclePluginResolver,
+                new LifecyclePluginSkipper());
     }
 
     public static MojoDescriptorCreator createMojoDescriptorCreator() {

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilderTest.java
@@ -33,6 +33,7 @@ import org.apache.maven.lifecycle.internal.stub.MojoExecutorStub;
 import org.apache.maven.lifecycle.internal.stub.ProjectDependencyGraphStub;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusTestCase;
@@ -61,7 +62,8 @@ public class LifecycleModuleBuilderTest extends PlexusTestCase {
         MavenExecutionRequest mavenExecutionRequest = new DefaultMavenExecutionRequest();
         mavenExecutionRequest.setExecutionListener(new AbstractExecutionListener());
         mavenExecutionRequest.setGoals(Arrays.asList("clean"));
-        final MavenSession session = new MavenSession(null, null, mavenExecutionRequest, defaultMavenExecutionResult);
+        final MavenSession session = new MavenSession(
+                null, MavenRepositorySystemUtils.newSession(), mavenExecutionRequest, defaultMavenExecutionResult);
         final ProjectDependencyGraphStub dependencyGraphStub = new ProjectDependencyGraphStub();
         session.setProjectDependencyGraph(dependencyGraphStub);
         session.setProjects(dependencyGraphStub.getSortedProjects());

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/ProjectDependencyGraphStub.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/ProjectDependencyGraphStub.java
@@ -42,6 +42,7 @@ import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 
 /**
  * A stub dependency graph that is custom made for testing concurrent build graph evaluations.
@@ -201,7 +202,8 @@ public class ProjectDependencyGraphStub implements ProjectDependencyGraph {
         mavenExecutionRequest.setExecutionListener(new AbstractExecutionListener());
         mavenExecutionRequest.setGoals(Arrays.asList("clean", "aggr", "install"));
         mavenExecutionRequest.setDegreeOfConcurrency(1);
-        final MavenSession session = new MavenSession(null, null, mavenExecutionRequest, defaultMavenExecutionResult);
+        final MavenSession session = new MavenSession(
+                null, MavenRepositorySystemUtils.newSession(), mavenExecutionRequest, defaultMavenExecutionResult);
         final ProjectDependencyGraphStub dependencyGraphStub = new ProjectDependencyGraphStub();
         session.setProjectDependencyGraph(dependencyGraphStub);
         session.setProjects(dependencyGraphStub.getSortedProjects());


### PR DESCRIPTION
A rough concept how could it work: this skipper simply plugs into lifecycle calculator and skips (removes) filtered out MojoExecutions.

Expression is simple: G[:A[:g[:e]]]

Where G means "groupId" and can be:
* "" (empty string) -- means "default plugin groupIds" (as in user settings)
* "*" (asterisk) -- any
* "string" -- string equality for groupId

A (artifactId), g (goal) and e (executionId) may have values:
* "*" (asterisk) -- any
* "string" -- string equality for artifactId, goal or executionId respectively.

Example invocations (only with relevant output):
```
$ mvn -f maven-core buildplan:list   // this is "original" plan
-----------------------------------------------------------------------------------------------------------------------------------------
PHASE                  | PLUGIN                        | VERSION  | GOAL                   | EXECUTION ID                                
-----------------------------------------------------------------------------------------------------------------------------------------
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-bytecode-version                    
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-maven-version                       
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-java-version                        
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | ensure-no-sonatype-cipher-and-sec-dispatcher
initialize             | buildnumber-maven-plugin      | 1.4      | create                 | create-buildnumber                          
generate-sources       | modello-maven-plugin          | 2.0.0    | java                   | modello                                     
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-reader            | modello                                     
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-writer            | modello                                     
verify                 | spotless-maven-plugin         | 2.28.0   | check                  | default                                     
verify                 | maven-checkstyle-plugin       | 3.2.0    | check                  | checkstyle-check                            
generate-resources     | maven-remote-resources-plugin | 1.7.0    | process                | process-resource-bundles                    
process-resources      | maven-resources-plugin        | 3.3.0    | resources              | default-resources                           
compile                | maven-compiler-plugin         | 3.10.1   | compile                | default-compile                             
process-test-classes   | animal-sniffer-maven-plugin   | 1.23     | check                  | check-java-compat                           
process-classes        | plexus-component-metadata             | 2.1.0    | generate-metadata      | default                                     
process-classes        | sisu-maven-plugin             | 0.3.5    | main-index             | index-project                               
process-test-resources | maven-resources-plugin        | 3.3.0    | testResources          | default-testResources                       
test-compile           | maven-compiler-plugin         | 3.10.1   | testCompile            | default-testCompile                         
process-test-classes   | plexus-component-metadata             | 2.1.0    | generate-test-metadata | default                                     
process-test-classes   | sisu-maven-plugin             | 0.3.5    | test-index             | index-project                               
test                   | maven-surefire-plugin         | 3.0.0-M7 | test                   | default-test                                
package                | maven-jar-plugin              | 3.3.0    | jar                    | default-jar                                 
package                | maven-site-plugin             | 3.12.1   | attach-descriptor      | attach-descriptor                           
install                | maven-install-plugin          | 3.1.0    | install                | default-install                             
deploy                 | maven-deploy-plugin           | 2.8.2    | deploy                 | default-deploy                              

$ mvn -f maven-core buildplan:list -Dmaven.lifecycle.filter=*:modello-maven-plugin:java // exclude java mojo
-----------------------------------------------------------------------------------------------------------------------------------------
PHASE                  | PLUGIN                        | VERSION  | GOAL                   | EXECUTION ID                                
-----------------------------------------------------------------------------------------------------------------------------------------
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-bytecode-version                    
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-maven-version                       
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-java-version                        
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | ensure-no-sonatype-cipher-and-sec-dispatcher
initialize             | buildnumber-maven-plugin      | 1.4      | create                 | create-buildnumber                          
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-reader            | modello                                     
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-writer            | modello                                     
verify                 | spotless-maven-plugin         | 2.28.0   | check                  | default                                     
verify                 | maven-checkstyle-plugin       | 3.2.0    | check                  | checkstyle-check                            
generate-resources     | maven-remote-resources-plugin | 1.7.0    | process                | process-resource-bundles                    
process-resources      | maven-resources-plugin        | 3.3.0    | resources              | default-resources                           
compile                | maven-compiler-plugin         | 3.10.1   | compile                | default-compile                             
process-test-classes   | animal-sniffer-maven-plugin   | 1.23     | check                  | check-java-compat                           
process-classes        | plexus-component-metadata             | 2.1.0    | generate-metadata      | default                                     
process-classes        | sisu-maven-plugin             | 0.3.5    | main-index             | index-project                               
process-test-resources | maven-resources-plugin        | 3.3.0    | testResources          | default-testResources                       
test-compile           | maven-compiler-plugin         | 3.10.1   | testCompile            | default-testCompile                         
process-test-classes   | plexus-component-metadata             | 2.1.0    | generate-test-metadata | default                                     
process-test-classes   | sisu-maven-plugin             | 0.3.5    | test-index             | index-project                               
test                   | maven-surefire-plugin         | 3.0.0-M7 | test                   | default-test                                
package                | maven-jar-plugin              | 3.3.0    | jar                    | default-jar                                 
package                | maven-site-plugin             | 3.12.1   | attach-descriptor      | attach-descriptor                           
install                | maven-install-plugin          | 3.1.0    | install                | default-install                             
deploy                 | maven-deploy-plugin           | 2.8.2    | deploy                 | default-deploy                              

$ mvn -f maven-core buildplan:list -Dmaven.lifecycle.filter=*:maven-enforcer-plugin:enforce // exclude enforce mojo
---------------------------------------------------------------------------------------------------------------------
PHASE                  | PLUGIN                        | VERSION  | GOAL                   | EXECUTION ID            
---------------------------------------------------------------------------------------------------------------------
initialize             | buildnumber-maven-plugin      | 1.4      | create                 | create-buildnumber      
generate-sources       | modello-maven-plugin          | 2.0.0    | java                   | modello                 
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-reader            | modello                 
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-writer            | modello                 
verify                 | spotless-maven-plugin         | 2.28.0   | check                  | default                 
verify                 | maven-checkstyle-plugin       | 3.2.0    | check                  | checkstyle-check        
generate-resources     | maven-remote-resources-plugin | 1.7.0    | process                | process-resource-bundles
process-resources      | maven-resources-plugin        | 3.3.0    | resources              | default-resources       
compile                | maven-compiler-plugin         | 3.10.1   | compile                | default-compile         
process-test-classes   | animal-sniffer-maven-plugin   | 1.23     | check                  | check-java-compat       
process-classes        | plexus-component-metadata             | 2.1.0    | generate-metadata      | default                 
process-classes        | sisu-maven-plugin             | 0.3.5    | main-index             | index-project           
process-test-resources | maven-resources-plugin        | 3.3.0    | testResources          | default-testResources   
test-compile           | maven-compiler-plugin         | 3.10.1   | testCompile            | default-testCompile     
process-test-classes   | plexus-component-metadata             | 2.1.0    | generate-test-metadata | default                 
process-test-classes   | sisu-maven-plugin             | 0.3.5    | test-index             | index-project           
test                   | maven-surefire-plugin         | 3.0.0-M7 | test                   | default-test            
package                | maven-jar-plugin              | 3.3.0    | jar                    | default-jar             
package                | maven-site-plugin             | 3.12.1   | attach-descriptor      | attach-descriptor       
install                | maven-install-plugin          | 3.1.0    | install                | default-install         
deploy                 | maven-deploy-plugin           | 2.8.2    | deploy                 | default-deploy          

$ mvn -f maven-core buildplan:list -Dmaven.lifecycle.filter=:maven-enforcer-plugin:enforce:enforce-maven-version // exclude enforce maven execution
-----------------------------------------------------------------------------------------------------------------------------------------
PHASE                  | PLUGIN                        | VERSION  | GOAL                   | EXECUTION ID                                
-----------------------------------------------------------------------------------------------------------------------------------------
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-bytecode-version                    
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | enforce-java-version                        
validate               | maven-enforcer-plugin         | 3.1.0    | enforce                | ensure-no-sonatype-cipher-and-sec-dispatcher
initialize             | buildnumber-maven-plugin      | 1.4      | create                 | create-buildnumber                          
generate-sources       | modello-maven-plugin          | 2.0.0    | java                   | modello                                     
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-reader            | modello                                     
generate-sources       | modello-maven-plugin          | 2.0.0    | xpp3-writer            | modello                                     
verify                 | spotless-maven-plugin         | 2.28.0   | check                  | default                                     
verify                 | maven-checkstyle-plugin       | 3.2.0    | check                  | checkstyle-check                            
generate-resources     | maven-remote-resources-plugin | 1.7.0    | process                | process-resource-bundles                    
process-resources      | maven-resources-plugin        | 3.3.0    | resources              | default-resources                           
compile                | maven-compiler-plugin         | 3.10.1   | compile                | default-compile                             
process-test-classes   | animal-sniffer-maven-plugin   | 1.23     | check                  | check-java-compat                           
process-classes        | plexus-component-metadata             | 2.1.0    | generate-metadata      | default                                     
process-classes        | sisu-maven-plugin             | 0.3.5    | main-index             | index-project                               
process-test-resources | maven-resources-plugin        | 3.3.0    | testResources          | default-testResources                       
test-compile           | maven-compiler-plugin         | 3.10.1   | testCompile            | default-testCompile                         
process-test-classes   | plexus-component-metadata             | 2.1.0    | generate-test-metadata | default                                     
process-test-classes   | sisu-maven-plugin             | 0.3.5    | test-index             | index-project                               
test                   | maven-surefire-plugin         | 3.0.0-M7 | test                   | default-test                                
package                | maven-jar-plugin              | 3.3.0    | jar                    | default-jar                                 
package                | maven-site-plugin             | 3.12.1   | attach-descriptor      | attach-descriptor                           
install                | maven-install-plugin          | 3.1.0    | install                | default-install                             
deploy                 | maven-deploy-plugin           | 2.8.2    | deploy                 | default-deploy                              

```

---

https://issues.apache.org/jira/browse/MNG-7691