### PR TITLE
[MNG-7823] Improve plugin validation level parsing

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -86,8 +86,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
             if (executionEvent.getType() == ExecutionEvent.Type.SessionStarted) {
                 RepositorySystemSession repositorySystemSession =
                         executionEvent.getSession().getRepositorySession();
-                ValidationReportLevel level = parseValidationReportLevel(repositorySystemSession);
-                repositorySystemSession.getData().set(MAVEN_PLUGIN_VALIDATION_KEY, level);
+                validationReportLevel(repositorySystemSession); // this will parse and store it in session
             } else if (executionEvent.getType() == ExecutionEvent.Type.SessionEnded) {
                 reportSessionCollectedValidationIssues(executionEvent.getSession());
             }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -95,7 +95,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
 
     private ValidationReportLevel validationReportLevel(RepositorySystemSession session) {
         return (ValidationReportLevel) session.getData()
-                .computeIfAbsent(MAVEN_PLUGIN_VALIDATION_KEY, () -> parseValidationReportLevel(session));
+                .computeIfAbsent(ValidationReportLevel.class, () -> parseValidationReportLevel(session));
     }
 
     private ValidationReportLevel parseValidationReportLevel(RepositorySystemSession session) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -86,7 +86,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
             if (executionEvent.getType() == ExecutionEvent.Type.SessionStarted) {
                 RepositorySystemSession repositorySystemSession =
                         executionEvent.getSession().getRepositorySession();
-                validationReportLevel(repositorySystemSession); // this will parse and store it in session
+                validationReportLevel(repositorySystemSession); // this will parse and store it in session.data
             } else if (executionEvent.getType() == ExecutionEvent.Type.SessionEnded) {
                 reportSessionCollectedValidationIssues(executionEvent.getSession());
             }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -83,13 +83,23 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
     public void onEvent(Object event) {
         if (event instanceof ExecutionEvent) {
             ExecutionEvent executionEvent = (ExecutionEvent) event;
-            if (executionEvent.getType() == ExecutionEvent.Type.SessionEnded) {
+            if (executionEvent.getType() == ExecutionEvent.Type.SessionStarted) {
+                RepositorySystemSession repositorySystemSession =
+                        executionEvent.getSession().getRepositorySession();
+                ValidationReportLevel level = parseValidationReportLevel(repositorySystemSession);
+                repositorySystemSession.getData().set(MAVEN_PLUGIN_VALIDATION_KEY, level);
+            } else if (executionEvent.getType() == ExecutionEvent.Type.SessionEnded) {
                 reportSessionCollectedValidationIssues(executionEvent.getSession());
             }
         }
     }
 
     private ValidationReportLevel validationReportLevel(RepositorySystemSession session) {
+        return (ValidationReportLevel) session.getData()
+                .computeIfAbsent(MAVEN_PLUGIN_VALIDATION_KEY, () -> parseValidationReportLevel(session));
+    }
+
+    private ValidationReportLevel parseValidationReportLevel(RepositorySystemSession session) {
         String level = ConfigUtils.getString(session, null, MAVEN_PLUGIN_VALIDATION_KEY);
         if (level == null || level.isEmpty()) {
             return DEFAULT_VALIDATION_LEVEL;


### PR DESCRIPTION
Changes:
* always parse it at session start
* hence, will WARN if needed there as well, and will warn once
* do not re-parse and possibly warn always, reuse parsed enum

---

https://issues.apache.org/jira/browse/MNG-7823