### PR TITLE
[MNG-7828] Bump guava from 30.1-jre to 32.0.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@ under the License.
     <plexusUtilsVersion>4.0.0</plexusUtilsVersion>
     <plexusXmlVersion>4.0.1</plexusXmlVersion>
     <guiceVersion>5.1.0</guiceVersion>
-    <guavaVersion>30.1-jre</guavaVersion>
+    <guavaVersion>32.0.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <wagonVersion>3.5.3</wagonVersion>
     <securityDispatcherVersion>2.0</securityDispatcherVersion>


### PR DESCRIPTION
Update due to CVE-2023-2976.

See https://issues.apache.org/jira/browse/MNG-7828 for more context.


--

Doing on master too, following @cstamas instructions at https://github.com/apache/maven/pull/1189#issuecomment-1611048094