### PR TITLE
[MNG-7874] Use name constants instead of free string literals

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/PluginsMetadataGeneratorFactory.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/PluginsMetadataGeneratorFactory.java
@@ -30,9 +30,11 @@ import org.eclipse.aether.installation.InstallRequest;
 /**
  * Maven G level metadata generator factory.
  */
-@Named("plugins")
+@Named(PluginsMetadataGeneratorFactory.NAME)
 @Singleton
 public class PluginsMetadataGeneratorFactory implements MetadataGeneratorFactory {
+    public static final String NAME = "plugins";
+
     @Override
     public MetadataGenerator newInstance(RepositorySystemSession session, InstallRequest request) {
         return new PluginsMetadataGenerator(session, request);

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/SnapshotMetadataGeneratorFactory.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/SnapshotMetadataGeneratorFactory.java
@@ -30,9 +30,11 @@ import org.eclipse.aether.installation.InstallRequest;
 /**
  * Maven GAV level metadata generator factory.
  */
-@Named("snapshot")
+@Named(SnapshotMetadataGeneratorFactory.NAME)
 @Singleton
 public class SnapshotMetadataGeneratorFactory implements MetadataGeneratorFactory {
+    public static final String NAME = "snapshot";
+
     @Override
     public MetadataGenerator newInstance(RepositorySystemSession session, InstallRequest request) {
         return new LocalSnapshotMetadataGenerator(session, request);

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadataGeneratorFactory.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadataGeneratorFactory.java
@@ -30,9 +30,11 @@ import org.eclipse.aether.installation.InstallRequest;
 /**
  * Maven GA level metadata generator factory.
  */
-@Named("versions")
+@Named(VersionsMetadataGeneratorFactory.NAME)
 @Singleton
 public class VersionsMetadataGeneratorFactory implements MetadataGeneratorFactory {
+    public static final String NAME = "versions";
+
     @Override
     public MetadataGenerator newInstance(RepositorySystemSession session, InstallRequest request) {
         return new VersionsMetadataGenerator(session, request);


### PR DESCRIPTION
Maven Resolver Provider: get rid of name free string literals.

---

https://issues.apache.org/jira/browse/MNG-7874
