### PR TITLE
[MNG-8089] Introduce fat-JAR types

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
@@ -61,10 +61,9 @@ public interface Type extends ExtensibleEnum {
     String JAR = "jar";
 
     /**
-     * Artifact type name for a fat-JAR file that can be placed either on the class-path or on the module-path.
+     * Artifact type name for a fat-JAR file that can be only on the class-path.
      * The fat-JAR is a self-contained JAR and its transitive dependencies will not be resolved, if any.
-     * The path (classes or modules) is chosen by the plugin, possibly using heuristic rules.
-     * This is the behavior of Maven 3.
+     * This type is new in Maven 4.
      */
     String FATJAR = "fatjar";
 
@@ -76,27 +75,11 @@ public interface Type extends ExtensibleEnum {
     String CLASSPATH_JAR = "classpath-jar";
 
     /**
-     * Artifact type name for a fat-JAR file to unconditionally place on the class-path.
-     * The fat-JAR is a self-contained JAR and its transitive dependencies will not be resolved, if any.
-     * If the fat-JAR is modular, its module information are ignored.
-     * This type is new in Maven 4.
-     */
-    String CLASSPATH_FATJAR = "classpath-fatjar";
-
-    /**
      * Artifact type name for a JAR file to unconditionally place on the module-path.
      * If the JAR is not modular, then it is loaded by Java as an unnamed module.
      * This type is new in Maven 4.
      */
     String MODULAR_JAR = "modular-jar";
-
-    /**
-     * Artifact type name for a JAR file to unconditionally place on the module-path.
-     * The fat-JAR is a self-contained JAR and its transitive dependencies will not be resolved, if any.
-     * If the fat-JAR is not modular, then it is loaded by Java as an unnamed module.
-     * This type is new in Maven 4.
-     */
-    String MODULAR_FATJAR = "modular-fatjar";
 
     /**
      * Artifact type name for source code packaged in a JAR file.

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
@@ -61,6 +61,14 @@ public interface Type extends ExtensibleEnum {
     String JAR = "jar";
 
     /**
+     * Artifact type name for a fat-JAR file that can be placed either on the class-path or on the module-path.
+     * The fat-JAR is a self-contained JAR and its transitive dependencies will not be resolved, if any.
+     * The path (classes or modules) is chosen by the plugin, possibly using heuristic rules.
+     * This is the behavior of Maven 3.
+     */
+    String FATJAR = "fatjar";
+
+    /**
      * Artifact type name for a JAR file to unconditionally place on the class-path.
      * If the JAR is modular, its module information are ignored.
      * This type is new in Maven 4.
@@ -68,11 +76,27 @@ public interface Type extends ExtensibleEnum {
     String CLASSPATH_JAR = "classpath-jar";
 
     /**
+     * Artifact type name for a fat-JAR file to unconditionally place on the class-path.
+     * The fat-JAR is a self-contained JAR and its transitive dependencies will not be resolved, if any.
+     * If the fat-JAR is modular, its module information are ignored.
+     * This type is new in Maven 4.
+     */
+    String CLASSPATH_FATJAR = "classpath-fatjar";
+
+    /**
      * Artifact type name for a JAR file to unconditionally place on the module-path.
      * If the JAR is not modular, then it is loaded by Java as an unnamed module.
      * This type is new in Maven 4.
      */
     String MODULAR_JAR = "modular-jar";
+
+    /**
+     * Artifact type name for a JAR file to unconditionally place on the module-path.
+     * The fat-JAR is a self-contained JAR and its transitive dependencies will not be resolved, if any.
+     * If the fat-JAR is not modular, then it is loaded by Java as an unnamed module.
+     * This type is new in Maven 4.
+     */
+    String MODULAR_FATJAR = "modular-fatjar";
 
     /**
      * Artifact type name for source code packaged in a JAR file.

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
@@ -57,6 +57,10 @@ public class DefaultTypeProvider implements TypeProvider {
                         JavaPathType.PATCH_MODULE),
                 new DefaultType(Type.MODULAR_JAR, Language.JAVA_FAMILY, "jar", null, false, JavaPathType.MODULES),
                 new DefaultType(Type.CLASSPATH_JAR, Language.JAVA_FAMILY, "jar", null, false, JavaPathType.CLASSES),
+                new DefaultType(
+                        Type.FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.CLASSES, JavaPathType.MODULES),
+                new DefaultType(Type.MODULAR_FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.MODULES),
+                new DefaultType(Type.CLASSPATH_FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.CLASSES),
                 // j2ee types
                 new DefaultType("ejb", Language.JAVA_FAMILY, "jar", null, false, JavaPathType.CLASSES),
                 new DefaultType("ejb-client", Language.JAVA_FAMILY, "jar", "client", false, JavaPathType.CLASSES),

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
@@ -57,13 +57,7 @@ public class DefaultTypeProvider implements TypeProvider {
                         JavaPathType.PATCH_MODULE),
                 new DefaultType(Type.MODULAR_JAR, Language.JAVA_FAMILY, "jar", null, false, JavaPathType.MODULES),
                 new DefaultType(Type.CLASSPATH_JAR, Language.JAVA_FAMILY, "jar", null, false, JavaPathType.CLASSES),
-                new DefaultType(
-                        Type.FATJAR,
-                        Language.JAVA_FAMILY,
-                        "jar",
-                        null,
-                        true,
-                        JavaPathType.CLASSES),
+                new DefaultType(Type.FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.CLASSES),
                 // j2ee types
                 new DefaultType("ejb", Language.JAVA_FAMILY, "jar", null, false, JavaPathType.CLASSES),
                 new DefaultType("ejb-client", Language.JAVA_FAMILY, "jar", "client", false, JavaPathType.CLASSES),

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
@@ -58,7 +58,13 @@ public class DefaultTypeProvider implements TypeProvider {
                 new DefaultType(Type.MODULAR_JAR, Language.JAVA_FAMILY, "jar", null, false, JavaPathType.MODULES),
                 new DefaultType(Type.CLASSPATH_JAR, Language.JAVA_FAMILY, "jar", null, false, JavaPathType.CLASSES),
                 new DefaultType(
-                        Type.FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.CLASSES, JavaPathType.MODULES),
+                        Type.FATJAR,
+                        Language.JAVA_FAMILY,
+                        "jar",
+                        null,
+                        true,
+                        JavaPathType.CLASSES,
+                        JavaPathType.MODULES),
                 new DefaultType(Type.MODULAR_FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.MODULES),
                 new DefaultType(Type.CLASSPATH_FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.CLASSES),
                 // j2ee types

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
@@ -63,10 +63,7 @@ public class DefaultTypeProvider implements TypeProvider {
                         "jar",
                         null,
                         true,
-                        JavaPathType.CLASSES,
-                        JavaPathType.MODULES),
-                new DefaultType(Type.MODULAR_FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.MODULES),
-                new DefaultType(Type.CLASSPATH_FATJAR, Language.JAVA_FAMILY, "jar", null, true, JavaPathType.CLASSES),
+                        JavaPathType.CLASSES),
                 // j2ee types
                 new DefaultType("ejb", Language.JAVA_FAMILY, "jar", null, false, JavaPathType.CLASSES),
                 new DefaultType("ejb-client", Language.JAVA_FAMILY, "jar", "client", false, JavaPathType.CLASSES),


### PR DESCRIPTION
These are dependency types to be used when dependency is "self contained", or is wanted be used as such: handle if like it has no dependencies, if any.

---

https://issues.apache.org/jira/browse/MNG-8089