### PR TITLE
[MNG-7834] Fix NullPointerException in flatten-maven-plugin

### DIFF
--- a/maven-model/src/test/java/org/apache/maven/model/DependencyManagementTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/DependencyManagementTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,5 +53,22 @@ class DependencyManagementTest {
     @Test
     void testToStringNullSafe() {
         assertNotNull(new DependencyManagement().toString());
+    }
+
+    @Test
+    void testDependencies() {
+        DependencyManagement dm = new DependencyManagement();
+        Dependency d1 = new Dependency();
+        d1.setGroupId("myGroupId");
+        assertNotNull(dm.getDependencies());
+        assertEquals(0, dm.getDependencies().size());
+        dm.addDependency(d1);
+        assertNotNull(dm.getDependencies());
+        assertEquals(1, dm.getDependencies().size());
+        dm.getDependencies().get(0).setArtifactId("myArtifactId");
+        assertEquals("myArtifactId", dm.getDependencies().get(0).getArtifactId());
+        dm.setDependencies(null);
+        assertNotNull(dm.getDependencies());
+        assertEquals(0, dm.getDependencies().size());
     }
 }

--- a/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
+++ b/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
@@ -20,8 +20,10 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -34,6 +36,19 @@ class ModelTest {
     @Test
     void testHashCodeNullSafe() {
         new Model().hashCode();
+    }
+
+    @Test
+    void testBuild() {
+        Model model = new Model();
+        Build build = new Build();
+        build.setOutputDirectory("myOutputDirectory");
+        model.setBuild(build);
+        Build build2 = model.getBuild();
+        assertNotNull(build2);
+        assertEquals("myOutputDirectory", build2.getOutputDirectory());
+        model.setBuild(null);
+        assertNull(model.getBuild());
     }
 
     @Test

--- a/src/mdo/model-v3.vm
+++ b/src/mdo/model-v3.vm
@@ -201,18 +201,25 @@ public class ${class.name}
         if (!Objects.equals(map, getDelegate().get${cap}())) {
             update(getDelegate().with${cap}(map));
         }
+      #elseif ( $field.to != "String" && $field.type == "java.util.List" && $field.multiplicity == "*" )
+        if (${field.name} == null) {
+            ${field.name} = Collections.emptyList();
+        }
+        if (!Objects.equals(${field.name}, ${pfx}${cap}())) {
+            update(getDelegate().with${cap}(
+                ${field.name}.stream().map(c -> c.getDelegate()).collect(Collectors.toList())));
+            ${field.name}.forEach(e -> e.childrenTracking = this::replace);
+        }
+      #elseif ( $field.to && $field.to != "String" )
+        if (!Objects.equals(${field.name}, ${pfx}${cap}())){
+            update(getDelegate().with${cap}(${field.name}.getDelegate()));
+            if (${field.name} != null) {
+                ${field.name}.childrenTracking = this::replace;
+            }
+        }
       #else
         if (!Objects.equals(${field.name}, ${pfx}${cap}())) {
-        #if ( $field.to != "String" && $field.type == "java.util.List" && $field.multiplicity == "*" )
-            update(getDelegate().with${cap}(
-                   ${field.name}.stream().map(c -> c.getDelegate()).collect(Collectors.toList())));
-            ${field.name}.forEach(e -> e.childrenTracking = this::replace);
-        #elseif ( $field.to && $field.to != "String" )
-            update(getDelegate().with${cap}(${field.name}.getDelegate()));
-            ${field.name}.childrenTracking = this::replace;
-        #else
             update(getDelegate().with${cap}(${field.name}));
-        #end
         }
       #end
     }

--- a/src/mdo/model-v3.vm
+++ b/src/mdo/model-v3.vm
@@ -212,9 +212,11 @@ public class ${class.name}
         }
       #elseif ( $field.to && $field.to != "String" )
         if (!Objects.equals(${field.name}, ${pfx}${cap}())){
-            update(getDelegate().with${cap}(${field.name}.getDelegate()));
             if (${field.name} != null) {
+                update(getDelegate().with${cap}(${field.name}.getDelegate()));
                 ${field.name}.childrenTracking = this::replace;
+            } else {
+                update(getDelegate().with${cap}(null));
             }
         }
       #else


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7834

The flatten-maven-plugin fails with a NPE:
```
[ERROR] Failed to execute goal org.codehaus.mojo:flatten-maven-plugin:1.5.0:flatten (default-cli) on project camel: failed to create a clean pom: Cannot invoke "java.util.List.stream()" 
because "dependencies" is null -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.mojo:flatten-maven-plugin:1.5.0:flatten (default-cli) on project camel: failed to create a clean 
pom
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:341)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:324)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:174)
	at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:77)
	at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:162)
	at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:159)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:114)
	at io.takari.maven.builder.smart.SmartBuilderImpl.buildProject(SmartBuilderImpl.java:204)
	at io.takari.maven.builder.smart.SmartBuilderImpl$ProjectBuildTask.run(SmartBuilderImpl.java:78)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1623)
Caused by: org.apache.maven.plugin.MojoExecutionException: failed to create a clean pom
	at org.codehaus.mojo.flatten.FlattenMojo.createFlattenedPom(FlattenMojo.java:556)
	at org.codehaus.mojo.flatten.FlattenMojo.execute(FlattenMojo.java:406)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:143)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:336)
	... 15 common frames omitted
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "dependencies" is null
	at org.apache.maven.model.ModelBase.setDependencies(ModelBase.java:164)
	at org.codehaus.mojo.flatten.FlattenMojo.createCleanPom(FlattenMojo.java:686)
	at org.codehaus.mojo.flatten.FlattenMojo.createFlattenedPom(FlattenMojo.java:554)
	... 18 common frames omitted
```
