### PR TITLE
Fix unneeded/wrong substring calls in expression evaluation and put back weak references in cache

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluator.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluator.java
@@ -172,11 +172,11 @@ public class PluginParameterExpressionEvaluator implements TypeAwareExpressionEv
                 int pathSeparator = expression.indexOf('/');
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, session);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), session);
+                    value = ReflectionValueExtractor.evaluate(expression, session);
                 }
             } catch (Exception e) {
                 // TODO don't catch exception
@@ -198,7 +198,7 @@ public class PluginParameterExpressionEvaluator implements TypeAwareExpressionEv
                     value = ReflectionValueExtractor.evaluate(pathExpression, project);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), project);
+                    value = ReflectionValueExtractor.evaluate(expression, project);
                 }
             } catch (Exception e) {
                 // TODO don't catch exception
@@ -214,11 +214,11 @@ public class PluginParameterExpressionEvaluator implements TypeAwareExpressionEv
                 int pathSeparator = expression.indexOf('/');
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, mojoExecution);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), mojoExecution);
+                    value = ReflectionValueExtractor.evaluate(expression, mojoExecution);
                 }
             } catch (Exception e) {
                 // TODO don't catch exception
@@ -234,11 +234,11 @@ public class PluginParameterExpressionEvaluator implements TypeAwareExpressionEv
                 PluginDescriptor pluginDescriptor = mojoDescriptor.getPluginDescriptor();
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, pluginDescriptor);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), pluginDescriptor);
+                    value = ReflectionValueExtractor.evaluate(expression, pluginDescriptor);
                 }
             } catch (Exception e) {
                 throw new ExpressionEvaluationException(
@@ -251,11 +251,11 @@ public class PluginParameterExpressionEvaluator implements TypeAwareExpressionEv
                 int pathSeparator = expression.indexOf('/');
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, session.getSettings());
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), session.getSettings());
+                    value = ReflectionValueExtractor.evaluate(expression, session.getSettings());
                 }
             } catch (Exception e) {
                 // TODO don't catch exception

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4.java
@@ -175,11 +175,11 @@ public class PluginParameterExpressionEvaluatorV4 implements TypeAwareExpression
                 int pathSeparator = expression.indexOf('/');
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, session);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), session);
+                    value = ReflectionValueExtractor.evaluate(expression, session);
                 }
             } catch (Exception e) {
                 // TODO don't catch exception
@@ -206,7 +206,7 @@ public class PluginParameterExpressionEvaluatorV4 implements TypeAwareExpression
                     value = ReflectionValueExtractor.evaluate(pathExpression, project);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), project);
+                    value = ReflectionValueExtractor.evaluate(expression, project);
                 }
             } catch (Exception e) {
                 // TODO don't catch exception
@@ -223,11 +223,11 @@ public class PluginParameterExpressionEvaluatorV4 implements TypeAwareExpression
                 int pathSeparator = expression.indexOf('/');
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, mojoExecution);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), mojoExecution);
+                    value = ReflectionValueExtractor.evaluate(expression, mojoExecution);
                 }
             } catch (Exception e) {
                 // TODO don't catch exception
@@ -246,11 +246,11 @@ public class PluginParameterExpressionEvaluatorV4 implements TypeAwareExpression
                         mojoExecution.getMojoDescriptor().getPluginDescriptor();
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, pluginDescriptor);
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), pluginDescriptor);
+                    value = ReflectionValueExtractor.evaluate(expression, pluginDescriptor);
                 }
             } catch (Exception e) {
                 throw new ExpressionEvaluationException(
@@ -263,11 +263,11 @@ public class PluginParameterExpressionEvaluatorV4 implements TypeAwareExpression
                 int pathSeparator = expression.indexOf('/');
 
                 if (pathSeparator > 0) {
-                    String pathExpression = expression.substring(1, pathSeparator);
+                    String pathExpression = expression.substring(0, pathSeparator);
                     value = ReflectionValueExtractor.evaluate(pathExpression, session.getSettings());
                     value = value + expression.substring(pathSeparator);
                 } else {
-                    value = ReflectionValueExtractor.evaluate(expression.substring(1), session.getSettings());
+                    value = ReflectionValueExtractor.evaluate(expression, session.getSettings());
                 }
             } catch (Exception e) {
                 // TODO don't catch exception


### PR DESCRIPTION
As indicated at https://github.com/apache/maven/pull/812#discussion_r990825335

If the interpolated string is `${settings.foo}`, the expression is `settings.foo` and we pass `ettings.foo` to the `ReflectionValueExtractor`. It's working because the call just ignore whatever is on the left of the first `.`...