### PR TITLE
[MNG-7786] Fix plugin validation misleading message

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator.java
@@ -18,9 +18,6 @@
  */
 package org.apache.maven.plugin.internal;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -33,9 +30,6 @@ import static java.util.Objects.requireNonNull;
  * @since 3.9.2
  */
 abstract class AbstractMavenPluginDependenciesValidator implements MavenPluginDependenciesValidator {
-
-    protected final List<String> expectedProvidedScopeExclusions = Arrays.asList(
-            "org.apache.maven:maven-archiver", "org.apache.maven:maven-jxr", "org.apache.maven:plexus-utils");
 
     protected final PluginValidationManager pluginValidationManager;
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
@@ -118,6 +120,23 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                                 "Plugin depends on the deprecated Maven 2.x compatibility layer, which may not be supported in Maven 4.x");
                     }
                 }
+
+                Set<String> mavenArtifacts = result.getDependencies().stream()
+                        .filter(d -> !JavaScopes.PROVIDED.equals(d.getScope()))
+                        .map(org.eclipse.aether.graph.Dependency::getArtifact)
+                        .filter(a -> "org.apache.maven".equals(a.getGroupId()))
+                        .filter(a -> !MavenPluginDependenciesValidator.EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA.contains(a.getGroupId() + ":" + a.getArtifactId()))
+                        .filter(a -> a.getVersion().startsWith("3."))
+                        .map(a -> a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion())
+                        .collect(Collectors.toSet());
+
+                if (!mavenArtifacts.isEmpty()) {
+                    pluginValidationManager.reportPluginValidationIssue(
+                            session,
+                            pluginArtifact,
+                            "Plugin should declare these Maven artifacts in `provided` scope: " + mavenArtifacts);
+                }
+
             }
 
             pluginArtifact = result.getArtifact();

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -23,9 +23,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
@@ -125,7 +125,8 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                         .filter(d -> !JavaScopes.PROVIDED.equals(d.getScope()))
                         .map(org.eclipse.aether.graph.Dependency::getArtifact)
                         .filter(a -> "org.apache.maven".equals(a.getGroupId()))
-                        .filter(a -> !MavenPluginDependenciesValidator.EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA.contains(a.getGroupId() + ":" + a.getArtifactId()))
+                        .filter(a -> !MavenPluginDependenciesValidator.EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA.contains(
+                                a.getGroupId() + ":" + a.getArtifactId()))
                         .filter(a -> a.getVersion().startsWith("3."))
                         .map(a -> a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion())
                         .collect(Collectors.toSet());
@@ -136,7 +137,6 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                             pluginArtifact,
                             "Plugin should declare these Maven artifacts in `provided` scope: " + mavenArtifacts);
                 }
-
             }
 
             pluginArtifact = result.getArtifact();

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
@@ -48,7 +48,7 @@ class Maven2DependenciesValidator extends AbstractMavenPluginDependenciesValidat
     protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
         Set<String> maven2Versions = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
                 .filter(d -> "org.apache.maven".equals(d.getGroupId()))
-                .filter(d -> !expectedProvidedScopeExclusions.contains(d.getGroupId() + ":" + d.getArtifactId()))
+                .filter(d -> !EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA.contains(d.getGroupId() + ":" + d.getArtifactId()))
                 .map(ComponentDependency::getVersion)
                 .filter(v -> v.startsWith("2."))
                 .collect(Collectors.toSet());

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
@@ -48,7 +48,7 @@ class MavenMixedDependenciesValidator extends AbstractMavenPluginDependenciesVal
     protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
         Set<String> mavenVersions = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
                 .filter(d -> "org.apache.maven".equals(d.getGroupId()))
