### PR TITLE
[MNG-7910] DefaultProfileSelector empty ctor uses immutable list

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/DefaultProfileSelector.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/DefaultProfileSelector.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -47,7 +46,7 @@ public class DefaultProfileSelector implements ProfileSelector {
     private final List<ProfileActivator> activators;
 
     public DefaultProfileSelector() {
-        this.activators = Collections.emptyList();
+        this.activators = new ArrayList<>();
     }
 
     @Inject


### PR DESCRIPTION
It uses immutable list and while it suggests it allows this below, it actually fails on constructs like this (worse even, it compiles ok, but fails runtime only): 
```
new DefaultProfileSelector()
                .addProfileActivator(new JdkVersionProfileActivator())
                .addProfileActivator(new PropertyProfileActivator())
```

As default ctor creates immutable list, but API kinda suggests this is ok. So either this PR should go in, or just remove `addProfileActivator` and make class immutable. Am fine with both (unless something else requires it to be extended).

---

https://issues.apache.org/jira/browse/MNG-7910