### PR TITLE
[MNG-8052] New lifecycle for Maven 4

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/After.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/After.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api.plugin.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.maven.api.annotations.Experimental;
+
+/**
+ * Specifies that the mojo should be run after the specific phase.
+ *
+ * @since 4.0.0
+ */
+@Experimental
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface After {
+
+    /**
+     * Type of pointer.
+     * @see org.apache.maven.api.Lifecycle.Pointer.Type
+     */
+    enum Type {
+        PROJECT,
+        DEPENDENCIES,
+        CHILDREN
+    }
+
+    /**
+     * The phase name.
+     */
+    String phase();
+
+    /**
+     * The type of this pointer.
+     */
+    Type type();
+
+    /**
+     * The scope for dependencies, only if {@code type() == Type.Dependencies}.
+     */
+    String scope() default "";
+}

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/LifecycleRegistry.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/LifecycleRegistry.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.api.services;
 
+import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -28,4 +29,6 @@ public interface LifecycleRegistry extends ExtensibleEnumRegistry<Lifecycle>, It
     default Stream<Lifecycle> stream() {
         return StreamSupport.stream(spliterator(), false);
     }
+
+    List<String> computePhases(Lifecycle lifecycle);
 }

--- a/api/maven-api-plugin/pom.xml
+++ b/api/maven-api-plugin/pom.xml
@@ -94,7 +94,7 @@ under the License.
             <phase>generate-sources</phase>
             <configuration>
               <velocityBasedir>${project.basedir}/../../src/mdo</velocityBasedir>
-              <version>1.0.0</version>
+              <version>2.0.0</version>
               <models>
                 <model>src/main/mdo/lifecycle.mdo</model>
               </models>

--- a/api/maven-api-plugin/src/main/mdo/lifecycle.mdo
+++ b/api/maven-api-plugin/src/main/mdo/lifecycle.mdo
@@ -30,12 +30,12 @@ under the License.
   <classes>
     <class rootElement="true" xml.tagName="lifecycles" xsd.compositor="sequence">
       <name>LifecycleConfiguration</name>
-      <version>1.0.0</version>
+      <version>1.0.0+</version>
       <description>Root element of the {@code lifecycle.xml} file.</description>
       <fields>
         <field>
           <name>lifecycles</name>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <association xml.itemsStyle="flat">
             <type>Lifecycle</type>
             <multiplicity>*</multiplicity>
@@ -45,19 +45,19 @@ under the License.
     </class>
     <class>
       <name>Lifecycle</name>
-      <version>1.0.0</version>
+      <version>1.0.0+</version>
       <description>A custom lifecycle mapping definition.</description>
       <fields>
         <field>
           <name>id</name>
           <required>true</required>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <type>String</type>
           <description>The ID of this lifecycle, for identification in the mojo descriptor.</description>
         </field>
         <field>
           <name>phases</name>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <description>The phase mappings for this lifecycle.</description>
           <association>
             <type>Phase</type>
@@ -68,19 +68,35 @@ under the License.
     </class>
     <class>
       <name>Phase</name>
-      <version>1.0.0</version>
+      <version>1.0.0+</version>
       <description>A phase mapping definition.</description>
       <fields>
         <field>
           <name>id</name>
           <required>true</required>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <type>String</type>
