### PR TITLE
[MNG-8005] Fix workspace reader drop bug

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -142,7 +142,6 @@ public class DefaultMaven implements Maven {
         this.superPomProvider = superPomProvider;
         this.ideWorkspaceReader = ideWorkspaceReader;
         this.defaultSessionFactory = defaultSessionFactory;
-
         this.projectSelector = new ProjectSelector(); // if necessary switch to DI
     }
 

--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -214,13 +214,8 @@ public class DefaultMaven implements Maven {
         // so that @SessionScoped components can be @Injected into AbstractLifecycleParticipants.
         //
         sessionScope.enter();
-        MavenChainedWorkspaceReader chainedWorkspaceReader = new MavenChainedWorkspaceReader();
-        if (request.getWorkspaceReader() != null) {
-            chainedWorkspaceReader.addReader(request.getWorkspaceReader());
-        }
-        if (ideWorkspaceReader != null) {
-            chainedWorkspaceReader.addReader(ideWorkspaceReader);
-        }
+        MavenChainedWorkspaceReader chainedWorkspaceReader =
+                new MavenChainedWorkspaceReader(request.getWorkspaceReader(), ideWorkspaceReader);
         try (CloseableSession closeableSession = newCloseableSession(request, chainedWorkspaceReader)) {
             MavenSession session = new MavenSession(closeableSession, request, result);
             session.setSession(defaultSessionFactory.getSession(session));

--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -75,6 +75,7 @@ import org.apache.maven.session.scope.internal.SessionScope;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.repository.WorkspaceReader;
+import org.eclipse.sisu.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
@@ -110,6 +111,8 @@ public class DefaultMaven implements Maven {
 
     private final DefaultSessionFactory defaultSessionFactory;
 
+    private final WorkspaceReader ideWorkspaceReader;
+
     private final ProjectSelector projectSelector;
 
     @Inject
@@ -125,7 +128,8 @@ public class DefaultMaven implements Maven {
             BuildResumptionAnalyzer buildResumptionAnalyzer,
             BuildResumptionDataRepository buildResumptionDataRepository,
             SuperPomProvider superPomProvider,
-            DefaultSessionFactory defaultSessionFactory) {
+            DefaultSessionFactory defaultSessionFactory,
+            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader) {
         this.lookup = lookup;
         this.lifecycleStarter = lifecycleStarter;
         this.eventCatapult = eventCatapult;
@@ -136,7 +140,9 @@ public class DefaultMaven implements Maven {
         this.buildResumptionAnalyzer = buildResumptionAnalyzer;
         this.buildResumptionDataRepository = buildResumptionDataRepository;
         this.superPomProvider = superPomProvider;
+        this.ideWorkspaceReader = ideWorkspaceReader;
         this.defaultSessionFactory = defaultSessionFactory;
+
         this.projectSelector = new ProjectSelector(); // if necessary switch to DI
     }
 
@@ -210,6 +216,12 @@ public class DefaultMaven implements Maven {
         //
         sessionScope.enter();
         MavenChainedWorkspaceReader chainedWorkspaceReader = new MavenChainedWorkspaceReader();
+        if (request.getWorkspaceReader() != null) {
+            chainedWorkspaceReader.addReader(request.getWorkspaceReader());
+        }
+        if (ideWorkspaceReader != null) {
+            chainedWorkspaceReader.addReader(ideWorkspaceReader);
+        }
         try (CloseableSession closeableSession = newCloseableSession(request, chainedWorkspaceReader)) {
             MavenSession session = new MavenSession(closeableSession, request, result);
             session.setSession(defaultSessionFactory.getSession(session));
@@ -238,8 +250,7 @@ public class DefaultMaven implements Maven {
         }
 
         try {
-            WorkspaceReader reactorReader = lookup.lookup(WorkspaceReader.class, ReactorReader.HINT);
-            chainedWorkspaceReader.setReaders(Collections.singletonList(reactorReader));
+            chainedWorkspaceReader.addReader(lookup.lookup(WorkspaceReader.class, ReactorReader.HINT));
         } catch (LookupException e) {
             return addExceptionToResult(result, e);
         }
@@ -336,7 +347,7 @@ public class DefaultMaven implements Maven {
         // 1) Reactor workspace reader
         WorkspaceReader reactorReader = lookup.lookup(WorkspaceReader.class, ReactorReader.HINT);
         workspaceReaders.add(reactorReader);
-        // 2) Repository system session-scoped workspace reader
+        // 2) Repository system session-scoped workspace reader (contains ide and exec request reader)
         for (WorkspaceReader repoWorkspaceReader : chainedWorkspaceReader.getReaders()) {
             if (repoWorkspaceReader != null && repoWorkspaceReader != reactorReader) {
                 workspaceReaders.add(repoWorkspaceReader);

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -68,7 +68,6 @@ import org.eclipse.aether.repository.AuthenticationSelector;
 import org.eclipse.aether.repository.ProxySelector;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
-import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
 import org.eclipse.aether.util.graph.version.*;
@@ -84,7 +83,6 @@ import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionRange;
 import org.eclipse.aether.version.VersionScheme;
-import org.eclipse.sisu.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,8 +178,6 @@ public class DefaultRepositorySystemSessionFactory {
 
     private final RepositorySystem repoSystem;
 
-    private final WorkspaceReader workspaceRepository;
-
     private final SettingsDecrypter settingsDecrypter;
 
     private final EventSpyDispatcher eventSpyDispatcher;
@@ -197,7 +193,6 @@ public class DefaultRepositorySystemSessionFactory {
     public DefaultRepositorySystemSessionFactory(
             ArtifactHandlerManager artifactHandlerManager,
             RepositorySystem repoSystem,
-            @Nullable @Named("ide") WorkspaceReader workspaceRepository,
             SettingsDecrypter settingsDecrypter,
             EventSpyDispatcher eventSpyDispatcher,
             RuntimeInformation runtimeInformation,
@@ -205,7 +200,6 @@ public class DefaultRepositorySystemSessionFactory {
             VersionScheme versionScheme) {
         this.artifactHandlerManager = artifactHandlerManager;
         this.repoSystem = repoSystem;
-        this.workspaceRepository = workspaceRepository;
         this.settingsDecrypter = settingsDecrypter;
         this.eventSpyDispatcher = eventSpyDispatcher;
         this.runtimeInformation = runtimeInformation;
@@ -260,9 +254,6 @@ public class DefaultRepositorySystemSessionFactory {
         }
 
         session.setArtifactTypeRegistry(RepositoryUtils.newArtifactTypeRegistry(artifactHandlerManager));
-
-        session.setWorkspaceReader(
-                request.getWorkspaceReader() != null ? request.getWorkspaceReader() : workspaceRepository);
 
         DefaultSettingsDecryptionRequest decrypt = new DefaultSettingsDecryptionRequest();
         decrypt.setProxies(request.getProxies());

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/MavenChainedWorkspaceReader.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/MavenChainedWorkspaceReader.java
@@ -19,12 +19,7 @@
 package org.apache.maven.internal.aether;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.maven.model.Model;
@@ -103,7 +98,9 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
 
     public synchronized void setReaders(Collection<WorkspaceReader> readers) {
         requireNonNull(readers, "readers");
-        this.readers = Collections.unmodifiableList(new ArrayList<>(readers));
+        // skip possible null entries
+        this.readers = Collections.unmodifiableList(
+                new ArrayList<>(readers.stream().filter(Objects::nonNull).collect(Collectors.toList())));
         Key key = new Key(this.readers);
         this.repository = new WorkspaceRepository(key.getContentType(), key);
     }

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/MavenChainedWorkspaceReader.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/MavenChainedWorkspaceReader.java
@@ -101,14 +101,22 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
         return Collections.unmodifiableList(new ArrayList<>(versions));
     }
 
-    public void setReaders(Collection<WorkspaceReader> readers) {
+    public synchronized void setReaders(Collection<WorkspaceReader> readers) {
+        requireNonNull(readers, "readers");
         this.readers = Collections.unmodifiableList(new ArrayList<>(readers));
         Key key = new Key(this.readers);
         this.repository = new WorkspaceRepository(key.getContentType(), key);
     }
 
-    public List<WorkspaceReader> getReaders() {
+    public synchronized List<WorkspaceReader> getReaders() {
         return readers;
+    }
+
+    public synchronized void addReader(WorkspaceReader workspaceReader) {
+        requireNonNull(workspaceReader, "workspaceReader");
+        ArrayList<WorkspaceReader> newReaders = new ArrayList<>(this.readers);
+        newReaders.add(workspaceReader);
+        setReaders(newReaders);
     }
 
     private static class Key {

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/MavenChainedWorkspaceReader.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/MavenChainedWorkspaceReader.java
@@ -32,6 +32,9 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A maven workspace reader that delegates to a chain of other readers, effectively aggregating their contents.
+ * <p>
+ * This class, while technically is not immutable, should be considered as such once set up. If not mutated, it is also
+ * thread-safe. <em>The mutation of this class instances should happen beforehand their use in session</em>.
  */
 public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
 
@@ -96,7 +99,7 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
         return Collections.unmodifiableList(new ArrayList<>(versions));
     }
 
-    public synchronized void setReaders(Collection<WorkspaceReader> readers) {
+    public void setReaders(Collection<WorkspaceReader> readers) {
         requireNonNull(readers, "readers");
         // skip possible null entries
         this.readers = Collections.unmodifiableList(
@@ -105,11 +108,11 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
         this.repository = new WorkspaceRepository(key.getContentType(), key);
     }
 
-    public synchronized List<WorkspaceReader> getReaders() {
+    public List<WorkspaceReader> getReaders() {
         return readers;
     }
 
-    public synchronized void addReader(WorkspaceReader workspaceReader) {
+    public void addReader(WorkspaceReader workspaceReader) {
         requireNonNull(workspaceReader, "workspaceReader");
         ArrayList<WorkspaceReader> newReaders = new ArrayList<>(this.readers);
         newReaders.add(workspaceReader);

--- a/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
@@ -84,7 +84,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -108,7 +107,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -144,7 +142,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -188,7 +185,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -226,7 +222,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -268,7 +263,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -304,7 +298,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -346,7 +339,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -365,7 +357,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,
@@ -412,7 +403,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
                 artifactHandlerManager,
                 aetherRepositorySystem,
-                null,
                 settingsDecrypter,
                 eventSpyDispatcher,
                 information,

--- a/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
@@ -100,16 +100,9 @@ public class BootstrapCoreExtensionManager {
     public List<CoreExtensionEntry> loadCoreExtensions(
             MavenExecutionRequest request, Set<String> providedArtifacts, List<CoreExtension> extensions)
             throws Exception {
-        MavenChainedWorkspaceReader chainedWorkspaceReader = new MavenChainedWorkspaceReader();
-        if (request.getWorkspaceReader() != null) {
-            chainedWorkspaceReader.addReader(request.getWorkspaceReader());
-        }
-        if (ideWorkspaceReader != null) {
-            chainedWorkspaceReader.addReader(ideWorkspaceReader);
-        }
         try (CloseableSession repoSession = repositorySystemSessionFactory
                 .newRepositorySessionBuilder(request)
-                .setWorkspaceReader(chainedWorkspaceReader)
+                .setWorkspaceReader(new MavenChainedWorkspaceReader(request.getWorkspaceReader(), ideWorkspaceReader))
                 .build()) {
             List<RemoteRepository> repositories = RepositoryUtils.toRepos(request.getPluginArtifactRepositories());
             Interpolator interpolator = createInterpolator(request);

--- a/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
@@ -35,6 +35,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.extension.internal.CoreExports;
 import org.apache.maven.extension.internal.CoreExtensionEntry;
 import org.apache.maven.internal.aether.DefaultRepositorySystemSessionFactory;
+import org.apache.maven.internal.aether.MavenChainedWorkspaceReader;
 import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver;
 import org.codehaus.plexus.DefaultPlexusContainer;
@@ -99,9 +100,16 @@ public class BootstrapCoreExtensionManager {
     public List<CoreExtensionEntry> loadCoreExtensions(
             MavenExecutionRequest request, Set<String> providedArtifacts, List<CoreExtension> extensions)
             throws Exception {
+        MavenChainedWorkspaceReader chainedWorkspaceReader = new MavenChainedWorkspaceReader();
+        if (request.getWorkspaceReader() != null) {
+            chainedWorkspaceReader.addReader(request.getWorkspaceReader());
+        }
+        if (ideWorkspaceReader != null) {
+            chainedWorkspaceReader.addReader(ideWorkspaceReader);
+        }
         try (CloseableSession repoSession = repositorySystemSessionFactory
                 .newRepositorySessionBuilder(request)
-                .setWorkspaceReader(ideWorkspaceReader)
+                .setWorkspaceReader(chainedWorkspaceReader)
                 .build()) {
             List<RemoteRepository> repositories = RepositoryUtils.toRepos(request.getPluginArtifactRepositories());
             Interpolator interpolator = createInterpolator(request);

--- a/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
@@ -50,9 +50,11 @@ import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.filter.ExclusionsDependencyFilter;
+import org.eclipse.sisu.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,17 +79,21 @@ public class BootstrapCoreExtensionManager {
 
     private final ClassRealm parentRealm;
 
+    private final WorkspaceReader ideWorkspaceReader;
+
     @Inject
     public BootstrapCoreExtensionManager(
             DefaultPluginDependenciesResolver pluginDependenciesResolver,
             DefaultRepositorySystemSessionFactory repositorySystemSessionFactory,
             CoreExports coreExports,
-            PlexusContainer container) {
+            PlexusContainer container,
+            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader) {
         this.pluginDependenciesResolver = pluginDependenciesResolver;
         this.repositorySystemSessionFactory = repositorySystemSessionFactory;
         this.coreExports = coreExports;
         this.classWorld = ((DefaultPlexusContainer) container).getClassWorld();
         this.parentRealm = container.getContainerRealm();
+        this.ideWorkspaceReader = ideWorkspaceReader;
     }
 
     public List<CoreExtensionEntry> loadCoreExtensions(
@@ -95,6 +101,7 @@ public class BootstrapCoreExtensionManager {
             throws Exception {
         try (CloseableSession repoSession = repositorySystemSessionFactory
                 .newRepositorySessionBuilder(request)
+                .setWorkspaceReader(ideWorkspaceReader)
                 .build()) {
             List<RemoteRepository> repositories = RepositoryUtils.toRepos(request.getPluginArtifactRepositories());
             Interpolator interpolator = createInterpolator(request);


### PR DESCRIPTION
Maven4 seems sets but then drops/overrides some workspace readers. Partially due hazy borders who or what manages them, as role is split between session factory and session factory caller.

Changes:
* session factory does NOTHING re workspace readers, it becomes fully the caller duty
* two spots calling session factory (default maven, extension bootstrap) are now fully in charge to properly setup workspace readers

Co-authored-by: Jonas Rutishauser <jonas.rutishauser@alumni.ethz.ch>

---

https://issues.apache.org/jira/browse/MNG-8005