### PR TITLE
[MNG-7961] Up japicmp baseline

### DIFF
--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -310,7 +310,7 @@ under the License.
               <!-- was only a workaround for Plexus Container, hopefully never used by anyone else -->
               <exclude>org.apache.maven.plugin.DefaultBuildPluginManager#setMojoExecutionListeners(java.util.List)</exclude>
               <!-- could have never been used due to usage of non-export class (CoreExportsProvider) -->
-              <exclude>org.apache.maven.classrealm.DefaultClassRealmManager#DefaultClassRealmManager(org.codehaus.plexus.logging.Logger,org.codehaus.plexus.PlexusContainer,java.util.List,org.apache.maven.extension.internal.CoreExportsProvider)</exclude>
+              <exclude>org.apache.maven.classrealm.DefaultClassRealmManager#DefaultClassRealmManager(org.codehaus.plexus.logging.Logger,org.codehaus.plexus.PlexusContainer,java.util.List,org.apache.maven.extension.internal.CoreExports)</exclude>
               <!-- internal field removed -->
               <exclude>org.apache.maven.graph.DefaultGraphBuilder#projectBuilder</exclude>
               <!-- MavenPluginValidator has been transformed into an interface -->

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ under the License.
   <properties>
     <javaVersion>8</javaVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <maven.baseline>3.8.7</maven.baseline>
+    <maven.baseline>3.8.8</maven.baseline>
     <!-- Control the name of the distribution and information output by mvn -->
     <distributionId>apache-maven</distributionId>
     <distributionShortName>Maven</distributionShortName>


### PR DESCRIPTION
From 3.8.7 to 3.8.8, but these two minors have binary incompatibilities (in ctor), so ignores updated as well.

---

https://issues.apache.org/jira/browse/MNG-7961