### PR TITLE
[3.9.x] [MNG-7913] Upgrade Sisu version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
     <javaVersion>8</javaVersion>
     <minimalMavenBuildVersion>3.5.4</minimalMavenBuildVersion>
 
-    <sisuVersion>0.3.5</sisuVersion>
+    <sisuVersion>0.9.0.M2</sisuVersion>
     <classWorldsVersion>2.7.0</classWorldsVersion>
     <commonsCliVersion>1.5.0</commonsCliVersion>
     <commonsIoVersion>2.11.0</commonsIoVersion>


### PR DESCRIPTION
To version that supports gleaning JSR330 component classes up to Java 19. The reasoning of this change is only to allow 3rd party Maven plugins/Maven extensions/other JSR330 components (managed by Maven embedded Sisu) to use bytecode newer that Java 14 (Sisu 0.3.5).

---

https://issues.apache.org/jira/browse/MNG-7913