### PR TITLE
[MNG-7906] Add unit test

### DIFF
--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
@@ -169,12 +169,22 @@ class DefaultModelBuilderTest {
         assertNotNull(builder);
 
         DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
-        request.setModelSource(new FileModelSource(new File(getClass().getResource("/poms/depmgmt/root-dep-first.xml").getFile())));
+        request.setModelSource(new FileModelSource(new File(
+                getClass().getResource("/poms/depmgmt/root-dep-first.xml").getFile())));
         request.setModelResolver(new BaseModelResolver() {
-            public ModelSource resolveModel(org.apache.maven.model.Dependency dependency) throws UnresolvableModelException {
+            public ModelSource resolveModel(org.apache.maven.model.Dependency dependency)
+                    throws UnresolvableModelException {
                 switch (dependency.getManagementKey()) {
-                    case "test:import:pom": return new FileModelSource(new File(getClass().getResource("/poms/depmgmt/import.xml").getFile()));
-                    default: throw new UnresolvableModelException("Cannot resolve", dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+                    case "test:import:pom":
+                        return new FileModelSource(new File(getClass()
+                                .getResource("/poms/depmgmt/import.xml")
+                                .getFile()));
+                    default:
+                        throw new UnresolvableModelException(
+                                "Cannot resolve",
+                                dependency.getGroupId(),
+                                dependency.getArtifactId(),
+                                dependency.getVersion());
                 }
             }
         });
@@ -182,7 +192,8 @@ class DefaultModelBuilderTest {
         ModelBuildingResult result = builder.build(request);
         Dependency dep = result.getEffectiveModel().getDelegate().getDependencyManagement().getDependencies().stream()
                 .filter(d -> "test:mydep:jar".equals(d.getManagementKey()))
-                .findFirst().get();
+                .findFirst()
+                .get();
         assertEquals("0.2", dep.getVersion());
     }
 
@@ -192,12 +203,22 @@ class DefaultModelBuilderTest {
         assertNotNull(builder);
 
         DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
-        request.setModelSource(new FileModelSource(new File(getClass().getResource("/poms/depmgmt/root-dep-last.xml").getFile())));
+        request.setModelSource(new FileModelSource(new File(
+                getClass().getResource("/poms/depmgmt/root-dep-last.xml").getFile())));
         request.setModelResolver(new BaseModelResolver() {
-            public ModelSource resolveModel(org.apache.maven.model.Dependency dependency) throws UnresolvableModelException {
+            public ModelSource resolveModel(org.apache.maven.model.Dependency dependency)
+                    throws UnresolvableModelException {
                 switch (dependency.getManagementKey()) {
-                    case "test:import:pom": return new FileModelSource(new File(getClass().getResource("/poms/depmgmt/import.xml").getFile()));
-                    default: throw new UnresolvableModelException("Cannot resolve", dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+                    case "test:import:pom":
+                        return new FileModelSource(new File(getClass()
+                                .getResource("/poms/depmgmt/import.xml")
+                                .getFile()));
+                    default:
+                        throw new UnresolvableModelException(
+                                "Cannot resolve",
+                                dependency.getGroupId(),
+                                dependency.getArtifactId(),
+                                dependency.getVersion());
                 }
             }
         });
@@ -205,7 +226,8 @@ class DefaultModelBuilderTest {
         ModelBuildingResult result = builder.build(request);
         Dependency dep = result.getEffectiveModel().getDelegate().getDependencyManagement().getDependencies().stream()
                 .filter(d -> "test:mydep:jar".equals(d.getManagementKey()))
-                .findFirst().get();
+                .findFirst()
+                .get();
         assertEquals("0.2", dep.getVersion());
     }
 
@@ -215,13 +237,26 @@ class DefaultModelBuilderTest {
         assertNotNull(builder);
 
         DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
-        request.setModelSource(new FileModelSource(new File(getClass().getResource("/poms/depmgmt/root-two-imports.xml").getFile())));
+        request.setModelSource(new FileModelSource(new File(
+                getClass().getResource("/poms/depmgmt/root-two-imports.xml").getFile())));
         request.setModelResolver(new BaseModelResolver() {
-            public ModelSource resolveModel(org.apache.maven.model.Dependency dependency) throws UnresolvableModelException {
+            public ModelSource resolveModel(org.apache.maven.model.Dependency dependency)
+                    throws UnresolvableModelException {
                 switch (dependency.getManagementKey()) {
-                    case "test:import:pom": return new FileModelSource(new File(getClass().getResource("/poms/depmgmt/import.xml").getFile()));
-                    case "test:other:pom": return new FileModelSource(new File(getClass().getResource("/poms/depmgmt/other-import.xml").getFile()));
-                    default: throw new UnresolvableModelException("Cannot resolve", dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+                    case "test:import:pom":
+                        return new FileModelSource(new File(getClass()
+                                .getResource("/poms/depmgmt/import.xml")
+                                .getFile()));
+                    case "test:other:pom":
+                        return new FileModelSource(new File(getClass()
+                                .getResource("/poms/depmgmt/other-import.xml")
+                                .getFile()));
+                    default:
+                        throw new UnresolvableModelException(
+                                "Cannot resolve",
+                                dependency.getGroupId(),
+                                dependency.getArtifactId(),
+                                dependency.getVersion());
                 }
             }
         });
@@ -229,7 +264,8 @@ class DefaultModelBuilderTest {
         ModelBuildingResult result = builder.build(request);
         Dependency dep = result.getEffectiveModel().getDelegate().getDependencyManagement().getDependencies().stream()
                 .filter(d -> "test:mydep:jar".equals(d.getManagementKey()))
-                .findFirst().get();
+                .findFirst()
+                .get();
         assertEquals("0.3", dep.getVersion());
     }
 }

--- a/maven-model-builder/src/test/resources/poms/depmgmt/distant-import.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/distant-import.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>other</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>bom</artifactId>
+                <version>0.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/import.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/import.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>import</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>mydep</artifactId>
+                <version>0.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/junit-0.1.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/junit-0.1.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>org.junit</groupId>
+    <artifactId>bom</artifactId>
+    <version>0.1</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>0.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/junit-0.2.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/junit-0.2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>org.junit</groupId>
+    <artifactId>bom</artifactId>
+    <version>0.2</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>0.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/other-import.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/other-import.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>other-import</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>mydep</artifactId>
+                <version>0.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/root-dep-first.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/root-dep-first.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>mydep</artifactId>
+                <version>0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>import</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/root-dep-last.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/root-dep-last.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>import</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>mydep</artifactId>
+                <version>0.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/root-distance.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/root-distance.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>other</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>bom</artifactId>
+                <version>0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/depmgmt/root-two-imports.xml
+++ b/maven-model-builder/src/test/resources/poms/depmgmt/root-two-imports.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>other</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>test</groupId>
+                <artifactId>import</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>


### PR DESCRIPTION
This PR currently provides 3 unit tests for [MNG-7906](https://issues.apache.org/jira/browse/MNG-7906).
The first two tests (`testManagedDependencyBeforeImport` and `testManagedDependencyAfterImport`) work in an expected way, i.e. the managed dependency defined in the POM is the one used.
The third one (`testManagedDependencyTwoImports`) is the problematic one, showing that the algorithm used to resolve conflicting managed dependencies is almost (apart from the two first tests) a "first wins" and not a "last wins" or even better a "closest then last wins".

It was proposed to add a WARNING when such conflict happens.