### PR TITLE
MNG-7875 colorize transfer messages

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/transfer/AbstractMavenTransferListener.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/transfer/AbstractMavenTransferListener.java
@@ -24,6 +24,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 import org.apache.commons.lang3.Validate;
+import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.eclipse.aether.transfer.AbstractTransferListener;
 import org.eclipse.aether.transfer.TransferCancelledException;
 import org.eclipse.aether.transfer.TransferEvent;
@@ -33,6 +34,10 @@ import org.eclipse.aether.transfer.TransferResource;
  * AbstractMavenTransferListener
  */
 public abstract class AbstractMavenTransferListener extends AbstractTransferListener {
+
+    private static final String ESC = "\u001B";
+    private static final String ANSI_DARK_SET = ESC + "[90m";
+    private static final String ANSI_DARK_RESET = ESC + "[0m";
 
     // CHECKSTYLE_OFF: LineLength
     /**
@@ -184,14 +189,18 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
 
     @Override
     public void transferInitiated(TransferEvent event) {
+        String darkOn = MessageUtils.isColorEnabled() ? ANSI_DARK_SET : "";
+        String darkOff = MessageUtils.isColorEnabled() ? ANSI_DARK_RESET : "";
+
         String action = event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploading" : "Downloading";
         String direction = event.getRequestType() == TransferEvent.RequestType.PUT ? "to" : "from";
 
         TransferResource resource = event.getResource();
         StringBuilder message = new StringBuilder();
-        message.append(action).append(' ').append(direction).append(' ').append(resource.getRepositoryId());
-        message.append(": ");
-        message.append(resource.getRepositoryUrl()).append(resource.getResourceName());
+        message.append(darkOn).append(action).append(' ').append(direction).append(' ');
+        message.append(darkOff).append(resource.getRepositoryId());
+        message.append(darkOn).append(": ").append(resource.getRepositoryUrl());
+        message.append(darkOff).append(resource.getResourceName());
 
         out.println(message.toString());
     }
@@ -206,6 +215,9 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
 
     @Override
     public void transferSucceeded(TransferEvent event) {
+        String darkOn = MessageUtils.isColorEnabled() ? ANSI_DARK_SET : "";
+        String darkOff = MessageUtils.isColorEnabled() ? ANSI_DARK_RESET : "";
+
         String action = (event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploaded" : "Downloaded");
         String direction = event.getRequestType() == TransferEvent.RequestType.PUT ? "to" : "from";
 
@@ -214,10 +226,11 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
         FileSizeFormat format = new FileSizeFormat(Locale.ENGLISH);
 
         StringBuilder message = new StringBuilder();
-        message.append(action).append(' ').append(direction).append(' ').append(resource.getRepositoryId());
-        message.append(": ");
-        message.append(resource.getRepositoryUrl()).append(resource.getResourceName());
-        message.append(" (").append(format.format(contentLength));
+        message.append(action).append(darkOn).append(' ').append(direction).append(' ');
+        message.append(darkOff).append(resource.getRepositoryId());
+        message.append(darkOn).append(": ").append(resource.getRepositoryUrl());
+        message.append(darkOff).append(resource.getResourceName());
+        message.append(darkOn).append(" (").append(format.format(contentLength));
 
         long duration = System.currentTimeMillis() - resource.getTransferStartTime();
         if (duration > 0L) {
@@ -225,7 +238,7 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
             message.append(" at ").append(format.format((long) bytesPerSecond)).append("/s");
         }
 
-        message.append(')');
+        message.append(')').append(darkOff);
         out.println(message.toString());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MNG-7875
before:
![MNG-7875_before_output](https://github.com/apache/maven/assets/237462/06fd0920-1e16-4e7f-812a-db339e1f292b)


after: 
![MNG-7875_colorized_output_second](https://github.com/apache/maven/assets/237462/9d74cd8e-66d5-4b48-839c-01f3d30a60bf)

(initial proposal:
![MNG-7875_colorized_output](https://github.com/apache/maven/assets/237462/56fb3705-01d1-45cd-b249-0dc6f9c62c6c)
)