### PR TITLE
[MNG-8030] Backport itr: ignore transitive repositories

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionRequest.java
@@ -65,6 +65,8 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
 
     private boolean cacheNotFound;
 
+    private boolean ignoreTransitiveRepositories;
+
     private List<Proxy> proxies;
 
     private List<Server> servers;
@@ -169,6 +171,7 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
         copy.setOffline(original.isOffline());
         copy.setInteractiveMode(original.isInteractiveMode());
         copy.setCacheNotFound(original.isCacheNotFound());
+        copy.setIgnoreTransitiveRepositories(original.isIgnoreTransitiveRepositories());
         copy.setCacheTransferError(original.isCacheTransferError());
         copy.setProxies(original.getProxies());
         copy.setServers(original.getServers());
@@ -1015,6 +1018,17 @@ public class DefaultMavenExecutionRequest implements MavenExecutionRequest {
     @Override
     public MavenExecutionRequest setCacheNotFound(boolean cacheNotFound) {
         this.cacheNotFound = cacheNotFound;
+        return this;
+    }
+
+    @Override
+    public boolean isIgnoreTransitiveRepositories() {
+        return ignoreTransitiveRepositories;
+    }
+
+    @Override
+    public MavenExecutionRequest setIgnoreTransitiveRepositories(boolean ignoreTransitiveRepositories) {
+        this.ignoreTransitiveRepositories = ignoreTransitiveRepositories;
         return this;
     }
 

--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -252,6 +252,16 @@ public interface MavenExecutionRequest {
 
     MavenExecutionRequest setCacheNotFound(boolean cacheNotFound);
 
+    /**
+     * @since 3.9.7
+     */
+    boolean isIgnoreTransitiveRepositories();
+
+    /**
+     * @since 3.9.7
+     */
+    MavenExecutionRequest setIgnoreTransitiveRepositories(boolean ignoreTransitiveRepositories);
+
     // Profiles
     List<Profile> getProfiles();
 

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -341,6 +341,8 @@ public class DefaultRepositorySystemSessionFactory {
 
         session.setRepositoryListener(eventSpyDispatcher.chainListener(new LoggingRepositoryListener(logger)));
 
+        session.setIgnoreArtifactDescriptorRepositories(request.isIgnoreTransitiveRepositories());
+
         boolean recordReverseTree = ConfigUtils.getBoolean(session, false, MAVEN_REPO_LOCAL_RECORD_REVERSE_TREE);
         if (recordReverseTree) {
             session.setRepositoryListener(new ChainedRepositoryListener(

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -107,6 +107,8 @@ public class CLIManager {
 
     public static final String COLOR = "color";
 
+    public static final String IGNORE_TRANSITIVE_REPOSITORIES = "itr";
+
     protected Options options;
 
     @SuppressWarnings({"checkstyle:linelength", "checkstyle:MethodLength"})
@@ -260,6 +262,10 @@ public class CLIManager {
         options.addOption(Option.builder(NO_TRANSFER_PROGRESS)
                 .longOpt("no-transfer-progress")
                 .desc("Do not display transfer progress when downloading or uploading")
+                .build());
+        options.addOption(Option.builder(IGNORE_TRANSITIVE_REPOSITORIES)
+                .longOpt("ignore-transitive-repositories")
+                .desc("If set, Maven will ignore remote repositories introduced by transitive dependencies.")
                 .build());
 
         // Adding this back in for compatibility with the verifier that hard codes this option.

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1409,6 +1409,7 @@ public class MavenCli {
 
         request.setCacheNotFound(true);
         request.setCacheTransferError(false);
+        request.setIgnoreTransitiveRepositories(commandLine.hasOption(CLIManager.IGNORE_TRANSITIVE_REPOSITORIES));
 
         //
         // Builder, concurrency and parallelism


### PR DESCRIPTION
Backport of the Maven4 feature: ignore transitive repositories.

---

https://issues.apache.org/jira/browse/MNG-8030