### PR TITLE
[MNG-8108] Fix problem when building the consumer pom

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.maven.api.SessionData;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.DistributionManagement;
@@ -65,6 +66,7 @@ import org.apache.maven.internal.impl.model.DefaultModelBuilder;
 import org.apache.maven.internal.impl.model.DefaultProfileSelector;
 import org.apache.maven.internal.impl.model.ProfileActivationFilePathInterpolator;
 import org.apache.maven.internal.impl.resolver.DefaultModelCache;
+import org.apache.maven.internal.impl.resolver.DefaultModelRepositoryHolder;
 import org.apache.maven.model.v4.MavenModelVersion;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
@@ -196,13 +198,15 @@ class DefaultConsumerPomBuilder implements ConsumerPomBuilder {
                 profileActivationFilePathInterpolator,
                 modelTransformer,
                 versionParser);
+        InternalSession iSession = InternalSession.from(session);
         ModelBuilderRequest.ModelBuilderRequestBuilder request = ModelBuilderRequest.builder();
         request.projectBuild(true);
-        request.session(InternalSession.from(session));
+        request.session(iSession);
         request.source(ModelSource.fromPath(src));
         request.validationLevel(ModelBuilderRequest.VALIDATION_LEVEL_MINIMAL);
         request.locationTracking(false);
         request.modelResolver(modelResolver);
+        request.modelRepositoryHolder(iSession.getData().get(SessionData.key(DefaultModelRepositoryHolder.class)));
         request.transformerContextBuilder(modelBuilder.newTransformerContextBuilder());
         request.systemProperties(session.getSystemProperties());
         request.userProperties(session.getUserProperties());

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import org.apache.maven.ProjectCycleException;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.Session;
+import org.apache.maven.api.SessionData;
 import org.apache.maven.api.feature.Features;
 import org.apache.maven.api.model.*;
 import org.apache.maven.api.services.ModelBuilder;
@@ -1041,13 +1042,15 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             modelBuildingRequest.userProperties(toMap(request.getUserProperties()));
             // bv4: modelBuildingRequest.setBuildStartTime(request.getBuildStartTime());
             modelBuildingRequest.modelResolver(resolver);
-            modelBuildingRequest.modelRepositoryHolder(new DefaultModelRepositoryHolder(
+            DefaultModelRepositoryHolder holder = new DefaultModelRepositoryHolder(
                     internalSession,
                     DefaultModelRepositoryHolder.RepositoryMerging.valueOf(
                             request.getRepositoryMerging().name()),
                     repositories.stream()
                             .map(internalSession::getRemoteRepository)
-                            .toList()));
+                            .toList());
+            internalSession.getData().set(SessionData.key(DefaultModelRepositoryHolder.class), holder);
+            modelBuildingRequest.modelRepositoryHolder(holder);
             modelBuildingRequest.modelCache(modelCache);
             modelBuildingRequest.transformerContextBuilder(transformerContextBuilder);
             /* TODO: bv4


### PR DESCRIPTION
When building projects, the following can happen:
```
[INFO] --------------------------------------------------------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] --------------------------------------------------------------------------------------------------------------------------
[INFO] Total time:  3.423 s
[INFO] Finished at: 2024-05-13T10:12:27+02:00
[INFO] --------------------------------------------------------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-install-plugin:3.1.1:install (default-install) on project camel-util: Execution default-install of goal org.apache.maven.plugins:maven-install-plugin:3.1.1:install failed: 2 problems were encountered while building the effective model for /Users/gnodet/work/git/camel/core/camel-util/target/camel-util-4.6.0-SNAPSHOT.pom
[ERROR]     - [WARNING] 'parent.relativePath' points at org.apache.camel:camel-util instead of org.apache.camel:core, please verify your project structure @ line 22, column 3
[ERROR]     - [FATAL] Non-parseable POM org.apache.camel:core:4.6.0-SNAPSHOT: Unable to read model: Is a directory
[ERROR] -> [Help 1]
[ERROR] 
```