### PR TITLE
[MNG-7792] Use a standalone asm version

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -99,7 +99,6 @@ under the License.
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.5</version>
     </dependency>
   </dependencies>
 

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -96,6 +96,11 @@ under the License.
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.5</version>
+    </dependency>
   </dependencies>
 
   <pluginRepositories>

--- a/apache-maven/src/main/appended-resources/licenses/unrecognized-asm-9.5.txt
+++ b/apache-maven/src/main/appended-resources/licenses/unrecognized-asm-9.5.txt
@@ -1,0 +1,27 @@
+ASM: a very small and fast Java bytecode manipulation framework
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holders nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -106,10 +106,12 @@ under the License.
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
+      <classifier>no_asm</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -79,6 +79,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <exclusions>
         <!-- MNG-7068 Active dependency management for Google Guice / Google Guava. Excludes of Guava are managed in parent POM -->
         <exclusion>

--- a/maven-model-builder/pom.xml
+++ b/maven-model-builder/pom.xml
@@ -69,6 +69,7 @@ under the License.
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
+      <classifier>no_asm</classifier>
     </dependency>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
@@ -78,6 +79,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-resolver-provider/pom.xml
+++ b/maven-resolver-provider/pom.xml
@@ -93,6 +93,10 @@ under the License.
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <optional>true</optional>

--- a/maven-resolver-provider/pom.xml
+++ b/maven-resolver-provider/pom.xml
@@ -79,6 +79,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <optional>true</optional>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@ under the License.
     <jxpathVersion>1.3</jxpathVersion>
     <resolverVersion>1.9.14</resolverVersion>
     <sisuVersion>0.9.0.M2</sisuVersion>
+    <asmVersion>9.5</asmVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.6.4</xmlunitVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
@@ -285,6 +286,11 @@ under the License.
         <artifactId>org.eclipse.sisu.inject</artifactId>
         <version>${sisuVersion}</version>
         <classifier>no_asm</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${asmVersion}</version>
       </dependency>
       <dependency>
         <groupId>javax.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@ under the License.
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guiceVersion}</version>
+        <classifier>classes</classifier>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -272,12 +273,18 @@ under the License.
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
           </exclusion>
+          <!-- we use the no_asm classifier for sisu.inject -->
+          <exclusion>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.inject</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.inject</artifactId>
         <version>${sisuVersion}</version>
+        <classifier>no_asm</classifier>
       </dependency>
       <dependency>
         <groupId>javax.inject</groupId>


### PR DESCRIPTION
- [MNG-7587] Upgrade to sisu 0.9.0.M2
- Use a non shaded version of asm in guice and sisu
- Fix missing asm for maven-resolver-provider
- IT PR: https://github.com/apache/maven-integration-testing/pull/290

I've extracted the use of a standalone ASM version as JDK 17 support is already covered by the upgrade to 0.9.0.M2.
To support JDK >= 19, we need ASM 9.5 and we thus need to use a standalone version of ASM and upgrade it.

This is a follow-up to https://github.com/apache/maven/pull/1119