### PR TITLE
[MNG-7959] User controlled relocations Addendum

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -237,7 +237,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                 throw new ArtifactDescriptorException(result);
             }
 
-            Artifact relocatedArtifact = getRelocation(session, request, model);
+            Artifact relocatedArtifact = getRelocation(session, result, model);
             if (relocatedArtifact != null) {
                 result.addRelocation(a);
                 a = relocatedArtifact;
@@ -259,10 +259,12 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         return props;
     }
 
-    private Artifact getRelocation(RepositorySystemSession session, ArtifactDescriptorRequest request, Model model) {
+    private Artifact getRelocation(
+            RepositorySystemSession session, ArtifactDescriptorResult artifactDescriptorResult, Model model)
+            throws ArtifactDescriptorException {
         Artifact result = null;
         for (MavenArtifactRelocationSource source : artifactRelocationSources.values()) {
-            result = source.relocatedTarget(session, request, model);
+            result = source.relocatedTarget(session, artifactDescriptorResult, model);
             if (result != null) {
                 break;
             }

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenArtifactRelocationSource.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenArtifactRelocationSource.java
@@ -21,7 +21,8 @@ package org.apache.maven.repository.internal;
 import org.apache.maven.model.Model;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 
 /**
  * Maven relocation source.
@@ -33,9 +34,10 @@ public interface MavenArtifactRelocationSource {
      * Returns {@link Artifact} instance where to relocate to, or {@code null}.
      *
      * @param session The session, never {@code null}.
-     * @param request The artifact descriptor request, never {@code null}.
+     * @param result The artifact descriptor result, never {@code null}.
      * @param model The artifact model, never {@code null}.
      * @return The {@link Artifact} to relocate to, or {@code null} if no relocation wanted.
      */
-    Artifact relocatedTarget(RepositorySystemSession session, ArtifactDescriptorRequest request, Model model);
+    Artifact relocatedTarget(RepositorySystemSession session, ArtifactDescriptorResult result, Model model)
+            throws ArtifactDescriptorException;
 }

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSource.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSource.java
@@ -28,7 +28,7 @@ import org.apache.maven.repository.internal.MavenArtifactRelocationSource;
 import org.apache.maven.repository.internal.RelocatedArtifact;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.sisu.Priority;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,13 +49,14 @@ public final class DistributionManagementArtifactRelocationSource implements Mav
     private static final Logger LOGGER = LoggerFactory.getLogger(DistributionManagementArtifactRelocationSource.class);
 
     @Override
-    public Artifact relocatedTarget(RepositorySystemSession session, ArtifactDescriptorRequest request, Model model) {
+    public Artifact relocatedTarget(
+            RepositorySystemSession session, ArtifactDescriptorResult artifactDescriptorResult, Model model) {
         DistributionManagement distMgmt = model.getDistributionManagement();
         if (distMgmt != null) {
             Relocation relocation = distMgmt.getRelocation();
             if (relocation != null) {
                 Artifact result = new RelocatedArtifact(
-                        request.getArtifact(),
+                        artifactDescriptorResult.getRequest().getArtifact(),
                         relocation.getGroupId(),
                         relocation.getArtifactId(),
                         null,
@@ -64,7 +65,7 @@ public final class DistributionManagementArtifactRelocationSource implements Mav
                         relocation.getMessage());
                 LOGGER.debug(
                         "The artifact {} has been relocated to {}: {}",
-                        request.getArtifact(),
+                        artifactDescriptorResult.getRequest().getArtifact(),
                         result,
                         relocation.getMessage());
                 return result;


### PR DESCRIPTION
I had this change parked on laptop, assumed was pushed :(

The "ban" was unfinished and wrong: what is actually needed is to have exception with proper explanation instead.

---

https://issues.apache.org/jira/browse/MNG-7959

---

Now the command line:
```
$ mvn clean install -Dmaven.relocations.entries="org.slf4j:*:*>>"
```
(global ban of ANY org.slf4j group artifact) causes output like this:

https://gist.github.com/cstamas/c57efa1e1d56ca605fdfa88c431eab97