### PR TITLE
[MNG-8062] Maven should factor in session close into result

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -224,6 +224,9 @@ public class DefaultMaven implements Maven {
 
             result = doExecute(request, session, result, chainedWorkspaceReader);
         } catch (Exception e) {
+            if (e instanceof ClassCastException) {
+                throw e;
+            }
             result.addException(e);
         } finally {
             sessionScope.exit();

--- a/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -222,10 +222,13 @@ public class DefaultMaven implements Maven {
 
             legacySupport.setSession(session);
 
-            return doExecute(request, session, result, chainedWorkspaceReader);
+            result = doExecute(request, session, result, chainedWorkspaceReader);
+        } catch (Exception e) {
+            result.addException(e);
         } finally {
             sessionScope.exit();
         }
+        return result;
     }
 
     private MavenExecutionResult doExecute(


### PR DESCRIPTION
Currently, if (reposys) session close fails for any reason, Maven will report "success" (exit code 0). This is wrong.

Make it report error and behave as expected.

The point is that in this try-with-resource construct, the CloseableSession may throw when being closed.

---

https://issues.apache.org/jira/browse/MNG-8062