### PR TITLE
[MNG-7862] The ModelLocator should always be used when locating pom.xml

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -1802,7 +1802,7 @@
             ]]>
           </description>
           <type>String</type>
-          <defaultValue>../pom.xml</defaultValue>
+          <defaultValue>..</defaultValue>
         </field>
       </fields>
       <codeSegments>

--- a/maven-core/src/main/java/org/apache/maven/project/ReactorModelPool.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ReactorModelPool.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.project;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
@@ -58,23 +57,6 @@ class ReactorModelPool {
                             "Multiple modules with key " + a.getGroupId() + ':' + a.getArtifactId());
                 })
                 .orElse(null);
-    }
-
-    /**
-     * Find model by path, useful when location the parent by relativePath
-     *
-     * @param path
-     * @return the matching model or {@code null}
-     * @since 4.0.0
-     */
-    public Model get(Path path) {
-        final Path pomFile;
-        if (Files.isDirectory(path)) {
-            pomFile = path.resolve("pom.xml");
-        } else {
-            pomFile = path;
-        }
-        return modelsByPath.get(pomFile);
     }
 
     private String getVersion(Model model) {

--- a/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
@@ -74,17 +74,17 @@ class ConsumerPomArtifactTransformerTest {
 
         @Override
         public Model getRawModel(String groupId, String artifactId) throws IllegalStateException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public Model getRawModel(Path p) {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public Path locate(Path path) {
-            return null;
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformerTest.java
@@ -81,5 +81,10 @@ class ConsumerPomArtifactTransformerTest {
         public Model getRawModel(Path p) {
             return null;
         }
+
+        @Override
+        public Path locate(Path path) {
+            return null;
+        }
     }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1349,23 +1349,20 @@ public class MavenCli {
             alternatePomFile = commandLine.getOptionValue(CLIManager.ALTERNATE_POM_FILE);
         }
 
+        File current = baseDirectory;
         if (alternatePomFile != null) {
-            File pom = resolveFile(new File(alternatePomFile), workingDirectory);
-            if (pom.isDirectory()) {
-                if (modelProcessor != null) {
-                    pom = modelProcessor.locatePom(pom);
-                } else {
-                    pom = new File(pom, "pom.xml");
-                }
-            }
+            current = resolveFile(new File(alternatePomFile), workingDirectory);
+        }
 
+        File pom;
+        if (current.isDirectory() && modelProcessor != null) {
+            pom = modelProcessor.locatePom(current);
+        } else {
+            pom = current;
+        }
+
+        if (pom.isFile()) {
             return pom;
-        } else if (modelProcessor != null) {
-            File pom = modelProcessor.locatePom(baseDirectory);
-
-            if (pom.isFile()) {
-                return pom;
-            }
         }
 
         return null;

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultBuildPomXMLFilterFactory.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultBuildPomXMLFilterFactory.java
@@ -52,6 +52,11 @@ public class DefaultBuildPomXMLFilterFactory extends BuildToRawPomXMLFilterFacto
     }
 
     @Override
+    protected Function<Path, Path> getModelLocator() {
+        return context::locate;
+    }
+
+    @Override
     protected BiFunction<String, String, String> getDependencyKeyToVersionMapper() {
         return (g, a) -> Optional.ofNullable(context.getRawModel(g, a))
                 .map(DefaultBuildPomXMLFilterFactory::toVersion)

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultTransformerContext.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultTransformerContext.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.apache.maven.model.Model;
+import org.apache.maven.model.locator.ModelLocator;
 
 /**
  *
@@ -32,6 +33,8 @@ import org.apache.maven.model.Model;
  * @since 4.0.0
  */
 class DefaultTransformerContext implements TransformerContext {
+    final ModelLocator modelLocator;
+
     final Map<String, String> userProperties = new ConcurrentHashMap<>();
 
     final Map<Path, Holder> modelByPath = new ConcurrentHashMap<>();
@@ -77,6 +80,10 @@ class DefaultTransformerContext implements TransformerContext {
         }
     }
 
+    DefaultTransformerContext(ModelLocator modelLocator) {
+        this.modelLocator = modelLocator;
+    }
+
     @Override
     public String getUserProperty(String key) {
         return userProperties.get(key);
@@ -90,6 +97,11 @@ class DefaultTransformerContext implements TransformerContext {
     @Override
     public Model getRawModel(String groupId, String artifactId) {
         return Holder.deref(modelByGA.get(new GAKey(groupId, artifactId)));
+    }
+
+    @Override
+    public Path locate(Path path) {
+        return modelLocator.locatePom(path.toFile()).toPath();
     }
 
     static class GAKey {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
@@ -22,13 +22,14 @@ import java.io.File;
 import java.net.URI;
 
 import org.apache.maven.building.FileSource;
+import org.apache.maven.model.locator.ModelLocator;
 
 /**
  * Wraps an ordinary {@link File} as a model source.
  *
  * @author Benjamin Bentmann
  */
-public class FileModelSource extends FileSource implements ModelSource2 {
+public class FileModelSource extends FileSource implements ModelSource3 {
 
     /**
      * Creates a new model source backed by the specified file.
@@ -51,18 +52,17 @@ public class FileModelSource extends FileSource implements ModelSource2 {
     }
 
     @Override
-    public ModelSource2 getRelatedSource(String relPath) {
+    public ModelSource3 getRelatedSource(ModelLocator locator, String relPath) {
         relPath = relPath.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 
         File relatedPom = new File(getFile().getParentFile(), relPath);
 
-        if (relatedPom.isDirectory()) {
-            // TODO figure out how to reuse ModelLocator.locatePom(File) here
-            relatedPom = new File(relatedPom, "pom.xml");
+        if (relatedPom.isDirectory() && locator != null) {
+            relatedPom = locator.locatePom(relatedPom);
         }
 
         if (relatedPom.isFile() && relatedPom.canRead()) {
-            return new FileModelSource(new File(relatedPom.toURI().normalize()));
+            return new FileModelSource(relatedPom.toPath().normalize().toFile());
         }
 
         return null;

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelSource3.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelSource3.java
@@ -37,9 +37,9 @@ public interface ModelSource3 extends ModelSource2 {
      * to find the POM file, else if no locator is provided, a file named 'pom.xml' needs to be
      * used by the requested model source.
      *
-     * @param locator locator used to actually locate the pom file.
-     * @param relPath path of the requested model source relative to this model source POM.
-     * @return related model source or <code>null</code> if no such model source.
+     * @param locator locator used to locate the pom file
+     * @param relPath path of the requested model source relative to this model source POM
+     * @return related model source or <code>null</code> if no such model source
      */
     ModelSource3 getRelatedSource(ModelLocator locator, String relPath);
 

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelSource3.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelSource3.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.building;
+
+import org.apache.maven.model.locator.ModelLocator;
+
+/**
+ * Enhancement to the {@link ModelSource2} to support locating POM files using the {@link ModelLocator}
+ * when pointing to a directory.
+ */
+public interface ModelSource3 extends ModelSource2 {
+    /**
+     * Returns model source identified by a path relative to this model source POM. Implementation <strong>MUST</strong>
+     * accept <code>relPath</code> parameter values that
+     * <ul>
+     * <li>use either / or \ file path separator</li>
+     * <li>have .. parent directory references</li>
+     * <li>point either at file or directory</li>
+     * </ul>
+     * If the given path points at a directory, the provided {@code ModelLocator} will be used
+     * to find the POM file, else if no locator is provided, a file named 'pom.xml' needs to be
+     * used by the requested model source.
+     *
+     * @param locator locator used to actually locate the pom file.
+     * @param relPath path of the requested model source relative to this model source POM.
+     * @return related model source or <code>null</code> if no such model source.
+     */
+    ModelSource3 getRelatedSource(ModelLocator locator, String relPath);
+
+    /**
+     * When using a ModelSource3, the method with a {@code ModelLocator} argument should
+     * be used instead.
+     *
+     * @deprecated use {@link #getRelatedSource(ModelLocator, String)} instead
+     */
+    @Deprecated
+    default ModelSource3 getRelatedSource(String relPath) {
+        return getRelatedSource(null, relPath);
+    }
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/TransformerContext.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/TransformerContext.java
@@ -59,4 +59,6 @@ public interface TransformerContext {
      * @throws IllegalStateException if multiple versions of the same GA are part of the reactor
      */
     Model getRawModel(String groupId, String artifactId);
+
+    Path locate(Path path);
 }

--- a/maven-model-transform/src/main/java/org/apache/maven/model/transform/BuildToRawPomXMLFilterFactory.java
+++ b/maven-model-transform/src/main/java/org/apache/maven/model/transform/BuildToRawPomXMLFilterFactory.java
@@ -56,7 +56,7 @@ public class BuildToRawPomXMLFilterFactory {
         }
 
         if (getRelativePathMapper() != null) {
-            parser = new ParentXMLFilter(parser, getRelativePathMapper(), projectFile.getParent());
+            parser = new ParentXMLFilter(parser, getRelativePathMapper(), getModelLocator(), projectFile.getParent());
         }
 
         CiFriendlyXMLFilter ciFriendlyFilter = new CiFriendlyXMLFilter(parser, consume);
@@ -74,6 +74,10 @@ public class BuildToRawPomXMLFilterFactory {
      * @return the mapper or {@code null} if relativePaths don't need to be mapped
      */
     protected Function<Path, Optional<RelativeProject>> getRelativePathMapper() {
+        return null;
+    }
+
+    protected Function<Path, Path> getModelLocator() {
         return null;
     }
 


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7862
IT PR: https://github.com/apache/maven-integration-testing/pull/289

There are a few places where the `pom.xml` file name is hardcoded. There's a known interface to locate those, so those references should be cleaned.
One IT has to be adjusted (see PR) because the default value in the model is changed from `../pom.xml` to `..` for the parent `relativePath` default value.