-          <description>The ID of this phase, e.g., &lt;code&gt;generate-sources&lt;/code&gt;.</description>
+          <description>The ID of this phase, e.g., {@code generate-sources}.</description>
+        </field>
+        <field xml.attribute="true">
+          <name>executionPoint</name>
+          <required>false</required>
+          <version>2.0.0+</version>
+          <type>String</type>
+          <defaultValue><![CDATA[]]></defaultValue>
+          <description><![CDATA[If specified, identifies this phase as a dynamic phase to decorate the specified phase id, e.g. {@code after} or {@code before}.]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>priority</name>
+          <required>false</required>
+          <version>2.0.0+</version>
+          <type>int</type>
+          <defaultValue>0</defaultValue>
+          <description>If specified, identifies a within phase prioritization of executions.</description>
         </field>
         <field>
           <name>executions</name>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <description>The goals to execute within the phase.</description>
           <association>
             <type>Execution</type>
@@ -89,26 +105,51 @@ under the License.
         </field>
         <field>
           <name>configuration</name>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <type>DOM</type>
           <description>Configuration to pass to all goals run in this phase.</description>
         </field>
       </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>2.0.0+</version>
+          <code><![CDATA[
+    /**
+     * Get the effective ID of this phase, e.g.,
+     * {@code generate-sources} or {@code after:integration-test[1000]}.
+     *
+     * @return String
+     */
+    public String getEffectiveId() {
+        if (executionPoint == null) {
+            if (priority == 0) {
+                return id;
+            }
+            return id + '[' + priority + ']';
+        }
+        if (priority == 0) {
+            return executionPoint + ':' + id;
+        }
+        return executionPoint + ':' + id + '[' + priority + ']';
+    }
+]]></code>
+        </codeSegment>
+      </codeSegments>
     </class>
     <class>
       <name>Execution</name>
-      <version>1.0.0</version>
+      <version>1.0.0+</version>
       <description>A set of goals to execute.</description>
       <fields>
         <field>
           <name>configuration</name>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <type>DOM</type>
           <description>Configuration to pass to the goals.</description>
         </field>
         <field>
           <name>goals</name>
-          <version>1.0.0</version>
+          <version>1.0.0+</version>
           <description>The goals to execute.</description>
           <association>
             <type>String</type>

--- a/maven-api-impl/src/test/java/org/apache/maven/internal/impl/standalone/ApiRunner.java
+++ b/maven-api-impl/src/test/java/org/apache/maven/internal/impl/standalone/ApiRunner.java
@@ -364,6 +364,11 @@ public class ApiRunner {
             public Optional<Lifecycle> lookup(String id) {
                 return Optional.empty();
             }
+
+            @Override
+            public List<String> computePhases(Lifecycle lifecycle) {
+                return List.of();
+            }
         };
     }
 

--- a/maven-compat/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
+++ b/maven-compat/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
@@ -62,6 +62,11 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
         public Optional<Lifecycle> lookup(String id) {
             return Optional.empty();
         }
+
+        @Override
+        public List<String> computePhases(Lifecycle lifecycle) {
+            return List.of();
+        }
     };
 
     private static final PackagingRegistry emptyPackagingRegistry = new PackagingRegistry() {
@@ -139,6 +144,11 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
 
         protected LifecycleRegistry getDelegate() {
             return lifecycleRegistry;
+        }
+
+        @Override
+        public List<String> computePhases(Lifecycle lifecycle) {
+            return List.of();
         }
     }
 

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
@@ -18,21 +18,52 @@
  */
 package org.apache.maven.internal.impl;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
 import org.apache.maven.api.model.Plugin;
 import org.apache.maven.api.model.PluginExecution;
 
