### PR TITLE
[MNG-7893] Allow versioning the superpom according to the model version

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/SuperPomProviderException.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/SuperPomProviderException.java
@@ -18,24 +18,26 @@
  */
 package org.apache.maven.api.services;
 
-import org.apache.maven.api.Service;
-import org.apache.maven.api.annotations.Experimental;
-import org.apache.maven.api.annotations.Nonnull;
-import org.apache.maven.api.model.Model;
-
 /**
- * Provides the super POM that all models implicitly inherit from.
+ * Exceptions thrown by the {@link SuperPomProvider} service.
+ *
+ * @since 4.0.0
  */
-@Experimental
-public interface SuperPomProvider extends Service {
+public class SuperPomProviderException extends MavenException {
 
-    /**
-     * Gets the super POM for the specified model version.
-     *
-     * @param version The model version to retrieve the super POM for (e.g. "4.0.0"), must not be {@code null}.
-     * @return The super POM, never {@code null}.
-     * @throws SuperPomProviderException if the super POM could not be retrieved
-     */
-    @Nonnull
-    Model getSuperPom(@Nonnull String version);
+    public SuperPomProviderException() {
+        super();
+    }
+
+    public SuperPomProviderException(String message) {
+        super(message);
+    }
+
+    public SuperPomProviderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SuperPomProviderException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -495,6 +495,7 @@ public class DefaultMaven implements Maven {
      * @return A {@link Set} of profile identifiers, never {@code null}.
      */
     private Set<String> getAllProfiles(MavenSession session) {
+        // TODO: which version of super pom should we use here ?
         final Model superPomModel = superPomProvider.getSuperModel("4.0.0").getDelegate();
         final Set<MavenProject> projectsIncludingParents = new HashSet<>();
         for (MavenProject project : session.getProjects()) {

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSuperPomProvider.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSuperPomProvider.java
@@ -24,6 +24,7 @@ import javax.inject.Singleton;
 
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.services.SuperPomProvider;
+import org.apache.maven.api.services.SuperPomProviderException;
 
 @Named
 @Singleton
@@ -38,6 +39,10 @@ public class DefaultSuperPomProvider implements SuperPomProvider {
 
     @Override
     public Model getSuperPom(String version) {
-        return provider.getSuperModel(version).getDelegate();
+        try {
+            return provider.getSuperModel(version).getDelegate();
+        } catch (IllegalStateException e) {
+            throw new SuperPomProviderException("Could not retrieve super pom " + version, e);
+        }
     }
 }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -746,7 +746,8 @@ public class DefaultModelBuilder implements ModelBuilder {
         problems.setRootModel(inputModel);
 
         ModelData resultData = new ModelData(request.getModelSource(), inputModel);
-        ModelData superData = new ModelData(null, getSuperModel());
+        String superModelVersion = inputModel.getModelVersion() != null ? inputModel.getModelVersion() : "4.0.0";
+        ModelData superData = new ModelData(null, getSuperModel(superModelVersion));
 
         // profile activation
         DefaultProfileActivationContext profileActivationContext = getProfileActivationContext(request);
@@ -1605,8 +1606,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                 modelSource, parentModel, parent.getGroupId(), parent.getArtifactId(), parent.getVersion());
     }
 
-    private Model getSuperModel() {
-        return superPomProvider.getSuperModel("4.0.0");
+    private Model getSuperModel(String modelVersion) {
+        return superPomProvider.getSuperModel(modelVersion);
     }
 
     private void importDependencyManagement(

--- a/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.1.0.xml
+++ b/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.1.0.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- START SNIPPET: superpom -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <build>
+    <directory>${project.basedir}/target</directory>
+    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+    <finalName>${project.artifactId}-${project.version}</finalName>
+    <testOutputDirectory>${project.build.directory}/test-classes</testOutputDirectory>
+    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+    <scriptSourceDirectory>${project.basedir}/src/main/scripts</scriptSourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${project.basedir}/src/main/resources-filtered</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>${project.basedir}/src/test/resources</directory>
+      </testResource>
+      <testResource>
+        <directory>${project.basedir}/src/test/resources-filtered</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+  </build>
+
+  <reporting>
+    <outputDirectory>${project.build.directory}/site</outputDirectory>
+  </reporting>
+
+</project>
+<!-- END SNIPPET: superpom -->


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7893


Btw, I wonder if the recent changes such as https://github.com/apache/maven/pull/1139 and https://github.com/apache/maven/pull/1085 should be updated to only affect the 4.1.0 superpom...  Thoughts welcomed.

