### PR TITLE
Fix dependabot alerts

### DIFF
--- a/maven-core/src/test/projects/lifecycle-executor/project-with-inheritance/pom.xml
+++ b/maven-core/src/test/projects/lifecycle-executor/project-with-inheritance/pom.xml
@@ -58,7 +58,7 @@ under the License.
     <plexusInteractivityVersion>1.0-alpha-6</plexusInteractivityVersion>
     <plexusInterpolationVersion>1.1</plexusInterpolationVersion>
     <plexusPluginManagerVersion>1.0-alpha-1</plexusPluginManagerVersion>
-    <plexusUtilsVersion>1.5.8</plexusUtilsVersion>
+    <plexusUtilsVersion>3.0.16</plexusUtilsVersion>
     <plexusJetty6Version>1.6</plexusJetty6Version>
     <plexusWebdavVersion>1.0</plexusWebdavVersion>
     <wagonVersion>1.0-beta-4</wagonVersion>

--- a/maven-core/src/test/projects/plugin-manager/project-with-inheritance/pom.xml
+++ b/maven-core/src/test/projects/plugin-manager/project-with-inheritance/pom.xml
@@ -58,7 +58,7 @@ under the License.
     <plexusInteractivityVersion>1.0-alpha-6</plexusInteractivityVersion>
     <plexusInterpolationVersion>1.1</plexusInterpolationVersion>
     <plexusPluginManagerVersion>1.0-alpha-1</plexusPluginManagerVersion>
-    <plexusUtilsVersion>1.5.8</plexusUtilsVersion>
+    <plexusUtilsVersion>3.0.16</plexusUtilsVersion>
     <plexusJetty6Version>1.6</plexusJetty6Version>
     <plexusWebdavVersion>1.0</plexusWebdavVersion>
     <wagonVersion>1.0-beta-4</wagonVersion>

--- a/maven-core/src/test/resources-project-builder/micromailer/pom.xml
+++ b/maven-core/src/test/resources-project-builder/micromailer/pom.xml
@@ -78,8 +78,8 @@
 
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <version>1.5</version>
+      <artifactId>velocity-engine-core</artifactId>
+      <version>2.3</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
(that are not applicable, but look ugly).

These tests are NOT built, but are taken from real projects several years ago, and used in POM related UTs.

Hence, for example update of velocity is completely okay, even if in "real life" it would not compile.