+import static java.util.Arrays.asList;
+
 public class Lifecycles {
 
     static Lifecycle.Phase phase(String name) {
-        return new DefaultPhase(name, Collections.emptyList(), Collections.emptyList());
+        return new DefaultPhase(name, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    }
+
+    static Lifecycle.Phase phase(String name, Lifecycle.Phase... phases) {
+        return new DefaultPhase(name, Collections.emptyList(), Collections.emptyList(), asList(phases));
+    }
+
+    static Lifecycle.Phase phase(String name, Lifecycle.Link link, Lifecycle.Phase... phases) {
+        return new DefaultPhase(name, Collections.emptyList(), Collections.singletonList(link), asList(phases));
     }
 
     static Lifecycle.Phase phase(String name, Plugin plugin) {
-        return new DefaultPhase(name, Collections.singletonList(plugin), Collections.emptyList());
+        return new DefaultPhase(
+                name, Collections.singletonList(plugin), Collections.emptyList(), Collections.emptyList());
+    }
+
+    static Lifecycle.Phase phase(String name, Lifecycle.Link link, Plugin plugin) {
+        return new DefaultPhase(
+                name, Collections.singletonList(plugin), Collections.singletonList(link), Collections.emptyList());
+    }
+
+    static Lifecycle.Phase phase(String name, Lifecycle.Link link1, Lifecycle.Link link2, Lifecycle.Phase... phases) {
+        return new DefaultPhase(name, Collections.emptyList(), asList(link1, link2), asList(phases));
+    }
+
+    static Lifecycle.Phase phase(
+            String name, Lifecycle.Link link1, Lifecycle.Link link2, Lifecycle.Link link3, Lifecycle.Phase... phases) {
+        return new DefaultPhase(name, Collections.emptyList(), asList(link1, link2, link3), asList(phases));
+    }
+
+    static Lifecycle.Phase phase(String name, Collection<Lifecycle.Link> links, Lifecycle.Phase... phases) {
+        return new DefaultPhase(name, Collections.emptyList(), links, asList(phases));
     }
 
     static Plugin plugin(String coords, String phase) {
@@ -49,14 +80,66 @@ public class Lifecycles {
                 .build();
     }
 
+    /** Indicates the phase is after the phases given in arguments */
+    static Lifecycle.Link after(String b) {
+        return new Lifecycle.Link() {
+            @Override
+            public Kind kind() {
+                return Kind.AFTER;
+            }
+
+            @Override
+            public Lifecycle.Pointer pointer() {
+                return new Lifecycle.PhasePointer() {
+                    @Override
+                    public String phase() {
+                        return b;
+                    }
+                };
+            }
+        };
+    }
+
+    /** Indicates the phase is after the phases for the dependencies in the given scope */
+    static Lifecycle.Link dependencies(String scope, String phase) {
+        return new Lifecycle.Link() {
+            @Override
+            public Kind kind() {
+                return Kind.AFTER;
+            }
+
+            @Override
+            public Lifecycle.Pointer pointer() {
+                return new Lifecycle.DependenciesPointer() {
+                    @Override
+                    public String phase() {
+                        return phase;
+                    }
+
+                    @Override
+                    public String scope() {
+                        return scope;
+                    }
+                };
+            }
+        };
+    }
+
+    static Lifecycle.Alias alias(String v3Phase, String v4Phase) {
+        return new DefaultAlias(v3Phase, v4Phase);
+    }
+
     static class DefaultPhase implements Lifecycle.Phase {
         private final String name;
         private final List<Plugin> plugins;
+        private final Collection<Lifecycle.Link> links;
         private final List<Lifecycle.Phase> phases;
 
-        DefaultPhase(String name, List<Plugin> plugins, List<Lifecycle.Phase> phases) {
+        DefaultPhase(
+                String name, List<Plugin> plugins, Collection<Lifecycle.Link> links, List<Lifecycle.Phase> phases) {
             this.name = name;
             this.plugins = plugins;
+            this.links = links;
             this.phases = phases;
         }
 
@@ -68,6 +151,41 @@ public class Lifecycles {
         @Override
         public List<Plugin> plugins() {
             return plugins;
+        }
+
+        @Override
+        public Collection<Lifecycle.Link> links() {
+            return links;
+        }
+
+        @Override
+        public List<Lifecycle.Phase> phases() {
+            return phases;
+        }
+
+        @Override
+        public Stream<Lifecycle.Phase> allPhases() {
+            return Stream.concat(Stream.of(this), phases().stream().flatMap(Lifecycle.Phase::allPhases));
+        }
+    }
+
+    static class DefaultAlias implements Lifecycle.Alias {
+        private final String v3Phase;
+        private final String v4Phase;
+
+        DefaultAlias(String v3Phase, String v4Phase) {
+            this.v3Phase = v3Phase;
+            this.v4Phase = v4Phase;
+        }
+
+        @Override
+        public String v3Phase() {
+            return v3Phase;
+        }
+
+        @Override
+        public String v4Phase() {
+            return v4Phase;
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/Lifecycle.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/Lifecycle.java
@@ -23,8 +23,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.maven.lifecycle.mapping.LifecyclePhase;
+
+import static org.apache.maven.api.Lifecycle.AFTER;
+import static org.apache.maven.api.Lifecycle.BEFORE;
 
 /**
  * Lifecycle definition, with eventual plugin bindings (when they are not packaging-specific).
@@ -42,7 +46,9 @@ public class Lifecycle {
             org.apache.maven.api.services.LifecycleRegistry registry, org.apache.maven.api.Lifecycle lifecycle) {
         this.lifecycle = lifecycle;
         this.id = lifecycle.id();
-        this.phases = registry.computePhases(lifecycle);
+        this.phases = registry.computePhases(lifecycle).stream()
+                .flatMap(p -> Stream.of(BEFORE + p, p, AFTER + p))
+                .toList();
         this.defaultPhases = getDefaultPhases(lifecycle);
     }
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -475,7 +475,14 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         }
 
         for (Phase phase : lifecycleOverlay.getPhases()) {
-            List<MojoExecution> forkedExecutions = lifecycleMappings.get(phase.getId());
+            String phaseId = defaultLifecycles.getLifeCycles().stream()
+                    .flatMap(l -> l.getDelegate().aliases().stream())
+                    .filter(a -> phase.getId().equals(a.v3Phase()))
+                    .findFirst()
+                    .map(a -> a.v4Phase())
+                    .orElse(phase.getId());
+
+            List<MojoExecution> forkedExecutions = lifecycleMappings.get(phaseId);
 
             if (forkedExecutions != null) {
                 for (Execution execution : phase.getExecutions()) {

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseComparator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseComparator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.internal;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Compares phases within the context of a specific lifecycle with secondary sorting based on the {@link PhaseId}.
+ */
+public class PhaseComparator implements Comparator<String> {
+    /**
+     * The lifecycle phase ordering.
+     */
+    private final List<String> lifecyclePhases;
+
+    /**
+     * Constructor.
+     *
+     * @param lifecyclePhases the lifecycle phase ordering.
+     */
+    public PhaseComparator(List<String> lifecyclePhases) {
+        this.lifecyclePhases = lifecyclePhases;
+    }
+
+    @Override
+    public int compare(String o1, String o2) {
+        PhaseId p1 = PhaseId.of(o1);
+        PhaseId p2 = PhaseId.of(o2);
+        int i1 = lifecyclePhases.indexOf(p1.phase());
+        int i2 = lifecyclePhases.indexOf(p2.phase());
+        if (i1 == -1 && i2 == -1) {
+            // unknown phases, leave in existing order
+            return 0;
+        }
+        if (i1 == -1) {
+            // second one is known, so it comes first
+            return 1;
+        }
+        if (i2 == -1) {
+            // first one is known, so it comes first
+            return -1;
+        }
+        int rv = Integer.compare(i1, i2);
+        if (rv != 0) {
+            return rv;
+        }
+        // same phase, now compare execution points
+        i1 = p1.executionPoint().ordinal();
+        i2 = p2.executionPoint().ordinal();
+        rv = Integer.compare(i1, i2);
+        if (rv != 0) {
+            return rv;
+        }
+        // same execution point, now compare priorities
+        return Integer.compare(p1.priority(), p2.priority());
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseExecutionPoint.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseExecutionPoint.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.internal;
+
+/**
+ * Represents where a dynamic phase should be executed within a static phase.
+ */
+public enum PhaseExecutionPoint {
+    /**
+     * Execution must occur before any executions of the phase proper. Failure of any {@code #BEFORE} dynamic phase
+     * execution will prevent the {@link #AT} phase but will not prevent any {@link #AFTER} dynamic phases.
+     */
+    BEFORE("before:"),
+    /**
+     * Execution is the execution of the phase proper. Failure of any {@code #AT} dynamic phase execution will fail
+     * the phase. Any {@link #AFTER} phases will still be executed.
+     */
+    AT(""),
+    /**
+     * Guaranteed execution dynamic phases on completion of the static phase. All {@code #AFTER} dynamic phases will
+     * be executed provided at least one {@link #BEFORE} or {@link #AT} dynamic phase has started execution.
+     */
+    AFTER("after:");
+
+    private final String prefix;
+
+    PhaseExecutionPoint(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String prefix() {
+        return prefix;
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseId.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseId.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.internal;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.WeakHashMap;
+
+/**
+ * Represents a parsed phase identifier.
+ */
+public class PhaseId {
+    /**
+     * Interned {@link PhaseId} instances.
+     */
+    private static final Map<String, PhaseId> INSTANCES = new WeakHashMap<>();
+
+    /**
+     * The execution point of this {@link PhaseId}.
+     */
+    private final PhaseExecutionPoint executionPoint;
+
+    /**
+     * The static phase that this dynamic phase belongs to.
+     */
+    private final String phase;
+
+    /**
+     * The priority of this dynamic phase within the static phase.
+     */
+    private final int priority;
+
+    /**
+     * Parses the phase identifier.
+     *
+     * @param phase the phase identifier.
+     * @return the {@link PhaseId}.
+     */
+    public static synchronized PhaseId of(String phase) {
+        return INSTANCES.computeIfAbsent(phase, PhaseId::new);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param phase the phase identifier string.
+     */
+    private PhaseId(String phase) {
+        int phaseStart;
+        if (phase.startsWith(PhaseExecutionPoint.BEFORE.prefix())) {
+            executionPoint = PhaseExecutionPoint.BEFORE;
+            phaseStart = PhaseExecutionPoint.BEFORE.prefix().length();
+        } else if (phase.startsWith(PhaseExecutionPoint.AFTER.prefix())) {
+            executionPoint = PhaseExecutionPoint.AFTER;
+            phaseStart = PhaseExecutionPoint.AFTER.prefix().length();
+        } else {
+            executionPoint = PhaseExecutionPoint.AT;
+            phaseStart = 0;
+        }
+        int phaseEnd = phase.indexOf('[');
+        if (phaseEnd == -1) {
+            priority = 0;
+            this.phase = phase.substring(phaseStart);
+        } else {
+            int priorityEnd = phase.lastIndexOf(']');
+            boolean hasPriority;
+            int priority;
+            if (priorityEnd < phaseEnd + 1) {
+                priority = 0;
+                hasPriority = false;
+            } else {
+                try {
+                    priority = Integer.parseInt(phase.substring(phaseEnd + 1, priorityEnd));
+                    hasPriority = true;
+                } catch (NumberFormatException e) {
+                    // priority must be an integer
+                    priority = 0;
+                    hasPriority = false;
+                }
+            }
+            if (hasPriority) {
+                this.phase = phase.substring(phaseStart, phaseEnd);
+                this.priority = priority;
+            } else {
+                this.phase = phase.substring(phaseStart);
+                this.priority = 0;
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        } else {
+            PhaseId phaseId = (PhaseId) o;
+            return Objects.equals(executionPoint(), phaseId.executionPoint())
+                    && Objects.equals(phase(), phaseId.phase())
+                    && Objects.equals(priority(), phaseId.priority());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(executionPoint(), phase(), priority());
+    }
+
+    @Override
+    public String toString() {
+        return executionPoint().prefix() + phase() + (priority() != 0 ? "[" + priority() + ']' : "");
+    }
+
+    public PhaseExecutionPoint executionPoint() {
+        return executionPoint;
+    }
+
+    public String phase() {
+        return phase;
+    }
+
+    public int priority() {
+        return priority;
+    }
+}

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseRecorder.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/PhaseRecorder.java
@@ -38,11 +38,12 @@ public class PhaseRecorder {
         String lifecyclePhase = mojoExecution.getLifecyclePhase();
 
         if (lifecyclePhase != null) {
+            PhaseId phaseId = PhaseId.of(lifecyclePhase);
             if (lastLifecyclePhase == null) {
-                lastLifecyclePhase = lifecyclePhase;
-            } else if (!lifecyclePhase.equals(lastLifecyclePhase)) {
+                lastLifecyclePhase = phaseId.phase();
+            } else if (!phaseId.phase().equals(lastLifecyclePhase)) {
                 project.addLifecyclePhase(lastLifecyclePhase);
-                lastLifecyclePhase = lifecyclePhase;
+                lastLifecyclePhase = phaseId.phase();
             }
         }
 
@@ -56,6 +57,6 @@ public class PhaseRecorder {
         if (lifecyclePhase == null) {
             return lastLifecyclePhase != null;
         }
-        return !lifecyclePhase.equals(lastLifecyclePhase);
+        return !PhaseId.of(lifecyclePhase).phase().equals(lastLifecyclePhase);
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -59,28 +59,28 @@ class DefaultLifecyclesTest {
     void testDefaultLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("default");
         assertThat(lifecycle.getId(), is("default"));
-        assertThat(lifecycle.getPhases(), hasSize(18));
+        assertThat(lifecycle.getPhases(), hasSize(54));
     }
 
     @Test
     void testCleanLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("clean");
         assertThat(lifecycle.getId(), is("clean"));
-        assertThat(lifecycle.getPhases(), hasSize(1));
+        assertThat(lifecycle.getPhases(), hasSize(3));
     }
 
     @Test
     void testSiteLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("site");
         assertThat(lifecycle.getId(), is("site"));
-        assertThat(lifecycle.getPhases(), hasSize(2));
+        assertThat(lifecycle.getPhases(), hasSize(6));
     }
 
     @Test
     void testWrapperLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("wrapper");
         assertThat(lifecycle.getId(), is("wrapper"));
-        assertThat(lifecycle.getPhases(), hasSize(1));
+        assertThat(lifecycle.getPhases(), hasSize(3));
     }
 
     @Test

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -59,21 +59,21 @@ class DefaultLifecyclesTest {
     void testDefaultLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("default");
         assertThat(lifecycle.getId(), is("default"));
-        assertThat(lifecycle.getPhases(), hasSize(23));
+        assertThat(lifecycle.getPhases(), hasSize(18));
     }
 
     @Test
     void testCleanLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("clean");
         assertThat(lifecycle.getId(), is("clean"));
-        assertThat(lifecycle.getPhases(), hasSize(3));
+        assertThat(lifecycle.getPhases(), hasSize(1));
     }
 
     @Test
     void testSiteLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("site");
         assertThat(lifecycle.getId(), is("site"));
-        assertThat(lifecycle.getPhases(), hasSize(4));
+        assertThat(lifecycle.getPhases(), hasSize(2));
     }
 
     @Test

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
@@ -152,6 +152,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     // We need to take in multiple lifecycles
+    @Test
     public void testCalculationOfBuildPlanTasksOfTheCleanLifecycleAndTheInstallLifecycle() throws Exception {
         File pom = getProject("project-with-additional-lifecycle-elements");
         MavenSession session = createMavenSession(pom);
@@ -195,6 +196,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     // We need to take in multiple lifecycles
+    @Test
     public void testCalculationOfBuildPlanWithMultipleExecutionsOfModello() throws Exception {
         File pom = getProject("project-with-multiple-executions");
         MavenSession session = createMavenSession(pom);

--- a/maven-core/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
+++ b/maven-core/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
@@ -61,6 +61,11 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
         public Optional<Lifecycle> lookup(String id) {
             return Optional.empty();
         }
+
+        @Override
+        public List<String> computePhases(Lifecycle lifecycle) {
+            return List.of();
+        }
     };
 
     private static final PackagingRegistry emptyPackagingRegistry = new PackagingRegistry() {
@@ -138,6 +143,11 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
 
         protected LifecycleRegistry getDelegate() {
             return lifecycleRegistry;
+        }
+
+        @Override
+        public List<String> computePhases(Lifecycle lifecycle) {
+            return List.of();
         }
     }
 

--- a/maven-plugin-api/pom.xml
+++ b/maven-plugin-api/pom.xml
@@ -117,7 +117,7 @@ under the License.
               <models>
                 <model>../api/maven-api-plugin/src/main/mdo/lifecycle.mdo</model>
               </models>
-              <version>1.0.0</version>
+              <version>2.0.0</version>
             </configuration>
           </execution>
           <execution>

--- a/src/mdo/reader-stax.vm
+++ b/src/mdo/reader-stax.vm
@@ -551,6 +551,9 @@ public class ${className} {
   #foreach ( $field in $allFields )
     #if ( $Helper.xmlFieldMetadata( $field ).attribute )
       #set ( $fieldTagName = $Helper.xmlFieldMetadata( $field ).tagName )
+      #if ( ! $fieldTagName )
+        #set ( $fieldTagName = $field.name )
+      #end
       #set ( $fieldCapName = $Helper.capitalise( $field.name ) )
             } else if ("$fieldTagName".equals(name)) {
       #if ( $locationTracking )
@@ -562,6 +565,8 @@ public class ${className} {
                 ${classLcapName}.${field.name}(interpolatedTrimmed(value, "$fieldTagName"));
       #elseif ( $field.type == "boolean" || $field.type == "Boolean" )
                 ${classLcapName}.${field.name}(getBooleanValue(interpolatedTrimmed(value, "$fieldTagName"), "$fieldTagName", parser, ${field.defaultValue}));
+      #elseif ( $field.type == "int" || $field.type == "Integer" )
+                ${classLcapName}.${field.name}(getIntegerValue(interpolatedTrimmed(value, "$fieldTagName"), "$fieldTagName", parser, strict, ${field.defaultValue}));
       #else
                 // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end

--- a/src/mdo/writer-stax.vm
+++ b/src/mdo/writer-stax.vm
@@ -227,6 +227,9 @@ public class ${className} {
   #foreach ( $field in $allFields )
     #if ( $Helper.xmlFieldMetadata( $field ).attribute && ! $Helper.xmlFieldMetadata( $field ).format )
       #set ( $fieldTagName = $Helper.xmlFieldMetadata( $field ).tagName )
+      #if ( ! $fieldTagName )
+        #set ( $fieldTagName = $field.name )
+      #end
       #set ( $fieldCapName = $Helper.capitalise( $field.name ) )
       #if ( $field.type == "String" )
             writeAttr("$fieldTagName", ${classLcapName}.get${fieldCapName}(), serializer);
@@ -237,6 +240,8 @@ public class ${className} {
         #else
             writeAttr("$fieldTagName", ${classLcapName}.is${fieldCapName}() ? "true" : null, serializer);
         #end
+      #elseif ( $field.type == "int" || $field.type == "Integer" )
+            writeAttr("$fieldTagName", Integer.toString(${classLcapName}.get${fieldCapName}()), serializer);
       #else
             // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end

--- a/src/mdo/writer.vm
+++ b/src/mdo/writer.vm
@@ -152,6 +152,9 @@ public class ${className} {
   #foreach ( $field in $allFields )
     #if ( $Helper.xmlFieldMetadata( $field ).attribute )
       #set ( $fieldTagName = $Helper.xmlFieldMetadata( $field ).tagName )
+      #if ( ! $fieldTagName )
+        #set ( $fieldTagName = $field.name )
+      #end
       #set ( $fieldCapName = $Helper.capitalise( $field.name ) )
       #if ( $field.type == "String" )
             writeAttr("$fieldTagName", ${classLcapName}.get${fieldCapName}(), serializer);
@@ -162,6 +165,8 @@ public class ${className} {
         #else
             writeAttr("$fieldTagName", ${classLcapName}.is${fieldCapName}() ? "true" : null, serializer);
         #end
+      #elseif ( $field.type == "int" || $field.type == "Integer" )
+            writeAttr("$fieldTagName", Integer.toString(${classLcapName}.get${fieldCapName}()), serializer);
       #else
             // TODO: type=${field.type} to=${field.to} multiplicity=${field.multiplicity}
       #end


### PR DESCRIPTION
JIRA issue: [MNG-8052](https://issues.apache.org/jira/browse/MNG-8052)

The lifecycle is now defined as a tree of phases, each phase being split with a `before:` phase and a `after:` phase.  Each phase is given a list of timing constraints: a phase from the same lifecycle (`compile` must be executed after `sources`), a phase in project dependencies (`compile` must execute after `compile-only` project dependencies have reached the `ready` phase), or a set of children project dependencies (to re-define aggregators, not yet implemented).
The default lifecycle is defined in the [`DefaultLifecycleRegistry`](https://github.com/gnodet/maven/blob/dynamic-phases/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java#L349-L379)

In addition to the `before:` and `after:` prefixes, an ordering can be defined by appending an integer inside brackets, for example, `after:integration-test[1000]`.

Note that there are a few changes with the Maven 3 default lifecycle: it's a graph, so `sources` does not always execute after `resources`, nor `compile` after `resources`.  Also, unit tests and integration tests have been moved to the `verify` phase which is run last inside the `build` phase, but not in the `package` phase.  The goal is to have a phase (here, `package` which can run all the reactor with no tests).  In order to be compatible, old phases are mapped to new ones using [aliases](https://github.com/gnodet/maven/blob/lifecycle/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java#L381-L393).  The `install` and `deploy` phases now depends on `package`, but not `verify` (and `deploy` does not require `install`).  This currently has no effect when calling `mvn deploy`, as the ordered _list_ of phases is still used to compute the build plan (see #1429).

It's missing the ability to create some scheduling constraints in the POM and to define custom phases.  All executions in a given phase such as `compile` or `after:sources` are executed sequentially, but it would be nice to be able to execute them in different subphases, so that they could be executed concurrently.

This PR is required for #1429