### PR TITLE
[discuss] Enables to resolve direct pom dependencies (not transitive ones) location as project.dependencies. reference - eases javaagent usage for ex

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/interpolation/ExtendedStringVisitorModelInterpolator.java
+++ b/maven-core/src/main/java/org/apache/maven/interpolation/ExtendedStringVisitorModelInterpolator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.interpolation;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.File;
+
+import org.apache.maven.api.model.Model;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelProblemCollector;
+import org.apache.maven.model.interpolation.StringVisitorModelInterpolator;
+import org.apache.maven.model.path.PathTranslator;
+import org.apache.maven.model.path.UrlNormalizer;
+import org.apache.maven.model.root.RootLocator;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Add support for implicit local location of artifacts for pom reference.
+ * <p>
+ * Mainly enables to make the interpolator resolver aware.
+ */
+@Named
+@Singleton
+public class ExtendedStringVisitorModelInterpolator extends StringVisitorModelInterpolator {
+    private final ThreadLocal<Model.Builder> model = new ThreadLocal<>();
+
+    @Inject
+    public ExtendedStringVisitorModelInterpolator(
+            final PathTranslator pathTranslator,
+            final UrlNormalizer urlNormalizer,
+            final RootLocator rootLocator,
+            final ResolverValueSource resolverValueSource) {
+        super(pathTranslator, urlNormalizer, rootLocator, singletonList(resolverValueSource));
+        resolverValueSource.setModelProvider(() -> model.get().build());
+    }
+
+    @Override
+    protected void beforeTransform(final Model.Builder builder, final Model target) {
+        model.set(builder);
+    }
+
+    @Override
+    public Model interpolateModel(
+            final Model model,
+            final File projectDir,
+            final ModelBuildingRequest config,
+            final ModelProblemCollector problems) {
+        try {
+            return super.interpolateModel(model, projectDir, config, problems);
+        } finally {
+            this.model.remove();
+        }
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/interpolation/ResolverValueSource.java
+++ b/maven-core/src/main/java/org/apache/maven/interpolation/ResolverValueSource.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.interpolation;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.apache.maven.api.Session;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.internal.impl.AbstractSession;
+import org.codehaus.plexus.interpolation.AbstractValueSource;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Collections.singleton;
+
+/**
+ * Enables to resolve a <b>direct</b> dependency path using <code>${project.dependencies.gav}</code> syntax.
+ */
+// dev note: could be a InterpolationPostProcessor but not strong reason as of today
+@Named
+@Singleton
+public class ResolverValueSource extends AbstractValueSource {
+    private final Provider<RepositorySystem> repositorySystemProvider;
+    private final Provider<MavenSession> mavenSessionProvider;
+    private Supplier<Model> modelSupplier;
+
+    @Inject
+    public ResolverValueSource(
+            Provider<RepositorySystem> repositorySystemProvider, Provider<MavenSession> mavenSessionProvider) {
+        super(false);
+        this.repositorySystemProvider = repositorySystemProvider;
+        this.mavenSessionProvider = mavenSessionProvider;
+    }
+
+    @Override
+    public Object getValue(final String expression) {
+        if (!expression.startsWith("project.dependencies.") || modelSupplier == null) {
+            return null;
+        }
+        final String gav = expression.substring("project.dependencies.".length());
+        try {
+            final MavenSession mavenSession = mavenSessionProvider.get();
+            final Artifact artifact = findArtifact(gav, modelSupplier.get());
+            if (artifact == null) {
+                LoggerFactory.getLogger(getClass().getName()) // lazy
+                        .error("Can't resolve '" + gav + "', didn't find the dependency");
+                return null;
+            }
+
+            final Session session = mavenSession.getSession();
+            if (!(session instanceof AbstractSession)) {
+                return null;
+            }
+
+            final AbstractSession as = (AbstractSession) session;
+            final List<RemoteRepository> repositories = as.toRepositories(session.getRemoteRepositories());
+            final ArtifactRequest request = new ArtifactRequest(artifact, repositories, null);
+            final List<ArtifactResult> results = repositorySystemProvider
+                    .get()
+                    .resolveArtifacts(mavenSession.getRepositorySession(), singleton(request));
+            for (final ArtifactResult result : results) {
+                final File file = result.getArtifact().getFile();
+                if (file != null) {
+                    return file.getAbsolutePath();
+                }
+            }
+        } catch (final RuntimeException | ArtifactResolutionException e) {
+            LoggerFactory.getLogger(getClass().getName()) // lazy
+                    .error("Can't resolve '" + gav + "'", e);
+        }
+        return null;
+    }
+
+    private Artifact findArtifact(final String gav, final Model model) {
+        if (model == null) {
+            return null;
+        }
+        // warn: for now it MUST be a *direct* dependency, ideally we would use currentProject but not set there
+        return model.getDependencies().stream()
+                .filter(
+                        it -> { // this is sufficient due to the number of reference as of *today* and fast enough
+                            if (!(gav.startsWith(it.getGroupId())
+                                    && gav.length() > it.getGroupId().length()
+                                    && gav.charAt(it.getGroupId().length()) == '.')) {
+                                return false;
+                            }
+
+                            final String sub1 = gav.substring(it.getGroupId().length() + 1);
+                            if (Objects.equals(sub1, it.getArtifactId())) {
+                                return true;
+                            }
+
+                            if (it.getClassifier() == null || it.getClassifier().isEmpty()) {
+                                return false;
+                            }
+
+                            if (!(sub1.startsWith(it.getArtifactId())
+                                    && sub1.length() > it.getArtifactId().length()
+                                    && sub1.charAt(it.getArtifactId().length()) == '.')) {
+                                return false;
+                            }
+
+                            return sub1.substring(it.getArtifactId().length() + 1)
+                                    .equals(it.getClassifier());
+                        })
+                .findFirst()
+                .map(it -> new DefaultArtifact(
+                        it.getGroupId(), it.getArtifactId(), it.getClassifier(), it.getType(), it.getVersion()))
+                .orElse(null);
+    }
+
+    public void setModelProvider(final Supplier<Model> modelSupplier) {
+        this.modelSupplier = modelSupplier;
+    }
+}

--- a/maven-core/src/test/java/org/apache/maven/interpolation/ResolverValueSourceTest.java
+++ b/maven-core/src/test/java/org/apache/maven/interpolation/ResolverValueSourceTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.interpolation;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.maven.api.model.Model;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.handler.manager.DefaultArtifactHandlerManager;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.bridge.MavenRepositorySystem;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.internal.impl.DefaultRemoteRepository;
+import org.apache.maven.internal.impl.DefaultSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.building.DefaultModelBuildingRequest;
+import org.apache.maven.model.interpolation.StringVisitorModelInterpolator;
+import org.apache.maven.model.io.ModelReader;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
+import org.apache.maven.session.scope.internal.SessionScope;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.DefaultSessionData;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
+import org.eclipse.aether.internal.impl.DefaultLocalPathPrefixComposerFactory;
+import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
+import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.artifact.DefaultArtifactTypeRegistry;
+import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
+import org.eclipse.aether.util.repository.DefaultAuthenticationSelector;
+import org.eclipse.aether.util.repository.DefaultMirrorSelector;
+import org.eclipse.aether.util.repository.DefaultProxySelector;
+import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@PlexusTest
+public class ResolverValueSourceTest {
+    @Inject
+    private StringVisitorModelInterpolator interpolator;
+
+    @Inject
+    private ModelReader reader;
+
+    @Inject
+    private SessionScope sessionScope;
+
+    @Inject
+    private PlexusContainer container;
+
+    @Inject
+    private RepositorySystem repositorySystem;
+
+    @Test
+    void resolvesExtendedInstance() {
+        assertInstanceOf(ExtendedStringVisitorModelInterpolator.class, interpolator);
+    }
+
+    @Test
+    void interpolateDependencyLocation(@TempDir final Path work) throws IOException, NoLocalRepositoryManagerException {
+        final Path pom = Files.write(
+                work.resolve("pom.xml"),
+                ("" + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n"
+                                + "  <modelVersion>4.0.0</modelVersion>\n"
+                                + "\n"
+                                + "  <groupId>org.apache.maven.test</groupId>\n"
+                                + "  <artifactId>maven-core</artifactId>\n"
+                                + "  <version>5.6.7-SNAPSHOT</version>\n"
+                                + "\n"
+                                + "  <properties>\n"
+                                + "    <dummy.version>1.2.3</dummy.version>\n"
+                                + "  </properties>\n"
+                                + "\n"
+                                + "  <dependencies>\n"
+                                + "    <dependency>\n"
+                                + "      <groupId>com.bar</groupId>\n"
+                                + "      <artifactId>dummy-agent</artifactId>\n"
+                                + "      <version>${dummy.version}</version>\n"
+                                + "    </dependency>\n"
+                                + "  </dependencies>\n"
+                                + "\n"
+                                + "  <build>\n"
+                                + "    <plugins>\n"
+                                + "      <plugin>\n"
+                                + "        <groupId>foo</groupId>\n"
+                                + "        <artifactId>bar-plugin</artifactId>\n"
+                                + "        <version>9.8.7</version>\n"
+                                + "        <configuration>\n"
+                                + "          <agents>\n"
+                                + "            <agent>${project.dependencies.com.bar.dummy-agent}</agent>\n"
+                                + "          </agents>\n"
+                                + "        </configuration>\n"
+                                + "      </plugin>\n"
+                                + "    </plugins>\n"
+                                + "  </build>\n"
+                                + "</project>\n"
+                                + "")
+                        .getBytes(StandardCharsets.UTF_8));
+        final Path repo = Files.createDirectories(work.resolve("m2"));
+        final Path fakeArtifact = Files.write(
+                        Files.createDirectories(repo.resolve("com/bar/dummy-agent/1.2.3"))
+                                .resolve("dummy-agent-1.2.3.jar"),
+                        "1.2.3".getBytes(StandardCharsets.UTF_8))
+                .toAbsolutePath()
+                .normalize();
+
+        final Model model = reader.read(pom.toFile(), emptyMap()).getDelegate();
+
+        final DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
+        request.setPomFile(pom.toFile());
+
+        final MavenProject currentProject = new MavenProject();
+        currentProject.setDependencies(
+                model.getDependencies().stream().map(Dependency::new).collect(toList()));
+
+        final DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory(
+                        new DefaultLocalPathComposer(),
+                        new DefaultTrackingFileManager(),
+                        new DefaultLocalPathPrefixComposerFactory())
+                .newInstance(repositorySession, new LocalRepository(repo.toFile())));
+        repositorySession.setDependencyManager(new ClassicDependencyManager());
+        repositorySession.setArtifactDescriptorPolicy(new SimpleArtifactDescriptorPolicy(false, false));
+        repositorySession.setArtifactTypeRegistry(new DefaultArtifactTypeRegistry());
+        repositorySession.setSystemProperties(emptyMap());
+        repositorySession.setUserProperties(emptyMap());
+        repositorySession.setConfigProperties(emptyMap());
+        repositorySession.setMirrorSelector(new DefaultMirrorSelector());
+        repositorySession.setProxySelector(new DefaultProxySelector());
+        repositorySession.setAuthenticationSelector(new DefaultAuthenticationSelector());
+        repositorySession.setData(new DefaultSessionData());
+
+        final MavenSession mavenSession = new MavenSession(
+                container, repositorySession, new DefaultMavenExecutionRequest(), new DefaultMavenExecutionResult());
+        mavenSession.setCurrentProject(currentProject);
+        mavenSession.setSession(new DefaultSession(
+                mavenSession,
+                repositorySystem,
+                singletonList(new DefaultRemoteRepository(new RemoteRepository.Builder(
+                                "test", "default", repo.toUri().toString())
+                        .build())),
+                new MavenRepositorySystem(
+                        new DefaultArtifactHandlerManager(singletonMap("jar", new DefaultArtifactHandler("jar"))),
+                        singletonMap("default", new DefaultRepositoryLayout())),
+                container,
+                new DefaultRuntimeInformation(new GenericVersionScheme())));
+
+        sessionScope.enter();
+        sessionScope.seed(MavenSession.class, mavenSession);
+        try {
+            final Model interpolated = interpolator.interpolateModel(model, pom.toFile(), request, req -> {
+                throw new UnsupportedOperationException();
+            });
+            final String interpolatedValue = interpolated
+                    .getBuild()
+                    .getPlugins()
+                    .get(0)
+                    .getConfiguration()
+                    .getChild("agents")
+                    .getChildren()
+                    .get(0)
+                    .getValue();
+            assertEquals(
+                    fakeArtifact, Paths.get(interpolatedValue).toAbsolutePath().normalize());
+        } finally {
+            sessionScope.exit();
+        }
+    }
+}

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java
@@ -72,6 +72,8 @@ import org.apache.maven.model.superpom.SuperPomProvider;
 import org.apache.maven.model.validation.DefaultModelValidator;
 import org.apache.maven.model.validation.ModelValidator;
 
+import static java.util.Collections.emptyList;
+
 /**
  * A factory to create model builder instances when no dependency injection is available. <em>Note:</em> This class is
  * only meant as a utility for developers that want to employ the model builder outside the Maven build system, Maven
@@ -264,7 +266,7 @@ public class DefaultModelBuilderFactory {
         UrlNormalizer normalizer = newUrlNormalizer();
         PathTranslator pathTranslator = newPathTranslator();
         RootLocator rootLocator = newRootLocator();
-        return new StringVisitorModelInterpolator(pathTranslator, normalizer, rootLocator);
+        return new StringVisitorModelInterpolator(pathTranslator, normalizer, rootLocator, emptyList());
     }
 
     protected ModelVersionProcessor newModelVersionPropertiesProcessor() {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator.java
@@ -79,15 +79,19 @@ public abstract class AbstractStringBasedModelInterpolator implements ModelInter
 
     private final PathTranslator pathTranslator;
     private final UrlNormalizer urlNormalizer;
-
     private final RootLocator rootLocator;
+    private final List<ValueSource> customValueSources;
 
     @Inject
     public AbstractStringBasedModelInterpolator(
-            PathTranslator pathTranslator, UrlNormalizer urlNormalizer, RootLocator rootLocator) {
+            PathTranslator pathTranslator,
+            UrlNormalizer urlNormalizer,
+            RootLocator rootLocator,
+            List<ValueSource> customValueSources) {
         this.pathTranslator = pathTranslator;
         this.urlNormalizer = urlNormalizer;
         this.rootLocator = rootLocator;
+        this.customValueSources = customValueSources;
     }
 
     @Override
@@ -199,6 +203,11 @@ public abstract class AbstractStringBasedModelInterpolator implements ModelInter
         });
 
         valueSources.add(prefixlessObjectBasedValueSource);
+
+        // don't override default behavior so append it
+        if (customValueSources != null && !customValueSources.isEmpty()) {
+            valueSources.addAll(customValueSources);
+        }
 
         return valueSources;
     }

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolatorTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.maven.model.interpolation;
 
+import static java.util.Collections.emptyList;
+
 public class StringVisitorModelInterpolatorTest extends AbstractModelInterpolatorTest {
     protected ModelInterpolator createInterpolator() {
-        return new StringVisitorModelInterpolator(null, null, bd -> true);
+        return new StringVisitorModelInterpolator(null, null, bd -> true, emptyList());
     }
 }

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/bean/SimpleInterpolator.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/bean/SimpleInterpolator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.repository.internal.bean;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.model.interpolation.StringVisitorModelInterpolator;
+import org.apache.maven.model.path.PathTranslator;
+import org.apache.maven.model.path.UrlNormalizer;
+import org.apache.maven.model.root.RootLocator;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * just to provide an impl for tests.
+ */
+@Named
+@Singleton
+public class SimpleInterpolator extends StringVisitorModelInterpolator {
+    @Inject
+    public SimpleInterpolator(
+            final PathTranslator pathTranslator, final UrlNormalizer urlNormalizer, final RootLocator rootLocator) {
+        super(pathTranslator, urlNormalizer, rootLocator, emptyList());
+    }
+}

--- a/maven-resolver-provider/src/test/resources/META-INF/sisu/javax.inject.Named
+++ b/maven-resolver-provider/src/test/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,1 @@
+org.apache.maven.repository.internal.bean.SimpleInterpolator


### PR DESCRIPTION
Sample proposal to try to ease https://github.com/mockito/mockito/issues/3037.

Main issue of this PR is to not support transitive deps but think it is not a bad compromise (using `javaagent` "scope" would be as bad + totally wrong/broken in terms of design - would loose the scope to be clear, and adding an attribute sounds overkill until we get something like gradle configuration).
Main advantage is it makes it easy to work for everybody and stays aligned on the JVM (explicit toggling with ordering) for javaagent cases.

So overall think it can be a good compromise. If validated we have to document it properly - probably in maven site and surefire one?

@bmarwell if you want to try/take this over, but thought a PR would be easier than slack ;)