### PR TITLE
[MNG-7780] DefaultArtifact.equals throws NullPointerException if o.version is null

### DIFF
--- a/maven-artifact/src/main/java/org/apache/maven/artifact/DefaultArtifact.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/DefaultArtifact.java
@@ -19,11 +19,7 @@
 package org.apache.maven.artifact;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.metadata.ArtifactMetadata;
@@ -287,46 +283,25 @@ public class DefaultArtifact implements Artifact {
         return sb.toString();
     }
 
-    public int hashCode() {
-        int result = 17;
-        result = 37 * result + groupId.hashCode();
-        result = 37 * result + artifactId.hashCode();
-        result = 37 * result + type.hashCode();
-        if (version != null) {
-            result = 37 * result + version.hashCode();
-        }
-        result = 37 * result + (classifier != null ? classifier.hashCode() : 0);
-        return result;
-    }
-
+    @Override
     public boolean equals(Object o) {
-        if (o == this) {
+        if (this == o) {
             return true;
         }
-
-        if (!(o instanceof Artifact)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        DefaultArtifact that = (DefaultArtifact) o;
+        return Objects.equals(groupId, that.groupId)
+                && Objects.equals(artifactId, that.artifactId)
+                && Objects.equals(type, that.type)
+                && Objects.equals(classifier, that.classifier)
+                && Objects.equals(version, that.version);
+    }
 
-        Artifact a = (Artifact) o;
-
-        if (!a.getGroupId().equals(groupId)) {
-            return false;
-        } else if (!a.getArtifactId().equals(artifactId)) {
-            return false;
-        } else if (a.getVersion() != null && !a.getVersion().equals(version)) {
-            return false;
-        } else if (a.getVersion() == null && version != null) {
-            return false;
-        } else if (!a.getType().equals(type)) {
-            return false;
-        } else {
-            return a.getClassifier() == null
-                    ? classifier == null
-                    : a.getClassifier().equals(classifier);
-        }
-
-        // We don't consider the version range in the comparison, just the resolved version
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, type, classifier, version);
     }
 
     public String getBaseVersion() {

--- a/maven-artifact/src/main/java/org/apache/maven/artifact/DefaultArtifact.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/DefaultArtifact.java
@@ -314,7 +314,9 @@ public class DefaultArtifact implements Artifact {
             return false;
         } else if (!a.getArtifactId().equals(artifactId)) {
             return false;
-        } else if (!a.getVersion().equals(version)) {
+        } else if (a.getVersion() != null && !a.getVersion().equals(version)) {
+            return false;
+        } else if (a.getVersion() == null && version != null) {
             return false;
         } else if (!a.getType().equals(type)) {
             return false;

--- a/maven-artifact/src/test/java/org/apache/maven/artifact/DefaultArtifactTest.java
+++ b/maven-artifact/src/test/java/org/apache/maven/artifact/DefaultArtifactTest.java
@@ -140,4 +140,16 @@ class DefaultArtifactTest {
         assertNull(artifact.getVersion());
         assertNull(artifact.getBaseVersion());
     }
+
+    @Test
+    void testMNG7780() throws Exception {
+        VersionRange vr = VersionRange.createFromVersionSpec("[1.0,2.0)");
+        artifact = new DefaultArtifact(groupId, artifactId, vr, scope, type, null, artifactHandler);
+        assertNull(artifact.getVersion());
+        assertNull(artifact.getBaseVersion());
+
+        DefaultArtifact nullVersionArtifact =
+                new DefaultArtifact(groupId, artifactId, vr, scope, type, null, artifactHandler);
+        assertEquals(artifact, nullVersionArtifact);
+    }
 }


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [ ] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
