### PR TITLE
[MNG-7774] Maven config and command line interpolation

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -579,7 +579,7 @@ public class MavenCli {
             System.err.println(message);
             throw new UnrecognizedOptionException(message);
         } catch (IllegalUseOfUndefinedProperty e) {
-            String message = "ERROR: Invalid use of undefined property: " + e.property;
+            String message = "ERROR: Illegal use of undefined property: " + e.property;
             System.err.println(message);
             if (cliRequest.multiModuleProjectDirectory == null) {
                 System.err.println();

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1549,14 +1549,9 @@ public class MavenCli {
                         throw new IllegalUseOfUndefinedProperty(expression);
                     }
                 } else if ("session.rootDirectory".equals(expression)) {
-                    String rootDirectory = cliRequest.request.getMultiModuleProjectDirectory() == null
-                            ? null
-                            : cliRequest
-                                    .request
-                                    .getMultiModuleProjectDirectory()
-                                    .getAbsolutePath();
+                    File rootDirectory = cliRequest.request.getMultiModuleProjectDirectory();
                     if (rootDirectory != null) {
-                        return rootDirectory;
+                        return rootDirectory.getAbsolutePath();
                     } else {
                         throw new IllegalUseOfUndefinedProperty(expression);
                     }


### PR DESCRIPTION
This is "mild introduction" of subset of new Maven4 features into Maven 3.9.x land, with single intent: be able to store resolver configuration along with checked in project sources in SCM.

Changes:
* interpolate properties and arguments
* introduce two new special properties "session.rootDirectory" and "session.topDirectory"
* these two properties may be undefined (the .mvn may not be found)
* these two properties if undefined, but referenced during interpolation, causes Maven to bail out (error out), and will prevent starting.
* some other minor cosmetic cleanup

---

https://issues.apache.org/jira/browse/MNG-7774