### PR TITLE
[MNG-7966] Augment api to provide a Map<Dependency, Path> in the resolution result

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverResult.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.maven.api.Artifact;
+import org.apache.maven.api.Dependency;
 import org.apache.maven.api.Node;
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;
@@ -34,11 +34,11 @@ public interface DependencyResolverResult extends DependencyCollectorResult {
      * The ordered list of the flattened dependency nodes.
      */
     @Nonnull
-    List<Node> getDependencies();
+    List<Node> getNodes();
 
     @Nonnull
     List<Path> getPaths();
 
     @Nonnull
-    Map<Artifact, Path> getArtifacts();
+    Map<Dependency, Path> getDependencies();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverResult.java
@@ -20,7 +20,9 @@ package org.apache.maven.api.services;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.maven.api.Artifact;
 import org.apache.maven.api.Node;
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;
@@ -36,4 +38,7 @@ public interface DependencyResolverResult extends DependencyCollectorResult {
 
     @Nonnull
     List<Path> getPaths();
+
+    @Nonnull
+    Map<Artifact, Path> getArtifacts();
 }

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultArtifactDeployer.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultArtifactDeployer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.internal.impl;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -30,7 +29,6 @@ import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.services.ArtifactDeployer;
 import org.apache.maven.api.services.ArtifactDeployerException;
 import org.apache.maven.api.services.ArtifactDeployerRequest;
-import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.deployment.DeployResult;
 import org.eclipse.aether.deployment.DeploymentException;
@@ -43,12 +41,6 @@ import static org.apache.maven.internal.impl.Utils.nonNull;
 @Named
 @Singleton
 public class DefaultArtifactDeployer implements ArtifactDeployer {
-    private final @Nonnull RepositorySystem repositorySystem;
-
-    @Inject
-    DefaultArtifactDeployer(@Nonnull RepositorySystem repositorySystem) {
-        this.repositorySystem = nonNull(repositorySystem, "repositorySystem");
-    }
 
     @Override
     public void deploy(@Nonnull ArtifactDeployerRequest request) {
@@ -61,7 +53,7 @@ public class DefaultArtifactDeployer implements ArtifactDeployer {
                     .setRepository(session.toRepository(repository))
                     .setArtifacts(session.toArtifacts(artifacts));
 
-            DeployResult result = repositorySystem.deploy(session.getSession(), deployRequest);
+            DeployResult result = session.getRepositorySystem().deploy(session.getSession(), deployRequest);
         } catch (DeploymentException e) {
             throw new ArtifactDeployerException("Unable to deploy artifacts", e);
         }

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultArtifactResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultArtifactResolver.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.internal.impl;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -30,13 +29,11 @@ import java.util.Map;
 
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.ArtifactCoordinate;
-import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.services.ArtifactManager;
 import org.apache.maven.api.services.ArtifactResolver;
 import org.apache.maven.api.services.ArtifactResolverException;
 import org.apache.maven.api.services.ArtifactResolverRequest;
 import org.apache.maven.api.services.ArtifactResolverResult;
-import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
@@ -47,12 +44,6 @@ import static org.apache.maven.internal.impl.Utils.nonNull;
 @Named
 @Singleton
 public class DefaultArtifactResolver implements ArtifactResolver {
-    private final RepositorySystem repositorySystem;
-
-    @Inject
-    DefaultArtifactResolver(@Nonnull RepositorySystem repositorySystem) {
-        this.repositorySystem = nonNull(repositorySystem, "repositorySystem");
-    }
 
     @Override
     public ArtifactResolverResult resolve(ArtifactResolverRequest request)
@@ -75,7 +66,8 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                 }
             }
             if (!requests.isEmpty()) {
-                List<ArtifactResult> results = repositorySystem.resolveArtifacts(session.getSession(), requests);
+                List<ArtifactResult> results =
+                        session.getRepositorySystem().resolveArtifacts(session.getSession(), requests);
                 for (ArtifactResult result : results) {
                     Artifact artifact = session.getArtifact(result.getArtifact());
                     Path path = result.getArtifact().getFile().toPath();

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultDependencyCollector.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultDependencyCollector.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.internal.impl;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -31,7 +30,6 @@ import org.apache.maven.api.services.DependencyCollectorException;
 import org.apache.maven.api.services.DependencyCollectorRequest;
 import org.apache.maven.api.services.DependencyCollectorResult;
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.collection.CollectRequest;
@@ -46,13 +44,6 @@ import static org.apache.maven.internal.impl.Utils.nonNull;
 @Named
 @Singleton
 public class DefaultDependencyCollector implements DependencyCollector {
-
-    private final RepositorySystem repositorySystem;
-
-    @Inject
-    DefaultDependencyCollector(@Nonnull RepositorySystem repositorySystem) {
-        this.repositorySystem = repositorySystem;
-    }
 
     @Nonnull
     @Override
@@ -79,7 +70,8 @@ public class DefaultDependencyCollector implements DependencyCollector {
         }
 
         try {
-            final CollectResult result = repositorySystem.collectDependencies(systemSession, collectRequest);
+            final CollectResult result =
+                    session.getRepositorySystem().collectDependencies(systemSession, collectRequest);
             return new DependencyCollectorResult() {
                 @Override
                 public List<Exception> getExceptions() {

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolver.java
@@ -26,13 +26,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.ArtifactCoordinate;
 import org.apache.maven.api.Node;
@@ -43,8 +44,8 @@ import org.apache.maven.api.Session;
 import org.apache.maven.api.services.*;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.lifecycle.internal.LifecycleDependencyResolver;
+import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
-import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.graph.DependencyVisitor;
@@ -81,7 +82,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
     private static DependencyFilter getScopeDependencyFilter(ResolutionScope scope) {
         Set<String> scopes = scope.scopes().stream().map(Scope::id).collect(Collectors.toSet());
         return (n, p) -> {
-            Dependency d = n.getDependency();
+            org.eclipse.aether.graph.Dependency d = n.getDependency();
             return d == null || scopes.contains(d.getScope());
         };
     }
@@ -93,15 +94,26 @@ public class DefaultDependencyResolver implements DependencyResolver {
         InternalSession session = InternalSession.from(request.getSession());
 
         if (request.getProject().isPresent()) {
-            List<Artifact> artifacts = resolveDependencies(
+            DependencyResolutionResult result = resolveDependencies(
                     request.getSession(), request.getProject().get(), request.getResolutionScope());
-            List<Path> paths = artifacts.stream()
-                    .map(a -> request.getSession()
-                            .getService(ArtifactManager.class)
-                            .getPath(a)
-                            .get())
-                    .collect(Collectors.toList());
-            return new DefaultDependencyResolverResult(Collections.emptyList(), null, Collections.emptyList(), paths);
+
+            Map<org.eclipse.aether.graph.Dependency, org.eclipse.aether.graph.DependencyNode> nodes = stream(
+                            result.getDependencyGraph())
+                    .filter(n -> n.getDependency() != null)
+                    .collect(Collectors.toMap(DependencyNode::getDependency, n -> n));
+
+            Node root = session.getNode(result.getDependencyGraph());
+            List<Node> dependencies = new ArrayList<>();
+            Map<Artifact, Path> artifacts = new LinkedHashMap<>();
+            List<Path> paths = new ArrayList<>();
+            for (org.eclipse.aether.graph.Dependency dep : result.getResolvedDependencies()) {
+                dependencies.add(session.getNode(nodes.get(dep)));
+                Path path = dep.getArtifact().getFile().toPath();
+                artifacts.put(session.getDependency(dep), path);
+                paths.add(path);
+            }
+            return new DefaultDependencyResolverResult(
+                    result.getCollectionErrors(), root, dependencies, paths, artifacts);
         }
 
         DependencyCollectorResult collectorResult =
@@ -122,22 +134,25 @@ public class DefaultDependencyResolver implements DependencyResolver {
                 .collect(Collectors.toList());
 
         return new DefaultDependencyResolverResult(
-                collectorResult.getExceptions(), collectorResult.getRoot(), dependencies, paths);
+                collectorResult.getExceptions(), collectorResult.getRoot(), dependencies, paths, artifacts);
     }
 
-    private List<Artifact> resolveDependencies(Session session, Project project, ResolutionScope scope) {
+    private Stream<DependencyNode> stream(DependencyNode node) {
+        return Stream.concat(Stream.of(node), node.getChildren().stream().flatMap(this::stream));
+    }
+
+    private DependencyResolutionResult resolveDependencies(Session session, Project project, ResolutionScope scope) {
         Collection<String> toResolve = toScopes(scope);
         try {
             LifecycleDependencyResolver lifecycleDependencyResolver =
                     session.getService(Lookup.class).lookup(LifecycleDependencyResolver.class);
-            Set<org.apache.maven.artifact.Artifact> artifacts = lifecycleDependencyResolver.resolveProjectArtifacts(
+            return lifecycleDependencyResolver.getProjectDependencyResolutionResult(
                     getMavenProject(project),
                     toResolve,
                     toResolve,
                     InternalSession.from(session).getMavenSession(),
                     false,
                     Collections.emptySet());
-            return map(artifacts, a -> InternalSession.from(session).getArtifact(RepositoryUtils.toArtifact(a)));
         } catch (LifecycleExecutionException e) {
             throw new DependencyResolverException("Unable to resolve project dependencies", e);
         }
@@ -156,13 +171,19 @@ public class DefaultDependencyResolver implements DependencyResolver {
         private final Node root;
         private final List<Node> dependencies;
         private final List<Path> paths;
+        private final Map<Artifact, Path> artifacts;
 
         DefaultDependencyResolverResult(
-                List<Exception> exceptions, Node root, List<Node> dependencies, List<Path> paths) {
+                List<Exception> exceptions,
+                Node root,
+                List<Node> dependencies,
+                List<Path> paths,
+                Map<Artifact, Path> artifacts) {
             this.exceptions = exceptions;
             this.root = root;
             this.dependencies = dependencies;
             this.paths = paths;
+            this.artifacts = artifacts;
         }
 
         @Override
@@ -183,6 +204,11 @@ public class DefaultDependencyResolver implements DependencyResolver {
         @Override
         public List<Path> getPaths() {
             return paths;
+        }
+
+        @Override
+        public Map<Artifact, Path> getArtifacts() {
+            return artifacts;
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -169,6 +169,24 @@ public class LifecycleDependencyResolver {
         }
     }
 
+    public DependencyResolutionResult getProjectDependencyResolutionResult(
+            MavenProject project,
+            Collection<String> scopesToCollect,
+            Collection<String> scopesToResolve,
+            MavenSession session,
+            boolean aggregating,
+            Set<Artifact> projectArtifacts)
+            throws LifecycleExecutionException {
+
+        Set<Artifact> resolvedArtifacts = resolveProjectArtifacts(
+                project, scopesToCollect, scopesToResolve, session, aggregating, projectArtifacts);
+        if (resolvedArtifacts instanceof ProjectArtifactsCache.ArtifactsSetWithResult) {
+            return ((ProjectArtifactsCache.ArtifactsSetWithResult) resolvedArtifacts).getResult();
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
     public Set<Artifact> resolveProjectArtifacts(
             MavenProject project,
             Collection<String> scopesToCollect,
@@ -270,7 +288,7 @@ public class LifecycleDependencyResolver {
                     Collections.singletonList(project.getArtifact().getId()),
                     collectionFilter);
         }
-        return artifacts;
+        return new SetWithResolutionResult(result, artifacts);
     }
 
     private boolean areAllDependenciesInReactor(

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -234,7 +234,7 @@ public class LifecycleDependencyResolver {
         }
 
         if (scopesToCollect.isEmpty() && scopesToResolve.isEmpty()) {
-            return new LinkedHashSet<>();
+            return new SetWithResolutionResult(null, new LinkedHashSet<>());
         }
 
         scopesToCollect = new HashSet<>(scopesToCollect);

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/SetWithResolutionResult.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/SetWithResolutionResult.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.internal;
+
+import java.util.AbstractSet;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.artifact.ProjectArtifactsCache;
+
+public class SetWithResolutionResult extends AbstractSet<Artifact>
+        implements ProjectArtifactsCache.ArtifactsSetWithResult {
+    final DependencyResolutionResult result;
+    final Set<Artifact> artifacts;
+
+    public SetWithResolutionResult(DependencyResolutionResult result, Set<Artifact> artifacts) {
+        this.result = result;
+        this.artifacts = Collections.unmodifiableSet(artifacts);
+    }
+
+    @Override
+    public Iterator<Artifact> iterator() {
+        return artifacts.iterator();
+    }
+
+    @Override
+    public int size() {
+        return artifacts.size();
+    }
+
+    @Override
+    public DependencyResolutionResult getResult() {
+        return result;
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCache.java
+++ b/maven-core/src/main/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCache.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.apache.maven.lifecycle.internal.SetWithResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.LocalRepository;
@@ -195,8 +196,17 @@ public class DefaultProjectArtifactsCache implements ProjectArtifactsCache {
 
         assertUniqueKey(key);
 
-        CacheRecord record = new CacheRecord(Collections.unmodifiableSet(new LinkedHashSet<>(projectArtifacts)));
+        SetWithResolutionResult artifacts;
+        if (projectArtifacts instanceof SetWithResolutionResult) {
+            artifacts = (SetWithResolutionResult) projectArtifacts;
+        } else if (projectArtifacts instanceof ArtifactsSetWithResult) {
+            artifacts = new SetWithResolutionResult(
+                    ((ArtifactsSetWithResult) projectArtifacts).getResult(), projectArtifacts);
+        } else {
+            throw new IllegalArgumentException("projectArtifacts must implement ArtifactsSetWithResult");
+        }
 
+        CacheRecord record = new CacheRecord(artifacts);
         cache.put(key, record);
 
         return record;

--- a/maven-core/src/main/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCache.java
+++ b/maven-core/src/main/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCache.java
@@ -141,13 +141,10 @@ public class DefaultProjectArtifactsCache implements ProjectArtifactsCache {
             if (o == this) {
                 return true;
             }
-
             if (!(o instanceof CacheKey)) {
                 return false;
             }
-
             CacheKey that = (CacheKey) o;
-
             return Objects.equals(groupId, that.groupId)
                     && Objects.equals(artifactId, that.artifactId)
                     && Objects.equals(version, that.version)
@@ -182,18 +179,15 @@ public class DefaultProjectArtifactsCache implements ProjectArtifactsCache {
     @Override
     public CacheRecord get(Key key) throws LifecycleExecutionException {
         CacheRecord cacheRecord = cache.get(key);
-
         if (cacheRecord != null && cacheRecord.getException() != null) {
             throw cacheRecord.getException();
         }
-
         return cacheRecord;
     }
 
     @Override
     public CacheRecord put(Key key, Set<Artifact> projectArtifacts) {
         Objects.requireNonNull(projectArtifacts, "projectArtifacts cannot be null");
-
         assertUniqueKey(key);
 
         SetWithResolutionResult artifacts;
@@ -208,7 +202,15 @@ public class DefaultProjectArtifactsCache implements ProjectArtifactsCache {
 
         CacheRecord record = new CacheRecord(artifacts);
         cache.put(key, record);
+        return record;
+    }
 
+    @Override
+    public CacheRecord put(Key key, LifecycleExecutionException exception) {
+        Objects.requireNonNull(exception, "exception cannot be null");
+        assertUniqueKey(key);
+        CacheRecord record = new CacheRecord(exception);
+        cache.put(key, record);
         return record;
     }
 
@@ -216,19 +218,6 @@ public class DefaultProjectArtifactsCache implements ProjectArtifactsCache {
         if (cache.containsKey(key)) {
             throw new IllegalStateException("Duplicate artifact resolution result for project " + key);
         }
-    }
-
-    @Override
-    public CacheRecord put(Key key, LifecycleExecutionException exception) {
-        Objects.requireNonNull(exception, "exception cannot be null");
-
-        assertUniqueKey(key);
-
-        CacheRecord record = new CacheRecord(exception);
-
-        cache.put(key, record);
-
-        return record;
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/project/artifact/ProjectArtifactsCache.java
+++ b/maven-core/src/main/java/org/apache/maven/project/artifact/ProjectArtifactsCache.java
@@ -51,15 +51,7 @@ public interface ProjectArtifactsCache {
      */
     class CacheRecord {
 
-        public Set<Artifact> getArtifacts() {
-            return artifacts;
-        }
-
         private final Set<Artifact> artifacts;
-
-        public LifecycleExecutionException getException() {
-            return exception;
-        }
 
         private final LifecycleExecutionException exception;
 
@@ -71,6 +63,14 @@ public interface ProjectArtifactsCache {
         CacheRecord(LifecycleExecutionException exception) {
             this.artifacts = null;
             this.exception = exception;
+        }
+
+        public Set<Artifact> getArtifacts() {
+            return artifacts;
+        }
+
+        public LifecycleExecutionException getException() {
+            return exception;
         }
     }
 

--- a/maven-core/src/main/java/org/apache/maven/project/artifact/ProjectArtifactsCache.java
+++ b/maven-core/src/main/java/org/apache/maven/project/artifact/ProjectArtifactsCache.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystemSession;
 
@@ -39,6 +40,10 @@ public interface ProjectArtifactsCache {
      */
     interface Key {
         // marker interface for cache keys
+    }
+
+    interface ArtifactsSetWithResult extends Set<Artifact> {
+        DependencyResolutionResult getResult();
     }
 
     /**

--- a/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCacheTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCacheTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.lifecycle.internal.SetWithResolutionResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,7 @@ class DefaultProjectArtifactsCacheTest {
         artifacts.add(new DefaultArtifact("g", "a3", "v", "compile", "jar", "", null));
         artifacts.add(new DefaultArtifact("g", "a4", "v", "compile", "jar", "", null));
 
-        cache.put(project1, artifacts);
+        cache.put(project1, new SetWithResolutionResult(null, artifacts));
 
         assertArrayEquals(
                 artifacts.toArray(new Artifact[0]),
@@ -61,7 +62,7 @@ class DefaultProjectArtifactsCacheTest {
         artifacts.add(new DefaultArtifact("g", "a2", "v", "compile", "jar", "", null));
         artifacts.add(new DefaultArtifact("g", "a1", "v", "compile", "jar", "", null));
 
-        cache.put(project2, reversedArtifacts);
+        cache.put(project2, new SetWithResolutionResult(null, reversedArtifacts));
 
         assertArrayEquals(
                 reversedArtifacts.toArray(new Artifact[0]),


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7966

This is a bit of an ugly hack, but I don't think we should modify the Maven 3 api for the `ProjectArtifactCache`, so I introduced:
```
    interface ArtifactsSetWithResult extends Set<Artifact> {
        DependencyResolutionResult getResult();
    }
```

If that's deemed too ugly, I can modify the `ProjectArtifactCache` to add a `DependencyResolutionResult` in the `CacheRecord` maybe...