### PR TITLE
[MNG-7879] Add a bom packaging

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/artifact/handler/providers/BomArtifactHandlerProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/artifact/handler/providers/BomArtifactHandlerProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.handler.providers;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+
+/**
+ * {@code bom} artifact handler provider.
+ */
+@Named("bom")
+@Singleton
+public class BomArtifactHandlerProvider implements Provider<ArtifactHandler> {
+    private final ArtifactHandler artifactHandler;
+
+    @Inject
+    public BomArtifactHandlerProvider() {
+        this.artifactHandler = new DefaultArtifactHandler("pom", null, null, null, null, false, "none", false);
+    }
+
+    @Override
+    public ArtifactHandler get() {
+        return artifactHandler;
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
@@ -63,6 +63,10 @@ import org.eclipse.aether.installation.InstallRequest;
 @Named("consumer-pom")
 public final class ConsumerPomArtifactTransformer {
 
+    private static final String BOM_PACKAGING = "bom";
+
+    public static final String POM_PACKAGING = "pom";
+
     private static final String CONSUMER_POM_CLASSIFIER = "consumer";
 
     private static final String BUILD_POM_CLASSIFIER = "build";
@@ -237,6 +241,9 @@ public final class ConsumerPomArtifactTransformer {
             }
 
             // raw to consumer transform
+            if (BOM_PACKAGING.equals(consumer.getPackaging())) {
+                consumer = consumer.withPackaging(POM_PACKAGING);
+            }
             consumer = consumer.withRoot(false).withModules(null);
             if (consumer.getParent() != null) {
                 consumer = consumer.withParent(consumer.getParent().withRelativePath(null));

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/BomLifecycleMappingProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/BomLifecycleMappingProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.providers.packaging;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * {@code bom} packaging plugins bindings provider for {@code default} lifecycle.
+ */
+@Named("bom")
+@Singleton
+public final class BomLifecycleMappingProvider extends AbstractLifecycleMappingProvider {
+    // START SNIPPET: bom
+    @SuppressWarnings("checkstyle:linelength")
+    private static final String[] BINDINGS = {
+        "install", "org.apache.maven.plugins:maven-install-plugin:" + INSTALL_PLUGIN_VERSION + ":install",
+        "deploy", "org.apache.maven.plugins:maven-deploy-plugin:" + DEPLOY_PLUGIN_VERSION + ":deploy"
+    };
+    // END SNIPPET: bom
+
+    @Inject
+    public BomLifecycleMappingProvider() {
+        super(BINDINGS);
+    }
+}


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7879
Doc PR: https://github.com/apache/maven-site/pull/451

The purpose of the BOM packaging is to more cleanly identify POM that will be consumed as BOM from POM that will be used as parents.  The BOMs can be turned into a consumer POM, whereas parents can not lose any information.

