### PR TITLE
[MNG-8035] Update to Resolver 2.0.0-alpha-7

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/scopes/MavenDependencyScopes.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/scopes/MavenDependencyScopes.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.repository.internal.scopes;
 
+import org.eclipse.aether.util.artifact.DependencyScopes;
+
 /**
  * The dependency scopes used for Java dependencies in Maven. This class defines labels only, that are doing pass-thru
  * over Resolver.
@@ -28,10 +30,8 @@ public final class MavenDependencyScopes {
 
     /**
      * Important: keep this label in sync with Resolver.
-     *
-     * TODO: once Resolver 2.0.0-alpha-7 is out, use org.eclipse.aether.util.artifact.DependencyScopes#SYSTEM
      */
-    public static final String SYSTEM = "system";
+    public static final String SYSTEM = DependencyScopes.SYSTEM;
 
     public static final String COMPILE_ONLY = "compile-only";
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ under the License.
     <plexusInterpolationVersion>1.26</plexusInterpolationVersion>
     <plexusTestingVersion>1.0.0</plexusTestingVersion>
     <plexusXmlVersion>4.0.1</plexusXmlVersion>
-    <resolverVersion>2.0.0-alpha-6</resolverVersion>
+    <resolverVersion>2.0.0-alpha-7</resolverVersion>
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
     <sisuVersion>0.9.0.M2</sisuVersion>
     <slf4jVersion>2.0.11</slf4jVersion>
@@ -754,6 +754,7 @@ under the License.
                 <exclude>src/test/remote-repo/**</exclude>
                 <exclude>**/*.odg</exclude>
                 <exclude>.asf.yaml</exclude>
+                <exclude>.mvn/**</exclude>
                 <!--
                   ! Excluded the license files itself cause they do not have have a license of themselves.
                 -->


### PR DESCRIPTION
Update to Resolver 2.0.0-alpha-7, sort out TODO.

This is also one simple change "sneaked in" for RAT, to ignore local `.mvn` that is unrelated to all this, but does not make any harm. In turn, it allows dev local checkout to have various stuff set without
decorating those with headers or fighing RAT plugin.

---

https://issues.apache.org/jira/browse/MNG-8035