### PR TITLE
[MNG-7899] Various memory usage improvements 5

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilder.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilder.java
@@ -206,4 +206,11 @@ public interface MessageBuilder {
      */
     @Nonnull
     String build();
+
+    /**
+     * Set the buffer length.
+     *
+     * @param length the new length
+     */
+    void setLength(int length);
 }

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultMessageBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultMessageBuilder.java
@@ -154,4 +154,9 @@ public class DefaultMessageBuilder implements MessageBuilder {
     public String toString() {
         return build();
     }
+
+    @Override
+    public void setLength(int length) {
+        buffer.setLength(length);
+    }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -497,19 +497,6 @@ public class MavenCli {
         cliRequest.quiet = !cliRequest.verbose && commandLine.hasOption(CLIManager.QUIET);
         cliRequest.showErrors = cliRequest.verbose || commandLine.hasOption(CLIManager.ERRORS);
 
-        slf4jLoggerFactory = LoggerFactory.getILoggerFactory();
-        Slf4jConfiguration slf4jConfiguration = Slf4jConfigurationFactory.getConfiguration(slf4jLoggerFactory);
-
-        if (cliRequest.verbose) {
-            cliRequest.request.setLoggingLevel(MavenExecutionRequest.LOGGING_LEVEL_DEBUG);
-            slf4jConfiguration.setRootLoggerLevel(Slf4jConfiguration.Level.DEBUG);
-        } else if (cliRequest.quiet) {
-            cliRequest.request.setLoggingLevel(MavenExecutionRequest.LOGGING_LEVEL_ERROR);
-            slf4jConfiguration.setRootLoggerLevel(Slf4jConfiguration.Level.ERROR);
-        }
-        // else fall back to default log level specified in conf
-        // see https://issues.apache.org/jira/browse/MNG-2570
-
         // LOG COLOR
         String styleColor = cliRequest.getUserProperties().getProperty(STYLE_COLOR_PROPERTY, "auto");
         styleColor = commandLine.getOptionValue(COLOR, styleColor);
@@ -527,6 +514,19 @@ public class MavenCli {
                 MessageUtils.setColorEnabled(false);
             }
         }
+
+        slf4jLoggerFactory = LoggerFactory.getILoggerFactory();
+        Slf4jConfiguration slf4jConfiguration = Slf4jConfigurationFactory.getConfiguration(slf4jLoggerFactory);
+
+        if (cliRequest.verbose) {
+            cliRequest.request.setLoggingLevel(MavenExecutionRequest.LOGGING_LEVEL_DEBUG);
+            slf4jConfiguration.setRootLoggerLevel(Slf4jConfiguration.Level.DEBUG);
+        } else if (cliRequest.quiet) {
+            cliRequest.request.setLoggingLevel(MavenExecutionRequest.LOGGING_LEVEL_ERROR);
+            slf4jConfiguration.setRootLoggerLevel(Slf4jConfiguration.Level.ERROR);
+        }
+        // else fall back to default log level specified in conf
+        // see https://issues.apache.org/jira/browse/MNG-2570
 
         // LOG STREAMS
         if (commandLine.hasOption(CLIManager.LOG_FILE)) {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/jansi/JansiMessageBuilder.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/jansi/JansiMessageBuilder.java
@@ -26,12 +26,16 @@ import org.fusesource.jansi.Ansi;
 @Experimental
 public class JansiMessageBuilder implements MessageBuilder {
     private final Ansi ansi;
+    private StringBuilder sb;
 
+    @SuppressWarnings("magicnumber")
     public JansiMessageBuilder() {
+        this.sb = new StringBuilder(80);
         this.ansi = Ansi.ansi();
     }
 
     public JansiMessageBuilder(StringBuilder sb) {
+        this.sb = sb;
         this.ansi = Ansi.ansi(sb);
     }
 
@@ -158,5 +162,10 @@ public class JansiMessageBuilder implements MessageBuilder {
     @Override
     public String toString() {
         return build();
+    }
+
+    @Override
+    public void setLength(int length) {
+        sb.setLength(length);
     }
 }

--- a/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
@@ -20,6 +20,8 @@ package org.slf4j.impl;
 
 import java.io.PrintStream;
 
+import org.apache.maven.api.services.MessageBuilder;
+
 import static org.apache.maven.cli.jansi.MessageUtils.builder;
 
 /**
@@ -63,29 +65,30 @@ public class MavenSimpleLogger extends SimpleLogger {
         if (t == null) {
             return;
         }
-        stream.print(builder().failure(t.getClass().getName()));
+        MessageBuilder builder = builder().failure(t.getClass().getName());
         if (t.getMessage() != null) {
-            stream.print(": ");
-            stream.print(builder().failure(t.getMessage()));
+            builder.a(": ").failure(t.getMessage());
         }
-        stream.println();
+        stream.println(builder);
 
         printStackTrace(t, stream, "");
     }
 
     private void printStackTrace(Throwable t, PrintStream stream, String prefix) {
+        StringBuilder builder = new StringBuilder();
         for (StackTraceElement e : t.getStackTrace()) {
-            stream.print(prefix);
-            stream.print("    ");
-            stream.print(builder().strong("at"));
-            stream.print(" ");
-            stream.print(e.getClassName());
-            stream.print(".");
-            stream.print(e.getMethodName());
-            stream.print(" (");
-            stream.print(builder().strong(getLocation(e)));
-            stream.print(")");
-            stream.println();
+            builder.append(prefix);
+            builder.append("    ");
+            builder(builder).strong("at");
+            builder.append(" ");
+            builder.append(e.getClassName());
+            builder.append(".");
+            builder.append(e.getMethodName());
+            builder.append(" (");
+            builder(builder).strong(getLocation(e));
+            builder.append(")");
+            stream.println(builder);
+            builder.setLength(0);
         }
         for (Throwable se : t.getSuppressed()) {
             writeThrowable(se, stream, "Suppressed", prefix + "    ");
@@ -97,15 +100,12 @@ public class MavenSimpleLogger extends SimpleLogger {
     }
 
     private void writeThrowable(Throwable t, PrintStream stream, String caption, String prefix) {
-        stream.print(prefix);
-        stream.print(builder().strong(caption));
-        stream.print(": ");
-        stream.print(t.getClass().getName());
+        MessageBuilder builder =
+                builder().a(prefix).strong(caption).a(": ").a(t.getClass().getName());
         if (t.getMessage() != null) {
-            stream.print(": ");
-            stream.print(builder().failure(t.getMessage()));
+            builder.a(": ").failure(t.getMessage());
         }
-        stream.println();
+        stream.println(builder);
 
         printStackTrace(t, stream, prefix);
     }
@@ -118,7 +118,7 @@ public class MavenSimpleLogger extends SimpleLogger {
         } else if (e.getFileName() == null) {
             return "Unknown Source";
         } else if (e.getLineNumber() >= 0) {
-            return String.format("%s:%s", e.getFileName(), e.getLineNumber());
+            return e.getFileName() + ":" + e.getLineNumber();
         } else {
             return e.getFileName();
         }

--- a/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
@@ -20,8 +20,7 @@ package org.slf4j.impl;
 
 import java.io.PrintStream;
 
-import org.apache.maven.api.services.MessageBuilder;
-import org.apache.maven.cli.jansi.MessageUtils;
+import static org.apache.maven.cli.jansi.MessageUtils.builder;
 
 /**
  * Logger for Maven, that support colorization of levels and stacktraces. This class implements 2 methods introduced in
@@ -30,6 +29,14 @@ import org.apache.maven.cli.jansi.MessageUtils;
  * @since 3.5.0
  */
 public class MavenSimpleLogger extends SimpleLogger {
+
+    private static final String TRACE_RENDERED_LEVEL = builder().trace("TRACE").build();
+    private static final String DEBUG_RENDERED_LEVEL = builder().debug("DEBUG").build();
+    private static final String INFO_RENDERED_LEVEL = builder().info("INFO").build();
+    private static final String WARN_RENDERED_LEVEL =
+            builder().warning("WARNING").build();
+    private static final String ERROR_RENDERED_LEVEL = builder().error("ERROR").build();
+
     MavenSimpleLogger(String name) {
         super(name);
     }
@@ -38,16 +45,16 @@ public class MavenSimpleLogger extends SimpleLogger {
     protected String renderLevel(int level) {
         switch (level) {
             case LOG_LEVEL_TRACE:
-                return builder().trace("TRACE").build();
+                return TRACE_RENDERED_LEVEL;
             case LOG_LEVEL_DEBUG:
-                return builder().debug("DEBUG").build();
+                return DEBUG_RENDERED_LEVEL;
             case LOG_LEVEL_INFO:
-                return builder().info("INFO").build();
+                return INFO_RENDERED_LEVEL;
             case LOG_LEVEL_WARN:
-                return builder().warning("WARNING").build();
+                return WARN_RENDERED_LEVEL;
             case LOG_LEVEL_ERROR:
             default:
-                return builder().error("ERROR").build();
+                return ERROR_RENDERED_LEVEL;
         }
     }
 
@@ -71,8 +78,13 @@ public class MavenSimpleLogger extends SimpleLogger {
             stream.print(prefix);
             stream.print("    ");
             stream.print(builder().strong("at"));
-            stream.print(" " + e.getClassName() + "." + e.getMethodName());
-            stream.print(builder().a(" (").strong(getLocation(e)).a(")"));
+            stream.print(" ");
+            stream.print(e.getClassName());
+            stream.print(".");
+            stream.print(e.getMethodName());
+            stream.print(" (");
+            stream.print(builder().strong(getLocation(e)));
+            stream.print(")");
             stream.println();
         }
         for (Throwable se : t.getSuppressed()) {
@@ -85,7 +97,10 @@ public class MavenSimpleLogger extends SimpleLogger {
     }
 
     private void writeThrowable(Throwable t, PrintStream stream, String caption, String prefix) {
-        stream.print(builder().a(prefix).strong(caption).a(": ").a(t.getClass().getName()));
+        stream.print(prefix);
+        stream.print(builder().strong(caption));
+        stream.print(": ");
+        stream.print(t.getClass().getName());
         if (t.getMessage() != null) {
             stream.print(": ");
             stream.print(builder().failure(t.getMessage()));
@@ -107,9 +122,5 @@ public class MavenSimpleLogger extends SimpleLogger {
         } else {
             return e.getFileName();
         }
-    }
-
-    private MessageBuilder builder() {
-        return MessageUtils.builder();
     }
 }

--- a/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/impl/MavenSimpleLogger.java
@@ -32,12 +32,11 @@ import static org.apache.maven.cli.jansi.MessageUtils.builder;
  */
 public class MavenSimpleLogger extends SimpleLogger {
 
-    private static final String TRACE_RENDERED_LEVEL = builder().trace("TRACE").build();
-    private static final String DEBUG_RENDERED_LEVEL = builder().debug("DEBUG").build();
-    private static final String INFO_RENDERED_LEVEL = builder().info("INFO").build();
-    private static final String WARN_RENDERED_LEVEL =
-            builder().warning("WARNING").build();
-    private static final String ERROR_RENDERED_LEVEL = builder().error("ERROR").build();
+    private final String traceRenderedLevel = builder().trace("TRACE").build();
+    private final String debugRenderedLevel = builder().debug("DEBUG").build();
+    private final String infoRenderedLevel = builder().info("INFO").build();
+    private final String warnRenderedLevel = builder().warning("WARNING").build();
+    private final String errorRenderedLevel = builder().error("ERROR").build();
 
     MavenSimpleLogger(String name) {
         super(name);
@@ -47,16 +46,16 @@ public class MavenSimpleLogger extends SimpleLogger {
     protected String renderLevel(int level) {
         switch (level) {
             case LOG_LEVEL_TRACE:
-                return TRACE_RENDERED_LEVEL;
+                return traceRenderedLevel;
             case LOG_LEVEL_DEBUG:
-                return DEBUG_RENDERED_LEVEL;
+                return debugRenderedLevel;
             case LOG_LEVEL_INFO:
-                return INFO_RENDERED_LEVEL;
+                return infoRenderedLevel;
             case LOG_LEVEL_WARN:
-                return WARN_RENDERED_LEVEL;
+                return warnRenderedLevel;
             case LOG_LEVEL_ERROR:
             default:
-                return ERROR_RENDERED_LEVEL;
+                return errorRenderedLevel;
         }
     }
 
@@ -75,18 +74,18 @@ public class MavenSimpleLogger extends SimpleLogger {
     }
 
     private void printStackTrace(Throwable t, PrintStream stream, String prefix) {
-        StringBuilder builder = new StringBuilder();
+        MessageBuilder builder = builder();
         for (StackTraceElement e : t.getStackTrace()) {
-            builder.append(prefix);
-            builder.append("    ");
-            builder(builder).strong("at");
-            builder.append(" ");
-            builder.append(e.getClassName());
-            builder.append(".");
-            builder.append(e.getMethodName());
-            builder.append(" (");
-            builder(builder).strong(getLocation(e));
-            builder.append(")");
+            builder.a(prefix);
+            builder.a("    ");
+            builder.strong("at");
+            builder.a(" ");
+            builder.a(e.getClassName());
+            builder.a(".");
+            builder.a(e.getMethodName());
+            builder.a(" (");
+            builder.strong(getLocation(e));
+            builder.a(")");
             stream.println(builder);
             builder.setLength(0);
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MNG-7899
Multiple optimizations :

- renderLevel() method use static constants instead of rebuilding the
strings on each call
- replace + operator usage with more PrintStream.print() calls to reduce
temporary strings creation
- reduce usage of MessageBuilder.a() method usage with more
PrintStream.print() calls to reduce temporary strings creation
- replace the builder() method with a static import

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/