### PR TITLE
[MNG-7899] Various memory usage improvements 3

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/event/ExecutionEventLogger.java
@@ -198,9 +198,9 @@ public class ExecutionEventLogger extends AbstractExecutionListener {
 
         List<MavenProject> projects = session.getProjects();
 
-        for (MavenProject project : projects) {
-            StringBuilder buffer = new StringBuilder(128);
+        StringBuilder buffer = new StringBuilder(128);
 
+        for (MavenProject project : projects) {
             buffer.append(project.getName());
             buffer.append(' ');
 
@@ -243,6 +243,7 @@ public class ExecutionEventLogger extends AbstractExecutionListener {
             }
 
             logger.info(buffer.toString());
+            buffer.setLength(0);
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MNG-7899
Reuse a StringBuilder in a for loop by setting its lenght to zero.
Help reduce temporary objects creation.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/