### PR TITLE
Fix grammar in validation message

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultDependencyManagementImporter.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultDependencyManagementImporter.java
@@ -78,7 +78,7 @@ public class DefaultDependencyManagementImporter implements DependencyManagement
                                 Severity.WARNING,
                                 Version.V40,
                                 "Ignored POM import for: " + toString(dependency) + " as already imported "
-                                        + toString(present) + ".  Add a the conflicting managed dependency directly "
+                                        + toString(present) + ". Add the conflicting managed dependency directly "
                                         + "to the dependencyManagement section of the POM.");
                     }
                 }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultDependencyManagementImporter.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/composition/DefaultDependencyManagementImporter.java
@@ -70,7 +70,7 @@ public class DefaultDependencyManagementImporter implements DependencyManagement
                         problems.add(new ModelProblemCollectorRequest(
                                         ModelProblem.Severity.WARNING, ModelProblem.Version.V40)
                                 .setMessage("Ignored POM import for: " + toString(dependency) + " as already imported "
-                                        + toString(present) + ".  Add a the conflicting managed dependency directly "
+                                        + toString(present) + ". Add the conflicting managed dependency directly "
                                         + "to the dependencyManagement section of the POM."));
                     }
                 }


### PR DESCRIPTION
Fix grammar and whitespace in validation message.

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [ ] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
