### PR TITLE
Use 4.0.99 as as intermediate model to keep 4.1.0 for the Maven 4.x model

### DIFF
--- a/api/maven-api-model/pom.xml
+++ b/api/maven-api-model/pom.xml
@@ -51,7 +51,7 @@ under the License.
               <goal>velocity</goal>
             </goals>
             <configuration>
-              <version>4.2.0</version>
+              <version>4.1.0</version>
               <velocityBasedir>${project.basedir}/../../src/mdo</velocityBasedir>
               <models>
                 <model>src/main/mdo/maven.mdo</model>

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -56,6 +56,7 @@
     <ul>
       <li><a href="https://maven.apache.org/xsd/maven-v3_0_0.xsd">https://maven.apache.org/xsd/maven-v3_0_0.xsd</a> for Maven 1.1.</li>
       <li><a href="https://maven.apache.org/xsd/maven-4.0.0.xsd">https://maven.apache.org/xsd/maven-4.0.0.xsd</a> for Maven 2.0.</li>
+      <li><a href="https://maven.apache.org/xsd/maven-4.1.0.xsd">https://maven.apache.org/xsd/maven-4.1.0.xsd</a> for Maven 4.0.</li>
     </ul>
     ]]>
   </description>
@@ -80,7 +81,7 @@
 
         <field xml.transient="true">
           <name>pomFile</name>
-          <version>4.2.0+</version>
+          <version>4.1.0+</version>
           <required>false</required>
           <description>Originating POM file</description>
           <type>DOM</type> <!-- This is transformed to a File/Path in the template -->
