### PR TITLE
[MNG-7059][MNG-4645] Move Central repo definition out of Maven's core so it can be more easily changed

### DIFF
--- a/apache-maven/src/assembly/maven/conf/settings.xml
+++ b/apache-maven/src/assembly/maven/conf/settings.xml
@@ -43,9 +43,9 @@ under the License.
  | values (values used when the setting is not specified) are provided.
  |
  |-->
-<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+<settings xmlns="http://maven.apache.org/SETTINGS/1.3.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.3.0 https://maven.apache.org/xsd/settings-1.3.0.xsd">
   <!-- localRepository
    | The path to the local repository maven will use to store artifacts.
    |
@@ -165,6 +165,38 @@ under the License.
       <blocked>true</blocked>
     </mirror>
   </mirrors>
+
+  <!-- repositories
+   | Specifies the list of default remote repositories that maven will search artifacts for.
+  -->
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <!-- plugin repositories
+   | Specifies the list of default remote repositories that maven will search plugins for.
+  -->
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
+
 
   <!-- profiles
    | This is a list of profiles which can be activated in a variety of ways, and which can modify

--- a/api/maven-api-settings/pom.xml
+++ b/api/maven-api-settings/pom.xml
@@ -65,6 +65,20 @@ under the License.
               </params>
             </configuration>
           </execution>
+          <execution>
+            <id>modello-site-docs</id>
+            <goals>
+              <goal>xdoc</goal>
+              <goal>xsd</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <version>1.3.0</version>
+              <models>
+                <model>src/main/mdo/settings.mdo</model>
+              </models>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/api/maven-api-settings/src/main/mdo/settings.mdo
+++ b/api/maven-api-settings/src/main/mdo/settings.mdo
@@ -224,6 +224,39 @@
           </association>
         </field>
         <field xdoc.separator="blank">
+          <name>repositories</name>
+          <version>1.3.0+</version>
+          <description>
+            <![CDATA[
+            The lists of the remote repositories.
+            ]]>
+          </description>
+          <association>
+            <type>Repository</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
+        <field>
+          <name>pluginRepositories</name>
+          <version>1.3.0+</version>
+          <description>
+            <![CDATA[
+            The lists of the remote repositories for discovering plugins.
+            ]]>
+          </description>
+          <association>
+            <type>Repository</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <comment>
+            <![CDATA[
+            This may be removed or relocated in the near
+            future. It is undecided whether plugins really need a remote
+            repository set of their own.
+            ]]>
+          </comment>
+        </field>
+        <field xdoc.separator="blank">
           <name>profiles</name>
           <version>1.0.0+</version>
           <description>
@@ -266,7 +299,7 @@
       </fields>
       <codeSegments>
         <codeSegment>
