### PR TITLE
[MNG-7810] Provide a SPI for the v4 api

### DIFF
--- a/api/maven-api-spi/pom.xml
+++ b/api/maven-api-spi/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven</groupId>
+    <artifactId>maven-api</artifactId>
+    <version>4.0.0-alpha-8-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>maven-api-spi</artifactId>
+  <name>Maven 4 API :: SPI</name>
+  <description>Maven 4 API - Maven SPI.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-meta</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-core</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -38,6 +38,7 @@
     <module>maven-api-settings</module>
     <module>maven-api-toolchain</module>
     <module>maven-api-core</module>
+    <module>maven-api-spi</module>
   </modules>
 
   <properties>

--- a/maven-bom/pom.xml
+++ b/maven-bom/pom.xml
@@ -114,6 +114,11 @@ under the License.
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
+        <artifactId>maven-api-spi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
         <artifactId>maven-api-toolchain</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -84,6 +84,10 @@ under the License.
       <artifactId>maven-api-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-spi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-impl</artifactId>
     </dependency>


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7810

This PR provides an empty placeholder for the Maven 4 SPI.

The package is `org.apache.maven.api.spi` and should contain all services that can be easily provided by extensions.

