### PR TITLE
[MNG-5693] Remove unhelpful links that don't describe failure reasons from output

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -32,7 +32,6 @@ import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelProblemUtils;
 import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.PluginContainerException;
 import org.apache.maven.plugin.PluginExecutionException;
 import org.apache.maven.project.ProjectBuildingException;
@@ -171,8 +170,6 @@ public class DefaultExceptionHandler implements ExceptionHandler {
                         reference = ConnectException.class.getSimpleName();
                     }
                 }
-            } else if (exception instanceof MojoFailureException) {
-                reference = MojoFailureException.class.getSimpleName();
             } else if (exception instanceof LinkageError) {
                 reference = LinkageError.class.getSimpleName();
             } else if (exception instanceof PluginExecutionException) {


### PR DESCRIPTION
[MNG-5693] Remove unhelpful links that don't describe failure reasons from output

This removes these lines from the end of every failing build:

```
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```