### PR TITLE
[MNG-7846] Break out of endless loop

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 import org.apache.maven.lifecycle.LifecycleExecutionException;
@@ -226,9 +225,8 @@ public class DefaultExceptionHandler implements ExceptionHandler {
     private String getMessage(String message, Throwable exception) {
         String fullMessage = (message != null) ? message : "";
 
-        // To break out of possible endless loop when there is a cycle in causes chain
-        HashSet<Throwable> processed = new HashSet<>();
-        for (Throwable t = exception; t != null && processed.add(t); t = t.getCause()) {
+        // To break out of possible endless loop when getCause returns "this"
+        for (Throwable t = exception; t != null && t != t.getCause(); t = t.getCause()) {
             String exceptionMessage = t.getMessage();
 
             if (t instanceof AbstractMojoExecutionException) {

--- a/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.exception;
 
-import java.util.HashSet;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -26,6 +25,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.maven.lifecycle.LifecycleExecutionException;

--- a/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.exception;
 
+import java.util.HashSet;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -225,7 +226,9 @@ public class DefaultExceptionHandler implements ExceptionHandler {
     private String getMessage(String message, Throwable exception) {
         String fullMessage = (message != null) ? message : "";
 
-        for (Throwable t = exception; t != null; t = t.getCause()) {
+        // To break out of possible endless loop when there is a cycle in causes chain
+        HashSet<Throwable> processed = new HashSet<>();
+        for (Throwable t = exception; t != null && processed.add(t); t = t.getCause()) {
             String exceptionMessage = t.getMessage();
 
             if (t instanceof AbstractMojoExecutionException) {

--- a/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
@@ -95,4 +95,24 @@ class DefaultExceptionHandlerTest {
         String expectedReference = "http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException";
         assertEquals(expectedReference, summary.getReference());
     }
+
+    @Test
+    void testHandleExceptionLoopInCause() {
+        // loop here: cause -> cause2 -> cause...
+        Exception cause2 = new RuntimeException("loop");
+        Plugin plugin = new Plugin();
+        Exception cause = new PluginContainerException(plugin, null, null, cause2);
+        cause2.initCause(cause);
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        MojoDescriptor mojoDescriptor = new MojoDescriptor();
+        mojoDescriptor.setPluginDescriptor(pluginDescriptor);
+        MojoExecution mojoExecution = new MojoExecution(mojoDescriptor);
+        Throwable exception = new PluginExecutionException(mojoExecution, null, cause);
+
+        DefaultExceptionHandler handler = new DefaultExceptionHandler();
+        ExceptionSummary summary = handler.handleException(exception);
+
+        String expectedReference = "http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException";
+        assertEquals(expectedReference, summary.getReference());
+    }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
@@ -150,7 +150,9 @@ public final class CLIReportingUtils {
             if (e != null) {
                 logger.error(e.getMessage());
 
-                for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+                for (Throwable cause = e.getCause();
+                        cause != null && cause != cause.getCause();
+                        cause = cause.getCause()) {
                     logger.error("Caused by: {}", cause.getMessage());
                 }
             }

--- a/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
@@ -79,7 +79,7 @@ public class MavenSimpleLogger extends SimpleLogger {
             writeThrowable(se, stream, "Suppressed", prefix + "    ");
         }
         Throwable cause = t.getCause();
-        if (cause != null) {
+        if (cause != null && t != cause) {
             writeThrowable(cause, stream, "Caused by", prefix);
         }
     }


### PR DESCRIPTION
When there is a loop in throwable causes, DefaultExceptionHandler falls into an endless loop to produce message. Use plain hashSet to gather processed throwable instances to break out.

---

https://issues.apache.org/jira/browse/MNG-7846