### PR TITLE
[MNG-8121] Fix NPE in metadata merge

### DIFF
--- a/api/maven-api-metadata/src/main/mdo/metadata.mdo
+++ b/api/maven-api-metadata/src/main/mdo/metadata.mdo
@@ -100,7 +100,7 @@ under the License.
 
             for ( Plugin preExisting : getPlugins() )
             {
-                if ( preExisting.getPrefix().equals( plugin.getPrefix() ) )
+                if ( java.util.Objects.equals( preExisting.getPrefix(), plugin.getPrefix() ) )
                 {
                     found = true;
                     break;


### PR DESCRIPTION
There is an NPE if existing metadata due bug of nx-staging-m-p had no prefix present.

---

https://issues.apache.org/jira/browse/MNG-8121