-                .filter(d -> !expectedProvidedScopeExclusions.contains(d.getGroupId() + ":" + d.getArtifactId()))
+                .filter(d -> !EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA.contains(d.getGroupId() + ":" + d.getArtifactId()))
                 .map(ComponentDependency::getVersion)
                 .collect(Collectors.toSet());
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.plugin.internal;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
@@ -27,6 +31,14 @@ import org.apache.maven.plugin.descriptor.MojoDescriptor;
  * @since 3.9.2
  */
 interface MavenPluginDependenciesValidator {
+
+    /**
+     * The collection of "G:A" combinations that do NOT belong to Maven Core, hence, should be excluded from
+     * "expected in provided scope" type of checks.
+     */
+    Collection<String> EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA = Collections.unmodifiableCollection(Arrays.asList(
+            "org.apache.maven:maven-archiver", "org.apache.maven:maven-jxr", "org.apache.maven:plexus-utils"));
+
     /**
      * Checks mojo dependency issues.
      */

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDependenciesValidator.java
@@ -35,6 +35,8 @@ interface MavenPluginDependenciesValidator {
     /**
      * The collection of "G:A" combinations that do NOT belong to Maven Core, hence, should be excluded from
      * "expected in provided scope" type of checks.
+     *
+     * @since 3.9.3
      */
     Collection<String> EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA = Collections.unmodifiableCollection(Arrays.asList(
             "org.apache.maven:maven-archiver", "org.apache.maven:maven-jxr", "org.apache.maven:plexus-utils"));

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDescriptorDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDescriptorDependenciesValidator.java
@@ -30,16 +30,26 @@ import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
 /**
- * Detects presence of Maven3 artifacts in plugin descriptor.
+ * Detects presence of unwanted Maven3 artifacts in plugin descriptor (for multitude reasons, among them is
+ * "wrong scope" dependency declaration as well).
+ * <p>
+ * Historically this class was named as "MavenScopeDependenciesValidator" due original intent to check "wrong Maven
+ * Artifact scopes", but since then it turned out that the value set (the plugin descriptor dependencies), that is
+ * built ot plugin build time, and affected by built time used maven-plugin-plugin version is potentially not inline
+ * with "reality" (actual plugin dependencies).
+ * <p>
+ * The original intent related check is moved to
+ * {@link DefaultPluginDependenciesResolver#resolve(org.apache.maven.model.Plugin, java.util.List, org.eclipse.aether.RepositorySystemSession)}
+ * method instead.
  *
  * @since 3.9.2
  */
 @Singleton
 @Named
-class MavenScopeDependenciesValidator extends AbstractMavenPluginDependenciesValidator {
+class MavenPluginDescriptorDependenciesValidator extends AbstractMavenPluginDependenciesValidator {
 
     @Inject
-    MavenScopeDependenciesValidator(PluginValidationManager pluginValidationManager) {
+    MavenPluginDescriptorDependenciesValidator(PluginValidationManager pluginValidationManager) {
         super(pluginValidationManager);
     }
 

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDescriptorDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDescriptorDependenciesValidator.java
@@ -30,19 +30,19 @@ import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
 /**
- * Detects presence of unwanted Maven3 artifacts in plugin descriptor, possibly caused by multitude reasons, among
+ * Detects presence of unwanted Maven3 artifacts in plugin descriptor, possibly caused by multitude of reasons, among
  * them is "wrong scope" dependency declaration as well.
  * <p>
- * Historically this class was named as "MavenScopeDependenciesValidator" due original intent to check "wrong Maven
- * Artifact scopes", but since then it turned out that the value set (the plugin descriptor dependencies), that is
- * built ot plugin build time, and affected by built time used maven-plugin-plugin version is potentially not inline
- * with "reality" (actual plugin dependencies).
+ * Historically, this class was named as "MavenScopeDependenciesValidator" due original intent to check "wrong Maven
+ * Artifact scopes". Since then, it turned out that the values validated (the plugin descriptor dependencies, that is
+ * produced at plugin build time by maven-plugin-plugin) may be off (for example due maven-plugin-plugin bug), and
+ * is potentially not inline with "reality" (actual plugin dependencies).
  * <p>
  * The original intent related check is moved to
  * {@link DefaultPluginDependenciesResolver#resolve(org.apache.maven.model.Plugin, java.util.List, org.eclipse.aether.RepositorySystemSession)}
  * method instead.
  *
- * @since 3.9.2
+ * @since 3.9.3
  */
 @Singleton
 @Named

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDescriptorDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenPluginDescriptorDependenciesValidator.java
@@ -30,8 +30,8 @@ import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
 /**
- * Detects presence of unwanted Maven3 artifacts in plugin descriptor (for multitude reasons, among them is
- * "wrong scope" dependency declaration as well).
+ * Detects presence of unwanted Maven3 artifacts in plugin descriptor, possibly caused by multitude reasons, among
+ * them is "wrong scope" dependency declaration as well.
  * <p>
  * Historically this class was named as "MavenScopeDependenciesValidator" due original intent to check "wrong Maven
  * Artifact scopes", but since then it turned out that the value set (the plugin descriptor dependencies), that is

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
@@ -30,7 +30,7 @@ import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 
 /**
- * Detects Maven3 artifacts in bad scope in plugins.
+ * Detects presence of Maven3 artifacts in plugin descriptor.
  *
  * @since 3.9.2
  */
@@ -47,7 +47,7 @@ class MavenScopeDependenciesValidator extends AbstractMavenPluginDependenciesVal
     protected void doValidate(MavenSession mavenSession, MojoDescriptor mojoDescriptor) {
         Set<String> mavenArtifacts = mojoDescriptor.getPluginDescriptor().getDependencies().stream()
                 .filter(d -> "org.apache.maven".equals(d.getGroupId()))
-                .filter(d -> !expectedProvidedScopeExclusions.contains(d.getGroupId() + ":" + d.getArtifactId()))
+                .filter(d -> !EXPECTED_PROVIDED_SCOPE_EXCLUSIONS_GA.contains(d.getGroupId() + ":" + d.getArtifactId()))
                 .filter(d -> d.getVersion().startsWith("3."))
                 .map(d -> d.getGroupId() + ":" + d.getArtifactId() + ":" + d.getVersion())
                 .collect(Collectors.toSet());
@@ -56,7 +56,7 @@ class MavenScopeDependenciesValidator extends AbstractMavenPluginDependenciesVal
             pluginValidationManager.reportPluginValidationIssue(
                     mavenSession,
                     mojoDescriptor,
-                    "Plugin should declare these Maven artifacts in `provided` scope: " + mavenArtifacts);
+                    "Plugin descriptor should not contain these Maven artifacts: " + mavenArtifacts);
         }
     }
 }


### PR DESCRIPTION
Reword the validation warning and add new check for real plugin dependencies in wrong scopes (do not rely on build-time derived descriptor, but on real data instead).

---

https://issues.apache.org/jira/browse/MNG-7786
