### PR TITLE
MNG-7758 workaround

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactResolver.java
@@ -188,9 +188,11 @@ public class DefaultArtifactResolver implements ArtifactResolver, Disposable {
                 result = repoSystem.resolveArtifact(session, artifactRequest);
             } catch (org.eclipse.aether.resolution.ArtifactResolutionException e) {
                 if (e.getCause() instanceof org.eclipse.aether.transfer.ArtifactNotFoundException) {
-                    throw new ArtifactNotFoundException(e.getMessage(), artifact, remoteRepositories, e);
+                    throw new ArtifactNotFoundException(
+                            "Could not find artifact '" + artifact + "'", artifact, remoteRepositories, e);
                 } else {
-                    throw new ArtifactResolutionException(e.getMessage(), artifact, remoteRepositories, e);
+                    throw new ArtifactResolutionException(
+                            "Failed to resolve artifact '" + artifact + "'", artifact, remoteRepositories, e);
                 }
             }
 

--- a/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactResolver.java
@@ -187,7 +187,9 @@ public class DefaultArtifactResolver implements ArtifactResolver, Disposable {
 
                 result = repoSystem.resolveArtifact(session, artifactRequest);
             } catch (org.eclipse.aether.resolution.ArtifactResolutionException e) {
-                if (e.getCause() instanceof org.eclipse.aether.transfer.ArtifactNotFoundException) {
+                // This is a workaround for MNG-7758/MRESOLVER-335
+                if (e.getResult().getExceptions().stream()
+                        .anyMatch(re -> re instanceof org.eclipse.aether.transfer.ArtifactNotFoundException)) {
                     throw new ArtifactNotFoundException(
                             "Could not find artifact '" + artifact + "'", artifact, remoteRepositories, e);
                 } else {

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -310,8 +310,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             if (e.getResults().get(0).isMissing() && allowStubModel) {
                 return build(null, createStubModelSource(artifact), config);
             }
-            throw new ProjectBuildingException(
-                    artifact.getId(), "Error resolving project artifact: " + e.getMessage(), e);
+            throw new ProjectBuildingException(artifact.getId(), "Error resolving project artifact", e);
         }
 
         File pomFile = pomArtifact.getFile();

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -307,7 +307,10 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             pomArtifact = pomResult.getArtifact();
             localProject = pomResult.getRepository() instanceof WorkspaceRepository;
         } catch (org.eclipse.aether.resolution.ArtifactResolutionException e) {
-            if (e.getResults().get(0).isMissing() && allowStubModel) {
+            // This is a workaround for MNG-7758/MRESOLVER-335
+            if (e.getResult().getExceptions().stream()
+                            .anyMatch(re -> re instanceof org.eclipse.aether.transfer.ArtifactNotFoundException)
+                    && allowStubModel) {
                 return build(null, createStubModelSource(artifact), config);
             }
             throw new ProjectBuildingException(artifact.getId(), "Error resolving project artifact", e);

--- a/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
@@ -166,7 +166,12 @@ public class ProjectModelResolver implements ModelResolver {
             request.setTrace(trace);
             pomArtifact = resolver.resolveArtifact(session, request).getArtifact();
         } catch (ArtifactResolutionException e) {
-            throw new UnresolvableModelException(e.getMessage(), groupId, artifactId, version, e);
+            throw new UnresolvableModelException(
+                    String.format("Failed to resolve model artifact '%s'", pomArtifact),
+                    groupId,
+                    artifactId,
+                    version,
+                    e);
         }
 
         return new ArtifactModelSource(pomArtifact.getFile(), groupId, artifactId, version);

--- a/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
+++ b/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
@@ -160,7 +160,10 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy 
                     Predicate<Exception> pluginArtifactNotFoundException = exc -> exc instanceof PluginManagerException
                             && exc.getCause() instanceof PluginResolutionException
                             && exc.getCause().getCause() instanceof ArtifactResolutionException
-                            && exc.getCause().getCause().getCause() instanceof ArtifactNotFoundException;
+                            // This is a workaround for MNG-7758/MRESOLVER-335
+                            && ((ArtifactResolutionException) exc.getCause().getCause())
+                                    .getResult().getExceptions().stream()
+                                            .anyMatch(re -> re instanceof ArtifactNotFoundException);
 
                     Predicate<Plugin> isPluginPartOfRequestScope = plugin -> projectsInRequestScope.stream()
                             .anyMatch(project -> project.getGroupId().equals(plugin.getGroupId())

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
@@ -69,7 +69,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
                 () -> newModelResolver().resolveModel(parent.getDelegate(), new AtomicReference<>()),
                 "Expected 'UnresolvableModelException' not thrown.");
         assertNotNull(e.getMessage());
-        assertThat(e.getMessage(), containsString("Could not find artifact org.apache:apache:pom:0 in central"));
+        assertThat(e.getMessage(), containsString("Failed to resolve model artifact 'org.apache:apache:pom:0'"));
     }
 
     @Test
@@ -135,7 +135,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
                 () -> newModelResolver().resolveModel(dependency.getDelegate(), new AtomicReference<>()),
                 "Expected 'UnresolvableModelException' not thrown.");
         assertNotNull(e.getMessage());
-        assertThat(e.getMessage(), containsString("Could not find artifact org.apache:apache:pom:0 in central"));
+        assertThat(e.getMessage(), containsString("Failed to resolve model artifact 'org.apache:apache:pom:0'"));
     }
 
     @Test

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -170,8 +170,12 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                 pomArtifact = resolveResult.getArtifact();
                 result.setRepository(resolveResult.getRepository());
             } catch (ArtifactResolutionException e) {
-                if (e.getCause() instanceof ArtifactNotFoundException) {
-                    missingDescriptor(session, trace, a, (Exception) e.getCause());
+                // This is a workaround for MNG-7758/MRESOLVER-335
+                if (e.getResult().getExceptions().stream().anyMatch(re -> re instanceof ArtifactNotFoundException)) {
+                    missingDescriptor(session, trace, a, (Exception) e.getResult().getExceptions().stream()
+                            .filter(re -> re instanceof ArtifactNotFoundException)
+                            .findFirst()
+                            .get());
                     if ((getPolicy(session, a, request) & ArtifactDescriptorPolicy.IGNORE_MISSING) != 0) {
                         return null;
                     }

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -157,7 +157,12 @@ class DefaultModelResolver implements ModelResolver {
             request.setTrace(trace);
             pomArtifact = resolver.resolveArtifact(session, request).getArtifact();
         } catch (ArtifactResolutionException e) {
-            throw new UnresolvableModelException(e.getMessage(), groupId, artifactId, version, e);
+            throw new UnresolvableModelException(
+                    String.format("Failed to resolve model artifact '%s'", pomArtifact),
+                    groupId,
+                    artifactId,
+                    version,
+                    e);
         }
 
         return new ArtifactModelSource(pomArtifact.getFile(), groupId, artifactId, version);

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
@@ -65,7 +65,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
                 () -> newModelResolver().resolveModel(parent, new AtomicReference<>()),
                 "Expected 'UnresolvableModelException' not thrown.");
         assertNotNull(e.getMessage());
-        assertTrue(e.getMessage().contains("Could not find artifact ut.simple:artifact:pom:0 in repo"));
+        assertTrue(e.getMessage().contains("Failed to resolve model artifact 'ut.simple:artifact:pom:0'"));
     }
 
     @Test
@@ -138,7 +138,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
                 () -> newModelResolver().resolveModel(dependency, new AtomicReference<>()),
                 "Expected 'UnresolvableModelException' not thrown.");
         assertNotNull(e.getMessage());
