### PR TITLE
Maven 3.10.x should use Maven 3.1 validation in strict mode

### DIFF
--- a/maven-core/src/test/resources/projects/duplicate-plugins-merged-pom.xml
+++ b/maven-core/src/test/resources/projects/duplicate-plugins-merged-pom.xml
@@ -1,5 +1,5 @@
-<project>
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
     <groupId>tests.project</groupId>
     <artifactId>duplicate-plugin-defs-merged</artifactId>
     <version>1</version>
@@ -8,6 +8,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
           <dependencies>
             <dependency>
               <groupId>group</groupId>
@@ -24,25 +25,36 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>group</groupId>
-              <artifactId>second</artifactId>
-              <version>1</version>
-            </dependency>
-          </dependencies>
-          <executions>
-            <execution>
-              <id>second</id>
-              <goals>
-                <goal>compile</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
+       </plugins>
     </build>
+
+  <profiles>
+    <profile>
+      <id>foo</id>
+      <activation><activeByDefault>true</activeByDefault></activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>group</groupId>
+                <artifactId>second</artifactId>
+                <version>1</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <id>second</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingRequest.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingRequest.java
@@ -60,7 +60,7 @@ public interface ModelBuildingRequest {
     /**
      * Denotes strict validation as recommended by the current Maven version.
      */
-    int VALIDATION_LEVEL_STRICT = VALIDATION_LEVEL_MAVEN_3_0;
+    int VALIDATION_LEVEL_STRICT = VALIDATION_LEVEL_MAVEN_3_1;
 
     /**
      * Gets the raw model to build. If not set, model source will be used to load raw model.

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -54,6 +54,10 @@ public class DefaultModelValidatorTest {
         return validateEffective(pom, UnaryOperator.identity());
     }
 
+    private SimpleProblemCollector validate(String pom, int level) throws Exception {
+        return validateEffective(pom, mbr -> mbr.setValidationLevel(level));
+    }
+
     private SimpleProblemCollector validateRaw(String pom) throws Exception {
         return validateRaw(pom, UnaryOperator.identity());
     }
@@ -428,7 +432,7 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testHardCodedSystemPath() throws Exception {
-        SimpleProblemCollector result = validateRaw("hard-coded-system-path.xml");
+        SimpleProblemCollector result = validateRaw("hard-coded-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 1);
 
@@ -437,7 +441,7 @@ public class DefaultModelValidatorTest {
                 "'dependencies.dependency.systemPath' for test:a:jar should use a variable instead of a hard-coded path");
 
         SimpleProblemCollector result31 =
-                validateRaw("hard-coded-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1);
+                validateRaw("hard-coded-system-path.xml");
 
         assertViolations(result31, 0, 0, 3);
 
@@ -462,8 +466,8 @@ public class DefaultModelValidatorTest {
     }
 
     @Test
-    public void testDuplicatePlugin() throws Exception {
-        SimpleProblemCollector result = validateRaw("duplicate-plugin.xml");
+    public void testDuplicatePlugin30() throws Exception {
+        SimpleProblemCollector result = validateRaw("duplicate-plugin.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 4);
 
@@ -471,6 +475,18 @@ public class DefaultModelValidatorTest {
         assertTrue(result.getWarnings().get(1).contains("duplicate declaration of plugin test:managed-duplicate"));
         assertTrue(result.getWarnings().get(2).contains("duplicate declaration of plugin profile:duplicate"));
         assertTrue(result.getWarnings().get(3).contains("duplicate declaration of plugin profile:managed-duplicate"));
+    }
+
+    @Test
+    public void testDuplicatePlugin() throws Exception {
+        SimpleProblemCollector result = validateRaw("duplicate-plugin.xml");
+
+        assertViolations(result, 0, 4, 0);
+
+        assertTrue(result.getErrors().get(0).contains("duplicate declaration of plugin test:duplicate"));
+        assertTrue(result.getErrors().get(1).contains("duplicate declaration of plugin test:managed-duplicate"));
+        assertTrue(result.getErrors().get(2).contains("duplicate declaration of plugin profile:duplicate"));
+        assertTrue(result.getErrors().get(3).contains("duplicate declaration of plugin profile:managed-duplicate"));
     }
 
     @Test
@@ -486,8 +502,8 @@ public class DefaultModelValidatorTest {
     }
 
     @Test
-    public void testReservedRepositoryId() throws Exception {
-        SimpleProblemCollector result = validate("reserved-repository-id.xml");
+    public void testReservedRepositoryId30() throws Exception {
+        SimpleProblemCollector result = validate("reserved-repository-id.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 4);
 
@@ -496,6 +512,19 @@ public class DefaultModelValidatorTest {
         assertContains(result.getWarnings().get(2), "'distributionManagement.repository.id' must not be 'local'");
         assertContains(
                 result.getWarnings().get(3), "'distributionManagement.snapshotRepository.id' must not be 'local'");
+    }
+
+    @Test
+    public void testReservedRepositoryId() throws Exception {
+        SimpleProblemCollector result = validate("reserved-repository-id.xml");
+
+        assertViolations(result, 0, 4, 0);
+
+        assertContains(result.getErrors().get(0), "'repositories.repository.id'" + " must not be 'local'");
+        assertContains(result.getErrors().get(1), "'pluginRepositories.pluginRepository.id' must not be 'local'");
+        assertContains(result.getErrors().get(2), "'distributionManagement.repository.id' must not be 'local'");
+        assertContains(
+                result.getErrors().get(3), "'distributionManagement.snapshotRepository.id' must not be 'local'");
     }
 
     @Test
@@ -535,8 +564,8 @@ public class DefaultModelValidatorTest {
     }
 
     @Test
-    public void testBadVersion() throws Exception {
-        SimpleProblemCollector result = validate("bad-version.xml");
+    public void testBadVersion30() throws Exception {
+        SimpleProblemCollector result = validate("bad-version.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 1);
 
@@ -544,8 +573,17 @@ public class DefaultModelValidatorTest {
     }
 
     @Test
-    public void testBadSnapshotVersion() throws Exception {
-        SimpleProblemCollector result = validate("bad-snapshot-version.xml");
+    public void testBadVersion() throws Exception {
+        SimpleProblemCollector result = validate("bad-version.xml");
+
+        assertViolations(result, 0, 1, 0);
+
+        assertContains(result.getErrors().get(0), "'version' must not contain any of these characters");
+    }
+
+    @Test
+    public void testBadSnapshotVersion30() throws Exception {
+        SimpleProblemCollector result = validate("bad-snapshot-version.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 1);
 
@@ -553,8 +591,17 @@ public class DefaultModelValidatorTest {
     }
 
     @Test
-    public void testBadRepositoryId() throws Exception {
-        SimpleProblemCollector result = validate("bad-repository-id.xml");
+    public void testBadSnapshotVersion() throws Exception {
+        SimpleProblemCollector result = validate("bad-snapshot-version.xml");
+
+        assertViolations(result, 0, 1, 0);
+
+        assertContains(result.getErrors().get(0), "'version' uses an unsupported snapshot version format");
+    }
+
+    @Test
+    public void testBadRepositoryId30() throws Exception {
+        SimpleProblemCollector result = validate("bad-repository-id.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 4);
 
@@ -568,6 +615,25 @@ public class DefaultModelValidatorTest {
                 "'distributionManagement.repository.id' must not contain any of these characters");
         assertContains(
                 result.getWarnings().get(3),
+                "'distributionManagement.snapshotRepository.id' must not contain any of these characters");
+    }
+
+    @Test
+    public void testBadRepositoryId() throws Exception {
+        SimpleProblemCollector result = validate("bad-repository-id.xml");
+
+        assertViolations(result, 0, 4, 0);
+
+        assertContains(
+                result.getErrors().get(0), "'repositories.repository.id' must not contain any of these characters");
+        assertContains(
+                result.getErrors().get(1),
+                "'pluginRepositories.pluginRepository.id' must not contain any of these characters");
+        assertContains(
+                result.getErrors().get(2),
+                "'distributionManagement.repository.id' must not contain any of these characters");
+        assertContains(
+                result.getErrors().get(3),
                 "'distributionManagement.snapshotRepository.id' must not contain any of these characters");
     }
 
@@ -629,7 +695,7 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testSystemPathRefersToProjectBasedir() throws Exception {
-        SimpleProblemCollector result = validateRaw("basedir-system-path.xml");
+        SimpleProblemCollector result = validateRaw("basedir-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 2);
 
@@ -641,7 +707,7 @@ public class DefaultModelValidatorTest {
                 "'dependencies.dependency.systemPath' for test:b:jar should not point at files within the project directory");
 
         SimpleProblemCollector result31 =
-                validateRaw("basedir-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1);
+                validateRaw("basedir-system-path.xml");
 
         assertViolations(result31, 0, 0, 4);
 

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -432,7 +432,8 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testHardCodedSystemPath() throws Exception {
-        SimpleProblemCollector result = validateRaw("hard-coded-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+        SimpleProblemCollector result =
+                validateRaw("hard-coded-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 1);
 
@@ -440,8 +441,7 @@ public class DefaultModelValidatorTest {
                 result.getWarnings().get(0),
                 "'dependencies.dependency.systemPath' for test:a:jar should use a variable instead of a hard-coded path");
 
-        SimpleProblemCollector result31 =
-                validateRaw("hard-coded-system-path.xml");
+        SimpleProblemCollector result31 = validateRaw("hard-coded-system-path.xml");
 
         assertViolations(result31, 0, 0, 3);
 
@@ -467,7 +467,8 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testDuplicatePlugin30() throws Exception {
-        SimpleProblemCollector result = validateRaw("duplicate-plugin.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+        SimpleProblemCollector result =
+                validateRaw("duplicate-plugin.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 4);
 
@@ -503,7 +504,8 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testReservedRepositoryId30() throws Exception {
-        SimpleProblemCollector result = validate("reserved-repository-id.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+        SimpleProblemCollector result =
+                validate("reserved-repository-id.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 4);
 
@@ -523,8 +525,7 @@ public class DefaultModelValidatorTest {
         assertContains(result.getErrors().get(0), "'repositories.repository.id'" + " must not be 'local'");
         assertContains(result.getErrors().get(1), "'pluginRepositories.pluginRepository.id' must not be 'local'");
         assertContains(result.getErrors().get(2), "'distributionManagement.repository.id' must not be 'local'");
-        assertContains(
-                result.getErrors().get(3), "'distributionManagement.snapshotRepository.id' must not be 'local'");
+        assertContains(result.getErrors().get(3), "'distributionManagement.snapshotRepository.id' must not be 'local'");
     }
 
     @Test
@@ -583,7 +584,8 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testBadSnapshotVersion30() throws Exception {
-        SimpleProblemCollector result = validate("bad-snapshot-version.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+        SimpleProblemCollector result =
+                validate("bad-snapshot-version.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 1);
 
@@ -601,7 +603,8 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testBadRepositoryId30() throws Exception {
-        SimpleProblemCollector result = validate("bad-repository-id.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+        SimpleProblemCollector result =
+                validate("bad-repository-id.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 4);
 
@@ -695,7 +698,8 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testSystemPathRefersToProjectBasedir() throws Exception {
-        SimpleProblemCollector result = validateRaw("basedir-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+        SimpleProblemCollector result =
+                validateRaw("basedir-system-path.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
         assertViolations(result, 0, 0, 2);
 
@@ -706,8 +710,7 @@ public class DefaultModelValidatorTest {
                 result.getWarnings().get(1),
                 "'dependencies.dependency.systemPath' for test:b:jar should not point at files within the project directory");
 
-        SimpleProblemCollector result31 =
-                validateRaw("basedir-system-path.xml");
+        SimpleProblemCollector result31 = validateRaw("basedir-system-path.xml");
 
         assertViolations(result31, 0, 0, 4);
 


### PR DESCRIPTION
Changes `VALIDATION_LEVEL_STRICT` from `VALIDATION_LEVEL_MAVEN_3_0` (30) to `VALIDATION_LEVEL_MAVEN_3_1` (31).

In strict mode (the default for project builds), the `getSeverity(request, errorThreshold)` method returns `ERROR` when `validationLevel >= threshold` and `WARNING` otherwise. By raising the strict level from 3.0 to 3.1, the following checks are promoted from warnings to errors:

- **Duplicate plugin declarations** in `build/plugins`
- **Banned characters in version strings** (e.g. backslash, expression fragments)
- **Unsupported snapshot version formats** (non-standard SNAPSHOT qualifiers)
- **Banned characters in repository IDs**
- **Reserved repository ID `local`**

Additional warnings are now emitted for:
- `system` scope dependency deprecation
- Hard-coded system paths in `systemPath`
- `${basedir}`-relative system paths

The test resource `duplicate-plugins-merged-pom.xml` was updated to move the duplicate plugin into a profile (avoiding the raw validation error while still testing plugin merge behavior).

Unit tests updated to explicitly use `VALIDATION_LEVEL_MAVEN_3_0` where the test exercises pre-3.1 behavior, and to use the default (now 3.1) level where the stricter validation is expected.

Companion IT PR: https://github.com/apache/maven-integration-testing/pull/441