### PR TITLE
[MNG-7228] MavenProject.getOriginalModel returns interpolated parts

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -480,7 +480,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             noErrors = false;
         }
 
-        Model model = result.getFileModel();
+        Model model = request.getFileModel();
 
         poolBuilder.put(model.getPomFile().toPath(), model);
 

--- a/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
@@ -175,7 +175,7 @@ class PomConstructionTest {
         assertEquals("||${project.basedir}||", originalModel.getProperties().get("prop-outside"));
 
         List<Plugin> outsidePlugins = originalModel.getBuild().getPlugins();
-        assertEquals(2, outsidePlugins.size());
+        assertEquals(1, outsidePlugins.size());
 
         checkBuildPluginWithArtifactId(
                 outsidePlugins,
@@ -270,7 +270,7 @@ class PomConstructionTest {
         assertEquals("||${project.basedir}||", originalModel.getProperties().get("prop-outside"));
 
         List<ReportPlugin> outsidePlugins = originalModel.getReporting().getPlugins();
-        assertEquals(2, outsidePlugins.size(), "Wrong number of plugins found");
+        assertEquals(1, outsidePlugins.size(), "Wrong number of plugins found");
 
         checkReportPluginWithArtifactId(
                 outsidePlugins,

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -658,7 +658,7 @@ public class DefaultModelBuilder implements ModelBuilder {
         Model fileModel = readFileModel(request, problems);
 
         request.setFileModel(fileModel);
-        result.setFileModel(fileModel);
+        result.setFileModel(fileModel.clone());
 
         activateFileModel(request, result, problems);
 


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7228
IT PR: https://github.com/apache/maven-integration-testing/pull/273