-        assertTrue(e.getMessage().contains("Could not find artifact ut.simple:artifact:pom:0 in repo"));
+        assertTrue(e.getMessage().contains("Failed to resolve model artifact 'ut.simple:artifact:pom:0'"));
     }
 
     @Test


### PR DESCRIPTION
This has been intentionally broken up into two commits/issues:

* [MNG-7771](https://issues.apache.org/jira/browse/MNG-7771) uses rather synthetic exception messages rather than to rely on the order of exception messages in `ArtifactResult`. No more first wins.
* [MNG-7770](https://issues.apache.org/jira/browse/MNG-7770) is an attempt to create a workaround meanwhile. 

Two IT failures:
* MNG-7128 (repo blocker): The exception for POM contains two exceptions (1) TransferException (blocked), (2) ArtifactNotFoundException (not in `file:target/null`) , the behavioral change is that the POM is now considered missing and the JAR fails. Previously, it failed already with the POM.
* MNG-3470 (checksum validation fails): Similar case, the checksum validation of the POM fails, it is not considered as missing, the build succeeds since the checksum for the JAR was fine. This is a behavioral change since the validation exception is traded for a not found exception in `file:target/null`).

See output: https://gist.github.com/michael-o/c9932567ac004a30021d44a464a37dbf

One of the general questions is: When is an artifact consindered not to be found? When ALL repos say not found, or is one sufficient? What if one repo is technically offline which could or could not contain it, then rest does not contain? Why fail the build?

Important reads:
* https://issues.apache.org/jira/browse/MNG-7758
* https://issues.apache.org/jira/browse/MRESOLVER-335

Let me know what you think.