@@ -387,7 +388,7 @@
       </fields>
       <codeSegments>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     /**
@@ -460,7 +461,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.2.0+</version>
+          <version>4.1.0+</version>
           <code>
             <![CDATA[
     /**
@@ -650,7 +651,7 @@
       </fields>
       <codeSegments>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     Map<String, Plugin> pluginMap;
@@ -688,7 +689,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.2.0+</version>
+          <version>4.1.0+</version>
           <code>
             <![CDATA[
     volatile Map<String, Plugin> pluginMap;
@@ -1295,7 +1296,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     public void setOptional( boolean optional )
@@ -2093,7 +2094,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     public void setFiltering( boolean filtering )
@@ -2279,7 +2280,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     public void setEnabled( boolean enabled )
@@ -2499,7 +2500,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     public void setExtensions(boolean extensions) {
@@ -2574,7 +2575,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.2.0+</version>
+          <version>4.1.0+</version>
           <code>
             <![CDATA[
     /**
@@ -2634,7 +2635,7 @@
         </field>
         <field xml.transient="true">
           <name>priority</name>
-          <version>4.0.0</version>
+          <version>4.0.0/4.0.99</version>
           <type>int</type>
           <description>
             <![CDATA[
@@ -2649,9 +2650,13 @@
           <name>priority</name>
           <version>4.1.0+</version>
           <type>int</type>
-          <description>The priority of this execution compared to other executions which are bound to the same phase.
+          <description>
+            <![CDATA[
+            The priority of this execution compared to other executions which are bound to the same phase.
             Executions derived from the default lifecycle have a negative priority by default so that they are executed
             before any custom plugin executions.
+            <br><b>Since</b>: Maven 4.0.0
+            ]]>
           </description>
         </field>
         <field>
@@ -2761,7 +2766,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     public void setExcludeDefaults( boolean excludeDefaults )
@@ -2813,7 +2818,7 @@
       </fields>
       <codeSegments>
         <codeSegment>
-          <version>4.0.0/4.1.0</version>
+          <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
     public static final String SOURCE_POM = "pom";
@@ -2841,7 +2846,7 @@
           </code>
         </codeSegment>
         <codeSegment>
-          <version>4.2.0+</version>
+          <version>4.1.0+</version>
           <code>
             <![CDATA[
     public static final String SOURCE_POM = "pom";
@@ -3293,13 +3298,18 @@
         <field>
           <name>configuration</name>
           <version>4.1.0+</version>
-          <description>The configuration of the extension.</description>
+          <description>
+            <![CDATA[
+            The configuration of the extension.
+            <br><b>Since</b>: Maven 4.0.0
+            ]]>
+          </description>
           <type>DOM</type>
         </field>
       </fields>
       <codeSegments>
         <codeSegment>
-          <version>4.2.0+</version>
+          <version>4.1.0+</version>
           <code>
             <![CDATA[
     /**

--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/ConsumerPomArtifactTransformer.java
@@ -107,7 +107,7 @@ public final class ConsumerPomArtifactTransformer {
             deferDeleteFile(consumer);
 
             project.addAttachedArtifact(createConsumerPomArtifact(project, consumer, session));
-        } else if (project.getModel().isRoot()) {
+        } else if (project.getModel().getDelegate().isRoot()) {
             throw new IllegalStateException(
                     "The use of the root attribute on the model requires the buildconsumer feature to be active");
         }

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
@@ -151,7 +151,7 @@ public class DefaultProjectBuildingHelper implements ProjectBuildingHelper {
                 plugin.setGroupId(extension.getGroupId());
                 plugin.setArtifactId(extension.getArtifactId());
                 plugin.setVersion(extension.getVersion());
-                plugin.setConfiguration(extension.getConfiguration());
+                plugin.setConfiguration(extension.getDelegate().getConfiguration());
                 extensionPlugins.add(plugin);
             }
 

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.RepositoryUtils;
+import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -50,6 +51,7 @@ import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.util.filter.ExclusionsDependencyFilter;
 import org.slf4j.Logger;
@@ -151,7 +153,10 @@ public class DefaultProjectBuildingHelper implements ProjectBuildingHelper {
                 plugin.setGroupId(extension.getGroupId());
                 plugin.setArtifactId(extension.getArtifactId());
                 plugin.setVersion(extension.getVersion());
-                plugin.setConfiguration(extension.getDelegate().getConfiguration());
+                XmlNode configuration = extension.getDelegate().getConfiguration();
+                if (configuration != null) {
+                    plugin.setConfiguration(new Xpp3Dom(configuration));
+                }
                 extensionPlugins.add(plugin);
             }
 

--- a/maven-embedder/pom.xml
+++ b/maven-embedder/pom.xml
@@ -195,6 +195,7 @@ under the License.
             <id>modello</id>
             <goals>
               <goal>velocity</goal>
+              <goal>xsd</goal>
             </goals>
           </execution>
         </executions>

--- a/maven-model/pom.xml
+++ b/maven-model/pom.xml
@@ -72,7 +72,7 @@ under the License.
         <configuration>
           <basedir>${project.basedir}/../api/maven-api-model</basedir>
           <velocityBasedir>${project.basedir}/../src/mdo</velocityBasedir>
-          <version>4.0.0</version>
+          <version>4.1.0</version>
           <models>
             <model>src/main/mdo/maven.mdo</model>
           </models>
@@ -107,7 +107,7 @@ under the License.
             </goals>
             <phase>generate-sources</phase>
             <configuration>
-              <version>4.1.0</version>
+              <version>4.0.99</version>
               <templates>
                 <template>model-v3.vm</template>
               </templates>
@@ -120,7 +120,7 @@ under the License.
             </goals>
             <phase>generate-sources</phase>
             <configuration>
-              <version>4.2.0</version>
+              <version>4.1.0</version>
               <templates>
                 <template>merger.vm</template>
                 <template>transformer.vm</template>

--- a/src/mdo/model-v3.vm
+++ b/src/mdo/model-v3.vm
@@ -198,7 +198,7 @@ public class ${class.name}
                 update(getDelegate().with${cap}(null));
             }
         } else {
-            throw new IllegalArgumentException("Expected an Xpp3Dom object but received: " + ${field.name});
+            throw new IllegalArgumentException("Expected an Xpp3Dom object but received a " + ${field.name}.getClass() + ": " + ${field.name});
         }
       #elseif( $field.type == "java.util.Properties" )
         Map<String, String> map = ${field.name}.entrySet().stream()


### PR DESCRIPTION
Fix model doc generation, change the intermediate model to use 4.0.99 and align the new model to 4.1.0

This requires https://github.com/apache/maven-integration-testing/pull/315 to pass ITs...

