### PR TITLE
[3.9.x][MNG-8106] Fix metadata merge

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: 'temurin'
+          distribution: 'zulu'
           cache: 'maven'
 
       - name: Build with Maven
@@ -125,7 +125,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'zulu'
           cache: 'maven'
 
       - name: Running integration tests

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/LocalSnapshotMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/LocalSnapshotMetadata.java
@@ -116,6 +116,10 @@ final class LocalSnapshotMetadata extends MavenMetadata {
 
             metadata.getVersioning().setSnapshotVersions(new ArrayList<>(versions.values()));
         }
+        // just carry-on as-is
+        if (!recessive.getPlugins().isEmpty()) {
+            metadata.setPlugins(new ArrayList<>(recessive.getPlugins()));
+        }
 
         artifacts.clear();
     }

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenMetadata.java
@@ -70,8 +70,6 @@ abstract class MavenMetadata extends AbstractMetadata implements MergeableMetada
     @Override
     public void merge(File existing, File result) throws RepositoryException {
         Metadata recessive = read(existing);
-        recessive.merge(metadata);
-        metadata = recessive;
 
         merge(recessive);
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenMetadata.java
@@ -70,6 +70,8 @@ abstract class MavenMetadata extends AbstractMetadata implements MergeableMetada
     @Override
     public void merge(File existing, File result) throws RepositoryException {
         Metadata recessive = read(existing);
+        recessive.merge(metadata);
+        metadata = recessive;
 
         merge(recessive);
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/PluginsMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/PluginsMetadata.java
@@ -74,11 +74,15 @@ final class PluginsMetadata extends MavenMetadata {
     protected void merge(Metadata recessive) {
         List<Plugin> recessivePlugins = recessive.getPlugins();
         List<Plugin> plugins = metadata.getPlugins();
-        if (!plugins.isEmpty()) {
+        if (!recessivePlugins.isEmpty() || !plugins.isEmpty()) {
             LinkedHashMap<String, Plugin> mergedPlugins = new LinkedHashMap<>();
             recessivePlugins.forEach(p -> mergedPlugins.put(p.getPrefix(), p));
             plugins.forEach(p -> mergedPlugins.put(p.getPrefix(), p));
             metadata.setPlugins(new ArrayList<>(mergedPlugins.values()));
+        }
+        // just carry-on as-is
+        if (recessive.getVersioning() != null) {
+            metadata.setVersioning(recessive.getVersioning());
         }
     }
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RemoteSnapshotMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RemoteSnapshotMetadata.java
@@ -124,6 +124,10 @@ final class RemoteSnapshotMetadata extends MavenSnapshotMetadata {
         if (!legacyFormat) {
             metadata.getVersioning().setSnapshotVersions(new ArrayList<>(versions.values()));
         }
+        // just carry-on as-is
+        if (!recessive.getPlugins().isEmpty()) {
+            metadata.setPlugins(new ArrayList<>(recessive.getPlugins()));
+        }
     }
 
     private static int getBuildNumber(Metadata metadata) {

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadata.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/VersionsMetadata.java
@@ -83,6 +83,10 @@ final class VersionsMetadata extends MavenMetadata {
             versions.addAll(versioning.getVersions());
             versioning.setVersions(new ArrayList<>(versions));
         }
+        // just carry-on as-is
+        if (!recessive.getPlugins().isEmpty()) {
+            metadata.setPlugins(new ArrayList<>(recessive.getPlugins()));
+        }
     }
 
     public Object getKey() {


### PR DESCRIPTION
As currently if given metadata serves multiple roles (G, A or V level), data loss occurs.

---

https://issues.apache.org/jira/browse/MNG-8106