### PR TITLE
[MNG-7994] Update to Resolver 2.0.0-alpha-6

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
+++ b/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
@@ -369,7 +369,7 @@ public class RepositoryUtils {
             }
             newSession = new DefaultRepositorySystemSession(session);
         } else {
-            newSession = new DefaultRepositorySystemSession();
+            newSession = new DefaultRepositorySystemSession(h -> false); // no close handle used
         }
 
         final LocalRepositoryManager llrm =

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilderTest.java
@@ -65,7 +65,10 @@ class LifecycleModuleBuilderTest {
         mavenExecutionRequest.setExecutionListener(new AbstractExecutionListener());
         mavenExecutionRequest.setGoals(Arrays.asList("clean"));
         final MavenSession session = new MavenSession(
-                null, new DefaultRepositorySystemSession(), mavenExecutionRequest, defaultMavenExecutionResult);
+                null,
+                new DefaultRepositorySystemSession(h -> false),
+                mavenExecutionRequest,
+                defaultMavenExecutionResult);
         final ProjectDependencyGraphStub dependencyGraphStub = new ProjectDependencyGraphStub();
         session.setProjectDependencyGraph(dependencyGraphStub);
         session.setProjects(dependencyGraphStub.getSortedProjects());

--- a/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
+++ b/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
@@ -312,7 +312,8 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
                 .setBaseDirectory(new File(""))
                 .setLocalRepository(repo);
 
-        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession repositorySession =
+                new DefaultRepositorySystemSession(h -> false); // no close handle
         repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
                 .newInstance(repositorySession, new LocalRepository(repo.getUrl())));
         MavenSession session =

--- a/maven-embedder/src/test/java/org/apache/maven/cli/transfer/ConsoleMavenTransferListenerTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/transfer/ConsoleMavenTransferListenerTest.java
@@ -72,7 +72,7 @@ class ConsoleMavenTransferListenerTest {
         TransferResource resource = new TransferResource(null, null, "http://maven.org/test/test-resource", null, null);
         resource.setContentLength(size - 1);
 
-        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> false); // no close handle
 
         // warm up
         test(listener, session, resource, 0);

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenRepositorySystemUtils.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenRepositorySystemUtils.java
@@ -63,7 +63,7 @@ public final class MavenRepositorySystemUtils {
      */
     @Deprecated
     public static DefaultRepositorySystemSession newSession() {
-        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> false); // no close handle
 
         DependencyTraverser depTraverser = new FatArtifactTraverser();
         session.setDependencyTraverser(depTraverser);

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ under the License.
     <plexusInterpolationVersion>1.26</plexusInterpolationVersion>
     <plexusTestingVersion>1.0.0</plexusTestingVersion>
     <plexusXmlVersion>4.0.1</plexusXmlVersion>
-    <resolverVersion>2.0.0-alpha-5</resolverVersion>
+    <resolverVersion>2.0.0-alpha-6</resolverVersion>
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
     <sisuVersion>0.9.0.M2</sisuVersion>
     <slf4jVersion>2.0.11</slf4jVersion>


### PR DESCRIPTION
Update to alpha-6. 

Also, move off from deprecated default ctor of def repo session in tests.

---

https://issues.apache.org/jira/browse/MNG-7994