### PR TITLE
[MNG-7854] Warn if imported depMgt is ignored as it already exists

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultDependencyManagementImporter.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultDependencyManagementImporter.java
@@ -30,7 +30,9 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelProblemCollector;
+import org.apache.maven.model.building.ModelProblemCollectorRequest;
 
 /**
  * Handles the import of dependency management from other models into the target model.
@@ -66,6 +68,11 @@ public class DefaultDependencyManagementImporter implements DependencyManagement
                     String key = dependency.getManagementKey();
                     if (!dependencies.containsKey(key)) {
                         dependencies.put(key, dependency);
+                    } else {
+                        problems.add(new ModelProblemCollectorRequest(
+                                        ModelProblem.Severity.WARNING, ModelProblem.Version.BASE)
+                                .setMessage("Ignored import for key as key is already present " + key)
+                                .setLocation(dependency.getLocation("")));
                     }
                 }
             }


### PR DESCRIPTION
Original issue described here https://issues.apache.org/jira/browse/MNG-7852 (as 3rd bullet) and related analysis is here https://github.com/hboutemy/sigstore-maven-plugin/blob/import/analysis.md

The problem was simply that previous ("deep" BOM) already imported protobuf-java, so 2nd depMgt import was simply ignored.

This simple change just adds warning.

Here is a reproducer:
https://github.com/cstamas/MNG-7852

W/ this PR output is like this:
https://gist.github.com/cstamas/b1ceadaea9f7015d419ec1047da5b51a

---

https://issues.apache.org/jira/browse/MNG-7854
