### PR TITLE
Get rid of deprecated method in the v4 Session interface

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
@@ -101,20 +101,6 @@ public interface Session {
     @Nonnull
     Path getRootDirectory();
 
-    /**
-     * @deprecated use {@link #getRootDirectory()} instead
-     */
-    @Nonnull
-    @Deprecated
-    Path getMultiModuleProjectDirectory();
-
-    /**
-     * @deprecated use {@link #getTopDirectory()} instead
-     */
-    @Deprecated
-    @Nonnull
-    Path getExecutionRootDirectory();
-
     @Nonnull
     List<Project> getProjects();
 

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
@@ -140,18 +140,6 @@ public class DefaultSession extends AbstractSession {
         return mavenSession.getStartTime().toInstant();
     }
 
-    @Nonnull
-    @Override
-    public Path getMultiModuleProjectDirectory() {
-        return mavenSession.getRequest().getMultiModuleProjectDirectory().toPath();
-    }
-
-    @Nonnull
-    @Override
-    public Path getExecutionRootDirectory() {
-        return getTopDirectory();
-    }
-
     @Override
     public Path getRootDirectory() {
         return mavenSession.getRequest().getRootDirectory();

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4.java
@@ -54,7 +54,7 @@ import org.codehaus.plexus.component.configurator.expression.TypeAwareExpression
  * <tr><td><code>settings</code></td>          <td></td>               <td>{@link Session#getSettings()}</td></tr>
  * <tr><td><code>settings.*</code></td>        <td></td>               <td></td></tr>
  * <tr><td><code>basedir</code></td>           <td></td>
- *                                 <td>{@link Session#getExecutionRootDirectory()} or
+ *                                 <td>{@link Session#getTopDirectory()} or
  *                                                 <code>System.getProperty( "user.dir" )</code> if null</td></tr>
  * <tr><td><code>mojoExecution</code></td>     <td></td>               <td>the actual {@link MojoExecution}</td></tr>
  * <tr><td><code>mojo</code></td>              <td>(since Maven 3)</td><td>same as <code>mojoExecution</code></td></tr>
@@ -112,7 +112,7 @@ public class PluginParameterExpressionEvaluatorV4 implements TypeAwareExpression
         }
 
         if (basedir == null) {
-            basedir = session.getExecutionRootDirectory();
+            basedir = session.getTopDirectory();
         }
 
         if (basedir == null) {


### PR DESCRIPTION
Maven 4 api is still in alpha, it would be better to not start adding deprecated methods now...

