### PR TITLE
Automatic discovery of JDK Toolchains

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Toolchain.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Toolchain.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.api;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.apache.maven.api.annotations.Experimental;
@@ -42,7 +43,7 @@ public interface Toolchain {
      * @param toolName the tool platform independent tool name
      * @return file representing the tool executable, or null if the tool cannot be found
      */
-    String findTool(String toolName);
+    Path findTool(String toolName);
 
     /**
      * Let the toolchain decide if it matches requirements defined

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainManager.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainManager.java
@@ -37,6 +37,11 @@ import org.apache.maven.api.annotations.Nonnull;
 public interface ToolchainManager extends Service {
 
     /**
+     * The type identifying JDK toolchains
+     */
+    String TYPE_JDK = "jdk";
+
+    /**
      *
      * @param session
      * @param type

--- a/api/maven-api-toolchain/src/main/mdo/toolchains.mdo
+++ b/api/maven-api-toolchain/src/main/mdo/toolchains.mdo
@@ -61,6 +61,7 @@
                 <![CDATA[
         public static final String USER_LEVEL = "user-level";
         public static final String GLOBAL_LEVEL = "global-level";
+        public static final String DISCOVERED_LEVEL = "discovered-level";
 
         private String sourceLevel = USER_LEVEL;
         private boolean sourceLevelSet = false;
@@ -71,9 +72,10 @@
             {
                 throw new IllegalStateException( "Cannot reset sourceLevel attribute; it is already set to: " + sourceLevel );
             }
-            else if ( !( USER_LEVEL.equals( sourceLevel ) || GLOBAL_LEVEL.equals( sourceLevel ) ) )
+            else if ( !( USER_LEVEL.equals( sourceLevel ) || GLOBAL_LEVEL.equals( sourceLevel )
+                        || DISCOVERED_LEVEL.equals( sourceLevel ) ) )
             {
-                throw new IllegalArgumentException( "sourceLevel must be one of: {" + USER_LEVEL + "," + GLOBAL_LEVEL + "}" );
+                throw new IllegalArgumentException( "sourceLevel must be one of: {" + USER_LEVEL + "," + GLOBAL_LEVEL + "," + DISCOVERED_LEVEL + "}" );
             }
             else
             {

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulator.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulator.java
@@ -23,11 +23,9 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -60,17 +58,8 @@ public class DefaultMavenExecutionRequestPopulator implements MavenExecutionRequ
     public MavenExecutionRequest populateFromToolchains(MavenExecutionRequest request, PersistedToolchains toolchains)
             throws MavenExecutionRequestPopulationException {
         if (toolchains != null) {
-            Map<String, List<ToolchainModel>> groupedToolchains = new HashMap<>(2);
-
-            for (ToolchainModel model : toolchains.getToolchains()) {
-                if (!groupedToolchains.containsKey(model.getType())) {
-                    groupedToolchains.put(model.getType(), new ArrayList<>());
-                }
-
-                groupedToolchains.get(model.getType()).add(model);
-            }
-
-            request.setToolchains(groupedToolchains);
+            request.setToolchains(
+                    toolchains.getToolchains().stream().collect(Collectors.groupingBy(ToolchainModel::getType)));
         }
         return request;
     }

--- a/maven-core/src/main/java/org/apache/maven/toolchain/DefaultToolchain.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/DefaultToolchain.java
@@ -83,18 +83,20 @@ implements Toolchain, ToolchainPrivate {
 
     @Override
     public boolean matchesRequirements(Map<String, String> requirements) {
-        for (Map.Entry<String, String> requirement : requirements.entrySet()) {
-            String key = requirement.getKey();
+        if (requirements != null) {
+            for (Map.Entry<String, String> requirement : requirements.entrySet()) {
+                String key = requirement.getKey();
 
-            RequirementMatcher matcher = provides.get(key);
+                RequirementMatcher matcher = provides.get(key);
 
-            if (matcher == null) {
-                getLog().debug("Toolchain " + this + " is missing required property: " + key);
-                return false;
-            }
-            if (!matcher.matches(requirement.getValue())) {
-                getLog().debug("Toolchain " + this + " doesn't match required property: " + key);
-                return false;
+                if (matcher == null) {
+                    getLog().debug("Toolchain " + this + " is missing required property: " + key);
+                    return false;
+                }
+                if (!matcher.matches(requirement.getValue())) {
+                    getLog().debug("Toolchain " + this + " doesn't match required property: " + key);
+                    return false;
+                }
             }
         }
         return true;

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -91,6 +91,7 @@ import org.apache.maven.shared.utils.logging.MessageBuilder;
 import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.apache.maven.toolchain.building.DefaultToolchainsBuildingRequest;
 import org.apache.maven.toolchain.building.ToolchainsBuilder;
+import org.apache.maven.toolchain.building.ToolchainsBuildingRequest;
 import org.apache.maven.toolchain.building.ToolchainsBuildingResult;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.DefaultContainerConfiguration;
@@ -132,6 +133,8 @@ public class MavenCli {
     public static final String LOCAL_REPO_PROPERTY = "maven.repo.local";
 
     public static final String MULTIMODULE_PROJECT_DIRECTORY = "maven.multiModuleProjectDirectory";
+
+    public static final String TOOLCHAINS_DISCOVERY_MODE = "maven.toolchainsDiscoveryMode";
 
     public static final String USER_HOME = System.getProperty("user.home");
 
@@ -1198,6 +1201,14 @@ public class MavenCli {
         if (userToolchainsFile.isFile()) {
             toolchainsRequest.setUserToolchainsSource(new FileSource(userToolchainsFile));
         }
+        String discoveryModeStr = cliRequest.getUserProperties().getProperty(TOOLCHAINS_DISCOVERY_MODE);
+        if (discoveryModeStr == null) {
+            discoveryModeStr = cliRequest.getSystemProperties().getProperty(TOOLCHAINS_DISCOVERY_MODE);
+        }
+        if (discoveryModeStr == null) {
+            discoveryModeStr = ToolchainsBuildingRequest.DiscoveryMode.IfNoneConfigured.toString();
+        }
+        toolchainsRequest.setDiscoveryMode(ToolchainsBuildingRequest.DiscoveryMode.valueOf(discoveryModeStr));
 
         eventSpyDispatcher.onEvent(toolchainsRequest);
 

--- a/maven-toolchain-builder/pom.xml
+++ b/maven-toolchain-builder/pom.xml
@@ -60,6 +60,11 @@ under the License.
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/maven-toolchain-builder/pom.xml
+++ b/maven-toolchain-builder/pom.xml
@@ -52,6 +52,10 @@ under the License.
       <artifactId>plexus-interpolation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/building/DefaultToolchainsBuildingRequest.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/building/DefaultToolchainsBuildingRequest.java
@@ -31,6 +31,8 @@ public class DefaultToolchainsBuildingRequest implements ToolchainsBuildingReque
 
     private Source userToolchainsSource;
 
+    private DiscoveryMode discoveryMode = DiscoveryMode.IfNoneConfigured;
+
     @Override
     public Source getGlobalToolchainsSource() {
         return globalToolchainsSource;
@@ -50,6 +52,17 @@ public class DefaultToolchainsBuildingRequest implements ToolchainsBuildingReque
     @Override
     public ToolchainsBuildingRequest setUserToolchainsSource(Source userToolchainsSource) {
         this.userToolchainsSource = userToolchainsSource;
+        return this;
+    }
+
+    @Override
+    public DiscoveryMode getDiscoveryMode() {
+        return discoveryMode;
+    }
+
+    @Override
+    public ToolchainsBuildingRequest setDiscoveryMode(DiscoveryMode discoveryMode) {
+        this.discoveryMode = discoveryMode;
         return this;
     }
 }

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/building/ToolchainsBuildingRequest.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/building/ToolchainsBuildingRequest.java
@@ -28,6 +28,16 @@ import org.apache.maven.building.Source;
  */
 public interface ToolchainsBuildingRequest {
 
+    /** Toolchains discovery mode */
+    enum DiscoveryMode {
+        /** Always add discovered toolchains */
+        Always,
+        /** Discover toolchains if none are configured */
+        IfNoneConfigured,
+        /** Never discover toolchains */
+        Never
+    }
+
     /**
      * Gets the global toolchains source.
      *
@@ -59,4 +69,8 @@ public interface ToolchainsBuildingRequest {
      * @return This request, never {@code null}.
      */
     ToolchainsBuildingRequest setUserToolchainsSource(Source userToolchainsSource);
+
+    DiscoveryMode getDiscoveryMode();
+
+    ToolchainsBuildingRequest setDiscoveryMode(DiscoveryMode discoveryMode);
 }

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/DefaultToolchainDiscoverer.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/DefaultToolchainDiscoverer.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.toolchain.discovery;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.api.toolchain.ToolchainModel;
+import org.apache.maven.internal.xml.XmlNodeImpl;
+import org.apache.maven.toolchain.model.PersistedToolchains;
+
+/**
+ * Implementation of ToolchainDiscoverer service
+ */
+@Named
+@Singleton
+public class DefaultToolchainDiscoverer implements ToolchainDiscoverer {
+
+    @Override
+    public PersistedToolchains discoverToolchains() {
+        try {
+            Set<String> jdks = JavaHomeFinder.suggestHomePaths(true);
+            List<ToolchainModel> tcs = new ArrayList<>();
+            for (Path jdk : jdks.stream().map(Paths::get).collect(Collectors.toList())) {
+                ToolchainModel tc = getToolchainModel(jdk);
+                if (tc != null) {
+                    tcs.add(tc);
+                }
+            }
+            tcs.sort(getToolchainModelComparator());
+            return new PersistedToolchains(org.apache.maven.api.toolchain.PersistedToolchains.newBuilder()
+                    .toolchains(tcs)
+                    .build());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    ToolchainModel getToolchainModel(Path jdk) throws IOException, InterruptedException {
+        Path bin = jdk.resolve("bin");
+        Path java = bin.resolve("java");
+        if (!Files.isRegularFile(java)) {
+            java = bin.resolve("java.exe");
+            if (!Files.isRegularFile(java)) {
+                System.err.println("Unable to find java executable for " + jdk);
+                return null;
+            }
+        }
+        Path temp = Files.createTempFile("jdk-opts-", ".out");
+        new ProcessBuilder()
+                .command(java.toString(), "-XshowSettings:properties", "-version")
+                .redirectError(temp.toFile())
+                .start()
+                .waitFor();
+        List<String> lines = Files.readAllLines(temp);
+        Files.delete(temp);
+        String jdkHome = lines.stream()
+                .filter(l -> l.contains("java.home"))
+                .map(l -> l.replaceFirst(".*=\\s*(.*)", "$1"))
+                .findFirst()
+                .get();
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        for (String name : Arrays.asList(
+                "java.version", "java.runtime.name", "java.runtime.version", "java.vendor", "java.vendor.version")) {
+            String v = lines.stream()
+                    .filter(l -> l.contains(name))
+                    .map(l -> l.replaceFirst(".*=\\s*(.*)", "$1"))
+                    .findFirst()
+                    .orElse(null);
+            String k = name.substring(5);
+            if (v != null) {
+                properties.put(k, v);
+            }
+        }
+        return ToolchainModel.newBuilder()
+                .type("jdk")
+                .provides(properties)
+                .configuration(new XmlNodeImpl(
+                        "configuration",
+                        null,
+                        null,
+                        Collections.singletonList(new XmlNodeImpl("jdkHome", jdkHome)),
+                        null))
+                .build();
+    }
+
+    Comparator<ToolchainModel> getToolchainModelComparator() {
+        return Comparator.comparing((ToolchainModel tc) -> tc.getProvides().get("vendor"))
+                .thenComparing(tc -> tc.getProvides().get("version"), this::compareVersion);
+    }
+
+    int compareVersion(String v1, String v2) {
+        String[] s1 = v1.split("\\.");
+        String[] s2 = v2.split("\\.");
+        return compare(s1, s2);
+    }
+
+    static <T extends Comparable<? super T>> int compare(T[] a, T[] b) {
+        int length = Math.min(a.length, b.length);
+        for (int i = 0; i < length; i++) {
+            T oa = a[i];
+            T ob = b[i];
+            if (oa != ob) {
+                // A null element is less than a non-null element
+                if (oa == null || ob == null) {
+                    return oa == null ? -1 : 1;
+                }
+                int v = oa.compareTo(ob);
+                if (v != 0) {
+                    return v;
+                }
+            }
+        }
+        return a.length - b.length;
+    }
+}

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/DefaultToolchainDiscoverer.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/DefaultToolchainDiscoverer.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultToolchainDiscoverer implements ToolchainDiscoverer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultToolchainDiscoverer.class);
+    private static final String DISCOVERED_TOOLCHAINS_CACHE_XML = ".m2/discovered-toolchains-cache.xml";
 
     private Map<Path, ToolchainModel> cache;
     private boolean cacheModified;
@@ -92,10 +93,9 @@ public class DefaultToolchainDiscoverer implements ToolchainDiscoverer {
     }
 
     private void readCache() {
-        cache = new ConcurrentHashMap<>();
-        Path cacheFile =
-                Paths.get(System.getProperty("user.home")).resolve(".m2").resolve("toolchains-cache.xml");
         try {
+            cache = new ConcurrentHashMap<>();
+            Path cacheFile = getCacheFile();
             if (Files.isRegularFile(cacheFile)) {
                 try (Reader r = Files.newBufferedReader(cacheFile)) {
                     PersistedToolchains pt = new PersistedToolchains(new MavenToolchainsXpp3Reader().read(r, false));
@@ -109,8 +109,8 @@ public class DefaultToolchainDiscoverer implements ToolchainDiscoverer {
     }
 
     private void writeCache() {
-        Path cacheFile = Paths.get(System.getProperty("user.home")).resolve(".m2/toolchains-cache.xml");
         try {
+            Path cacheFile = getCacheFile();
             Files.createDirectories(cacheFile.getParent());
             try (Writer w = Files.newBufferedWriter(cacheFile)) {
                 PersistedToolchains pt = new PersistedToolchains();
@@ -126,6 +126,10 @@ public class DefaultToolchainDiscoverer implements ToolchainDiscoverer {
         } catch (IOException e) {
             LOGGER.warn("Error writing toolchains cache: " + e);
         }
+    }
+
+    private static Path getCacheFile() {
+        return Paths.get(System.getProperty("user.home")).resolve(DISCOVERED_TOOLCHAINS_CACHE_XML);
     }
 
     private Path getJdkHome(ToolchainModel toolchain) {

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinder.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinder.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.toolchain.discovery;
+
+import java.util.Set;
+
+import org.codehaus.plexus.util.Os;
+
+public abstract class JavaHomeFinder {
+
+    static final boolean IS_WINDOWS = Os.isFamily(Os.FAMILY_WINDOWS);
+    static final boolean IS_MAC = Os.isFamily(Os.FAMILY_MAC);
+    static final boolean IS_LINUX = Os.OS_NAME.startsWith("linux");
+    static final boolean IS_SUNOS = Os.OS_NAME.startsWith("sunos");
+
+    /**
+     * Tries to find existing Java SDKs on this computer.
+     * If no JDK found, returns possible directories to start file chooser.
+     * @return suggested sdk home paths (sorted)
+     */
+    public static Set<String> suggestHomePaths() {
+        return suggestHomePaths(false);
+    }
+
+    /**
+     * Do the same as {@link #suggestHomePaths()} but always considers the embedded JRE,
+     * for using in tests that are performed when the registry is not properly initialized
+     * or that need the embedded JetBrains Runtime.
+     */
+    public static Set<String> suggestHomePaths(boolean forceEmbeddedJava) {
+        JavaHomeFinderBasic javaFinder = getFinder().checkEmbeddedJava(forceEmbeddedJava);
+        return javaFinder.findExistingJdks();
+    }
+
+    public static JavaHomeFinderBasic getFinder() {
+        if (IS_WINDOWS) {
+            return new JavaHomeFinderWindows(true);
+        }
+        if (IS_MAC) {
+            return new JavaHomeFinderMac();
+        }
+        if (IS_LINUX) {
+            return new JavaHomeFinderBasic().checkSpecifiedPaths(DEFAULT_JAVA_LINUX_PATHS);
+        }
+        if (IS_SUNOS) {
+            return new JavaHomeFinderBasic().checkSpecifiedPaths("/usr/jdk");
+        }
+        return new JavaHomeFinderBasic();
+    }
+
+    public static final String[] DEFAULT_JAVA_LINUX_PATHS = {"/usr/java", "/opt/java", "/usr/lib/jvm"};
+}

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinderBasic.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinderBasic.java
@@ -1,0 +1,410 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.toolchain.discovery;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JavaHomeFinderBasic {
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private final List<Supplier<? extends Set<String>>> myFinders = new ArrayList<>();
+
+    private boolean myCheckEmbeddedJava = false;
+
+    private String[] mySpecifiedPaths = new String[0];
+
+    public JavaHomeFinderBasic() {
+        myFinders.add(this::findInPATH);
+        myFinders.add(this::findInJavaHome);
+        myFinders.add(this::findInSpecifiedPaths);
+        myFinders.add(this::findJavaInstalledBySdkMan);
+        myFinders.add(this::findJavaInstalledByAsdfJava);
+        myFinders.add(this::findJavaInstalledByGradle);
+
+        myFinders.add(() -> myCheckEmbeddedJava ? scanAll(getJavaHome(), false) : Collections.emptySet());
+    }
+
+    static String execCommand(String command) throws IOException, InterruptedException {
+        Process process = Runtime.getRuntime().exec(command);
+        try (InputStream is = process.getInputStream();
+                ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[128];
+            for (int length = is.read(buffer); length > 0; length = is.read(buffer)) {
+                os.write(buffer, 0, length);
+            }
+            return new String(os.toByteArray(), StandardCharsets.UTF_8);
+        } finally {
+            process.waitFor();
+        }
+    }
+
+    public JavaHomeFinderBasic checkEmbeddedJava(boolean value) {
+        myCheckEmbeddedJava = value;
+        return this;
+    }
+
+    public JavaHomeFinderBasic checkSpecifiedPaths(String... paths) {
+        mySpecifiedPaths = paths;
+        return this;
+    }
+
+    private Set<String> findInSpecifiedPaths() {
+        List<Path> paths = Stream.of(mySpecifiedPaths).map(Paths::get).collect(Collectors.toList());
+        return scanAll(paths, true);
+    }
+
+    protected void registerFinder(Supplier<? extends Set<String>> finder) {
+        myFinders.add(finder);
+    }
+
+    public final Set<String> findExistingJdks() {
+        Set<String> result = new TreeSet<>();
+
+        for (Supplier<? extends Set<String>> action : myFinders) {
+            try {
+                result.addAll(action.get());
+            } catch (Exception e) {
+                log.warn("Failed to find Java Home. " + e.getMessage(), e);
+            }
+        }
+
+        return result;
+    }
+
+    private Set<String> findInJavaHome() {
+        String javaHome = getEnvironmentVariable("JAVA_HOME");
+        return javaHome != null ? scanAll(Paths.get(javaHome), false) : Collections.emptySet();
+    }
+
+    private Set<String> findInPATH() {
+        try {
+            String pathVarString = getEnvironmentVariable("PATH");
+            if (pathVarString == null || pathVarString.isEmpty()) {
+                return Collections.emptySet();
+            }
+
+            Set<Path> dirsToCheck = new HashSet<>();
+            for (String p : pathVarString.split(File.pathSeparator)) {
+                Path dir = Paths.get(p);
+                String fileName = dir.getFileName().toString();
+                if (!JavaHomeFinder.IS_WINDOWS && !JavaHomeFinder.IS_MAC) {
+                    fileName = fileName.toLowerCase(Locale.ROOT);
+                }
+                if (!"bin".equals(fileName)) {
+                    continue;
+                }
+
+                Path parentFile = dir.getParent();
+                if (parentFile == null) {
+                    continue;
+                }
+
+                dirsToCheck.addAll(listPossibleJdkInstallRootsFromHomes(parentFile));
+            }
+
+            return scanAll(dirsToCheck, false);
+        } catch (Exception e) {
+            log.warn("Failed to scan PATH for JDKs. " + e.getMessage(), e);
+            return Collections.emptySet();
+        }
+    }
+
+    protected Set<String> scanAll(Path file, boolean includeNestDirs) {
+        if (file == null) {
+            return Collections.emptySet();
+        }
+        return scanAll(Collections.singleton(file), includeNestDirs);
+    }
+
+    protected Set<String> scanAll(Collection<? extends Path> files, boolean includeNestDirs) {
+        Set<String> result = new HashSet<>();
+        for (Path root : new HashSet<>(files)) {
+            scanFolder(root, includeNestDirs, result);
+        }
+        return result;
+    }
+
+    protected void scanFolder(Path folder, boolean includeNestDirs, Collection<? super String> result) {
+        if (checkForJdk(folder)) {
+            result.add(folder.toAbsolutePath().toString());
+            return;
+        }
+
+        if (!includeNestDirs) {
+            return;
+        }
+        try (Stream<Path> files = Files.list(folder)) {
+            files.forEach(candidate -> {
+                for (Path adjusted : listPossibleJdkHomesFromInstallRoot(candidate)) {
+                    scanFolder(adjusted, false, result);
+                }
+            });
+        } catch (IOException ignore) {
+        }
+    }
+
+    protected List<Path> listPossibleJdkHomesFromInstallRoot(Path path) {
+        return Collections.singletonList(path);
+    }
+
+    protected List<Path> listPossibleJdkInstallRootsFromHomes(Path file) {
+        return Collections.singletonList(file);
+    }
+
+    private static Path getJavaHome() {
+        Path javaHome = Paths.get(System.getProperty("java.home"));
+        return Files.isDirectory(javaHome) ? javaHome : null;
+    }
+
+    /**
+     * Finds Java home directories installed by <a href="https://github.com/sdkman">SDKMAN</a>
+     */
+    private Set<String> findJavaInstalledBySdkMan() {
+        try {
+            Path candidatesDir = findSdkManCandidatesDir();
+            if (candidatesDir == null) {
+                return Collections.emptySet();
+            }
+            Path javasDir = candidatesDir.resolve("java");
+            if (!Files.isDirectory(javasDir)) {
+                return Collections.emptySet();
+            }
+            return listJavaHomeDirsInstalledBySdkMan(javasDir);
+        } catch (Exception e) {
+            log.warn(
+                    "Unexpected exception while looking for Sdkman directory: "
+                            + e.getClass().getSimpleName() + ": " + e.getMessage(),
+                    e);
+            return Collections.emptySet();
+        }
+    }
+
+    private Set<String> findJavaInstalledByGradle() {
+        Path jdks = getPathInUserHome(".gradle/jdks");
+        return jdks != null && Files.isDirectory(jdks) ? scanAll(jdks, true) : Collections.emptySet();
+    }
+
+    private Path findSdkManCandidatesDir() {
+        // first, try the special environment variable
+        String candidatesPath = getEnvironmentVariable("SDKMAN_CANDIDATES_DIR");
+        if (candidatesPath != null) {
+            Path candidatesDir = Paths.get(candidatesPath);
+            if (Files.isDirectory(candidatesDir)) {
+                return candidatesDir;
+            }
+        }
+
+        // then, try to use its 'primary' variable
+        String primaryPath = getEnvironmentVariable("SDKMAN_DIR");
+        if (primaryPath != null) {
+            Path candidatesDir = Paths.get(primaryPath, "candidates");
+            if (Files.isDirectory(candidatesDir)) {
+                return candidatesDir;
+            }
+        }
+
+        // finally, try the usual location in UNIX
+        if (!(this instanceof JavaHomeFinderWindows)) {
+            Path candidates = getPathInUserHome(".sdkman/candidates");
+            if (candidates != null && Files.isDirectory(candidates)) {
+                return candidates;
+            }
+        }
+
+        // no chances
+        return null;
+    }
+
+    protected String getEnvironmentVariable(String name) {
+        // TODO:
+        // https://github.com/JetBrains/intellij-community/blob/cc98eb4ac9cdc9bff55384f1c880d0d82e8b05fd/platform/util/src/com/intellij/util/EnvironmentUtil.java#L72C4-L81
+        return System.getenv(name);
+    }
+
+    protected Path getPathInUserHome(String relativePath) {
+        Path userHome = Paths.get(System.getProperty("user.home"));
+        return userHome.resolve(relativePath);
+    }
+
+    private Set<String> listJavaHomeDirsInstalledBySdkMan(Path javasDir) {
+        boolean mac = this instanceof JavaHomeFinderMac;
+        HashSet<String> result = new HashSet<>();
+
+        try (Stream<Path> stream = Files.list(javasDir)) {
+            List<Path> innerDirectories = stream.filter(Files::isDirectory).collect(Collectors.toList());
+            for (Path innerDir : innerDirectories) {
+                Path home = innerDir;
+                Path releaseFile = home.resolve("release");
+                if (!safeExists(releaseFile)) {
+                    continue;
+                }
+
+                if (mac) {
+                    // Zulu JDK on macOS has a rogue layout, with which Gradle failed to operate (see the bugreport
+                    // IDEA-253051),
+                    // and in order to get Gradle working with Zulu JDK we should use it's second home (when symbolic
+                    // links are resolved).
+                    try {
+                        if (Files.isSymbolicLink(releaseFile)) {
+                            Path realReleaseFile = releaseFile.toRealPath();
+                            if (!safeExists(realReleaseFile)) {
+                                log.warn("Failed to resolve the target file (it doesn't exist) for: " + releaseFile);
+                                continue;
+                            }
+                            Path realHome = realReleaseFile.getParent();
+                            if (realHome == null) {
+                                log.warn(
+                                        "Failed to resolve the target file (it has no parent dir) for: " + releaseFile);
+                                continue;
+                            }
+                            home = realHome;
+                        }
+                    } catch (IOException ioe) {
+                        log.warn("Failed to resolve the target file for: " + releaseFile + ": " + ioe.getMessage());
+                        continue;
+                    } catch (Exception e) {
+                        log.warn("Failed to resolve the target file for: " + releaseFile + ": Unexpected exception "
+                                + e.getClass().getSimpleName() + ": " + e.getMessage());
+                        continue;
+                    }
+                }
+
+                result.add(home.toString());
+            }
+        } catch (IOException ioe) {
+            log.warn("I/O exception while listing Java home directories installed by Sdkman: " + ioe.getMessage(), ioe);
+            return Collections.emptySet();
+        } catch (Exception e) {
+            log.warn(
+                    "Unexpected exception while listing Java home directories installed by Sdkman: "
+                            + e.getClass().getSimpleName()
+                            + ": "
+                            + e.getMessage(),
+                    e);
+            return Collections.emptySet();
+        }
+
+        return result;
+    }
+
+    /**
+     * Finds Java home directories installed by <a href="https://github.com/halcyon/asdf-java">asdf-java</a>
+     */
+    private Set<String> findJavaInstalledByAsdfJava() {
+        Path installsDir = findAsdfInstallsDir();
+        if (installsDir == null) {
+            return Collections.emptySet();
+        }
+        Path javasDir = installsDir.resolve("java");
+        return safeIsDirectory(javasDir) ? scanAll(javasDir, true) : Collections.emptySet();
+    }
+
+    private Path findAsdfInstallsDir() {
+        // try to use environment variable for custom data directory
+        // https://asdf-vm.com/#/core-configuration?id=environment-variables
+        String dataDir = getEnvironmentVariable("ASDF_DATA_DIR");
+        if (dataDir != null) {
+            Path primaryDir = Paths.get(dataDir);
+            if (safeIsDirectory(primaryDir)) {
+                Path installsDir = primaryDir.resolve("installs");
+                if (safeIsDirectory(installsDir)) {
+                    return installsDir;
+                }
+            }
+        }
+
+        // finally, try the usual location in Unix or macOS
+        if (!(this instanceof JavaHomeFinderWindows)) {
+            Path installsDir = getPathInUserHome(".asdf/installs");
+            if (installsDir != null && safeIsDirectory(installsDir)) {
+                return installsDir;
+            }
+        }
+
+        // no chances
+        return null;
+    }
+
+    private boolean safeIsDirectory(Path dir) {
+        try {
+            return Files.isDirectory(dir);
+        } catch (SecurityException se) {
+            return false; // when a directory is not accessible we should ignore it
+        } catch (Exception e) {
+            log.debug(
+                    "Failed to check directory existence: unexpected exception "
+                            + e.getClass().getSimpleName() + ": " + e.getMessage(),
+                    e);
+            return false;
+        }
+    }
+
+    private boolean safeExists(Path path) {
+        try {
+            return Files.exists(path);
+        } catch (Exception e) {
+            log.debug(
+                    "Failed to check file existence: unexpected exception "
+                            + e.getClass().getSimpleName() + ": " + e.getMessage(),
+                    e);
+            return false;
+        }
+    }
+
+    public static boolean checkForJdk(Path homePath) {
+        return (Files.exists(homePath.resolve("bin/javac")) || Files.exists(homePath.resolve("bin/javac.exe")))
+                && (isModularRuntime(homePath)
+                        || // Jigsaw JDK/JRE
+                        Files.exists(homePath.resolve("jre/lib/rt.jar"))
+                        || // pre-modular JDK
+                        Files.isDirectory(homePath.resolve("classes"))
+                        || // custom build
+                        Files.exists(homePath.resolve("jre/lib/vm.jar"))
+                        || // IBM JDK
+                        Files.exists(homePath.resolve("../Classes/classes.jar"))); // Apple JDK
+    }
+
+    public static boolean isModularRuntime(Path homePath) {
+        return Files.isRegularFile(homePath.resolve("lib/jrt-fs.jar")) || isExplodedModularRuntime(homePath);
+    }
+
+    public static boolean isExplodedModularRuntime(Path homePath) {
+        return Files.isDirectory(homePath.resolve("modules/java.base"));
+    }
+}

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinderMac.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinderMac.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.toolchain.discovery;
+
+import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class JavaHomeFinderMac extends JavaHomeFinderBasic {
+    public static final String JAVA_HOME_FIND_UTIL = "/usr/libexec/java_home";
+
+    static String defaultJavaLocation = "/Library/Java/JavaVirtualMachines";
+
+    public JavaHomeFinderMac() {
+        super();
+
+        registerFinder(() -> {
+            Set<String> result = new TreeSet<>();
+            Iterable<Path> roots = FileSystems.getDefault().getRootDirectories();
+            roots.forEach(root -> {
+                result.addAll(scanAll(root.resolve(defaultJavaLocation), true));
+            });
+            roots.forEach(root -> {
+                result.addAll(scanAll(root.resolve("System/Library/Java/JavaVirtualMachines"), true));
+            });
+            return result;
+        });
+
+        registerFinder(() -> {
+            Path jdk = getPathInUserHome("Library/Java/JavaVirtualMachines");
+            return jdk != null ? scanAll(jdk, true) : Collections.emptySet();
+        });
+        registerFinder(() -> scanAll(getSystemDefaultJavaHome(), false));
+    }
+
+    protected Path getSystemDefaultJavaHome() {
+        String homePath = null;
+        if (new File(JAVA_HOME_FIND_UTIL).canExecute()) {
+            try {
+                homePath = execCommand(JAVA_HOME_FIND_UTIL);
+            } catch (Exception e) {
+                // TODO: log ?
+            }
+        }
+        if (homePath != null) {
+            return Paths.get(homePath);
+        }
+        return null;
+    }
+
+    @Override
+    protected List<Path> listPossibleJdkHomesFromInstallRoot(Path path) {
+        return Arrays.asList(path, path.resolve("/Home"), path.resolve("Contents/Home"));
+    }
+
+    @Override
+    protected List<Path> listPossibleJdkInstallRootsFromHomes(Path file) {
+        List<Path> result = new ArrayList<>();
+        result.add(file);
+
+        Path home = file.getFileName();
+        if (home != null && home.toString().equalsIgnoreCase("Home")) {
+            Path parentFile = file.getParent();
+            if (parentFile != null) {
+                result.add(parentFile);
+
+                Path contents = parentFile.getFileName();
+                if (contents != null && contents.toString().equalsIgnoreCase("Contents")) {
+                    Path parentParentFile = parentFile.getParent();
+                    if (parentParentFile != null) {
+                        result.add(parentParentFile);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinderWindows.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/JavaHomeFinderWindows.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.toolchain.discovery;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Named("windows")
+@Singleton
+class JavaHomeFinderWindows extends JavaHomeFinderBasic {
+
+    private static final String REG_COMMAND = "reg query HKLM\\SOFTWARE\\JavaSoft\\JDK /s /v JavaHome";
+
+    private static final Pattern JAVA_HOME_PATTERN =
+            Pattern.compile("^\\s+JavaHome\\s+REG_SZ\\s+(\\S.+\\S)\\s*$", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+
+    private static Set<String> gatherHomePaths(CharSequence text) {
+        Set<String> paths = new TreeSet<>();
+        Matcher m = JAVA_HOME_PATTERN.matcher(text);
+        while (m.find()) {
+            paths.add(m.group(1));
+        }
+        return paths;
+    }
+
+    JavaHomeFinderWindows(boolean registeredJdks) {
+        if (registeredJdks) {
+            // Whether the OS is 64-bit (**important**: it's not the same as [com.intellij.util.system.CpuArch]).
+            String pfx86 = getEnvironmentVariable("ProgramFiles(x86)");
+            boolean os64bit = pfx86 != null && !pfx86.trim().isEmpty();
+            if (os64bit) {
+                registerFinder(() -> readRegisteredLocations(" /reg:64"));
+                registerFinder(() -> readRegisteredLocations(" /reg:32"));
+            } else {
+                registerFinder(() -> readRegisteredLocations(""));
+            }
+        }
+        registerFinder(this::guessPossibleLocations);
+    }
+
+    private Set<String> readRegisteredLocations(String bitness) {
+        String cmd = REG_COMMAND + bitness;
+        try {
+            CharSequence registryLines = execCommand(cmd);
+            Set<String> registeredPaths = gatherHomePaths(registryLines);
+            Set<Path> folders = new TreeSet<>();
+            for (String rp : registeredPaths) {
+                Path r = Paths.get(rp);
+                Path parent = r.getParent();
+                if (parent != null && Files.exists(parent)) {
+                    folders.add(parent);
+                } else if (Files.exists(r)) {
+                    folders.add(r);
+                }
+            }
+            return scanAll(folders, true);
+        } catch (InterruptedException ie) {
+            return Collections.emptySet();
+        } catch (Exception e) {
+            log.warn("Unable to detect registered JDK using the following command: $cmd", e);
+            return Collections.emptySet();
+        }
+    }
+
+    private Set<String> guessPossibleLocations() {
+        Iterable<Path> fsRoots = FileSystems.getDefault().getRootDirectories();
+        Set<Path> roots = new HashSet<>();
+        for (Path root : fsRoots) {
+            if (Files.exists(root)) {
+                roots.add(root.resolve("Program Files/Java"));
+                roots.add(root.resolve("Program Files (x86)/Java"));
+                roots.add(root.resolve("Java"));
+            }
+        }
+        Path puh = getPathInUserHome(".jdks");
+        if (puh != null) {
+            roots.add(puh);
+        }
+        return scanAll(roots, true);
+    }
+}

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/ToolchainDiscoverer.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/ToolchainDiscoverer.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.toolchain.discovery;
+
+import org.apache.maven.toolchain.model.PersistedToolchains;
+
+/**
+ * Service used to discover JDK toolchains
+ */
+public interface ToolchainDiscoverer {
+    PersistedToolchains discoverToolchains();
+}

--- a/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/ToolchainDiscoverer.java
+++ b/maven-toolchain-builder/src/main/java/org/apache/maven/toolchain/discovery/ToolchainDiscoverer.java
@@ -24,5 +24,10 @@ import org.apache.maven.toolchain.model.PersistedToolchains;
  * Service used to discover JDK toolchains
  */
 public interface ToolchainDiscoverer {
+
+    /**
+     * Returns a PersistedToolchains object containing a list of discovered toolchains,
+     * never <code>null</code>.
+     */
     PersistedToolchains discoverToolchains();
 }

--- a/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/DefaultToolchainsBuilderTest.java
+++ b/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/DefaultToolchainsBuilderTest.java
@@ -20,12 +20,15 @@ package org.apache.maven.toolchain.building;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.maven.building.StringSource;
+import org.apache.maven.toolchain.discovery.ToolchainDiscoverer;
 import org.apache.maven.toolchain.io.DefaultToolchainsReader;
 import org.apache.maven.toolchain.io.DefaultToolchainsWriter;
 import org.apache.maven.toolchain.io.ToolchainsParseException;
@@ -54,6 +57,9 @@ class DefaultToolchainsBuilderTest {
 
     @Spy
     private DefaultToolchainsWriter toolchainsWriter;
+
+    @Spy
+    private List<ToolchainDiscoverer> toolchainDiscoverers = new ArrayList<>();
 
     @InjectMocks
     private DefaultToolchainsBuilder toolchainBuilder;

--- a/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/DefaultToolchainsBuilderTest.java
+++ b/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/DefaultToolchainsBuilderTest.java
@@ -169,8 +169,8 @@ class DefaultToolchainsBuilderTest {
         PersistedToolchains globalResult = new PersistedToolchains();
         globalResult.setToolchains(Collections.singletonList(toolchain));
 
-        doReturn(globalResult)
-                .doReturn(userResult)
+        doReturn(userResult)
+                .doReturn(globalResult)
                 .when(toolchainsReader)
                 .read(any(InputStream.class), ArgumentMatchers.<String, Object>anyMap());
 

--- a/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/discovery/ToolchainDiscovererTest.java
+++ b/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/discovery/ToolchainDiscovererTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.toolchain.discovery;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.apache.maven.toolchain.io.DefaultToolchainsWriter;
+import org.apache.maven.toolchain.model.PersistedToolchains;
+import org.junit.jupiter.api.Test;
+
+class ToolchainDiscovererTest {
+
+    @Test
+    void testDiscovery() throws IOException {
+        PersistedToolchains pt = new DefaultToolchainDiscoverer().discoverToolchains();
+        StringWriter writer = new StringWriter();
+        new DefaultToolchainsWriter().write(writer, null, pt);
+        System.err.println(writer);
+    }
+}


### PR DESCRIPTION
Currently, the need to support JDK 8 as a target kinda implies that maven itself needs to run with JDK 8.  Toolchains are not easy to use and require a few manual steps.
This commit aims at reducing the burden of using toolchains so that maven get use JDK 11 as a requirement for running, but making it easy for users to target a different JDK.

The code currently adds automatic discovery of JDK on various platforms (though no WSL which looks quite complicated to support).  The idea is also to see if the configuration of the toolchain plugin in the pom can also be simplified somehow.

This borrows code from IntelliJ Idea (which is ASL2).