### PR TITLE
Use v4 api to resolve project dependencies

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
@@ -510,7 +510,7 @@ public interface Session {
 
     ProjectScope requireProjectScope(String id);
 
-    DependencyScope requireDependencyScope(String id);
+    DependencyScope requireDependencyScope(@Nonnull String id);
 
     PathScope requirePathScope(String id);
 }

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/AbstractSession.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/AbstractSession.java
@@ -560,7 +560,7 @@ public abstract class AbstractSession implements InternalSession {
 
     @Override
     public DependencyScope requireDependencyScope(String id) {
-        return DependencyScope.forId(id);
+        return DependencyScope.forId(nonNull(id, "id"));
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolver.java
@@ -72,31 +72,8 @@ public class DefaultDependencyResolver implements DependencyResolver {
     @Override
     public DependencyResolverResult resolve(DependencyResolverRequest request)
             throws DependencyCollectorException, DependencyResolverException, ArtifactResolverException {
-        nonNull(request, "request can not be null");
-        InternalSession session = InternalSession.from(request.getSession());
-
-        if (request.getProject().isPresent()) {
-            DependencyResolutionResult result = resolveDependencies(
-                    request.getSession(), request.getProject().get(), request.getPathScope());
-
-            Map<org.eclipse.aether.graph.Dependency, org.eclipse.aether.graph.DependencyNode> nodes = stream(
-                            result.getDependencyGraph())
-                    .filter(n -> n.getDependency() != null)
-                    .collect(Collectors.toMap(DependencyNode::getDependency, n -> n));
-
-            Node root = session.getNode(result.getDependencyGraph());
-            List<Node> dependencies = new ArrayList<>();
-            Map<Dependency, Path> artifacts = new LinkedHashMap<>();
-            List<Path> paths = new ArrayList<>();
-            for (org.eclipse.aether.graph.Dependency dep : result.getResolvedDependencies()) {
-                dependencies.add(session.getNode(nodes.get(dep)));
-                Path path = dep.getArtifact().getFile().toPath();
-                artifacts.put(session.getDependency(dep), path);
-                paths.add(path);
-            }
-            return new DefaultDependencyResolverResult(
-                    result.getCollectionErrors(), root, dependencies, paths, artifacts);
-        }
+        nonNull(request, "request");
+        Session session = InternalSession.from(request.getSession());
 
         DependencyCollectorResult collectorResult =
                 session.getService(DependencyCollector.class).collect(request);

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
@@ -182,7 +182,8 @@ public class DefaultProject implements Project {
             @Nonnull
             @Override
             public DependencyScope getScope() {
-                return session.requireDependencyScope(dependency.getScope());
+                String scope = dependency.getScope() != null ? dependency.getScope() : "";
+                return session.requireDependencyScope(scope);
             }
 
             @Override

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -33,6 +33,7 @@ import java.util.zip.ZipEntry;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.Session;
+import org.apache.maven.api.services.ProjectManager;
 import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.classrealm.ClassRealmManager;
@@ -523,6 +524,11 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
 
         InternalSession sessionV4 = InternalSession.from(session.getSession());
         Project project = sessionV4.getProject(session.getCurrentProject());
+
+        List<org.apache.maven.api.RemoteRepository> repos =
+                sessionV4.getService(ProjectManager.class).getRemoteProjectRepositories(project);
+        sessionV4 = InternalSession.from(sessionV4.withRemoteRepositories(repos));
+
         org.apache.maven.api.MojoExecution execution = new DefaultMojoExecution(sessionV4, mojoExecution);
         org.apache.maven.api.plugin.Log log = new DefaultLog(
                 LoggerFactory.getLogger(mojoExecution.getMojoDescriptor().getFullGoalName()));


### PR DESCRIPTION
Before the upgrade to maven-resolver 4.0.0-alpha-7, it was necessary to go through the maven 3 layer to resolve project dependencies.