### PR TITLE
Move maven-compat to jsr330

### DIFF
--- a/maven-compat/pom.xml
+++ b/maven-compat/pom.xml
@@ -89,10 +89,6 @@ under the License.
       <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
     </dependency>
@@ -127,8 +123,8 @@ under the License.
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.codehaus.modello</groupId>

--- a/maven-compat/src/main/java/org/apache/maven/artifact/deployer/DefaultArtifactDeployer.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/deployer/DefaultArtifactDeployer.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.artifact.deployer;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,8 +36,6 @@ import org.apache.maven.artifact.repository.metadata.MetadataBridge;
 import org.apache.maven.artifact.repository.metadata.SnapshotArtifactRepositoryMetadata;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.artifact.ProjectArtifactMetadata;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -49,13 +50,13 @@ import org.eclipse.aether.util.artifact.SubArtifact;
 /**
  * DefaultArtifactDeployer
  */
-@Component(role = ArtifactDeployer.class, instantiationStrategy = "per-lookup")
+@Named
 public class DefaultArtifactDeployer extends AbstractLogEnabled implements ArtifactDeployer {
 
-    @Requirement
+    @Inject
     private RepositorySystem repoSystem;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
     private Map<Object, MergeableMetadata> relatedMetadata = new ConcurrentHashMap<>();

--- a/maven-compat/src/main/java/org/apache/maven/artifact/installer/DefaultArtifactInstaller.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/installer/DefaultArtifactInstaller.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.artifact.installer;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 
 import org.apache.maven.RepositoryUtils;
@@ -32,8 +36,6 @@ import org.apache.maven.artifact.repository.metadata.SnapshotArtifactRepositoryM
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.artifact.ProjectArtifactMetadata;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -45,13 +47,14 @@ import org.eclipse.aether.util.artifact.SubArtifact;
 /**
  * @author Jason van Zyl
  */
-@Component(role = ArtifactInstaller.class)
+@Named
+@Singleton
 public class DefaultArtifactInstaller extends AbstractLogEnabled implements ArtifactInstaller {
 
-    @Requirement
+    @Inject
     private RepositorySystem repoSystem;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
     /** @deprecated we want to use the artifact method only, and ensure artifact.file is set correctly. */

--- a/maven-compat/src/main/java/org/apache/maven/artifact/manager/DefaultWagonManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/manager/DefaultWagonManager.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.artifact.manager;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
@@ -37,31 +41,30 @@ import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.proxy.ProxyInfo;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 
 /**
  * Manages <a href="https://maven.apache.org/wagon">Wagon</a> related operations in Maven.
  */
-@Component(role = WagonManager.class)
+@Named
+@Singleton
 public class DefaultWagonManager extends org.apache.maven.repository.legacy.DefaultWagonManager
         implements WagonManager {
 
     // NOTE: This must use a different field name than in the super class or IoC has no chance to inject the loggers
-    @Requirement
+    @Inject
     private Logger log;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
-    @Requirement
+    @Inject
     private SettingsDecrypter settingsDecrypter;
 
-    @Requirement
+    @Inject
     private MirrorSelector mirrorSelector;
 
-    @Requirement
+    @Inject
     private ArtifactRepositoryFactory artifactRepositoryFactory;
 
     public AuthenticationInfo getAuthenticationInfo(String id) {

--- a/maven-compat/src/main/java/org/apache/maven/artifact/repository/DefaultArtifactRepositoryFactory.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/repository/DefaultArtifactRepositoryFactory.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.artifact.repository;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -25,23 +29,22 @@ import org.apache.maven.artifact.UnknownRepositoryLayoutException;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.repository.RepositorySystem;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.aether.RepositorySystemSession;
 
 /**
  * @author jdcasey
  */
-@Component(role = ArtifactRepositoryFactory.class)
+@Named
+@Singleton
 public class DefaultArtifactRepositoryFactory implements ArtifactRepositoryFactory {
 
-    @Requirement
+    @Inject
     private org.apache.maven.repository.legacy.repository.ArtifactRepositoryFactory factory;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
-    @Requirement
+    @Inject
     private RepositorySystem repositorySystem;
 
     public ArtifactRepositoryLayout getLayout(String layoutId) throws UnknownRepositoryLayoutException {

--- a/maven-compat/src/main/java/org/apache/maven/artifact/repository/layout/FlatRepositoryLayout.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/repository/layout/FlatRepositoryLayout.java
@@ -18,16 +18,19 @@
  */
 package org.apache.maven.artifact.repository.layout;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * FlatRepositoryLayout
  */
-@Component(role = ArtifactRepositoryLayout.class, hint = "flat")
+@Named("flat")
+@Singleton
 public class FlatRepositoryLayout implements ArtifactRepositoryLayout {
 
     private static final char ARTIFACT_SEPARATOR = '-';

--- a/maven-compat/src/main/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManager.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.artifact.repository.metadata;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -40,20 +44,19 @@ import org.apache.maven.repository.legacy.UpdateCheckManager;
 import org.apache.maven.repository.legacy.WagonManager;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
  * @author Jason van Zyl
  */
-@Component(role = RepositoryMetadataManager.class)
+@Named
+@Singleton
 public class DefaultRepositoryMetadataManager extends AbstractLogEnabled implements RepositoryMetadataManager {
-    @Requirement
+    @Inject
     private WagonManager wagonManager;
 
-    @Requirement
+    @Inject
     private UpdateCheckManager updateCheckManager;
 
     public void resolve(

--- a/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactCollector.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactCollector.java
@@ -18,13 +18,15 @@
  */
 package org.apache.maven.artifact.resolver;
 
-import org.codehaus.plexus.component.annotations.Component;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 /**
  * Artifact collector - takes a set of original artifacts and resolves all of the best versions to use
  * along with their metadata. No artifacts are downloaded.
  */
 @Deprecated
-@Component(role = ArtifactCollector.class)
+@Named
+@Singleton
 public class DefaultArtifactCollector extends org.apache.maven.repository.legacy.resolver.DefaultLegacyArtifactCollector
         implements ArtifactCollector {}

--- a/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/resolver/DefaultArtifactResolver.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.artifact.resolver;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,8 +59,6 @@ import org.apache.maven.repository.legacy.metadata.MetadataResolutionRequest;
 import org.apache.maven.repository.legacy.resolver.conflict.ConflictResolver;
 import org.apache.maven.wagon.events.TransferListener;
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
@@ -69,30 +71,31 @@ import org.eclipse.aether.resolution.ArtifactResult;
 /**
  * @author Jason van Zyl
  */
-@Component(role = ArtifactResolver.class)
+@Named
+@Singleton
 public class DefaultArtifactResolver implements ArtifactResolver, Disposable {
-    @Requirement
+    @Inject
     private Logger logger;
 
-    @Requirement
+    @Inject
     protected ArtifactFactory artifactFactory;
 
-    @Requirement
+    @Inject
     private ArtifactCollector artifactCollector;
 
-    @Requirement
+    @Inject
     private ResolutionErrorHandler resolutionErrorHandler;
 
-    @Requirement
+    @Inject
     private ArtifactMetadataSource source;
 
-    @Requirement
+    @Inject
     private PlexusContainer container;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
-    @Requirement
+    @Inject
     private RepositorySystem repoSystem;
 
     private final Executor executor;

--- a/maven-compat/src/main/java/org/apache/maven/execution/DefaultRuntimeInformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/execution/DefaultRuntimeInformation.java
@@ -18,10 +18,12 @@
  */
 package org.apache.maven.execution;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 
@@ -31,10 +33,11 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationExce
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  */
 @Deprecated
-@Component(role = RuntimeInformation.class)
+@Named
+@Singleton
 public class DefaultRuntimeInformation implements RuntimeInformation, Initializable {
 
-    @Requirement
+    @Inject
     private org.apache.maven.rtinfo.RuntimeInformation rtInfo;
 
     private ArtifactVersion applicationVersion;

--- a/maven-compat/src/main/java/org/apache/maven/profiles/DefaultProfileManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/profiles/DefaultProfileManager.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.profiles;
 
+import javax.inject.Inject;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,7 +34,6 @@ import org.apache.maven.model.profile.ProfileSelector;
 import org.apache.maven.profiles.activation.ProfileActivationException;
 import org.codehaus.plexus.MutablePlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.Logger;
 
@@ -42,10 +43,10 @@ import org.codehaus.plexus.logging.Logger;
 @Deprecated
 public class DefaultProfileManager implements ProfileManager {
 
-    @Requirement
+    @Inject
     private Logger logger;
 
-    @Requirement
+    @Inject
     private ProfileSelector profileSelector;
 
     private List<String> activatedIds = new ArrayList<>();

--- a/maven-compat/src/main/java/org/apache/maven/project/DefaultMavenProjectBuilder.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/DefaultMavenProjectBuilder.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.project;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,22 +45,21 @@ import org.apache.maven.profiles.ProfileManager;
 import org.apache.maven.properties.internal.EnvironmentUtils;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.wagon.events.TransferListener;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 
 /**
  */
-@Component(role = MavenProjectBuilder.class)
 @Deprecated
+@Named
+@Singleton
 public class DefaultMavenProjectBuilder implements MavenProjectBuilder {
 
-    @Requirement
+    @Inject
     private ProjectBuilder projectBuilder;
 
-    @Requirement
+    @Inject
     private RepositorySystem repositorySystem;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
     // ----------------------------------------------------------------------

--- a/maven-compat/src/main/java/org/apache/maven/project/inheritance/DefaultModelInheritanceAssembler.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/inheritance/DefaultModelInheritanceAssembler.java
@@ -18,14 +18,17 @@
  */
 package org.apache.maven.project.inheritance;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * DefaultModelInheritanceAssembler
  */
-@Component(role = ModelInheritanceAssembler.class)
+@Named
+@Singleton
 public class DefaultModelInheritanceAssembler implements ModelInheritanceAssembler {
     @Override
     public void assembleModelInheritance(Model child, Model parent, String childPathAdjustment) {

--- a/maven-compat/src/main/java/org/apache/maven/project/interpolation/AbstractStringBasedModelInterpolator.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/interpolation/AbstractStringBasedModelInterpolator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.project.interpolation;
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -35,7 +37,6 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.project.DefaultProjectBuilderConfiguration;
 import org.apache.maven.project.ProjectBuilderConfiguration;
 import org.apache.maven.project.path.PathTranslator;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.interpolation.AbstractValueSource;
 import org.codehaus.plexus.interpolation.InterpolationException;
 import org.codehaus.plexus.interpolation.InterpolationPostProcessor;
@@ -86,7 +87,7 @@ public abstract class AbstractStringBasedModelInterpolator extends AbstractLogEn
         TRANSLATED_PATH_EXPRESSIONS = translatedPrefixes;
     }
 
-    @Requirement
+    @Inject
     private PathTranslator pathTranslator;
 
     private Interpolator interpolator;

--- a/maven-compat/src/main/java/org/apache/maven/project/interpolation/StringSearchModelInterpolator.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/interpolation/StringSearchModelInterpolator.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.project.interpolation;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -33,7 +36,6 @@ import java.util.WeakHashMap;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.ProjectBuilderConfiguration;
 import org.apache.maven.project.path.PathTranslator;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.interpolation.InterpolationPostProcessor;
 import org.codehaus.plexus.interpolation.Interpolator;
 import org.codehaus.plexus.interpolation.StringSearchInterpolator;
@@ -44,7 +46,8 @@ import org.codehaus.plexus.logging.Logger;
  * StringSearchModelInterpolator
  */
 @Deprecated
-@Component(role = ModelInterpolator.class)
+@Named
+@Singleton
 public class StringSearchModelInterpolator extends AbstractStringBasedModelInterpolator {
 
     private static final Map<Class<?>, Field[]> FIELDS_BY_CLASS = new WeakHashMap<>();

--- a/maven-compat/src/main/java/org/apache/maven/project/path/DefaultPathTranslator.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/path/DefaultPathTranslator.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.project.path;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,13 +29,13 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Reporting;
 import org.apache.maven.model.Resource;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * DefaultPathTranslator
  */
 @Deprecated
-@Component(role = PathTranslator.class)
+@Named
+@Singleton
 public class DefaultPathTranslator implements PathTranslator {
     private static final String[] BASEDIR_EXPRESSIONS = {"${basedir}", "${pom.basedir}", "${project.basedir}"};
 

--- a/maven-compat/src/main/java/org/apache/maven/project/validation/DefaultModelValidator.java
+++ b/maven-compat/src/main/java/org/apache/maven/project/validation/DefaultModelValidator.java
@@ -18,23 +18,26 @@
  */
 package org.apache.maven.project.validation;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelProblemCollector;
 import org.apache.maven.model.building.ModelProblemCollectorRequest;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
  */
-@Component(role = ModelValidator.class)
 @Deprecated
+@Named
+@Singleton
 public class DefaultModelValidator implements ModelValidator {
 
-    @Requirement
+    @Inject
     private org.apache.maven.model.validation.ModelValidator modelValidator;
 
     public ModelValidationResult validate(Model model) {

--- a/maven-compat/src/main/java/org/apache/maven/repository/DefaultMirrorSelector.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/DefaultMirrorSelector.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.repository;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -25,12 +28,12 @@ import java.util.List;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.settings.Mirror;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * DefaultMirrorSelector
  */
-@Component(role = MirrorSelector.class)
+@Named
+@Singleton
 public class DefaultMirrorSelector implements MirrorSelector {
 
     private static final String WILDCARD = "*";

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManager.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.repository.legacy;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -34,14 +37,14 @@ import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.Authentication;
 import org.apache.maven.artifact.repository.metadata.RepositoryMetadata;
 import org.apache.maven.repository.Proxy;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.logging.Logger;
 
 /**
  * DefaultUpdateCheckManager
  */
-@Component(role = UpdateCheckManager.class)
+@Named
+@Singleton
 public class DefaultUpdateCheckManager extends AbstractLogEnabled implements UpdateCheckManager {
 
     private static final String ERROR_KEY_SUFFIX = ".error";

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultWagonManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultWagonManager.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.repository.legacy;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -46,8 +50,6 @@ import org.apache.maven.wagon.observers.ChecksumObserver;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.Logger;
@@ -62,7 +64,8 @@ import org.eclipse.aether.util.ConfigUtils;
 /**
  * Manages <a href="https://maven.apache.org/wagon">Wagon</a> related operations in Maven.
  */
-@Component(role = WagonManager.class)
+@Named
+@Singleton
 public class DefaultWagonManager implements WagonManager {
 
     private static final String[] CHECKSUM_IDS = {"md5", "sha1"};
@@ -72,16 +75,16 @@ public class DefaultWagonManager implements WagonManager {
      */
     private static final String[] CHECKSUM_ALGORITHMS = {"MD5", "SHA-1"};
 
-    @Requirement
+    @Inject
     private Logger logger;
 
-    @Requirement
+    @Inject
     private PlexusContainer container;
 
-    @Requirement
+    @Inject
     private UpdateCheckManager updateCheckManager;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
     //

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.repository.legacy;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -67,8 +71,6 @@ import org.apache.maven.settings.crypto.SettingsDecryptionResult;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.proxy.ProxyUtils;
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.StringUtils;
@@ -81,34 +83,35 @@ import org.eclipse.aether.repository.RemoteRepository;
 /**
  * @author Jason van Zyl
  */
-@Component(role = RepositorySystem.class, hint = "default")
+@Named("default")
+@Singleton
 public class LegacyRepositorySystem implements RepositorySystem {
 
-    @Requirement
+    @Inject
     private Logger logger;
 
-    @Requirement
+    @Inject
     private ArtifactFactory artifactFactory;
 
-    @Requirement
+    @Inject
     private ArtifactResolver artifactResolver;
 
-    @Requirement
+    @Inject
     private ArtifactRepositoryFactory artifactRepositoryFactory;
 
-    @Requirement(role = ArtifactRepositoryLayout.class)
+    @Inject
     private Map<String, ArtifactRepositoryLayout> layouts;
 
-    @Requirement
+    @Inject
     private WagonManager wagonManager;
 
-    @Requirement
+    @Inject
     private PlexusContainer plexus;
 
-    @Requirement
+    @Inject
     private MirrorSelector mirrorSelector;
 
-    @Requirement
+    @Inject
     private SettingsDecrypter settingsDecrypter;
 
     public Artifact createArtifact(String groupId, String artifactId, String version, String scope, String type) {

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/repository/DefaultArtifactRepositoryFactory.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/repository/DefaultArtifactRepositoryFactory.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.repository.legacy.repository;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.Map;
 
 import org.apache.maven.artifact.UnknownRepositoryLayoutException;
@@ -26,20 +30,19 @@ import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout2;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 
 /**
  * @author jdcasey
  */
-@Component(role = ArtifactRepositoryFactory.class)
+@Named
+@Singleton
 public class DefaultArtifactRepositoryFactory implements ArtifactRepositoryFactory {
     // TODO use settings?
     private String globalUpdatePolicy;
 
     private String globalChecksumPolicy;
 
-    @Requirement(role = ArtifactRepositoryLayout.class)
+    @Inject
     private Map<String, ArtifactRepositoryLayout> repositoryLayouts;
 
     public ArtifactRepositoryLayout getLayout(String layoutId) throws UnknownRepositoryLayoutException {

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/DefaultLegacyArtifactCollector.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/DefaultLegacyArtifactCollector.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.repository.legacy.resolver;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -50,24 +54,24 @@ import org.apache.maven.repository.legacy.metadata.ArtifactMetadataRetrievalExce
 import org.apache.maven.repository.legacy.metadata.DefaultMetadataResolutionRequest;
 import org.apache.maven.repository.legacy.metadata.MetadataResolutionRequest;
 import org.apache.maven.repository.legacy.resolver.conflict.ConflictResolver;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  * @author Jason van Zyl
  */
-@Component(role = LegacyArtifactCollector.class)
+@Named
+@Singleton
 public class DefaultLegacyArtifactCollector implements LegacyArtifactCollector {
 
-    @Requirement(hint = "nearest")
+    @Inject
+    @Named("nearest")
     private ConflictResolver defaultConflictResolver;
 
-    @Requirement
+    @Inject
     private Logger logger;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
     private void injectSession(ArtifactResolutionRequest request) {

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/DefaultConflictResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/DefaultConflictResolver.java
@@ -18,7 +18,8 @@
  */
 package org.apache.maven.repository.legacy.resolver.conflict;
 
-import org.codehaus.plexus.component.annotations.Component;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 /**
  * The default conflict resolver that delegates to the nearest strategy.
@@ -28,5 +29,6 @@ import org.codehaus.plexus.component.annotations.Component;
  * @deprecated As of 3.0, use a specific implementation instead, e.g. {@link NearestConflictResolver}
  */
 @Deprecated
-@Component(role = ConflictResolver.class)
+@Named
+@Singleton
 public class DefaultConflictResolver extends NearestConflictResolver {}

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/DefaultConflictResolverFactory.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/DefaultConflictResolverFactory.java
@@ -18,10 +18,12 @@
  */
 package org.apache.maven.repository.legacy.resolver.conflict;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.context.ContextException;
@@ -34,14 +36,15 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
  * TODO you don't need the container in here with the active maps (jvz).
  * @since 3.0
  */
-@Component(role = ConflictResolverFactory.class)
+@Named
+@Singleton
 public class DefaultConflictResolverFactory implements ConflictResolverFactory, Contextualizable {
     // fields -----------------------------------------------------------------
 
     /**
      * The plexus container used to obtain instances from.
      */
-    @Requirement
+    @Inject
     private PlexusContainer container;
 
     // ConflictResolverFactory methods ----------------------------------------

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/FarthestConflictResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/FarthestConflictResolver.java
@@ -18,8 +18,10 @@
  */
 package org.apache.maven.repository.legacy.resolver.conflict;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.resolver.ResolutionNode;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Resolves conflicting artifacts by always selecting the <em>farthest</em> declaration. Farthest is defined as the
@@ -28,7 +30,8 @@ import org.codehaus.plexus.component.annotations.Component;
  * @author <a href="mailto:markhobson@gmail.com">Mark Hobson</a>
  * @since 3.0
  */
-@Component(role = ConflictResolver.class, hint = "farthest")
+@Named("farthest")
+@Singleton
 public class FarthestConflictResolver implements ConflictResolver {
     // ConflictResolver methods -----------------------------------------------
 

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolver.java
@@ -18,8 +18,10 @@
  */
 package org.apache.maven.repository.legacy.resolver.conflict;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.resolver.ResolutionNode;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Resolves conflicting artifacts by always selecting the <em>nearest</em> declaration. Nearest is defined as the
@@ -29,7 +31,8 @@ import org.codehaus.plexus.component.annotations.Component;
  * @author <a href="mailto:markhobson@gmail.com">Mark Hobson</a>
  * @since 3.0
  */
-@Component(role = ConflictResolver.class, hint = "nearest")
+@Named("nearest")
+@Singleton
 public class NearestConflictResolver implements ConflictResolver {
     // ConflictResolver methods -----------------------------------------------
 

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/NewestConflictResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/NewestConflictResolver.java
@@ -18,10 +18,12 @@
  */
 package org.apache.maven.repository.legacy.resolver.conflict;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.resolver.ResolutionNode;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Resolves conflicting artifacts by always selecting the <em>newest</em> declaration. Newest is defined as the
@@ -31,7 +33,8 @@ import org.codehaus.plexus.component.annotations.Component;
  * @see ArtifactVersion#compareTo
  * @since 3.0
  */
-@Component(role = ConflictResolver.class, hint = "newest")
+@Named("newest")
+@Singleton
 public class NewestConflictResolver implements ConflictResolver {
     // ConflictResolver methods -----------------------------------------------
 

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/OldestConflictResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/conflict/OldestConflictResolver.java
@@ -18,10 +18,12 @@
  */
 package org.apache.maven.repository.legacy.resolver.conflict;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.resolver.ResolutionNode;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Resolves conflicting artifacts by always selecting the <em>oldest</em> declaration. Oldest is defined as the
@@ -31,7 +33,8 @@ import org.codehaus.plexus.component.annotations.Component;
  * @see ArtifactVersion#compareTo
  * @since 3.0
  */
-@Component(role = ConflictResolver.class, hint = "oldest")
+@Named("oldest")
+@Singleton
 public class OldestConflictResolver implements ConflictResolver {
     // ConflictResolver methods -----------------------------------------------
 

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/AbstractVersionTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/AbstractVersionTransformation.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.repository.legacy.resolver.transform;
 
+import javax.inject.Inject;
+
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
@@ -34,7 +36,6 @@ import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.repository.legacy.WagonManager;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 /**
@@ -44,10 +45,10 @@ import org.codehaus.plexus.logging.AbstractLogEnabled;
  * TODO try and refactor to remove abstract methods - not particular happy about current design
  */
 public abstract class AbstractVersionTransformation extends AbstractLogEnabled implements ArtifactTransformation {
-    @Requirement
+    @Inject
     protected RepositoryMetadataManager repositoryMetadataManager;
 
-    @Requirement
+    @Inject
     protected WagonManager wagonManager;
 
     public void transformForResolve(

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/DefaultArtifactTransformationManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/DefaultArtifactTransformationManager.java
@@ -18,7 +18,15 @@
  */
 package org.apache.maven.repository.legacy.resolver.transform;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.deployer.ArtifactDeploymentException;
@@ -27,18 +35,23 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.RepositoryRequest;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 
 /**
  * @author Jason van Zyl
  */
-@Component(role = ArtifactTransformationManager.class)
+@Named
+@Singleton
 public class DefaultArtifactTransformationManager implements ArtifactTransformationManager {
-    @Requirement(
-            role = ArtifactTransformation.class,
-            hints = {"release", "latest", "snapshot"})
+
     private List<ArtifactTransformation> artifactTransformations;
+
+    @Inject
+    public DefaultArtifactTransformationManager(Map<String, ArtifactTransformation> artifactTransformations) {
+        this.artifactTransformations = Stream.of("release", "latest", "snapshot")
+                .map(artifactTransformations::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
 
     public void transformForResolve(Artifact artifact, RepositoryRequest request)
             throws ArtifactResolutionException, ArtifactNotFoundException {

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/LatestArtifactTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/LatestArtifactTransformation.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.repository.legacy.resolver.transform;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.RepositoryRequest;
@@ -25,12 +28,12 @@ import org.apache.maven.artifact.repository.metadata.RepositoryMetadataResolutio
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Describes a version transformation during artifact resolution - "latest" type
  */
-@Component(role = ArtifactTransformation.class, hint = "latest")
+@Named("latest")
+@Singleton
 public class LatestArtifactTransformation extends AbstractVersionTransformation {
 
     public void transformForResolve(Artifact artifact, RepositoryRequest request)

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/ReleaseArtifactTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/ReleaseArtifactTransformation.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.repository.legacy.resolver.transform;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -27,14 +30,14 @@ import org.apache.maven.artifact.repository.metadata.RepositoryMetadataResolutio
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Change the version <code>RELEASE</code> to the appropriate release version from the remote repository.
  *
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  */
-@Component(role = ArtifactTransformation.class, hint = "release")
+@Named("release")
+@Singleton
 public class ReleaseArtifactTransformation extends AbstractVersionTransformation {
 
     public void transformForResolve(Artifact artifact, RepositoryRequest request)

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/SnapshotTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/SnapshotTransformation.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.repository.legacy.resolver.transform;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -35,14 +38,14 @@ import org.apache.maven.artifact.repository.metadata.Snapshot;
 import org.apache.maven.artifact.repository.metadata.SnapshotArtifactRepositoryMetadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  * @author <a href="mailto:mmaczka@interia.pl">Michal Maczka</a>
  */
-@Component(role = ArtifactTransformation.class, hint = "snapshot")
+@Named("snapshot")
+@Singleton
 public class SnapshotTransformation extends AbstractVersionTransformation {
     private static final String DEFAULT_SNAPSHOT_TIMESTAMP_FORMAT = "yyyyMMdd.HHmmss";
 

--- a/maven-compat/src/main/java/org/apache/maven/repository/metadata/DefaultClasspathTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/metadata/DefaultClasspathTransformation.java
@@ -18,13 +18,15 @@
  */
 package org.apache.maven.repository.metadata;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.apache.maven.artifact.ArtifactScopeEnum;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 
 /**
  * default implementation of the metadata classpath transformer
@@ -32,9 +34,10 @@ import org.codehaus.plexus.component.annotations.Requirement;
  * @author <a href="oleg@codehaus.org">Oleg Gusakov</a>
  *
  */
-@Component(role = ClasspathTransformation.class)
+@Named
+@Singleton
 public class DefaultClasspathTransformation implements ClasspathTransformation {
-    @Requirement
+    @Inject
     GraphConflictResolver conflictResolver;
 
     // ----------------------------------------------------------------------------------------------------

--- a/maven-compat/src/main/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolutionPolicy.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolutionPolicy.java
@@ -18,16 +18,19 @@
  */
 package org.apache.maven.repository.metadata;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Configuration;
 
 /**
  * @author <a href="mailto:oleg@codehaus.org">Oleg Gusakov</a>
  *
  */
-@Component(role = GraphConflictResolutionPolicy.class)
+@Named
+@Singleton
 public class DefaultGraphConflictResolutionPolicy implements GraphConflictResolutionPolicy {
     /**
      * artifact, closer to the entry point, is selected

--- a/maven-compat/src/main/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolver.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolver.java
@@ -18,25 +18,28 @@
  */
 package org.apache.maven.repository.metadata;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 
 import org.apache.maven.artifact.ArtifactScopeEnum;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 
 /**
  * Default conflict resolver.Implements closer newer first policy by default, but could be configured via plexus
  *
  * @author <a href="mailto:oleg@codehaus.org">Oleg Gusakov</a>
  */
-@Component(role = GraphConflictResolver.class)
+@Named
+@Singleton
 public class DefaultGraphConflictResolver implements GraphConflictResolver {
     /**
      * artifact, closer to the entry point, is selected
      */
-    @Requirement(role = GraphConflictResolutionPolicy.class)
+    @Inject
     protected GraphConflictResolutionPolicy policy;
 
     // -------------------------------------------------------------------------------------

--- a/maven-compat/src/test/java/org/apache/maven/artifact/metadata/SwitchableMetadataSource.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/metadata/SwitchableMetadataSource.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.metadata;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.repository.legacy.metadata.MetadataResolutionRequest;
+import org.eclipse.sisu.Priority;
+
+@Singleton
+@Priority(10)
+@Named
+public class SwitchableMetadataSource implements ArtifactMetadataSource {
+    private ArtifactMetadataSource delegate;
+
+    @Inject
+    public SwitchableMetadataSource(@Named("test") ArtifactMetadataSource delegate) {
+        this.delegate = delegate;
+    }
+
+    public void setDelegate(ArtifactMetadataSource delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ResolutionGroup retrieve(MetadataResolutionRequest request) throws ArtifactMetadataRetrievalException {
+        return delegate.retrieve(request);
+    }
+
+    @Override
+    public ResolutionGroup retrieve(
+            Artifact artifact, ArtifactRepository localRepository, List<ArtifactRepository> remoteRepositories)
+            throws ArtifactMetadataRetrievalException {
+        return delegate.retrieve(artifact, localRepository, remoteRepositories);
+    }
+
+    @Override
+    public List<ArtifactVersion> retrieveAvailableVersions(MetadataResolutionRequest request)
+            throws ArtifactMetadataRetrievalException {
+        return delegate.retrieveAvailableVersions(request);
+    }
+
+    @Override
+    public List<ArtifactVersion> retrieveAvailableVersions(
+            Artifact artifact, ArtifactRepository localRepository, List<ArtifactRepository> remoteRepositories)
+            throws ArtifactMetadataRetrievalException {
+        return delegate.retrieveAvailableVersions(artifact, localRepository, remoteRepositories);
+    }
+
+    @Override
+    public List<ArtifactVersion> retrieveAvailableVersionsFromDeploymentRepository(
+            Artifact artifact, ArtifactRepository localRepository, ArtifactRepository remoteRepository)
+            throws ArtifactMetadataRetrievalException {
+        return delegate.retrieveAvailableVersionsFromDeploymentRepository(artifact, localRepository, remoteRepository);
+    }
+}

--- a/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.metadata.SwitchableMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
@@ -36,12 +37,15 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.RepositoryPolicy;
 import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.project.artifact.DefaultMetadataSource;
 import org.apache.maven.repository.legacy.LegacyRepositorySystem;
 import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.composition.CycleDetectedInComponentGraphException;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.codehaus.plexus.testing.PlexusExtension.getBasedir;
@@ -183,5 +187,16 @@ class LegacyRepositorySystemTest {
         assertEquals(localRepoDir, new File(basedir));
 
         assertEquals(localRepoDir.getPath(), basedir);
+    }
+
+    @Inject
+    DefaultMetadataSource defaultMetadataSource;
+
+    @Inject
+    SwitchableMetadataSource switchableMetadataSource;
+
+    @BeforeEach
+    void setup() throws CycleDetectedInComponentGraphException {
+        switchableMetadataSource.setDelegate(defaultMetadataSource);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,6 @@ under the License.
     <commonsLangVersion>3.12.0</commonsLangVersion>
     <junitVersion>5.9.1</junitVersion>
     <mockitoVersion>4.11.0</mockitoVersion>
-    <plexusVersion>2.1.0</plexusVersion>
     <plexusInterpolationVersion>1.26</plexusInterpolationVersion>
     <plexusUtilsVersion>4.0.0</plexusUtilsVersion>
     <plexusXmlVersion>4.0.0</plexusXmlVersion>
@@ -289,11 +288,6 @@ under the License.
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-annotations</artifactId>
-        <version>${plexusVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -494,19 +488,6 @@ under the License.
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-metadata</artifactId>
-          <version>${plexusVersion}</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>generate-metadata</goal>
-                <goal>generate-test-metadata</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
The goal of this PR is to completely get rid of old plexus annotations / plugins.
This requires moving maven-compat and the only remaining plexus components to JSR330. 