-          <version>1.0.0/1.2.0</version>
+          <version>1.0.0/1.3.0</version>
           <code>
             <![CDATA[
     public Boolean getInteractiveMode()
@@ -816,6 +849,7 @@
     <class java.clone="deep">
       <name>RepositoryBase</name>
       <version>1.0.0+</version>
+      <superClass>IdentifiableBase</superClass>
       <description>
         <![CDATA[
         Repository contains the information needed
@@ -823,18 +857,6 @@
         ]]>
       </description>
       <fields>
-        <field>
-          <name>id</name>
-          <version>1.0.0+</version>
-          <required>true</required>
-          <identifier>true</identifier>
-          <description>
-            <![CDATA[
-            A unique identifier for a repository.
-            ]]>
-          </description>
-          <type>String</type>
-        </field>
         <field>
           <name>name</name>
           <version>1.0.0+</version>

--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulator.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulator.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -83,10 +82,6 @@ public class DefaultMavenExecutionRequestPopulator implements MavenExecutionRequ
 
         populateDefaultPluginGroups(request);
 
-        injectDefaultRepositories(request);
-
-        injectDefaultPluginRepositories(request);
-
         return request;
     }
 
@@ -97,32 +92,6 @@ public class DefaultMavenExecutionRequestPopulator implements MavenExecutionRequ
     private void populateDefaultPluginGroups(MavenExecutionRequest request) {
         request.addPluginGroup("org.apache.maven.plugins");
         request.addPluginGroup("org.codehaus.mojo");
-    }
-
-    private void injectDefaultRepositories(MavenExecutionRequest request)
-            throws MavenExecutionRequestPopulationException {
-        Set<String> definedRepositories = repositorySystem.getRepoIds(request.getRemoteRepositories());
-
-        if (!definedRepositories.contains(MavenRepositorySystem.DEFAULT_REMOTE_REPO_ID)) {
-            try {
-                request.addRemoteRepository(repositorySystem.createDefaultRemoteRepository(request));
-            } catch (Exception e) {
-                throw new MavenExecutionRequestPopulationException("Cannot create default remote repository.", e);
-            }
-        }
-    }
-
-    private void injectDefaultPluginRepositories(MavenExecutionRequest request)
-            throws MavenExecutionRequestPopulationException {
-        Set<String> definedRepositories = repositorySystem.getRepoIds(request.getPluginArtifactRepositories());
-
-        if (!definedRepositories.contains(MavenRepositorySystem.DEFAULT_REMOTE_REPO_ID)) {
-            try {
-                request.addPluginArtifactRepository(repositorySystem.createDefaultRemoteRepository(request));
-            } catch (Exception e) {
-                throw new MavenExecutionRequestPopulationException("Cannot create default remote repository.", e);
-            }
-        }
     }
 
     private void localRepository(MavenExecutionRequest request) throws MavenExecutionRequestPopulationException {

--- a/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
@@ -133,10 +134,10 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
         assertNotNull(project.getArtifactId());
 
         assertNotNull(project.getRemoteArtifactRepositories());
-        assertFalse(project.getRemoteArtifactRepositories().isEmpty());
+        assertTrue(project.getRemoteArtifactRepositories().isEmpty());
 
         assertNotNull(project.getPluginArtifactRepositories());
-        assertFalse(project.getPluginArtifactRepositories().isEmpty());
+        assertTrue(project.getPluginArtifactRepositories().isEmpty());
 
         assertNull(project.getParent());
         assertNull(project.getParentArtifact());

--- a/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
@@ -575,7 +575,7 @@ class PomConstructionTest {
     @Test
     void testMultipleRepositories() throws Exception {
         PomTestWrapper pom = buildPom("multiple-repos/sub");
-        assertEquals(3, ((List<?>) pom.getValue("repositories")).size());
+        assertEquals(2, ((List<?>) pom.getValue("repositories")).size());
     }
 
     /** MNG-3965 */
@@ -1371,12 +1371,10 @@ class PomConstructionTest {
         assertEquals("org.apache.maven.its", pom.getValue("dependencies[1]/exclusions[1]/groupId"));
         assertEquals("excluded-dep", pom.getValue("dependencies[1]/exclusions[1]/artifactId"));
 
-        assertEquals(2, ((List<?>) pom.getValue("repositories")).size());
+        assertEquals(1, ((List<?>) pom.getValue("repositories")).size());
         assertEquals("project-remote-repo", pom.getValue("repositories[1]/id"));
         assertEquals("https://project.url/remote", pom.getValue("repositories[1]/url"));
         assertEquals("repo", pom.getValue("repositories[1]/name"));
-        assertEquals(MavenRepositorySystem.DEFAULT_REMOTE_REPO_ID, pom.getValue("repositories[2]/id"));
-        assertEquals(MavenRepositorySystem.DEFAULT_REMOTE_REPO_URL, pom.getValue("repositories[2]/url"));
 
         assertEquals("test", pom.getValue("build/defaultGoal"));
         assertEquals("coreit", pom.getValue("build/finalName"));

--- a/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java
@@ -233,6 +233,22 @@ public class SettingsXmlConfigurationProcessor implements ConfigurationProcessor
             request.addMirror(mirror);
         }
 
+        for (Repository remoteRepository : settings.getRepositories()) {
+            try {
+                request.addRemoteRepository(MavenRepositorySystem.buildArtifactRepository(remoteRepository));
+            } catch (InvalidRepositoryException e) {
+                // do nothing for now
+            }
+        }
+
+        for (Repository pluginRepository : settings.getPluginRepositories()) {
+            try {
+                request.addPluginArtifactRepository(MavenRepositorySystem.buildArtifactRepository(pluginRepository));
+            } catch (InvalidRepositoryException e) {
+                // do nothing for now
+            }
+        }
+
         request.setActiveProfiles(settings.getActiveProfiles());
 
         for (Profile rawProfile : settings.getProfiles()) {

--- a/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -28,33 +28,6 @@ under the License.
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>central</id>
-      <name>Maven Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-      <layout>default</layout>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>central</id>
-      <name>Maven Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-      <layout>default</layout>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <directory>${project.basedir}/target</directory>
     <outputDirectory>${project.build.directory}/classes</outputDirectory>

--- a/maven-settings-builder/src/main/java/org/apache/maven/settings/merge/MavenSettingsMerger.java
+++ b/maven-settings-builder/src/main/java/org/apache/maven/settings/merge/MavenSettingsMerger.java
@@ -88,6 +88,8 @@ public class MavenSettingsMerger {
         shallowMergeById(dominant.getServers(), recessive.getServers(), recessiveSourceLevel);
         shallowMergeById(dominant.getProxies(), recessive.getProxies(), recessiveSourceLevel);
         shallowMergeById(dominant.getProfiles(), recessive.getProfiles(), recessiveSourceLevel);
+        shallowMergeById(dominant.getRepositories(), recessive.getRepositories(), recessiveSourceLevel);
+        shallowMergeById(dominant.getPluginRepositories(), recessive.getPluginRepositories(), recessiveSourceLevel);
     }
 
     /**

--- a/maven-settings-builder/src/test/java/org/apache/maven/settings/validation/DefaultSettingsValidatorTest.java
+++ b/maven-settings-builder/src/test/java/org/apache/maven/settings/validation/DefaultSettingsValidatorTest.java
@@ -67,7 +67,7 @@ class DefaultSettingsValidatorTest {
         validator.validate(model, problems);
         assertEquals(0, problems.messages.size());
 
-        Repository repo = new Repository();
+        Repository repo = new Repository(org.apache.maven.api.settings.Repository.newInstance(false));
         prof.addRepository(repo);
         problems = new SimpleProblemCollector();
         validator.validate(model, problems);

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -94,7 +94,7 @@ under the License.
             </goals>
             <phase>generate-sources</phase>
             <configuration>
-              <version>1.2.0</version>
+              <version>1.3.0</version>
               <templates>
                 <template>model-v3.vm</template>
               </templates>


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-4645
IT PR: https://github.com/apache/maven-integration-testing/pull/266
Supersedes: https://github.com/apache/maven/pull/419
