### PR TITLE
[EXPERIMENT] MT model builder

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -571,7 +571,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 }
             }
 
-            return interimResults.stream()
+            return interimResults.parallelStream()
                     .map(interimResult -> doBuild(projectIndex, interimResult))
                     .flatMap(List::stream)
                     .collect(Collectors.toList());

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -571,7 +571,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 }
             }
 
-            return interimResults.parallelStream()
+            return interimResults.stream()
                     .map(interimResult -> doBuild(projectIndex, interimResult))
                     .flatMap(List::stream)
                     .collect(Collectors.toList());

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultTransformerContextBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultTransformerContextBuilder.java
@@ -119,8 +119,11 @@ class DefaultTransformerContextBuilder implements TransformerContextBuilder {
 
             private void loadFullReactor() {
                 if (fullReactorLoaded.compareAndSet(false, true)) {
-                    doLoadFullReactor();
-                    fullReactorLoadedLatch.countDown();
+                    try {
+                        doLoadFullReactor();
+                    } finally {
+                        fullReactorLoadedLatch.countDown();
+                    }
                 }
                 try {
                     fullReactorLoadedLatch.await();

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelCacheFactory.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelCacheFactory.java
@@ -23,6 +23,7 @@ import javax.inject.Singleton;
 
 import org.apache.maven.model.building.ModelCache;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.util.ConfigUtils;
 
 /**
  * Default implementation of {@link ModelCacheFactory}.
@@ -30,8 +31,17 @@ import org.eclipse.aether.RepositorySystemSession;
 @Singleton
 @Named
 public class DefaultModelCacheFactory implements ModelCacheFactory {
+    /**
+     * Flag that makes possible to shut down model cache use, mostly useful
+     * for debugging and/or thread dumps. Default value: {@code true}.
+     */
+    private static final String USE_MODEL_CACHE = "maven.modelBuilder.useModelCache";
+
     @Override
     public ModelCache createCache(RepositorySystemSession session) {
-        return DefaultModelCache.newInstance(session);
+        if (ConfigUtils.getBoolean(session, true, USE_MODEL_CACHE)) {
+            return DefaultModelCache.newInstance(session);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Changes:
* share "full reactor loaded" per build session, not per recursive call
* make possible to disable model cache (mostly for debugging purposes)
