### PR TITLE
[MNG-7805] Make the modelVersion optional when using build pom

### DIFF
--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/BuildToRawPomXMLFilterFactory.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/BuildToRawPomXMLFilterFactory.java
@@ -65,6 +65,8 @@ public class BuildToRawPomXMLFilterFactory {
         getSha1().ifPresent(ciFriendlyFilter::setSha1);
         parser = ciFriendlyFilter;
 
+        parser = new ModelVersionXMLFilter(parser);
+
         return parser;
     }
 

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/ModelVersionXMLFilter.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/ModelVersionXMLFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.transform;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.maven.model.transform.pull.NodeBufferingParser;
+import org.codehaus.plexus.util.xml.pull.XmlPullParser;
+
+public class ModelVersionXMLFilter extends NodeBufferingParser {
+
+    private static final Pattern S_FILTER = Pattern.compile("\\s+");
+    public static final String NAMESPACE_PREFIX = "http://maven.apache.org/POM/";
+
+    public ModelVersionXMLFilter(XmlPullParser xmlPullParser) {
+        super(xmlPullParser, "project");
+    }
+
+    @Override
+    protected void process(List<Event> buffer) {
+        if (buffer.stream().noneMatch(e -> e.event == XmlPullParser.START_TAG && "modelVersion".equals(e.name))) {
+            String namespace = null;
+            for (int pos = 0; pos < buffer.size(); pos++) {
+                Event e = buffer.get(pos);
+                if (namespace != null) {
+                    if (e.event == XmlPullParser.START_TAG) {
+                        Event prev = buffer.get(pos - 1);
+                        if (prev.event != TEXT || !S_FILTER.matcher(prev.text).matches()) {
+                            prev = null;
+                        }
+                        Event pmse = new Event();
+                        pmse.event = START_TAG;
+                        pmse.name = "modelVersion";
+                        pmse.namespace = namespace;
+                        buffer.add(pos++, pmse);
+                        Event pmve = new Event();
+                        pmve.event = TEXT;
+                        pmve.text = namespace.substring(NAMESPACE_PREFIX.length());
+                        buffer.add(pos++, pmve);
+                        Event pmee = new Event();
+                        pmee.event = END_TAG;
+                        pmee.name = "modelVersion";
+                        pmee.namespace = namespace;
+                        buffer.add(pos++, pmee);
+                        if (prev != null) {
+                            buffer.add(pos++, prev);
+                        }
+                        break;
+                    }
+                } else if (e.event == XmlPullParser.START_TAG
+                        && "project".equals(e.name)
+                        && e.namespace != null
+                        && e.namespace.startsWith(NAMESPACE_PREFIX)) {
+                    namespace = e.namespace;
+                }
+            }
+        }
+        buffer.forEach(this::pushEvent);
+    }
+}

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/NodeBufferingParser.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/pull/NodeBufferingParser.java
@@ -67,5 +67,10 @@ public abstract class NodeBufferingParser extends BufferingParser {
         return true;
     }
 
+    @Override
+    public boolean bypass() {
+        return !buffering && super.bypass();
+    }
+
     protected abstract void process(List<Event> buffer);
 }

--- a/maven-model-transform/src/test/java/org/apache/maven/model/transform/ModelVersionXMLFilterTest.java
+++ b/maven-model-transform/src/test/java/org/apache/maven/model/transform/ModelVersionXMLFilterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.transform;
+
+import org.codehaus.plexus.util.xml.pull.XmlPullParser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModelVersionXMLFilterTest extends AbstractXMLFilterTests {
+    @Override
+    protected XmlPullParser getFilter(XmlPullParser parser) {
+        return new ModelVersionXMLFilter(parser);
+    }
+
+    @Test
+    void modelVersionWithDefaultPrefix() throws Exception {
+        String input = "<project xmlns='http://maven.apache.org/POM/4.0.0'>"
+                + "  <groupId>GROUPID</groupId>"
+                + "  <artifactId>ARTIFACTID</artifactId>"
+                + "  <version>VERSION</version>"
+                + "</project>";
+        String expected = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">"
+                + "  <modelVersion>4.0.0</modelVersion>"
+                + "  <groupId>GROUPID</groupId>"
+                + "  <artifactId>ARTIFACTID</artifactId>"
+                + "  <version>VERSION</version>"
+                + "</project>";
+
+        // Check that the modelVersion is added
+        assertEquals(expected, transform(input));
+        // Check that the transformed POM is stable (modelVersion not added twice)
+        assertEquals(expected, transform(expected));
+    }
+
+    @Test
+    void modelVersionWithPrefix() throws Exception {
+        String input = "<maven:project xmlns:maven='http://maven.apache.org/POM/4.0.0'>"
+                + "  <maven:groupId>GROUPID</maven:groupId>"
+                + "  <maven:artifactId>ARTIFACTID</maven:artifactId>"
+                + "  <maven:version>VERSION</maven:version>"
+                + "</maven:project>";
+        String expected = "<maven:project xmlns:maven=\"http://maven.apache.org/POM/4.0.0\">"
+                + "  <maven:modelVersion>4.0.0</maven:modelVersion>"
+                + "  <maven:groupId>GROUPID</maven:groupId>"
+                + "  <maven:artifactId>ARTIFACTID</maven:artifactId>"
+                + "  <maven:version>VERSION</maven:version>"
+                + "</maven:project>";
+
+        // Check that the modelVersion is added
+        assertEquals(expected, transform(input));
+        // Check that the transformed POM is stable (modelVersion not added twice)
+        assertEquals(expected, transform(expected));
+    }
+}


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7805

The downside of this PR is that if the build/consumer feature is enabled, all poms will be parsed as events and kept in memory by the `ModelVersionXMLFilter`.  The reason is that in theory, the `modelVersion` element can be the last element of the root `project` element.  Given the way the build/consumer POM feature is implemented, the same mechanism is used to read the POM (i.e. xml to object model) and rewrite it (when installing/deploying), so that the transformed XML has to be _clean_ wrt formatting, etc...
A possible performance improvement would be to have filters operate in two modes, the first one during the first phase (I.e. xml element ordering, formatting is irrelevant, and this phase could even be done on the object model) and a second one to rewrite the POM. 
But I think the performance loss is quite negligible as the number of POMs parsed with the build/consumer feature filter enabled is the number of projects in the reactor, so it should be usually an order of magnitude lower than the total number of POMs parsed for plugins / dependencies.
