### PR TITLE
[MNG-7774] Maven config and command line interpolation

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.cli;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.commons.cli.CommandLine;
@@ -39,6 +40,10 @@ public class CliRequest {
     String workingDirectory;
 
     File multiModuleProjectDirectory;
+
+    Path rootDirectory;
+
+    Path topDirectory;
 
     boolean debug;
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -605,7 +605,7 @@ public class MavenCli {
         } catch (IllegalUseOfUndefinedProperty e) {
             String message = "ERROR: Illegal use of undefined property: " + e.property;
             System.err.println(message);
-            if (cliRequest.multiModuleProjectDirectory == null) {
+            if (cliRequest.rootDirectory == null) {
                 System.err.println();
                 System.err.println(UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE);
             }
@@ -1564,7 +1564,7 @@ public class MavenCli {
         return searchAcceptableRootDirectory(path.getParent());
     }
 
-    private static StringSearchInterpolator createInterpolator(CliRequest cliRequest, Properties... properties) {
+    protected static StringSearchInterpolator createInterpolator(CliRequest cliRequest, Properties... properties) {
         StringSearchInterpolator interpolator = new StringSearchInterpolator();
         interpolator.addValueSource(new AbstractValueSource(false) {
             @Override

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -358,12 +358,7 @@ public class MavenCli {
         // so we rely on the JDK services to eventually lookup a custom RootLocator.
         // This is used to compute {@code session.rootDirectory} but all {@code project.rootDirectory}
         // properties will be compute through the RootLocator found in the container.
-        Path rootDirectory = searchAcceptableRootDirectory(topDirectory);
-        if (rootDirectory == null) {
-            // fail when used, otherwise remain silent
-            // System.err.println(UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE);
-        }
-        cliRequest.rootDirectory = rootDirectory;
+        cliRequest.rootDirectory = searchAcceptableRootDirectory(topDirectory);;
 
         //
         // Make sure the Maven home directory is an absolute path to save us from confusion with say drive-relative
@@ -1554,11 +1549,11 @@ public class MavenCli {
         systemProperties.setProperty("maven.build.version", mavenBuildVersion);
     }
 
-    private boolean isAcceptableRootDirectory(Path path) {
+    protected boolean isAcceptableRootDirectory(Path path) {
         return path != null && Files.isDirectory(path.resolve(".mvn"));
     }
 
-    private Path searchAcceptableRootDirectory(Path path) {
+    protected Path searchAcceptableRootDirectory(Path path) {
         if (path == null) {
             return null;
         }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -326,10 +326,10 @@ public class MavenCli {
         for (String arg : cliRequest.args) {
             if (isAltFile) {
                 // this is the argument following -f/--file
-                Path path = Paths.get(arg);
+                Path path = topDirectory.resolve(arg);
                 if (Files.isDirectory(path)) {
                     topDirectory = path;
-                } else if (Files.isRegularFile(topDirectory)) {
+                } else if (Files.isRegularFile(path)) {
                     topDirectory = path.getParent();
                     if (!Files.isDirectory(topDirectory)) {
                         System.err.println("Directory " + topDirectory
@@ -360,7 +360,8 @@ public class MavenCli {
         // properties will be compute through the RootLocator found in the container.
         Path rootDirectory = searchAcceptableRootDirectory(topDirectory);
         if (rootDirectory == null) {
-            System.err.println(UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE);
+            // fail when used, otherwise remain silent
+            // System.err.println(UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE);
         }
         cliRequest.rootDirectory = rootDirectory;
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -358,7 +358,7 @@ public class MavenCli {
         // so we rely on the JDK services to eventually lookup a custom RootLocator.
         // This is used to compute {@code session.rootDirectory} but all {@code project.rootDirectory}
         // properties will be compute through the RootLocator found in the container.
-        cliRequest.rootDirectory = searchAcceptableRootDirectory(topDirectory);;
+        cliRequest.rootDirectory = searchAcceptableRootDirectory(topDirectory);
 
         //
         // Make sure the Maven home directory is an absolute path to save us from confusion with say drive-relative

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -357,9 +357,8 @@ public class MavenCli {
         }
         cliRequest.topDirectory = topDirectory;
         // We're very early in the process and we don't have the container set up yet,
-        // so we rely on the JDK services to eventually lookup a custom RootLocator.
-        // This is used to compute {@code session.rootDirectory} but all {@code project.rootDirectory}
-        // properties will be compute through the RootLocator found in the container.
+        // so we on searchAcceptableRootDirectory method to find us acceptable directory.
+        // The method may return null if nothing acceptable found.
         cliRequest.rootDirectory = searchAcceptableRootDirectory(topDirectory);
 
         //

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -144,14 +144,16 @@ public class MavenCli {
     public static final File DEFAULT_GLOBAL_TOOLCHAINS_FILE =
             new File(System.getProperty("maven.conf"), "toolchains.xml");
 
-    private static final String UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE =
-            "Unable to find the root directory. Create a .mvn directory in the project root directory to identify it.";
-
     private static final String EXT_CLASS_PATH = "maven.ext.class.path";
 
-    private static final String EXTENSIONS_FILENAME = ".mvn/extensions.xml";
+    private static final String DOT_MVN = ".mvn";
 
-    private static final String MVN_MAVEN_CONFIG = ".mvn/maven.config";
+    private static final String UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE = "Unable to find the root directory. Create a "
+            + DOT_MVN + " directory in the project root directory to identify it.";
+
+    private static final String EXTENSIONS_FILENAME = DOT_MVN + "/extensions.xml";
+
+    private static final String MVN_MAVEN_CONFIG = DOT_MVN + "/maven.config";
 
     public static final String STYLE_COLOR_PROPERTY = "style.color";
 
@@ -1550,7 +1552,7 @@ public class MavenCli {
     }
 
     protected boolean isAcceptableRootDirectory(Path path) {
-        return path != null && Files.isDirectory(path.resolve(".mvn"));
+        return path != null && Files.isDirectory(path.resolve(DOT_MVN));
     }
 
     protected Path searchAcceptableRootDirectory(Path path) {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -352,7 +352,7 @@ public class MavenCli {
         try {
             topDirectory = topDirectory.toAbsolutePath().toRealPath();
         } catch (IOException e) {
-            System.err.println("Error computing real path from " + topDirectory);
+            System.err.println("Error computing real path from " + topDirectory + ": " + e.getMessage());
             throw new ExitException(1);
         }
         cliRequest.topDirectory = topDirectory;

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -38,7 +38,6 @@ import org.junit.function.ThrowingRunnable;
 import org.mockito.InOrder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -395,9 +394,9 @@ public class MavenCliTest {
         // Assert
         assertThat(request.getUserProperties().getProperty("valFound"), is("sbari"));
         assertThat(request.getUserProperties().getProperty("valNotFound"), is("s${foz}i"));
-        assertThat(request.getUserProperties().getProperty("valRootDirectory"), endsWith("myRootDirectory/.mvn/foo"));
-        assertThat(request.getUserProperties().getProperty("valTopDirectory"), endsWith("myTopDirectory/pom.xml"));
-        assertThat(request.getCommandLine().getOptionValue('f'), endsWith("myRootDirectory/my-child"));
+        assertThat(request.getUserProperties().getProperty("valRootDirectory"), is("myRootDirectory/.mvn/foo"));
+        assertThat(request.getUserProperties().getProperty("valTopDirectory"), is("myTopDirectory/pom.xml"));
+        assertThat(request.getCommandLine().getOptionValue('f'), is("myRootDirectory/my-child"));
         assertThat(request.getCommandLine().getArgs(), equalTo(new String[] {"prefix:3.0.0:bar", "validate"}));
     }
 

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.maven.Maven;
@@ -36,6 +37,10 @@ import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.mockito.InOrder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -362,6 +367,38 @@ public class MavenCliTest {
 
         // then
         assertEquals(MessageUtils.stripAnsiCodes(versionOut), versionOut);
+    }
+
+    @Test
+    public void testPropertiesInterpolation() throws Exception {
+        // Arrange
+        CliRequest request = new CliRequest(
+                new String[] {
+                    "-Dfoo=bar",
+                    "-DvalFound=s${foo}i",
+                    "-DvalNotFound=s${foz}i",
+                    "-DvalRootDirectory=${session.rootDirectory}/.mvn/foo",
+                    "-DvalTopDirectory=${session.topDirectory}/pom.xml",
+                    "-f",
+                    "${session.rootDirectory}/my-child",
+                    "prefix:3.0.0:${foo}",
+                    "validate"
+                },
+                null);
+        request.rootDirectory = Paths.get("myRootDirectory");
+        request.topDirectory = Paths.get("myTopDirectory");
+
+        // Act
+        cli.cli(request);
+        cli.properties(request);
+
+        // Assert
+        assertThat(request.getUserProperties().getProperty("valFound"), is("sbari"));
+        assertThat(request.getUserProperties().getProperty("valNotFound"), is("s${foz}i"));
+        assertThat(request.getUserProperties().getProperty("valRootDirectory"), endsWith("myRootDirectory/.mvn/foo"));
+        assertThat(request.getUserProperties().getProperty("valTopDirectory"), endsWith("myTopDirectory/pom.xml"));
+        assertThat(request.getCommandLine().getOptionValue('f'), endsWith("myRootDirectory/my-child"));
+        assertThat(request.getCommandLine().getArgs(), equalTo(new String[] {"prefix:3.0.0:bar", "validate"}));
     }
 
     class ConcurrencyCalculator implements ThrowingRunnable {


### PR DESCRIPTION
Reuse as much as possible from master, but keep existing stuff like multiModuleProjectDirectory alone.

Changes:
* interpolate user properties and arguments
* introduce session.topDirectory and session.rootDirectory expressions (for interpolation only)
* Maven fails to start if any of the new properties are undefined but their use is attempted
* leave everything else untouched

---

https://issues.apache.org/jira/browse/MNG-7774