### PR TITLE
[MNG-8141] Model builder should report problems it finds during build

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -797,7 +797,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             if (activations.put(profile.getId(), activation) != null) {
                 problems.add(new ModelProblemCollectorRequest(
                                 failOnInvalidModel ? Severity.FATAL : Severity.WARNING, ModelProblem.Version.BASE)
-                        .setMessage("Duplicate activation for " + profile.getId()));
+                        .setMessage("Duplicate activation for profile " + profile.getId()));
             }
         }
 

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -99,8 +99,10 @@ import static org.apache.maven.model.building.Result.newResult;
 public class DefaultModelBuilder implements ModelBuilder {
     /**
      * Key for "fail on invalid model" property.
+     * <p>
+     * Visible for testing.
      */
-    private static final String FAIL_ON_INVALID_MODEL = "maven.modelBuilder.failOnInvalidModel";
+    static final String FAIL_ON_INVALID_MODEL = "maven.modelBuilder.failOnInvalidModel";
 
     /**
      * Checks user and system properties (in this order) for value of {@link #FAIL_ON_INVALID_MODEL} property key, if

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -431,7 +431,7 @@ public class DefaultModelBuilder implements ModelBuilder {
 
     private Map<String, Activation> getInterpolatedActivations(
             Model rawModel, DefaultProfileActivationContext context, DefaultModelProblemCollector problems) {
-        Map<String, Activation> interpolatedActivations = getProfileActivations(rawModel, true);
+        Map<String, Activation> interpolatedActivations = getProfileActivations(rawModel, true, problems);
 
         if (interpolatedActivations.isEmpty()) {
             return Collections.emptyMap();
@@ -753,7 +753,7 @@ public class DefaultModelBuilder implements ModelBuilder {
         }
     }
 
-    private Map<String, Activation> getProfileActivations(Model model, boolean clone) {
+    private Map<String, Activation> getProfileActivations(Model model, boolean clone, ModelProblemCollector problems) {
         Map<String, Activation> activations = new HashMap<>();
         for (Profile profile : model.getProfiles()) {
             Activation activation = profile.getActivation();
@@ -766,7 +766,10 @@ public class DefaultModelBuilder implements ModelBuilder {
                 activation = activation.clone();
             }
 
-            activations.put(profile.getId(), activation);
+            if (activations.put(profile.getId(), activation) != null) {
+                problems.add(new ModelProblemCollectorRequest(ModelProblem.Severity.FATAL, ModelProblem.Version.BASE)
+                        .setMessage("Duplicate activation for " + profile.getId()));
+            }
         }
 
         return activations;
@@ -787,7 +790,7 @@ public class DefaultModelBuilder implements ModelBuilder {
 
     private Model interpolateModel(Model model, ModelBuildingRequest request, ModelProblemCollector problems) {
         // save profile activations before interpolation, since they are evaluated with limited scope
-        Map<String, Activation> originalActivations = getProfileActivations(model, true);
+        Map<String, Activation> originalActivations = getProfileActivations(model, true, problems);
 
         Model interpolatedModel =
                 modelInterpolator.interpolateModel(model, model.getProjectDirectory(), request, problems);

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.model.building;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.resolution.InvalidRepositoryException;
@@ -26,7 +27,10 @@ import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.junit.Test;
 
+import java.io.File;
+
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Guillaume Nodet
@@ -85,6 +89,23 @@ public class DefaultModelBuilderTest {
         request.setModelResolver(new CycleInImportsResolver());
 
         builder.build(request);
+    }
+
+    @Test
+    public void testBadProfiles() {
+        ModelBuilder builder = new DefaultModelBuilderFactory().newInstance();
+        assertNotNull(builder);
+
+        DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
+        request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+        request.setModelSource(new FileModelSource(new File("src/test/resources/poms/building/badprofiles.xml")));
+        request.setModelResolver(new BaseModelResolver());
+
+        try {
+            builder.build(request);
+        } catch (ModelBuildingException e) {
+            assertTrue(e.getMessage().contains("Duplicate activation for profile badprofile"));
+        }
     }
 
     static class CycleInImportsResolver extends BaseModelResolver {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Guillaume Nodet
@@ -101,10 +102,25 @@ public class DefaultModelBuilderTest {
         request.setModelResolver(new BaseModelResolver());
 
         try {
-            builder.build(request);
+            builder.build(request); // throw, making "pom not available"
+            fail();
         } catch (ModelBuildingException e) {
             assertTrue(e.getMessage().contains("Duplicate activation for profile badprofile"));
         }
+    }
+
+    @Test
+    public void testBadProfilesCheckDisabled() throws Exception {
+        ModelBuilder builder = new DefaultModelBuilderFactory().newInstance();
+        assertNotNull(builder);
+
+        DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
+        request.getUserProperties().setProperty(DefaultModelBuilder.FAIL_ON_INVALID_MODEL, "false");
+        request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+        request.setModelSource(new FileModelSource(new File("src/test/resources/poms/building/badprofiles.xml")));
+        request.setModelResolver(new BaseModelResolver());
+
+        builder.build(request); // does not throw, old behaviour (but result may be fully off)
     }
 
     static class CycleInImportsResolver extends BaseModelResolver {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
@@ -18,16 +18,15 @@
  */
 package org.apache.maven.model.building;
 
+import java.io.File;
+
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.resolution.InvalidRepositoryException;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.junit.Test;
-
-import java.io.File;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/maven-model-builder/src/test/resources/poms/building/badprofiles.xml
+++ b/maven-model-builder/src/test/resources/poms/building/badprofiles.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test</groupId>
+  <artifactId>test</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <profiles>
+    <profile>
+      <id>badprofile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      </properties>
+    </profile>
+    <profile>
+      <id>badprofile</id>
+      <activation>
+        <file>
+          <exists>simple.xml</exists>
+        </file>
+      </activation>
+      <properties>
+        <profile.file>activated</profile.file>
+      </properties>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
And not rely that model was validated, which is not true in some cases. Model builder can still easily detect issues with models while building them.

Provides "escape hatch" for projects stuck on invalid models in form of user property that can be enabled with `-Dmaven.modelBuilder.failOnInvalidModel=false`, this reverts to _old_ behaviour of maven, and the JavaFX reproducer goes back to error "unable to resolve" errors with uninterpolated `${javafx.platform}` property as classifier.

---

https://issues.apache.org/jira/browse/MNG-8141