### PR TITLE
[MNG-8082] - Exceptions of proxied SessionScoped components are not working correctly

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/session/scope/internal/SessionScope.java
+++ b/maven-core/src/main/java/org/apache/maven/session/scope/internal/SessionScope.java
@@ -107,7 +107,11 @@ public class SessionScope implements Scope {
     private <T> T createProxy(Key<T> key, Provider<T> unscoped) {
         InvocationHandler dispatcher = (proxy, method, args) -> {
             method.setAccessible(true);
-            return method.invoke(getScopeState().scope(key, unscoped).get(), args);
+            try {
+                return method.invoke(getScopeState().scope(key, unscoped).get(), args);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
         };
         Class<T> superType = (Class<T>) key.getTypeLiteral().getRawType();
         Class<?>[] interfaces = getInterfaces(superType);

--- a/maven-core/src/test/java/org/apache/maven/session/scope/SessionScopeProxyTest.java
+++ b/maven-core/src/test/java/org/apache/maven/session/scope/SessionScopeProxyTest.java
@@ -74,6 +74,7 @@ public class SessionScopeProxyTest {
         assertNotNull(bean.myBean.getSession());
         assertNotNull(bean.myBean.getAnotherBean());
         assertSame(bean.myBean.getAnotherBean().getClass(), AnotherBean.class);
+        assertThrows(TestException.class, () -> bean.myBean.throwException());
     }
 
     @Named
@@ -102,6 +103,8 @@ public class SessionScopeProxyTest {
         Session getSession();
 
         BeanItf2 getAnotherBean();
+
+        void throwException() throws TestException;
     }
 
     interface BeanItf2 {}
@@ -127,5 +130,11 @@ public class SessionScopeProxyTest {
         public BeanItf2 getAnotherBean() {
             return anotherBean;
         }
+
+        public void throwException() throws TestException {
+            throw new TestException();
+        }
     }
+
+    static class TestException extends Exception {}
 }


### PR DESCRIPTION
Simple fix to handle the exception case correctly.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
