### PR TITLE
[MNG-7772] Allow to register maven core extension in .m2 directory instead of MAVEN_HOME

### DIFF
--- a/apache-maven/src/assembly/maven/bin/m2.conf
+++ b/apache-maven/src/assembly/maven/bin/m2.conf
@@ -6,6 +6,7 @@ set maven.conf default ${maven.home}/conf
 load       ${maven.conf}/logging
 optionally ${maven.home}/lib/ext/redisson/*.jar
 optionally ${maven.home}/lib/ext/hazelcast/*.jar
+optionally ${user.home}/.m2/ext/*.jar
 optionally ${maven.home}/lib/ext/*.jar
 load       ${maven.home}/lib/maven-*.jar
 load       ${maven.home}/lib/*.jar

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -145,7 +145,9 @@ public class MavenCli {
 
     private static final String EXT_CLASS_PATH = "maven.ext.class.path";
 
-    private static final String EXTENSIONS_FILENAME = ".mvn/extensions.xml";
+    private static final String EXTENSIONS_FILENAME = "extensions.xml";
+
+    private static final String MVN_EXTENSIONS_FILENAME = ".mvn/" + EXTENSIONS_FILENAME;
 
     private static final String MVN_MAVEN_CONFIG = ".mvn/maven.config";
 
@@ -737,12 +739,17 @@ public class MavenCli {
             return Collections.emptyList();
         }
 
-        File extensionsFile = new File(cliRequest.multiModuleProjectDirectory, EXTENSIONS_FILENAME);
-        if (!extensionsFile.isFile()) {
-            return Collections.emptyList();
+        File extensionsFile = new File(cliRequest.multiModuleProjectDirectory, MVN_EXTENSIONS_FILENAME);
+        File userHomeExtensionsFile = new File(USER_MAVEN_CONFIGURATION_HOME, EXTENSIONS_FILENAME);
+
+        List<CoreExtension> extensions = new ArrayList<>();
+        if (extensionsFile.isFile()) {
+            extensions.addAll(readCoreExtensionsDescriptor(extensionsFile));
+        }
+        if (userHomeExtensionsFile.isFile()) {
+            extensions.addAll(readCoreExtensionsDescriptor(userHomeExtensionsFile));
         }
 
-        List<CoreExtension> extensions = readCoreExtensionsDescriptor(extensionsFile);
         if (extensions.isEmpty()) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
Jira issue: [MNG-7772](https://issues.apache.org/jira/browse/MNG-7772)

Enables to register extensions through the ${user.home}/.m2 directory. An extension can be placed in an ext directory in the .m2 directory or by adding a extensions.xml file in the .m2 directory

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)