### PR TITLE
[MNG-7778] - Include suppressed exceptions when logging failures

### DIFF
--- a/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
@@ -63,25 +63,36 @@ public class MavenSimpleLogger extends SimpleLogger {
         }
         stream.println();
 
-        while (t != null) {
-            for (StackTraceElement e : t.getStackTrace()) {
-                stream.print("    ");
-                stream.print(buffer().strong("at"));
-                stream.print(" " + e.getClassName() + "." + e.getMethodName());
-                stream.print(buffer().a(" (").strong(getLocation(e)).a(")"));
-                stream.println();
-            }
+        printStackTrace(t, stream, "");
+    }
 
-            t = t.getCause();
-            if (t != null) {
-                stream.print(buffer().strong("Caused by").a(": ").a(t.getClass().getName()));
-                if (t.getMessage() != null) {
-                    stream.print(": ");
-                    stream.print(buffer().failure(t.getMessage()));
-                }
-                stream.println();
-            }
+    private void printStackTrace(Throwable t, PrintStream stream, String prefix) {
+        for (StackTraceElement e : t.getStackTrace()) {
+            stream.print(prefix);
+            stream.print("    ");
+            stream.print(buffer().strong("at"));
+            stream.print(" " + e.getClassName() + "." + e.getMethodName());
+            stream.print(buffer().a(" (").strong(getLocation(e)).a(")"));
+            stream.println();
         }
+        for (Throwable se : t.getSuppressed()) {
+            writeThrowable(se, stream, "Suppressed", prefix + "    ");
+        }
+        Throwable cause = t.getCause();
+        if (cause != null) {
+            writeThrowable(cause, stream, "Caused by", prefix);
+        }
+    }
+
+    private void writeThrowable(Throwable t, PrintStream stream, String caption, String prefix) {
+        stream.print(buffer().a(prefix).strong(caption).a(": ").a(t.getClass().getName()));
+        if (t.getMessage() != null) {
+            stream.print(": ");
+            stream.print(buffer().failure(t.getMessage()));
+        }
+        stream.println();
+
+        printStackTrace(t, stream, prefix);
     }
 
     protected String getLocation(final StackTraceElement e) {

--- a/maven-slf4j-provider/src/test/java/org/slf4j/impl/MavenSimpleLoggerTest.java
+++ b/maven-slf4j-provider/src/test/java/org/slf4j/impl/MavenSimpleLoggerTest.java
@@ -1,13 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.slf4j.impl;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
@@ -18,7 +36,8 @@ class MavenSimpleLoggerTest {
     void includesCauseAndSuppressedExceptionsWhenWritingThrowables(TestInfo testInfo) throws Exception {
         Exception causeOfSuppressed = new NoSuchElementException("cause of suppressed");
         Exception suppressed = new IllegalStateException("suppressed", causeOfSuppressed);
-        suppressed.addSuppressed(new IllegalArgumentException("suppressed suppressed", new ArrayIndexOutOfBoundsException("suppressed suppressed cause")));
+        suppressed.addSuppressed(new IllegalArgumentException(
+                "suppressed suppressed", new ArrayIndexOutOfBoundsException("suppressed suppressed cause")));
         Exception cause = new IllegalArgumentException("cause");
         cause.addSuppressed(suppressed);
         Exception throwable = new RuntimeException("top-level", cause);
@@ -32,7 +51,8 @@ class MavenSimpleLoggerTest {
 
         Class<?> testClass = testInfo.getTestClass().get();
         String testMethodName = testInfo.getTestMethod().get().getName();
-        String testClassStackTraceLinePattern = "at " + testClass.getName() + "." + testMethodName + " \\(" + testClass.getSimpleName() + ".java:\\d+\\)";
+        String testClassStackTraceLinePattern = "at " + testClass.getName() + "." + testMethodName + " \\("
+                + testClass.getSimpleName() + ".java:\\d+\\)";
         List<String> expectedLines = Arrays.asList(
                 "java.lang.RuntimeException: top-level",
                 "    " + testClassStackTraceLinePattern,
@@ -51,8 +71,7 @@ class MavenSimpleLoggerTest {
                 ">> stacktrace >>",
                 "    Caused by: java.util.NoSuchElementException: cause of suppressed",
                 "        " + testClassStackTraceLinePattern,
-                ">> stacktrace >>"
-        );
+                ">> stacktrace >>");
 
         assertLinesMatch(expectedLines, actualLines);
     }

--- a/maven-slf4j-provider/src/test/java/org/slf4j/impl/MavenSimpleLoggerTest.java
+++ b/maven-slf4j-provider/src/test/java/org/slf4j/impl/MavenSimpleLoggerTest.java
@@ -1,0 +1,59 @@
+package org.slf4j.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
+class MavenSimpleLoggerTest {
+
+    @Test
+    void includesCauseAndSuppressedExceptionsWhenWritingThrowables(TestInfo testInfo) throws Exception {
+        Exception causeOfSuppressed = new NoSuchElementException("cause of suppressed");
+        Exception suppressed = new IllegalStateException("suppressed", causeOfSuppressed);
+        suppressed.addSuppressed(new IllegalArgumentException("suppressed suppressed", new ArrayIndexOutOfBoundsException("suppressed suppressed cause")));
+        Exception cause = new IllegalArgumentException("cause");
+        cause.addSuppressed(suppressed);
+        Exception throwable = new RuntimeException("top-level", cause);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        new MavenSimpleLogger("logger").writeThrowable(throwable, new PrintStream(output));
+
+        String actual = output.toString(UTF_8.name());
+        List<String> actualLines = Arrays.asList(actual.split(System.lineSeparator()));
+
+        Class<?> testClass = testInfo.getTestClass().get();
+        String testMethodName = testInfo.getTestMethod().get().getName();
+        String testClassStackTraceLinePattern = "at " + testClass.getName() + "." + testMethodName + " \\(" + testClass.getSimpleName() + ".java:\\d+\\)";
+        List<String> expectedLines = Arrays.asList(
+                "java.lang.RuntimeException: top-level",
+                "    " + testClassStackTraceLinePattern,
+                ">> stacktrace >>",
+                "Caused by: java.lang.IllegalArgumentException: cause",
+                "    " + testClassStackTraceLinePattern,
+                ">> stacktrace >>",
+                "    Suppressed: java.lang.IllegalStateException: suppressed",
+                "        " + testClassStackTraceLinePattern,
+                ">> stacktrace >>",
+                "        Suppressed: java.lang.IllegalArgumentException: suppressed suppressed",
+                "            " + testClassStackTraceLinePattern,
+                ">> stacktrace >>",
+                "        Caused by: java.lang.ArrayIndexOutOfBoundsException: suppressed suppressed cause",
+                "            " + testClassStackTraceLinePattern,
+                ">> stacktrace >>",
+                "    Caused by: java.util.NoSuchElementException: cause of suppressed",
+                "        " + testClassStackTraceLinePattern,
+                ">> stacktrace >>"
+        );
+
+        assertLinesMatch(expectedLines, actualLines);
+    }
+}


### PR DESCRIPTION
Instead of only including causes, suppressed exceptions are now included
as well. A similar indentation strategy as in
`Throwable.printStackTrace` is used.

---

https://issues.apache.org/jira/browse/MNG-7778