### PR TITLE
[MNG-7800] Bump maven-resolver from 1.9.10 to 1.9.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@ under the License.
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
     <cipherVersion>2.0</cipherVersion>
     <jxpathVersion>1.3</jxpathVersion>
-    <resolverVersion>1.9.10</resolverVersion>
+    <resolverVersion>1.9.11</resolverVersion>
     <sisuVersion>0.9.0.M2</sisuVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.6.4</xmlunitVersion>


### PR DESCRIPTION
Resolver 1.9.11 release notes:
https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12320628&version=12353188

---

https://issues.apache.org/jira/browse/MNG-7800

