### PR TITLE
[MNG-7816] Update parent to 40, align maven requirements with those from plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>39</version>
+    <version>40</version>
     <relativePath />
   </parent>
 
@@ -125,12 +125,15 @@ under the License.
 
   <properties>
     <javaVersion>8</javaVersion>
+    <minimalMavenBuildVersion>3.5.4</minimalMavenBuildVersion>
+
     <classWorldsVersion>2.7.0</classWorldsVersion>
     <commonsCliVersion>1.5.0</commonsCliVersion>
     <commonsIoVersion>2.11.0</commonsIoVersion>
     <commonsLangVersion>3.12.0</commonsLangVersion>
     <junitVersion>4.13.2</junitVersion>
     <mockitoVersion>4.11.0</mockitoVersion>
+    <!-- plexus 2.1.1 is broken, no new release exists yet (nor will exist) -->
     <plexusVersion>2.1.0</plexusVersion>
     <plexusInterpolationVersion>1.26</plexusInterpolationVersion>
     <!-- Blocked by 3.4.0+ changes, see MNG-7710 -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@ under the License.
     <javaVersion>8</javaVersion>
     <minimalMavenBuildVersion>3.5.4</minimalMavenBuildVersion>
 
+    <sisuVersion>0.3.5</sisuVersion>
     <classWorldsVersion>2.7.0</classWorldsVersion>
     <commonsCliVersion>1.5.0</commonsCliVersion>
     <commonsIoVersion>2.11.0</commonsIoVersion>


### PR DESCRIPTION
Update parent to 40. Also align plugin requirements with those from parent.

This lowers plugin validation "external" warnings from 12 to 3 (site, plexus-component-metadata and rat).

---

https://issues.apache.org/jira/browse/MNG-7816