### PR TITLE
[MNG-8012] Warn if in-reactor BOM import happens

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -1847,6 +1847,10 @@ public class DefaultModelBuilder implements ModelBuilder {
 
             if (importSource instanceof FileModelSource && request.getRootDirectory() != null) {
                 URI sourceUri = ((FileModelSource) importSource).getLocationURI();
+                // URI.relativize does the job for us, as if the scheme and authority components of the two URIs
+                // are not identical, or if the path of this URI is not a prefix of the path of the passed URI,
+                // then the passed in URI is returned. Hence, if relativize succeeds, we should report problem,
+                // as the POM originates from within the reactor.
                 if (request.getRootDirectory().toUri().relativize(sourceUri) != sourceUri) {
                     problems.add(new ModelProblemCollectorRequest(Severity.WARNING, ModelProblem.Version.BASE)
                             .setMessage("BOM imports from within reactor should be avoided")

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -1846,7 +1846,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             }
 
             if (importSource instanceof FileModelSource && request.getRootDirectory() != null) {
-                URI sourceUri = ((FileModelSource) importSource).getLocationURI();
+                URI sourceUri = ((FileModelSource) importSource).getPath().toUri();
                 // URI.relativize does the job for us, as if the scheme and authority components of the two URIs
                 // are not identical, or if the path of this URI is not a prefix of the path of the passed URI,
                 // then the passed in URI is returned. Hence, if relativize succeeds, we should report problem,

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -25,9 +25,17 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URI;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1846,12 +1854,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             }
 
             if (importSource instanceof FileModelSource && request.getRootDirectory() != null) {
-                URI sourceUri = ((FileModelSource) importSource).getPath().toUri();
-                // URI.relativize does the job for us, as if the scheme and authority components of the two URIs
-                // are not identical, or if the path of this URI is not a prefix of the path of the passed URI,
-                // then the passed in URI is returned. Hence, if relativize succeeds, we should report problem,
-                // as the POM originates from within the reactor.
-                if (request.getRootDirectory().toUri().relativize(sourceUri) != sourceUri) {
+                Path sourcePath = ((FileModelSource) importSource).getPath();
+                if (sourcePath.startsWith(request.getRootDirectory())) {
                     problems.add(new ModelProblemCollectorRequest(Severity.WARNING, ModelProblem.Version.BASE)
                             .setMessage("BOM imports from within reactor should be avoided")
                             .setLocation(dependency.getLocation("")));

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.maven.model.building;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.maven.model.Model;
 
@@ -52,11 +53,31 @@ public interface ModelBuilder {
 
     /**
      * Performs only the part of {@link ModelBuilder#build(ModelBuildingRequest)} that loads the raw model
+     *
+     * @deprecated Use {@link #buildRawModel(Path, int, boolean)} instead.
      */
+    @Deprecated
     Result<? extends Model> buildRawModel(File pomFile, int validationLevel, boolean locationTracking);
 
+    /**
+     * Performs only the part of {@link ModelBuilder#build(ModelBuildingRequest)} that loads the raw model
+     *
+     * @since 4.0.0
+     */
+    Result<? extends Model> buildRawModel(Path pomFile, int validationLevel, boolean locationTracking);
+
+    /**
+     * @deprecated Use {@link #buildRawModel(Path, int, boolean, TransformerContext)} instead.
+     */
+    @Deprecated
     Result<? extends Model> buildRawModel(
             File pomFile, int validationLevel, boolean locationTracking, TransformerContext context);
+
+    /**
+     * @since 4.0.0
+     */
+    Result<? extends Model> buildRawModel(
+            Path pomFile, int validationLevel, boolean locationTracking, TransformerContext context);
 
     TransformerContextBuilder newTransformerContextBuilder();
 }


### PR DESCRIPTION
This should be in fact prevented.
Also, model builder missed File uses are corrected.

---

https://issues.apache.org/jira/browse/MNG-8012