### PR TITLE
PoC/experiment: new scope "import-plugins"

### DIFF
--- a/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
@@ -63,6 +63,8 @@ public interface Artifact extends Comparable<Artifact> {
 
     String SCOPE_IMPORT = "import"; // Used to import dependencyManagement dependencies
 
+    String SCOPE_IMPORT_PLUGINS = "import-plugins"; // Used to import pluginManagement plugins
+
     String getGroupId();
 
     String getArtifactId();

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -64,6 +64,7 @@ import org.apache.maven.model.Repository;
 import org.apache.maven.model.building.ModelProblem.Severity;
 import org.apache.maven.model.building.ModelProblem.Version;
 import org.apache.maven.model.composition.DependencyManagementImporter;
+import org.apache.maven.model.composition.PluginManagementImporter;
 import org.apache.maven.model.inheritance.InheritanceAssembler;
 import org.apache.maven.model.interpolation.ModelInterpolator;
 import org.apache.maven.model.interpolation.ModelVersionProcessor;
@@ -116,6 +117,7 @@ public class DefaultModelBuilder implements ModelBuilder {
     private final InheritanceAssembler inheritanceAssembler;
     private final ProfileSelector profileSelector;
     private final ProfileInjector profileInjector;
+    private final PluginManagementImporter pluginManagementImporter;
     private final PluginManagementInjector pluginManagementInjector;
     private final DependencyManagementInjector dependencyManagementInjector;
     private final DependencyManagementImporter dependencyManagementImporter;
@@ -138,6 +140,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             InheritanceAssembler inheritanceAssembler,
             ProfileSelector profileSelector,
             ProfileInjector profileInjector,
+            PluginManagementImporter pluginManagementImporter,
             PluginManagementInjector pluginManagementInjector,
             DependencyManagementInjector dependencyManagementInjector,
             DependencyManagementImporter dependencyManagementImporter,
@@ -156,6 +159,7 @@ public class DefaultModelBuilder implements ModelBuilder {
         this.inheritanceAssembler = inheritanceAssembler;
         this.profileSelector = profileSelector;
         this.profileInjector = profileInjector;
+        this.pluginManagementImporter = pluginManagementImporter;
         this.pluginManagementInjector = pluginManagementInjector;
         this.dependencyManagementInjector = dependencyManagementInjector;
         this.dependencyManagementImporter = dependencyManagementImporter;
@@ -183,6 +187,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -210,6 +215,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -237,6 +243,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -264,6 +271,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -291,6 +299,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -318,6 +327,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -345,6 +355,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -372,6 +383,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -399,6 +411,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -426,6 +439,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -453,6 +467,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -481,6 +496,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -509,6 +525,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -536,6 +553,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -563,6 +581,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -590,6 +609,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -618,6 +638,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 inheritanceAssembler,
                 profileSelector,
                 profileInjector,
+                pluginManagementImporter,
                 pluginManagementInjector,
                 dependencyManagementInjector,
                 dependencyManagementImporter,
@@ -901,6 +922,9 @@ public class DefaultModelBuilder implements ModelBuilder {
 
         // model path translation
         modelPathTranslator.alignToBaseDirectory(resultModel, resultModel.getProjectDirectory(), request);
+
+        // plugin management import
+        importPluginManagement(resultModel, request, problems, imports);
 
         // plugin management injection
         pluginManagementInjector.injectManagement(resultModel, request, problems);
@@ -1582,6 +1606,48 @@ public class DefaultModelBuilder implements ModelBuilder {
         return superPomProvider.getSuperModel("4.0.0");
     }
 
+    private void importPluginManagement(
+            Model model,
+            ModelBuildingRequest request,
+            DefaultModelProblemCollector problems,
+            Collection<String> importIds) {
+        DependencyManagement depMgmt = model.getDependencyManagement();
+
+        if (depMgmt == null) {
+            return;
+        }
+
+        String importing = model.getGroupId() + ':' + model.getArtifactId() + ':' + model.getVersion();
+
+        importIds.add(importing);
+
+        List<org.apache.maven.api.model.PluginManagement> importMgmts = null;
+
+        for (Iterator<Dependency> it = depMgmt.getDependencies().iterator(); it.hasNext(); ) {
+            Dependency dependency = it.next();
+
+            if (!"pom".equals(dependency.getType()) || !"import-plugins".equals(dependency.getScope())) {
+                continue;
+            }
+
+            it.remove();
+
+            PluginManagement importMgmt = loadPluginManagement(model, request, problems, dependency, importIds);
+
+            if (importMgmt != null) {
+                if (importMgmts == null) {
+                    importMgmts = new ArrayList<>();
+                }
+
+                importMgmts.add(importMgmt.getDelegate());
+            }
+        }
+
+        importIds.remove(importing);
+
+        model.update(pluginManagementImporter.importManagement(model.getDelegate(), importMgmts, request, problems));
+    }
+
     private void importDependencyManagement(
             Model model,
             ModelBuildingRequest request,
@@ -1623,6 +1689,72 @@ public class DefaultModelBuilder implements ModelBuilder {
 
         model.update(
                 dependencyManagementImporter.importManagement(model.getDelegate(), importMgmts, request, problems));
+    }
+
+    private PluginManagement loadPluginManagement(
+            Model model,
+            ModelBuildingRequest request,
+            DefaultModelProblemCollector problems,
+            Dependency dependency,
+            Collection<String> importIds) {
+        String groupId = dependency.getGroupId();
+        String artifactId = dependency.getArtifactId();
+        String version = dependency.getVersion();
+
+        if (groupId == null || groupId.length() <= 0) {
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage("'dependencyManagement.dependencies.dependency.groupId' for "
+                            + dependency.getManagementKey() + " is missing.")
+                    .setLocation(dependency.getLocation("")));
+            return null;
+        }
+        if (artifactId == null || artifactId.length() <= 0) {
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage("'dependencyManagement.dependencies.dependency.artifactId' for "
+                            + dependency.getManagementKey() + " is missing.")
+                    .setLocation(dependency.getLocation("")));
+            return null;
+        }
+        if (version == null || version.length() <= 0) {
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage("'dependencyManagement.dependencies.dependency.version' for "
+                            + dependency.getManagementKey() + " is missing.")
+                    .setLocation(dependency.getLocation("")));
+            return null;
+        }
+
+        String imported = groupId + ':' + artifactId + ':' + version;
+
+        if (importIds.contains(imported)) {
+            StringBuilder message =
+                    new StringBuilder("The dependencies of type=pom and with scope=import-plugins form a cycle: ");
+            for (String modelId : importIds) {
+                message.append(modelId).append(" -> ");
+            }
+            message.append(imported);
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE).setMessage(message.toString()));
+
+            return null;
+        }
+
+        org.apache.maven.api.model.PluginManagement importMgmt =
+                fromCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT_PLUGINS);
+        if (importMgmt == null) {
+            PluginManagement importMgmtV3 = doLoadPluginManagement(
+                    model, request, problems, dependency, groupId, artifactId, version, importIds);
+            if (importMgmtV3 != null) {
+                importMgmt = importMgmtV3.getDelegate();
+                intoCache(
+                        request.getModelCache(),
+                        groupId,
+                        artifactId,
+                        version,
+                        ModelCacheTag.IMPORT_PLUGINS,
+                        importMgmt);
+            }
+        }
+
+        return importMgmt != null ? new PluginManagement(importMgmt) : null;
     }
 
     private DependencyManagement loadDependencyManagement(
@@ -1703,6 +1835,91 @@ public class DefaultModelBuilder implements ModelBuilder {
 
     private boolean match(String match, String text) {
         return match.equals("*") || match.equals(text);
+    }
+
+    @SuppressWarnings("checkstyle:parameternumber")
+    private PluginManagement doLoadPluginManagement(
+            Model model,
+            ModelBuildingRequest request,
+            DefaultModelProblemCollector problems,
+            Dependency dependency,
+            String groupId,
+            String artifactId,
+            String version,
+            Collection<String> importIds) {
+        PluginManagement importMgmt = null;
+        final WorkspaceModelResolver workspaceResolver = request.getWorkspaceModelResolver();
+        final ModelResolver modelResolver = request.getModelResolver();
+        if (workspaceResolver == null && modelResolver == null) {
+            throw new NullPointerException(String.format(
+                    "request.workspaceModelResolver and request.modelResolver cannot be null (parent POM %s and POM %s)",
+                    ModelProblemUtils.toId(groupId, artifactId, version), ModelProblemUtils.toSourceHint(model)));
+        }
+
+        Model importModel = null;
+        if (workspaceResolver != null) {
+            try {
+                importModel = workspaceResolver.resolveEffectiveModel(groupId, artifactId, version);
+            } catch (UnresolvableModelException e) {
+                problems.add(new ModelProblemCollectorRequest(Severity.FATAL, Version.BASE)
+                        .setMessage(e.getMessage())
+                        .setException(e));
+                return null;
+            }
+        }
+
+        // no workspace resolver or workspace resolver returned null (i.e. model not in workspace)
+        if (importModel == null) {
+            final ModelSource importSource;
+            try {
+                importSource = modelResolver.resolveModel(dependency);
+            } catch (UnresolvableModelException e) {
+                StringBuilder buffer = new StringBuilder(256);
+                buffer.append("Non-resolvable import POM");
+                if (!containsCoordinates(e.getMessage(), groupId, artifactId, version)) {
+                    buffer.append(' ').append(ModelProblemUtils.toId(groupId, artifactId, version));
+                }
+                buffer.append(": ").append(e.getMessage());
+
+                problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                        .setMessage(buffer.toString())
+                        .setLocation(dependency.getLocation(""))
+                        .setException(e));
+                return null;
+            }
+
+            final ModelBuildingResult importResult;
+            try {
+                ModelBuildingRequest importRequest = new DefaultModelBuildingRequest();
+                importRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+                importRequest.setModelCache(request.getModelCache());
+                importRequest.setSystemProperties(request.getSystemProperties());
+                importRequest.setUserProperties(request.getUserProperties());
+                importRequest.setLocationTracking(request.isLocationTracking());
+
+                importRequest.setModelSource(importSource);
+                importRequest.setModelResolver(modelResolver.newCopy());
+
+                importResult = build(importRequest, importIds);
+            } catch (ModelBuildingException e) {
+                problems.addAll(e.getProblems());
+                return null;
+            }
+
+            problems.addAll(importResult.getProblems());
+
+            importModel = importResult.getEffectiveModel();
+        }
+
+        Build build = importModel.getBuild();
+        if (build != null) {
+            importMgmt = build.getPluginManagement();
+        }
+
+        if (importMgmt == null) {
+            importMgmt = new PluginManagement();
+        }
+        return importMgmt;
     }
 
     @SuppressWarnings("checkstyle:parameternumber")

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
@@ -22,7 +22,9 @@ import java.util.Arrays;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.composition.DefaultDependencyManagementImporter;
+import org.apache.maven.model.composition.DefaultPluginManagementImporter;
 import org.apache.maven.model.composition.DependencyManagementImporter;
+import org.apache.maven.model.composition.PluginManagementImporter;
 import org.apache.maven.model.inheritance.DefaultInheritanceAssembler;
 import org.apache.maven.model.inheritance.InheritanceAssembler;
 import org.apache.maven.model.interpolation.DefaultModelVersionProcessor;
@@ -93,6 +95,7 @@ public class DefaultModelBuilderFactory {
     private InheritanceAssembler inheritanceAssembler;
     private ProfileSelector profileSelector;
     private ProfileInjector profileInjector;
+    private PluginManagementImporter pluginManagementImporter;
     private PluginManagementInjector pluginManagementInjector;
     private DependencyManagementInjector dependencyManagementInjector;
     private DependencyManagementImporter dependencyManagementImporter;
@@ -151,6 +154,11 @@ public class DefaultModelBuilderFactory {
 
     public DefaultModelBuilderFactory setProfileInjector(ProfileInjector profileInjector) {
         this.profileInjector = profileInjector;
+        return this;
+    }
+
+    public DefaultModelBuilderFactory setPluginManagementImporter(PluginManagementImporter pluginManagementImporter) {
+        this.pluginManagementImporter = pluginManagementImporter;
         return this;
     }
 
@@ -303,6 +311,10 @@ public class DefaultModelBuilderFactory {
         return new StubLifecycleBindingsInjector();
     }
 
+    protected PluginManagementImporter newPluginManagementImporter() {
+        return new DefaultPluginManagementImporter();
+    }
+
     protected PluginManagementInjector newPluginManagementInjector() {
         return new DefaultPluginManagementInjector();
     }
@@ -341,6 +353,7 @@ public class DefaultModelBuilderFactory {
                 inheritanceAssembler != null ? inheritanceAssembler : newInheritanceAssembler(),
                 profileSelector != null ? profileSelector : newProfileSelector(),
                 profileInjector != null ? profileInjector : newProfileInjector(),
+                pluginManagementImporter != null ? pluginManagementImporter : newPluginManagementImporter(),
                 pluginManagementInjector != null ? pluginManagementInjector : newPluginManagementInjector(),
                 dependencyManagementInjector != null ? dependencyManagementInjector : newDependencyManagementInjector(),
                 dependencyManagementImporter != null ? dependencyManagementImporter : newDependencyManagementImporter(),

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelCacheTag.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelCacheTag.java
@@ -20,6 +20,7 @@ package org.apache.maven.model.building;
 
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.Model;
+import org.apache.maven.api.model.PluginManagement;
 
 /**
  * Describes a tag used by the model builder to access a {@link ModelCache}. This interface basically aggregates a name
@@ -110,6 +111,34 @@ interface ModelCacheTag<T> {
 
         @Override
         public DependencyManagement fromCache(DependencyManagement data) {
+            return data;
+        }
+    };
+
+    /**
+     * The tag used to denote an effective dependency management section from an imported model.
+     *
+     * @since TBD
+     */
+    ModelCacheTag<PluginManagement> IMPORT_PLUGINS = new ModelCacheTag<PluginManagement>() {
+
+        @Override
+        public String getName() {
+            return "import-plugins";
+        }
+
+        @Override
+        public Class<PluginManagement> getType() {
+            return PluginManagement.class;
+        }
+
+        @Override
+        public PluginManagement intoCache(PluginManagement data) {
+            return data;
+        }
+
+        @Override
+        public PluginManagement fromCache(PluginManagement data) {
             return data;
         }
     };

--- a/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultPluginManagementImporter.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultPluginManagementImporter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.composition;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.api.model.Build;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.model.Plugin;
+import org.apache.maven.api.model.PluginManagement;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelProblemCollector;
+
+/**
+ * Handles the import of plugin management from other models into the target model.
+ */
+@Named
+@Singleton
+public class DefaultPluginManagementImporter implements PluginManagementImporter {
+
+    @Override
+    public Model importManagement(
+            Model target,
+            List<? extends PluginManagement> sources,
+            ModelBuildingRequest request,
+            ModelProblemCollector problems) {
+        if (sources != null && !sources.isEmpty()) {
+            Map<String, Plugin> plugins = new LinkedHashMap<>();
+
+            Build build = target.getBuild();
+            if (build == null) {
+                build = Build.newInstance();
+            }
+
+            PluginManagement plgMgmt = build.getPluginManagement();
+            if (plgMgmt != null) {
+                for (Plugin plugin : plgMgmt.getPlugins()) {
+                    plugins.put(plugin.getKey(), plugin);
+                }
+            } else {
+                plgMgmt = PluginManagement.newInstance();
+            }
+
+            for (PluginManagement source : sources) {
+                for (Plugin plugin : source.getPlugins()) {
+                    String key = plugin.getKey();
+                    plugins.putIfAbsent(key, plugin);
+                }
+            }
+
+            return target.withBuild(build.withPluginManagement(plgMgmt.withPlugins(plugins.values())));
+        }
+        return target;
+    }
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/composition/PluginManagementImporter.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/composition/PluginManagementImporter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.composition;
+
+import java.util.List;
+
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.model.PluginManagement;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelProblemCollector;
+
+/**
+ * Handles the import of plugin management from other models into the target model.
+ *
+ * @since TBD
+ */
+public interface PluginManagementImporter {
+
+    /**
+     * Imports the specified plugin management sections into the given target model.
+     *
+     * @param target The model into which to import the plugin management section, must not be <code>null</code>.
+     * @param sources The plugin management sections to import, may be <code>null</code>.
+     * @param request The model building request that holds further settings, must not be {@code null}.
+     * @param problems The container used to collect problems that were encountered, must not be {@code null}.
+     */
+    Model importManagement(
+            Model target,
+            List<? extends PluginManagement> sources,
+            ModelBuildingRequest request,
+            ModelProblemCollector problems);
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -572,7 +572,7 @@ public class DefaultModelValidator implements ModelValidator {
         for (Dependency dependency : dependencies) {
             String key = dependency.getManagementKey();
 
-            if ("import".equals(dependency.getScope())) {
+            if ("import".equals(dependency.getScope()) || "import-plugins".equals(dependency.getScope())) {
                 if (!"pom".equals(dependency.getType())) {
                     addViolation(
                             problems,
@@ -753,7 +753,8 @@ public class DefaultModelValidator implements ModelValidator {
                             "runtime",
                             "test",
                             "system",
-                            "import");
+                            "import",
+                            "import-plugins");
                 }
             }
         }


### PR DESCRIPTION
Introduces new scope very similar to "import" but this one is "import-plugins" and as it's name says, imports pluginManagement.

To test it:
* build this PR
* use this POM https://gist.github.com/cstamas/8668205f68b0eaf42c8c34bba7d080a4
* invoke `mvn help:effective-pom`

Enjoy!