### PR TITLE
[MNG-7999] Confine Plexus Container as much as possible

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/Lookup.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/Lookup.java
@@ -20,16 +20,77 @@ package org.apache.maven.api.services;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.maven.api.Service;
+import org.apache.maven.api.annotations.Nonnull;
 
 public interface Lookup extends Service {
-
+    /**
+     * Performs a lookup for given typed component.
+     *
+     * @param type The component type.
+     * @return The component or {@code null} if no such component.
+     * @param <T> The component type.
+     * @throws LookupException if no such component or there is some provisioning related issue.
+     */
+    @Nonnull
     <T> T lookup(Class<T> type);
 
+    /**
+     * Performs a lookup for given typed component.
+     *
+     * @param type The component type.
+     * @param name The component name.
+     * @return The component or {@code null} if no such component.
+     * @param <T> The component type.
+     * @throws LookupException if no such component or there is some provisioning related issue.
+     */
+    @Nonnull
     <T> T lookup(Class<T> type, String name);
 
+    /**
+     * Performs a lookup for optional typed component.
+     *
+     * @param type The component type.
+     * @return The component or {@code null} if no such component.
+     * @param <T> The component type.
+     * @throws LookupException if there is some provisioning related issue.
+     */
+    @Nonnull
+    <T> Optional<T> lookupOptional(Class<T> type);
+
+    /**
+     * Performs a lookup for optional typed component.
+     *
+     * @param type The component type.
+     * @param name The component name.
+     * @return The component or {@code null} if no such component.
+     * @param <T> The component type.
+     * @throws LookupException if there is some provisioning related issue.
+     */
+    @Nonnull
+    <T> Optional<T> lookupOptional(Class<T> type, String name);
+
+    /**
+     * Performs a collection lookup for given typed components.
+     *
+     * @param type The component type.
+     * @return The list of components. The list may be empty if no components found.
+     * @param <T> The component type.
+     * @throws LookupException if there is some provisioning related issue.
+     */
+    @Nonnull
     <T> List<T> lookupList(Class<T> type);
 
+    /**
+     * Performs a collection lookup for given typed components.
+     *
+     * @param type The component type.
+     * @return The map of components. The map may be empty if no components found.
+     * @param <T> The component type.
+     * @throws LookupException if there is some provisioning related issue.
+     */
+    @Nonnull
     <T> Map<String, T> lookupMap(Class<T> type);
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/Lookup.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/Lookup.java
@@ -30,7 +30,7 @@ public interface Lookup extends Service {
      * Performs a lookup for given typed component.
      *
      * @param type The component type.
-     * @return The component or {@code null} if no such component.
+     * @return The component.
      * @param <T> The component type.
      * @throws LookupException if no such component or there is some provisioning related issue.
      */
@@ -42,7 +42,7 @@ public interface Lookup extends Service {
      *
      * @param type The component type.
      * @param name The component name.
-     * @return The component or {@code null} if no such component.
+     * @return The component.
      * @param <T> The component type.
      * @throws LookupException if no such component or there is some provisioning related issue.
      */
@@ -53,7 +53,7 @@ public interface Lookup extends Service {
      * Performs a lookup for optional typed component.
      *
      * @param type The component type.
-     * @return The component or {@code null} if no such component.
+     * @return Optional carrying component or empty optional if no such component.
      * @param <T> The component type.
      * @throws LookupException if there is some provisioning related issue.
      */
@@ -65,7 +65,7 @@ public interface Lookup extends Service {
      *
      * @param type The component type.
      * @param name The component name.
-     * @return The component or {@code null} if no such component.
+     * @return Optional carrying component or empty optional if no such component.
      * @param <T> The component type.
      * @throws LookupException if there is some provisioning related issue.
      */

--- a/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
@@ -39,6 +39,7 @@ import org.apache.maven.bridge.MavenRepositorySystem;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.internal.impl.DefaultLookup;
 import org.apache.maven.internal.impl.DefaultSessionFactory;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.repository.legacy.repository.ArtifactRepositoryFactory;
@@ -107,7 +108,7 @@ public abstract class AbstractArtifactComponentTestCase // extends PlexusTestCas
         new DefaultSessionFactory(
                         getContainer().lookup(RepositorySystem.class),
                         getContainer().lookup(MavenRepositorySystem.class),
-                        getContainer(),
+                        new DefaultLookup(getContainer()),
                         getContainer().lookup(RuntimeInformation.class))
                 .getSession(session);
 

--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -91,17 +91,17 @@ public class DefaultMaven implements Maven {
 
     protected ProjectBuilder projectBuilder;
 
-    private LifecycleStarter lifecycleStarter;
+    private final LifecycleStarter lifecycleStarter;
 
-    protected PlexusContainer container;
+    private final PlexusContainer container;
 
-    private ExecutionEventCatapult eventCatapult;
+    private final ExecutionEventCatapult eventCatapult;
 
-    private LegacySupport legacySupport;
+    private final LegacySupport legacySupport;
 
-    private SessionScope sessionScope;
+    private final SessionScope sessionScope;
 
-    private DefaultRepositorySystemSessionFactory repositorySessionFactory;
+    private final DefaultRepositorySystemSessionFactory repositorySessionFactory;
 
     private final GraphBuilder graphBuilder;
 
@@ -328,7 +328,7 @@ public class DefaultMaven implements Maven {
             try {
                 afterSessionEnd(session);
             } catch (MavenExecutionException e) {
-                return addExceptionToResult(result, e);
+                addExceptionToResult(result, e);
             }
         }
 

--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -429,16 +429,8 @@ public class DefaultMaven implements Maven {
 
     private <T> Collection<T> getExtensionComponents(Collection<MavenProject> projects, Class<T> role) {
         Collection<T> foundComponents = new LinkedHashSet<>();
-
-        try {
-            foundComponents.addAll(lookup.lookupList(role));
-        } catch (LookupException e) {
-            // this is just silly, lookupList should return an empty list!
-            logger.warn("Failed to lookup {}: {}", role, e.getMessage());
-        }
-
+        foundComponents.addAll(lookup.lookupList(role));
         foundComponents.addAll(getProjectScopedExtensionComponents(projects, role));
-
         return foundComponents;
     }
 
@@ -458,13 +450,7 @@ public class DefaultMaven implements Maven {
 
                 if (projectRealm != null && scannedRealms.add(projectRealm)) {
                     currentThread.setContextClassLoader(projectRealm);
-
-                    try {
-                        foundComponents.addAll(lookup.lookupList(role));
-                    } catch (LookupException e) {
-                        // this is just silly, lookupList should return an empty list!
-                        logger.warn("Failed to lookup {}: {}", role, e.getMessage());
-                    }
+                    foundComponents.addAll(lookup.lookupList(role));
                 }
             }
             return foundComponents;

--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.maven.api.services.Lookup;
 import org.apache.maven.eventspy.EventSpy;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
@@ -41,7 +42,6 @@ import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.artifact.ProjectArtifact;
 import org.apache.maven.repository.internal.MavenWorkspaceReader;
-import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.WorkspaceRepository;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
@@ -504,11 +504,11 @@ class ReactorReader implements MavenWorkspaceReader {
     @SuppressWarnings("unused")
     static class ReactorReaderSpy implements EventSpy {
 
-        final PlexusContainer container;
+        private final Lookup lookup;
 
         @Inject
-        ReactorReaderSpy(PlexusContainer container) {
-            this.container = container;
+        ReactorReaderSpy(Lookup lookup) {
+            this.lookup = lookup;
         }
 
         @Override
@@ -518,7 +518,7 @@ class ReactorReader implements MavenWorkspaceReader {
         @SuppressWarnings("checkstyle:MissingSwitchDefault")
         public void onEvent(Object event) throws Exception {
             if (event instanceof ExecutionEvent) {
-                ReactorReader reactorReader = container.lookup(ReactorReader.class);
+                ReactorReader reactorReader = lookup.lookup(ReactorReader.class);
                 reactorReader.processEvent((ExecutionEvent) event);
             }
         }

--- a/maven-core/src/main/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeModule.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeModule.java
@@ -23,8 +23,6 @@ import org.apache.maven.api.plugin.Log;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 /**
  * MojoExecutionScopeModule
@@ -32,11 +30,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 public class MojoExecutionScopeModule extends AbstractModule {
     protected final MojoExecutionScope scope;
 
-    public MojoExecutionScopeModule(PlexusContainer container) throws ComponentLookupException {
-        this(container.lookup(MojoExecutionScope.class));
-    }
-
-    protected MojoExecutionScopeModule(MojoExecutionScope scope) {
+    public MojoExecutionScopeModule(MojoExecutionScope scope) {
         this.scope = scope;
     }
 

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLookup.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLookup.java
@@ -24,6 +24,8 @@ import javax.inject.Singleton;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.apache.maven.api.services.Lookup;
 import org.apache.maven.api.services.LookupException;
@@ -55,6 +57,30 @@ public class DefaultLookup implements Lookup {
         try {
             return container.lookup(type, name);
         } catch (ComponentLookupException e) {
+            throw new LookupException(e);
+        }
+    }
+
+    @Override
+    public <T> Optional<T> lookupOptional(Class<T> type) {
+        try {
+            return Optional.of(container.lookup(type));
+        } catch (ComponentLookupException e) {
+            if (e.getCause() instanceof NoSuchElementException) {
+                return Optional.empty();
+            }
+            throw new LookupException(e);
+        }
+    }
+
+    @Override
+    public <T> Optional<T> lookupOptional(Class<T> type, String name) {
+        try {
+            return Optional.of(container.lookup(type, name));
+        } catch (ComponentLookupException e) {
+            if (e.getCause() instanceof NoSuchElementException) {
+                return Optional.empty();
+            }
             throw new LookupException(e);
         }
     }

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
@@ -35,7 +35,6 @@ import org.apache.maven.api.di.SessionScoped;
 import org.apache.maven.api.model.Resource;
 import org.apache.maven.api.services.*;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.sisu.Typed;
 
 import static org.apache.maven.internal.impl.Utils.map;
@@ -47,13 +46,10 @@ public class DefaultProjectManager implements ProjectManager {
 
     private final InternalSession session;
     private final ArtifactManager artifactManager;
-    private final PlexusContainer container;
-
     @Inject
-    public DefaultProjectManager(InternalSession session, ArtifactManager artifactManager, PlexusContainer container) {
+    public DefaultProjectManager(InternalSession session, ArtifactManager artifactManager) {
         this.session = session;
         this.artifactManager = artifactManager;
-        this.container = container;
     }
 
     @Nonnull

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
@@ -46,6 +46,7 @@ public class DefaultProjectManager implements ProjectManager {
 
     private final InternalSession session;
     private final ArtifactManager artifactManager;
+
     @Inject
     public DefaultProjectManager(InternalSession session, ArtifactManager artifactManager) {
         this.session = session;

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSessionFactory.java
@@ -23,10 +23,10 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.maven.api.Session;
+import org.apache.maven.api.services.Lookup;
 import org.apache.maven.bridge.MavenRepositorySystem;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.rtinfo.RuntimeInformation;
-import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.SessionData;
 
@@ -35,7 +35,7 @@ import org.eclipse.aether.SessionData;
 public class DefaultSessionFactory {
     private final RepositorySystem repositorySystem;
     private final MavenRepositorySystem mavenRepositorySystem;
-    private final PlexusContainer plexusContainer;
+    private final Lookup lookup;
     private final RuntimeInformation runtimeInformation;
 
     @Inject
@@ -43,11 +43,11 @@ public class DefaultSessionFactory {
     public DefaultSessionFactory(
             RepositorySystem repositorySystem,
             MavenRepositorySystem mavenRepositorySystem,
-            PlexusContainer plexusContainer,
+            Lookup lookup,
             RuntimeInformation runtimeInformation) {
         this.repositorySystem = repositorySystem;
         this.mavenRepositorySystem = mavenRepositorySystem;
-        this.plexusContainer = plexusContainer;
+        this.lookup = lookup;
         this.runtimeInformation = runtimeInformation;
     }
 
@@ -58,6 +58,6 @@ public class DefaultSessionFactory {
 
     private Session newSession(MavenSession mavenSession) {
         return new DefaultSession(
-                mavenSession, repositorySystem, null, mavenRepositorySystem, plexusContainer, runtimeInformation);
+                mavenSession, repositorySystem, null, mavenRepositorySystem, lookup, runtimeInformation);
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilder.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.RepositorySystemSession;
 
 /**
@@ -36,5 +35,5 @@ import org.eclipse.aether.RepositorySystemSession;
 interface ConsumerPomBuilder {
 
     Model build(RepositorySystemSession session, MavenProject project, Path src)
-            throws ModelBuildingException, ComponentLookupException, IOException, XMLStreamException;
+            throws ModelBuildingException, IOException, XMLStreamException;
 }

--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomArtifactTransformer.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomArtifactTransformer.java
@@ -41,7 +41,6 @@ import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.v4.MavenStaxWriter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.artifact.ProjectArtifact;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -113,7 +112,7 @@ class DefaultConsumerPomArtifactTransformer implements ConsumerPomArtifactTransf
     }
 
     void transform(MavenProject project, RepositorySystemSession session, Path src, Path tgt)
-            throws ModelBuildingException, ComponentLookupException, XMLStreamException, IOException {
+            throws ModelBuildingException, XMLStreamException, IOException {
         Model model = builder.build(session, project, src);
         write(model, tgt);
     }

--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/TransformedArtifact.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/TransformedArtifact.java
@@ -35,7 +35,6 @@ import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.internal.transformation.TransformationFailedException;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.RepositorySystemSession;
 
 /**
@@ -97,18 +96,13 @@ class TransformedArtifact extends DefaultArtifact {
                 return null;
             }
             return target.toFile();
-        } catch (IOException
-                | NoSuchAlgorithmException
-                | XMLStreamException
-                | ModelBuildingException
-                | ComponentLookupException e) {
+        } catch (IOException | NoSuchAlgorithmException | XMLStreamException | ModelBuildingException e) {
             throw new TransformationFailedException(e);
         }
     }
 
     private String mayUpdate()
-            throws IOException, NoSuchAlgorithmException, XMLStreamException, ModelBuildingException,
-                    ComponentLookupException {
+            throws IOException, NoSuchAlgorithmException, XMLStreamException, ModelBuildingException {
         String result;
         Path src = sourcePathProvider.get();
         if (src == null) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycleExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycleExecutor.java
@@ -31,7 +31,6 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.internal.LifecycleExecutionPlanCalculator;
 import org.apache.maven.lifecycle.internal.LifecycleStarter;
 import org.apache.maven.lifecycle.internal.LifecycleTaskSegmentCalculator;
-import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
 import org.apache.maven.lifecycle.internal.MojoExecutor;
 import org.apache.maven.lifecycle.internal.ProjectIndex;
 import org.apache.maven.lifecycle.internal.TaskSegment;
@@ -49,7 +48,7 @@ import org.apache.maven.project.MavenProject;
 
 /**
  * A facade that provides lifecycle services to components outside maven core.
- *
+ * <p>
  * Note that this component is not normally used from within core itself.
  *
  */
@@ -63,7 +62,6 @@ public class DefaultLifecycleExecutor implements LifecycleExecutor {
     private final LifecycleExecutionPlanCalculator lifecycleExecutionPlanCalculator;
     private final MojoExecutor mojoExecutor;
     private final LifecycleStarter lifecycleStarter;
-    private final MojoDescriptorCreator mojoDescriptorCreator;
 
     @Inject
     public DefaultLifecycleExecutor(
@@ -72,15 +70,13 @@ public class DefaultLifecycleExecutor implements LifecycleExecutor {
             LifecycleTaskSegmentCalculator lifecycleTaskSegmentCalculator,
             LifecycleExecutionPlanCalculator lifecycleExecutionPlanCalculator,
             MojoExecutor mojoExecutor,
-            LifecycleStarter lifecycleStarter,
-            MojoDescriptorCreator mojoDescriptorCreator) {
+            LifecycleStarter lifecycleStarter) {
         this.lifeCyclePluginAnalyzer = lifeCyclePluginAnalyzer;
         this.defaultLifeCycles = defaultLifeCycles;
         this.lifecycleTaskSegmentCalculator = lifecycleTaskSegmentCalculator;
         this.lifecycleExecutionPlanCalculator = lifecycleExecutionPlanCalculator;
         this.mojoExecutor = mojoExecutor;
         this.lifecycleStarter = lifecycleStarter;
-        this.mojoDescriptorCreator = mojoDescriptorCreator;
     }
 
     public void execute(MavenSession session) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.apache.maven.api.services.Lookup;
+import org.apache.maven.api.services.LookupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,26 +49,26 @@ public class DefaultLifecycles {
 
     // @Configuration(source="org/apache/maven/lifecycle/lifecycles.xml")
 
-    private final PlexusContainer plexusContainer;
+    private final Lookup lookup;
 
     private Map<String, Lifecycle> customLifecycles;
 
     public DefaultLifecycles() {
-        this.plexusContainer = null;
+        this.lookup = null;
     }
 
     /**
-     * @deprecated Rely on {@link #DefaultLifecycles(PlexusContainer)} instead
+     * @deprecated Rely on {@link #DefaultLifecycles(Lookup)} instead
      */
     @Deprecated
     public DefaultLifecycles(Map<String, Lifecycle> lifecycles, org.codehaus.plexus.logging.Logger logger) {
         this.customLifecycles = lifecycles;
-        this.plexusContainer = null;
+        this.lookup = null;
     }
 
     @Inject
-    public DefaultLifecycles(PlexusContainer plexusContainer) {
-        this.plexusContainer = plexusContainer;
+    public DefaultLifecycles(Lookup lookup) {
+        this.lookup = lookup;
     }
 
     /**
@@ -143,14 +143,14 @@ public class DefaultLifecycles {
     private Map<String, Lifecycle> lookupLifecycles() {
         // TODO: Remove the following code when maven-compat is gone
         // This code is here to ensure maven-compat's EmptyLifecycleExecutor keeps on working.
-        if (plexusContainer == null) {
+        if (lookup == null) {
             return customLifecycles != null ? customLifecycles : new HashMap<>();
         }
 
         // Lifecycles cannot be cached as extensions might add custom lifecycles later in the execution.
         try {
-            return plexusContainer.lookupMap(Lifecycle.class);
-        } catch (ComponentLookupException e) {
+            return lookup.lookupMap(Lifecycle.class);
+        } catch (LookupException e) {
             throw new IllegalStateException("Unable to lookup lifecycles from the plexus container", e);
         }
     }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/MavenExecutionPlan.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/MavenExecutionPlan.java
@@ -118,10 +118,7 @@ public class MavenExecutionPlan implements Iterable<ExecutionPlanItem> {
             List<ExecutionPlanItem> planItems) {
         LinkedHashSet<String> result = new LinkedHashSet<>();
         for (ExecutionPlanItem executionPlanItem : planItems) {
-            final String phase = executionPlanItem.getLifecyclePhase();
-            if (!result.contains(phase)) {
-                result.add(phase);
-            }
+            result.add(executionPlanItem.getLifecyclePhase());
         }
         return result;
     }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildThreadFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildThreadFactory.java
@@ -29,6 +29,7 @@ public class BuildThreadFactory implements ThreadFactory {
 
     private static final String PREFIX = "BuilderThread";
 
+    @Override
     public Thread newThread(Runnable r) {
         return new Thread(r, String.format("%s-%d", PREFIX, id.getAndIncrement()));
     }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/CompoundProjectExecutionListener.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/CompoundProjectExecutionListener.java
@@ -31,24 +31,28 @@ class CompoundProjectExecutionListener implements ProjectExecutionListener {
         this.listeners = listeners; // NB this is live injected collection
     }
 
+    @Override
     public void beforeProjectExecution(ProjectExecutionEvent event) throws LifecycleExecutionException {
         for (ProjectExecutionListener listener : listeners) {
             listener.beforeProjectExecution(event);
         }
     }
 
+    @Override
     public void beforeProjectLifecycleExecution(ProjectExecutionEvent event) throws LifecycleExecutionException {
         for (ProjectExecutionListener listener : listeners) {
             listener.beforeProjectLifecycleExecution(event);
         }
     }
 
+    @Override
     public void afterProjectExecutionSuccess(ProjectExecutionEvent event) throws LifecycleExecutionException {
         for (ProjectExecutionListener listener : listeners) {
             listener.afterProjectExecutionSuccess(event);
         }
     }
 
+    @Override
     public void afterProjectExecutionFailure(ProjectExecutionEvent event) {
         for (ProjectExecutionListener listener : listeners) {
             listener.afterProjectExecutionFailure(event);

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultExecutionEvent.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultExecutionEvent.java
@@ -44,22 +44,27 @@ class DefaultExecutionEvent implements ExecutionEvent {
         this.exception = exception;
     }
 
+    @Override
     public Type getType() {
         return type;
     }
 
+    @Override
     public MavenSession getSession() {
         return session;
     }
 
+    @Override
     public MavenProject getProject() {
         return session.getCurrentProject();
     }
 
+    @Override
     public MojoExecution getMojoExecution() {
         return mojoExecution;
     }
 
+    @Override
     public Exception getException() {
         return exception;
     }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultExecutionEventCatapult.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultExecutionEventCatapult.java
@@ -36,10 +36,12 @@ import org.apache.maven.plugin.MojoExecution;
 @Singleton
 public class DefaultExecutionEventCatapult implements ExecutionEventCatapult {
 
+    @Override
     public void fire(ExecutionEvent.Type eventType, MavenSession session, MojoExecution mojoExecution) {
         fire(eventType, session, mojoExecution, null);
     }
 
+    @Override
     public void fire(
             ExecutionEvent.Type eventType, MavenSession session, MojoExecution mojoExecution, Exception exception) {
         ExecutionListener listener = session.getRequest().getExecutionListener();

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -107,7 +107,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         this.standardDelegate = null;
         this.delegates = null;
         this.mojoExecutionConfigurators =
-                Collections.singletonMap("default", (MojoExecutionConfigurator) new DefaultMojoExecutionConfigurator());
+                Collections.singletonMap("default", new DefaultMojoExecutionConfigurator(null));
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -107,7 +107,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         this.standardDelegate = null;
         this.delegates = null;
         this.mojoExecutionConfigurators =
-                Collections.singletonMap("default", new DefaultMojoExecutionConfigurator(null));
+                Collections.singletonMap("default", new DefaultMojoExecutionConfigurator());
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -106,8 +106,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         this.lifecyclePluginResolver = lifecyclePluginResolver;
         this.standardDelegate = null;
         this.delegates = null;
-        this.mojoExecutionConfigurators =
-                Collections.singletonMap("default", new DefaultMojoExecutionConfigurator());
+        this.mojoExecutionConfigurators = Collections.singletonMap("default", new DefaultMojoExecutionConfigurator());
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleMappingDelegate.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleMappingDelegate.java
@@ -60,6 +60,7 @@ public class DefaultLifecycleMappingDelegate implements LifecycleMappingDelegate
         this.pluginManager = pluginManager;
     }
 
+    @Override
     public Map<String, List<MojoExecution>> calculateLifecycleMappings(
             MavenSession session, MavenProject project, Lifecycle lifecycle, String lifecyclePhase)
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
@@ -67,8 +67,7 @@ public class DefaultLifecyclePluginAnalyzer implements LifeCyclePluginAnalyzer {
     private final DefaultLifecycles defaultLifeCycles;
 
     @Inject
-    public DefaultLifecyclePluginAnalyzer(
-            PlexusContainer plexusContainer, DefaultLifecycles defaultLifeCycles) {
+    public DefaultLifecyclePluginAnalyzer(PlexusContainer plexusContainer, DefaultLifecycles defaultLifeCycles) {
         this.plexusContainer = requireNonNull(plexusContainer);
         this.defaultLifeCycles = requireNonNull(defaultLifeCycles);
     }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
@@ -68,7 +68,7 @@ public class DefaultLifecyclePluginAnalyzer implements LifeCyclePluginAnalyzer {
 
     @Inject
     public DefaultLifecyclePluginAnalyzer(
-            final PlexusContainer plexusContainer, final DefaultLifecycles defaultLifeCycles) {
+            PlexusContainer plexusContainer, DefaultLifecycles defaultLifeCycles) {
         this.plexusContainer = requireNonNull(plexusContainer);
         this.defaultLifeCycles = requireNonNull(defaultLifeCycles);
     }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
@@ -26,11 +26,9 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.apache.maven.api.services.Lookup;
-import org.apache.maven.api.services.LookupException;
 import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.LifeCyclePluginAnalyzer;
@@ -128,14 +126,7 @@ public class DefaultLifecyclePluginAnalyzer implements LifeCyclePluginAnalyzer {
      * from current module and for example not extensions coming from other modules.
      */
     private LifecycleMapping lookupLifecycleMapping(final String packaging) {
-        try {
-            return lookup.lookup(LifecycleMapping.class, packaging);
-        } catch (LookupException e) {
-            if (e.getCause() instanceof NoSuchElementException) {
-                return null;
-            }
-            throw new RuntimeException(e);
-        }
+        return lookup.lookupOptional(LifecycleMapping.class, packaging).orElse(null);
     }
 
     private void parseLifecyclePhaseDefinitions(Map<Plugin, Plugin> plugins, String phase, LifecyclePhase goals) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.apache.maven.api.services.Lookup;
+import org.apache.maven.api.services.LookupException;
 import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.LifeCyclePluginAnalyzer;
@@ -40,8 +42,6 @@ import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputSource;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,13 +62,13 @@ public class DefaultLifecyclePluginAnalyzer implements LifeCyclePluginAnalyzer {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final PlexusContainer plexusContainer;
+    private final Lookup lookup;
 
     private final DefaultLifecycles defaultLifeCycles;
 
     @Inject
-    public DefaultLifecyclePluginAnalyzer(PlexusContainer plexusContainer, DefaultLifecycles defaultLifeCycles) {
-        this.plexusContainer = requireNonNull(plexusContainer);
+    public DefaultLifecyclePluginAnalyzer(Lookup lookup, DefaultLifecycles defaultLifeCycles) {
+        this.lookup = requireNonNull(lookup);
         this.defaultLifeCycles = requireNonNull(defaultLifeCycles);
     }
 
@@ -129,8 +129,8 @@ public class DefaultLifecyclePluginAnalyzer implements LifeCyclePluginAnalyzer {
      */
     private LifecycleMapping lookupLifecycleMapping(final String packaging) {
         try {
-            return plexusContainer.lookup(LifecycleMapping.class, packaging);
-        } catch (ComponentLookupException e) {
+            return lookup.lookup(LifecycleMapping.class, packaging);
+        } catch (LookupException e) {
             if (e.getCause() instanceof NoSuchElementException) {
                 return null;
             }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
@@ -40,6 +40,8 @@ import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
 import org.apache.maven.project.MavenProject;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * <p>
  * Calculates the task segments in the build
@@ -62,6 +64,7 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
         this.lifecyclePluginResolver = lifecyclePluginResolver;
     }
 
+    @Override
     public List<TaskSegment> calculateTaskSegments(MavenSession session)
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,
                     MojoNotFoundException, NoPluginFoundForPrefixException, InvalidPluginDescriptorException,
@@ -69,9 +72,9 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
 
         MavenProject rootProject = session.getTopLevelProject();
 
-        List<String> tasks = session.getGoals();
+        List<String> tasks = requireNonNull(session.getGoals()); // session never returns null, but empty list
 
-        if ((tasks == null || tasks.isEmpty())
+        if (tasks.isEmpty()
                 && (rootProject.getDefaultGoal() != null
                         && !rootProject.getDefaultGoal().isEmpty())) {
             tasks = Stream.of(rootProject.getDefaultGoal().split("\\s+"))
@@ -82,6 +85,7 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
         return calculateTaskSegments(session, tasks);
     }
 
+    @Override
     public List<TaskSegment> calculateTaskSegments(MavenSession session, List<String> tasks)
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,
                     MojoNotFoundException, NoPluginFoundForPrefixException, InvalidPluginDescriptorException,
@@ -122,6 +126,7 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
         return taskSegments;
     }
 
+    @Override
     public boolean requiresProject(MavenSession session) {
         List<String> goals = session.getGoals();
         if (goals != null) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
@@ -52,8 +52,12 @@ import static java.util.Arrays.stream;
 public class DefaultMojoExecutionConfigurator implements MojoExecutionConfigurator {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
+    private final MessageBuilderFactory messageBuilderFactory;
+
     @Inject
-    MessageBuilderFactory messageBuilderFactory;
+    public DefaultMojoExecutionConfigurator(MessageBuilderFactory messageBuilderFactory) {
+        this.messageBuilderFactory = messageBuilderFactory; // in test ctor DefaultLifecycleExecutionPlanCalculator it is null
+    }
 
     @Override
     public void configure(MavenProject project, MojoExecution mojoExecution, boolean allowPluginLevelConfig) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
@@ -54,6 +54,11 @@ public class DefaultMojoExecutionConfigurator implements MojoExecutionConfigurat
 
     private final MessageBuilderFactory messageBuilderFactory;
 
+    @Deprecated
+    public DefaultMojoExecutionConfigurator() {
+        this.messageBuilderFactory = null; // used in test ctor of DefaultLifecycleExecutionPlanCalculator and some ITs
+    }
+
     @Inject
     public DefaultMojoExecutionConfigurator(MessageBuilderFactory messageBuilderFactory) {
         this.messageBuilderFactory =

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
@@ -56,7 +56,8 @@ public class DefaultMojoExecutionConfigurator implements MojoExecutionConfigurat
 
     @Inject
     public DefaultMojoExecutionConfigurator(MessageBuilderFactory messageBuilderFactory) {
-        this.messageBuilderFactory = messageBuilderFactory; // in test ctor DefaultLifecycleExecutionPlanCalculator it is null
+        this.messageBuilderFactory =
+                messageBuilderFactory; // in test ctor DefaultLifecycleExecutionPlanCalculator it is null
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.apache.maven.api.services.MessageBuilder;
 import org.apache.maven.api.services.MessageBuilderFactory;
 import org.apache.maven.api.xml.XmlNode;
+import org.apache.maven.internal.impl.DefaultMessageBuilderFactory;
 import org.apache.maven.internal.xml.XmlNodeImpl;
 import org.apache.maven.lifecycle.MojoExecutionConfigurator;
 import org.apache.maven.model.Plugin;
@@ -43,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
 
 /**
  * @since 3.3.1, MNG-5753
@@ -54,15 +56,20 @@ public class DefaultMojoExecutionConfigurator implements MojoExecutionConfigurat
 
     private final MessageBuilderFactory messageBuilderFactory;
 
+    /**
+     * Default ctor is used in IT and most probably some 3rd party code. For those cases, we do provide sane defaults
+     * but given this is a component, injection should be used, replacing direct instantiation.
+     *
+     * @deprecated Do not use this ctor directly, inject this component instead.
+     */
     @Deprecated
     public DefaultMojoExecutionConfigurator() {
-        this.messageBuilderFactory = null; // used in test ctor of DefaultLifecycleExecutionPlanCalculator and some ITs
+        this.messageBuilderFactory = new DefaultMessageBuilderFactory();
     }
 
     @Inject
     public DefaultMojoExecutionConfigurator(MessageBuilderFactory messageBuilderFactory) {
-        this.messageBuilderFactory =
-                messageBuilderFactory; // in test ctor DefaultLifecycleExecutionPlanCalculator it is null
+        this.messageBuilderFactory = requireNonNull(messageBuilderFactory);
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DependencyContext.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DependencyContext.java
@@ -43,7 +43,7 @@ public class DependencyContext {
 
     private final Collection<String> scopesToResolveForAggregatedProjects;
 
-    private volatile Collection<?> lastDependencyArtifacts = new ArrayList<>();
+    private volatile Collection<?> lastDependencyArtifacts = Collections.emptyList();
 
     private volatile int lastDependencyArtifactCount = -1;
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DependencyContext.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DependencyContext.java
@@ -18,10 +18,7 @@
  */
 package org.apache.maven.lifecycle.internal;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.apache.maven.project.MavenProject;
 
@@ -36,8 +33,6 @@ import org.apache.maven.project.MavenProject;
 // TODO From a concurrency perspective, this class is not good. The combination of mutable/immutable state is not nice
 public class DependencyContext {
 
-    private static final Collection<?> UNRESOLVED = Arrays.asList();
-
     private final MavenProject project;
 
     private final Collection<String> scopesToCollectForCurrentProject;
@@ -48,7 +43,7 @@ public class DependencyContext {
 
     private final Collection<String> scopesToResolveForAggregatedProjects;
 
-    private volatile Collection<?> lastDependencyArtifacts = UNRESOLVED;
+    private volatile Collection<?> lastDependencyArtifacts = new ArrayList<>();
 
     private volatile int lastDependencyArtifactCount = -1;
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -346,7 +346,7 @@ public class LifecycleDependencyResolver {
 
     private static class ReactorDependencyFilter implements DependencyFilter {
 
-        private Set<String> keys = new HashSet<>();
+        private final Set<String> keys = new HashSet<>();
 
         ReactorDependencyFilter(Collection<Artifact> artifacts) {
             for (Artifact artifact : artifacts) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
@@ -53,6 +53,7 @@ public class LifecycleModuleBuilder {
     private final ExecutionEventCatapult eventCatapult;
     private final ProjectExecutionListener projectExecutionListener;
     private final ConsumerPomArtifactTransformer consumerPomArtifactTransformer;
+
     @Inject
     public LifecycleModuleBuilder(
             MojoExecutor mojoExecutor,

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilder.java
@@ -35,7 +35,6 @@ import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.lifecycle.internal.builder.BuilderCommon;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.session.scope.internal.SessionScope;
 
 /**
  * <p>
@@ -54,22 +53,18 @@ public class LifecycleModuleBuilder {
     private final ExecutionEventCatapult eventCatapult;
     private final ProjectExecutionListener projectExecutionListener;
     private final ConsumerPomArtifactTransformer consumerPomArtifactTransformer;
-    private final SessionScope sessionScope;
-
     @Inject
     public LifecycleModuleBuilder(
             MojoExecutor mojoExecutor,
             BuilderCommon builderCommon,
             ExecutionEventCatapult eventCatapult,
             List<ProjectExecutionListener> listeners,
-            ConsumerPomArtifactTransformer consumerPomArtifactTransformer,
-            SessionScope sessionScope) {
+            ConsumerPomArtifactTransformer consumerPomArtifactTransformer) {
         this.mojoExecutor = mojoExecutor;
         this.builderCommon = builderCommon;
         this.eventCatapult = eventCatapult;
         this.projectExecutionListener = new CompoundProjectExecutionListener(listeners);
         this.consumerPomArtifactTransformer = consumerPomArtifactTransformer;
-        this.sessionScope = sessionScope;
     }
 
     public void buildProject(

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleStarter.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleStarter.java
@@ -58,8 +58,6 @@ public class LifecycleStarter {
 
     private final Map<String, Builder> builders;
 
-    private final SessionScope sessionScope;
-
     @Inject
     public LifecycleStarter(
             ExecutionEventCatapult eventCatapult,
@@ -75,7 +73,6 @@ public class LifecycleStarter {
         this.lifecycleDebugLogger = lifecycleDebugLogger;
         this.lifecycleTaskSegmentCalculator = lifecycleTaskSegmentCalculator;
         this.builders = builders;
-        this.sessionScope = sessionScope;
     }
 
     public void execute(MavenSession session) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
@@ -231,7 +231,7 @@ public class MojoDescriptorCreator {
         }
 
         return pluginManager.getMojoDescriptor(
-                plugin, goal.toString(), project.getRemotePluginRepositories(), session.getRepositorySession());
+                plugin, goal, project.getRemotePluginRepositories(), session.getRepositorySession());
     }
 
     // TODO take repo mans into account as one may be aggregating prefixes of many

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectBuildList.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectBuildList.java
@@ -76,6 +76,7 @@ public class ProjectBuildList implements Iterable<ProjectSegment> {
                 .orElse(null);
     }
 
+    @Override
     public Iterator<ProjectSegment> iterator() {
         return items.iterator();
     }

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginConfigurationException.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginConfigurationException.java
@@ -42,24 +42,36 @@ public class PluginConfigurationException extends Exception {
         this.originalMessage = originalMessage;
     }
 
+    /**
+     * Ctor left for binary compatibility.
+     *
+     * @deprecated Use {@link #PluginConfigurationException(PluginDescriptor, String, Throwable)}
+     */
+    @Deprecated
     public PluginConfigurationException(
             PluginDescriptor pluginDescriptor, String originalMessage, ExpressionEvaluationException cause) {
-        super(originalMessage, cause);
-        this.pluginDescriptor = pluginDescriptor;
-        this.originalMessage = originalMessage;
+        this(pluginDescriptor, originalMessage, (Throwable) cause);
     }
 
+    /**
+     * Ctor left for binary compatibility.
+     *
+     * @deprecated Use {@link #PluginConfigurationException(PluginDescriptor, String, Throwable)}
+     */
+    @Deprecated
     public PluginConfigurationException(
             PluginDescriptor pluginDescriptor, String originalMessage, ComponentConfigurationException cause) {
-        super(originalMessage, cause);
-        this.pluginDescriptor = pluginDescriptor;
-        this.originalMessage = originalMessage;
+        this(pluginDescriptor, originalMessage, (Throwable) cause);
     }
 
+    /**
+     * Ctor left for binary compatibility.
+     *
+     * @deprecated Use {@link #PluginConfigurationException(PluginDescriptor, String, Throwable)}
+     */
+    @Deprecated
     public PluginConfigurationException(
             PluginDescriptor pluginDescriptor, String originalMessage, ComponentLookupException cause) {
-        super(originalMessage, cause);
-        this.pluginDescriptor = pluginDescriptor;
-        this.originalMessage = originalMessage;
+        this(pluginDescriptor, originalMessage, (Throwable) cause);
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginContainerException.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginContainerException.java
@@ -58,18 +58,26 @@ public class PluginContainerException extends PluginManagerException {
         this.pluginRealm = pluginRealm;
     }
 
+    /**
+     * Ctor left for binary compatibility.
+     *
+     * @deprecated Use {@link #PluginContainerException(Plugin, ClassRealm, String, Throwable)}
+     */
+    @Deprecated
     public PluginContainerException(
             Plugin plugin, ClassRealm pluginRealm, String message, PlexusConfigurationException e) {
-        super(plugin, message, e);
-
-        this.pluginRealm = pluginRealm;
+        this(plugin, pluginRealm, message, (Throwable) e);
     }
 
+    /**
+     * Ctor left for binary compatibility.
+     *
+     * @deprecated Use {@link #PluginContainerException(Plugin, ClassRealm, String, Throwable)}
+     */
+    @Deprecated
     public PluginContainerException(
             Plugin plugin, ClassRealm pluginRealm, String message, ComponentRepositoryException e) {
-        super(plugin, message, e);
-
-        this.pluginRealm = pluginRealm;
+        this(plugin, pluginRealm, message, (Throwable) e);
     }
 
     public ClassRealm getPluginRealm() {

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginManagerException.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginManagerException.java
@@ -30,7 +30,6 @@ import org.codehaus.plexus.configuration.PlexusConfigurationException;
 
 /**
  * Exception in the plugin manager.
- *
  */
 public class PluginManagerException extends Exception {
 
@@ -96,7 +95,7 @@ public class PluginManagerException extends Exception {
         pluginVersion = plugin.getVersion();
     }
 
-    public PluginManagerException(Plugin plugin, String message, PlexusConfigurationException cause) {
+    public PluginManagerException(Plugin plugin, String message, Exception cause) {
         super(message, cause);
 
         pluginGroupId = plugin.getGroupId();
@@ -104,12 +103,24 @@ public class PluginManagerException extends Exception {
         pluginVersion = plugin.getVersion();
     }
 
-    public PluginManagerException(Plugin plugin, String message, ComponentRepositoryException cause) {
-        super(message, cause);
+    /**
+     * Constructor.
+     *
+     * @deprecated Left for binary compatibility.
+     */
+    @Deprecated
+    public PluginManagerException(Plugin plugin, String message, PlexusConfigurationException cause) {
+        this(plugin, message, (Exception) cause);
+    }
 
-        pluginGroupId = plugin.getGroupId();
-        pluginArtifactId = plugin.getArtifactId();
-        pluginVersion = plugin.getVersion();
+    /**
+     * Constructor.
+     *
+     * @deprecated Left for binary compatibility.
+     */
+    @Deprecated
+    public PluginManagerException(Plugin plugin, String message, ComponentRepositoryException cause) {
+        this(plugin, message, (Exception) cause);
     }
 
     public PluginManagerException(
@@ -137,12 +148,14 @@ public class PluginManagerException extends Exception {
         goal = mojoDescriptor.getGoal();
     }
 
+    /**
+     * Constructor.
+     *
+     * @deprecated Left for binary compatibility.
+     */
+    @Deprecated
     public PluginManagerException(Plugin plugin, String message, PlexusContainerException cause) {
-        super(message, cause);
-
-        pluginGroupId = plugin.getGroupId();
-        pluginArtifactId = plugin.getArtifactId();
-        pluginVersion = plugin.getVersion();
+        this(plugin, message, (Exception) cause);
     }
 
     public PluginManagerException(Plugin plugin, String message, MavenProject project) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginManagerException.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginManagerException.java
@@ -95,14 +95,6 @@ public class PluginManagerException extends Exception {
         pluginVersion = plugin.getVersion();
     }
 
-    public PluginManagerException(Plugin plugin, String message, Exception cause) {
-        super(message, cause);
-
-        pluginGroupId = plugin.getGroupId();
-        pluginArtifactId = plugin.getArtifactId();
-        pluginVersion = plugin.getVersion();
-    }
-
     /**
      * Constructor.
      *
@@ -110,7 +102,7 @@ public class PluginManagerException extends Exception {
      */
     @Deprecated
     public PluginManagerException(Plugin plugin, String message, PlexusConfigurationException cause) {
-        this(plugin, message, (Exception) cause);
+        this(plugin, message, (Throwable) cause);
     }
 
     /**
@@ -120,7 +112,7 @@ public class PluginManagerException extends Exception {
      */
     @Deprecated
     public PluginManagerException(Plugin plugin, String message, ComponentRepositoryException cause) {
-        this(plugin, message, (Exception) cause);
+        this(plugin, message, (Throwable) cause);
     }
 
     public PluginManagerException(
@@ -155,7 +147,7 @@ public class PluginManagerException extends Exception {
      */
     @Deprecated
     public PluginManagerException(Plugin plugin, String message, PlexusContainerException cause) {
-        this(plugin, message, (Exception) cause);
+        this(plugin, message, (Throwable) cause);
     }
 
     public PluginManagerException(Plugin plugin, String message, MavenProject project) {

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -45,6 +45,7 @@ import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.classrealm.ClassRealmManager;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.scope.internal.MojoExecutionScope;
 import org.apache.maven.execution.scope.internal.MojoExecutionScopeModule;
 import org.apache.maven.internal.impl.DefaultMojoExecution;
 import org.apache.maven.internal.impl.InternalSession;
@@ -83,6 +84,7 @@ import org.apache.maven.plugin.version.PluginVersionResolver;
 import org.apache.maven.project.ExtensionDescriptor;
 import org.apache.maven.project.ExtensionDescriptorBuilder;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.session.scope.internal.SessionScope;
 import org.apache.maven.session.scope.internal.SessionScopeModule;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
@@ -450,8 +452,8 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                                     }
                                 }
                             },
-                            new SessionScopeModule(container),
-                            new MojoExecutionScopeModule(container),
+                            new SessionScopeModule(container.lookup(SessionScope.class)),
+                            new MojoExecutionScopeModule(container.lookup(MojoExecutionScope.class)),
                             new PluginConfigurationModule(plugin.getDelegate()));
         } catch (ComponentLookupException | CycleDetectedInComponentGraphException e) {
             throw new PluginContainerException(

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
@@ -49,7 +49,6 @@ import org.apache.maven.plugin.MavenPluginManager;
 import org.apache.maven.plugin.PluginManagerException;
 import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
-import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.graph.DependencyFilter;
@@ -67,7 +66,6 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class DefaultProjectBuildingHelper implements ProjectBuildingHelper {
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final PlexusContainer container; // TODO not used? Then remove
     private final ClassRealmManager classRealmManager;
     private final ProjectRealmCache projectRealmCache;
     private final MavenRepositorySystem repositorySystem;
@@ -75,12 +73,10 @@ public class DefaultProjectBuildingHelper implements ProjectBuildingHelper {
 
     @Inject
     public DefaultProjectBuildingHelper(
-            PlexusContainer container,
             ClassRealmManager classRealmManager,
             ProjectRealmCache projectRealmCache,
             MavenRepositorySystem repositorySystem,
             MavenPluginManager pluginManager) {
-        this.container = container;
         this.classRealmManager = classRealmManager;
         this.projectRealmCache = projectRealmCache;
         this.repositorySystem = repositorySystem;

--- a/maven-core/src/main/java/org/apache/maven/session/scope/internal/SessionScopeModule.java
+++ b/maven-core/src/main/java/org/apache/maven/session/scope/internal/SessionScopeModule.java
@@ -26,8 +26,6 @@ import org.apache.maven.SessionScoped;
 import org.apache.maven.api.Session;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.internal.impl.InternalSession;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 /**
  * SessionScopeModule
@@ -41,11 +39,7 @@ public class SessionScopeModule extends AbstractModule {
         this(new SessionScope());
     }
 
-    public SessionScopeModule(PlexusContainer container) throws ComponentLookupException {
-        this(container.lookup(SessionScope.class));
-    }
-
-    private SessionScopeModule(SessionScope scope) {
+    public SessionScopeModule(SessionScope scope) {
         this.scope = scope;
     }
 

--- a/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
@@ -114,7 +114,7 @@ class TestApi {
                 repositorySystem,
                 Collections.emptyList(),
                 mavenRepositorySystem,
-                plexusContainer,
+                new DefaultLookup(plexusContainer),
                 runtimeInformation);
         DefaultLocalRepository localRepository =
                 new DefaultLocalRepository(new LocalRepository("target/test-classes/apiv4-repo"));

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.maven.internal.impl.DefaultLookup;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.testing.PlexusTest;
@@ -93,7 +94,7 @@ class DefaultLifecyclesTest {
         PlexusContainer mockedPlexusContainer = mock(PlexusContainer.class);
         when(mockedPlexusContainer.lookupMap(Lifecycle.class)).thenReturn(lifeCycles);
 
-        DefaultLifecycles dl = new DefaultLifecycles(mockedPlexusContainer);
+        DefaultLifecycles dl = new DefaultLifecycles(new DefaultLookup(mockedPlexusContainer));
 
         assertThat(dl.getLifeCycles().get(0).getId(), is("clean"));
         assertThat(dl.getLifeCycles().get(1).getId(), is("default"));

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/DefaultLifecyclesStub.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/DefaultLifecyclesStub.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.maven.internal.impl.DefaultLookup;
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.Lifecycle;
 import org.codehaus.plexus.PlexusContainer;
@@ -70,6 +71,6 @@ public class DefaultLifecyclesStub {
         PlexusContainer mockedContainer = mock(PlexusContainer.class);
         when(mockedContainer.lookupMap(Lifecycle.class)).thenReturn(lifeCycles);
 
-        return new DefaultLifecycles(mockedContainer);
+        return new DefaultLifecycles(new DefaultLookup(mockedContainer));
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
@@ -44,10 +44,7 @@ import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.internal.impl.AbstractSession;
-import org.apache.maven.internal.impl.DefaultMojoExecution;
-import org.apache.maven.internal.impl.DefaultProject;
-import org.apache.maven.internal.impl.DefaultSession;
+import org.apache.maven.internal.impl.*;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
@@ -394,8 +391,8 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
         mavenSession.getRequest().setRootDirectory(rootDirectory);
         mavenSession.getRequest().setTopDirectory(rootDirectory);
 
-        DefaultSession session =
-                new DefaultSession(mavenSession, mock(RepositorySystem.class), null, null, container, null);
+        DefaultSession session = new DefaultSession(
+                mavenSession, mock(RepositorySystem.class), null, null, new DefaultLookup(container), null);
 
         MojoExecution mojoExecution = newMojoExecution(session);
 
@@ -434,8 +431,8 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     private DefaultSession newSession() throws Exception {
-        DefaultSession session =
-                new DefaultSession(newMavenSession(), mock(RepositorySystem.class), null, null, container, null);
+        DefaultSession session = new DefaultSession(
+                newMavenSession(), mock(RepositorySystem.class), null, null, new DefaultLookup(container), null);
         return session;
     }
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -79,6 +79,7 @@ import org.apache.maven.execution.MavenExecutionRequestPopulator;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.ProfileActivation;
 import org.apache.maven.execution.ProjectActivation;
+import org.apache.maven.execution.scope.internal.MojoExecutionScope;
 import org.apache.maven.execution.scope.internal.MojoExecutionScopeModule;
 import org.apache.maven.extension.internal.CoreExports;
 import org.apache.maven.extension.internal.CoreExtensionEntry;
@@ -90,6 +91,7 @@ import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.properties.internal.EnvironmentUtils;
 import org.apache.maven.properties.internal.SystemProperties;
+import org.apache.maven.session.scope.internal.SessionScope;
 import org.apache.maven.session.scope.internal.SessionScopeModule;
 import org.apache.maven.toolchain.building.DefaultToolchainsBuildingRequest;
 import org.apache.maven.toolchain.building.ToolchainsBuilder;
@@ -705,8 +707,8 @@ public class MavenCli {
         for (CoreExtensionEntry extension : extensions) {
             container.discoverComponents(
                     extension.getClassRealm(),
-                    new SessionScopeModule(container),
-                    new MojoExecutionScopeModule(container),
+                    new SessionScopeModule(container.lookup(SessionScope.class)),
+                    new MojoExecutionScopeModule(container.lookup(MojoExecutionScope.class)),
                     new ExtensionConfigurationModule(extension, extensionSource));
         }
 


### PR DESCRIPTION
This is an ongoing effort to confine Plexus, but also perform a bit of cleanup in Maven Core and around. No logic changes, just replacing Plexus with Lookup (that is a thin wrapper around it), and removing unused members, redundant checks, etc. Module maven-compat omitted on purpose.

---

https://issues.apache.org/jira/browse/MNG-7999