### PR TITLE
[MNG-7670] Update misc dependencies

### DIFF
--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -154,11 +154,6 @@ under the License.
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/maven-core/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/pom.xml
+++ b/pom.xml
@@ -124,20 +124,19 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <maven.version>3.0.5</maven.version>
     <javaVersion>8</javaVersion>
-    <classWorldsVersion>2.6.0</classWorldsVersion>
-    <commonsCliVersion>1.4</commonsCliVersion>
+    <classWorldsVersion>2.7.0</classWorldsVersion>
+    <commonsCliVersion>1.5.0</commonsCliVersion>
     <commonsIoVersion>2.11.0</commonsIoVersion>
-    <commonsLangVersion>3.8.1</commonsLangVersion>
+    <commonsLangVersion>3.12.0</commonsLangVersion>
     <junitVersion>4.13.2</junitVersion>
-    <mockitoVersion>2.21.0</mockitoVersion>
+    <mockitoVersion>4.11.0</mockitoVersion>
     <plexusVersion>2.1.0</plexusVersion>
     <plexusInterpolationVersion>1.26</plexusInterpolationVersion>
     <!-- Blocked by 3.4.0+ changes, see MNG-7710 -->
     <plexusUtilsVersion>3.5.1</plexusUtilsVersion>
     <guiceVersion>5.1.0</guiceVersion>
-    <guavaVersion>30.1-jre</guavaVersion>
+    <guavaVersion>31.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <wagonVersion>3.5.3</wagonVersion>
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
@@ -145,8 +144,8 @@ under the License.
     <jxpathVersion>1.3</jxpathVersion>
     <resolverVersion>1.9.7</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <xmlunitVersion>2.2.1</xmlunitVersion>
-    <powermockVersion>1.7.4</powermockVersion>
+    <xmlunitVersion>2.9.1</xmlunitVersion>
+    <powermockVersion>2.0.9</powermockVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <!-- Control the name of the distribution and information output by mvn -->
     <distributionId>apache-maven</distributionId>
@@ -364,7 +363,7 @@ under the License.
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
         <optional>true</optional>
       </dependency>
       <!--  Wagon -->
@@ -424,6 +423,17 @@ under the License.
         <artifactId>maven-resolver-transport-wagon</artifactId>
         <version>${resolverVersion}</version>
       </dependency>
+      <!-- HttpClient: used by Wagon and Resolver-Http -->
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.16</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.14</version>
+      </dependency>
       <!--  Commons -->
       <dependency>
         <groupId>commons-cli</groupId>
@@ -476,12 +486,32 @@ under the License.
         <artifactId>xmlunit-core</artifactId>
         <version>${xmlunitVersion}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-matchers</artifactId>
         <version>${xmlunitVersion}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
@@ -490,15 +520,21 @@ under the License.
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <version>1.3</version>
+        <artifactId>hamcrest</artifactId>
+        <version>2.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junitVersion}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
     <!--bootstrap-start-comment-->
@@ -507,9 +543,13 @@ under the License.
   <!--bootstrap-start-comment-->
   <dependencies>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junitVersion}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
And do align them. Max Level is Java 8, but
we had several conflicts, like HttpClient
(used by Wagon but also by Resolver-Transport-Http).

---

https://issues.apache.org/jira/browse/MNG-7670