### PR TITLE
[MNG-8141][MNG-8147] Restore profile ID invariance but warn if duplicate IDs present

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -35,9 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
@@ -305,18 +303,17 @@ public class DefaultModelBuilder implements ModelBuilder {
 
             profileActivationContext.setProjectProperties(tmpModel.getProperties());
 
-            Map<String, Activation> interpolatedActivations =
-                    getInterpolatedActivations(rawModel, profileActivationContext, problems);
-            injectProfileActivations(tmpModel, interpolatedActivations);
+            List<Profile> interpolatedProfiles = getInterpolatedProfiles(rawModel, profileActivationContext, problems);
+            tmpModel.setProfiles(interpolatedProfiles);
 
             List<Profile> activePomProfiles =
                     profileSelector.getActiveProfiles(tmpModel.getProfiles(), profileActivationContext, problems);
 
-            Set<String> activeProfileIds =
-                    activePomProfiles.stream().map(Profile::getId).collect(Collectors.toSet());
-            currentData.setActiveProfiles(rawModel.getProfiles().stream()
-                    .filter(p -> activeProfileIds.contains(p.getId()))
-                    .collect(Collectors.toList()));
+            List<Profile> rawProfiles = new ArrayList<>();
+            for (Profile activePomProfile : activePomProfiles) {
+                rawProfiles.add(rawModel.getProfiles().get(interpolatedProfiles.indexOf(activePomProfile)));
+            }
+            currentData.setActiveProfiles(rawProfiles);
 
             // profile injection
             for (Profile activeProfile : activePomProfiles) {
@@ -429,12 +426,12 @@ public class DefaultModelBuilder implements ModelBuilder {
         String apply(String s) throws InterpolationException;
     }
 
-    private Map<String, Activation> getInterpolatedActivations(
+    private List<Profile> getInterpolatedProfiles(
             Model rawModel, DefaultProfileActivationContext context, DefaultModelProblemCollector problems) {
-        Map<String, Activation> interpolatedActivations = getProfileActivations(rawModel, true);
+        List<Profile> interpolatedActivations = getProfiles(rawModel, true);
 
         if (interpolatedActivations.isEmpty()) {
-            return Collections.emptyMap();
+            return Collections.emptyList();
         }
         RegexBasedInterpolator interpolator = new RegexBasedInterpolator();
 
@@ -466,8 +463,9 @@ public class DefaultModelBuilder implements ModelBuilder {
                 }
             }
         }
-        for (Activation activation : interpolatedActivations.values()) {
-            Optional<Activation> a = Optional.of(activation);
+        for (Profile profile : interpolatedActivations) {
+            Activation activation = profile.getActivation();
+            Optional<Activation> a = Optional.ofNullable(activation);
             a.map(Activation::getFile).ifPresent(fa -> {
                 Interpolation nt =
                         new Interpolation(fa, s -> profileActivationFilePathInterpolator.interpolate(s, context));
@@ -753,41 +751,20 @@ public class DefaultModelBuilder implements ModelBuilder {
         }
     }
 
-    private Map<String, Activation> getProfileActivations(Model model, boolean clone) {
-        Map<String, Activation> activations = new HashMap<>();
+    private List<Profile> getProfiles(Model model, boolean clone) {
+        ArrayList<Profile> profiles = new ArrayList<>();
         for (Profile profile : model.getProfiles()) {
-            Activation activation = profile.getActivation();
-
-            if (activation == null) {
-                continue;
-            }
-
             if (clone) {
-                activation = activation.clone();
+                profile = profile.clone();
             }
-
-            activations.put(profile.getId(), activation);
+            profiles.add(profile);
         }
-
-        return activations;
-    }
-
-    private void injectProfileActivations(Model model, Map<String, Activation> activations) {
-        for (Profile profile : model.getProfiles()) {
-            Activation activation = profile.getActivation();
-
-            if (activation == null) {
-                continue;
-            }
-
-            // restore activation
-            profile.setActivation(activations.get(profile.getId()));
-        }
+        return profiles;
     }
 
     private Model interpolateModel(Model model, ModelBuildingRequest request, ModelProblemCollector problems) {
         // save profile activations before interpolation, since they are evaluated with limited scope
-        Map<String, Activation> originalActivations = getProfileActivations(model, true);
+        List<Profile> originalActivations = getProfiles(model, true);
 
         Model interpolatedModel =
                 modelInterpolator.interpolateModel(model, model.getProjectDirectory(), request, problems);
@@ -815,7 +792,7 @@ public class DefaultModelBuilder implements ModelBuilder {
         interpolatedModel.setPomFile(model.getPomFile());
 
         // restore profiles with file activation to their value before full interpolation
-        injectProfileActivations(model, originalActivations);
+        model.setProfiles(originalActivations);
 
         return interpolatedModel;
     }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -463,7 +464,12 @@ public class DefaultModelBuilder implements ModelBuilder {
                 }
             }
         }
+        HashSet<String> profileIds = new HashSet<>();
         for (Profile profile : interpolatedActivations) {
+            if (!profileIds.add(profile.getId())) {
+                problems.add(new ModelProblemCollectorRequest(Severity.WARNING, ModelProblem.Version.BASE)
+                        .setMessage("Duplicate activation for profile " + profile.getId()));
+            }
             Activation activation = profile.getActivation();
             Optional<Activation> a = Optional.ofNullable(activation);
             a.map(Activation::getFile).ifPresent(fa -> {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingException.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingException.java
@@ -122,7 +122,7 @@ public class ModelBuildingException extends Exception {
         return Collections.unmodifiableList(result.getProblems());
     }
 
-    public static String toMessage(ModelBuildingResult result) {
+    private static String toMessage(ModelBuildingResult result) {
         if (result != null && !result.getModelIds().isEmpty()) {
             return toMessage(result.getModelIds().get(0), result.getProblems());
         }
@@ -137,7 +137,7 @@ public class ModelBuildingException extends Exception {
         writer.print(problems.size());
         writer.print((problems.size() == 1) ? " problem was " : " problems were ");
         writer.print("encountered while building the effective model");
-        if (modelId != null && !modelId.isEmpty()) {
+        if (modelId != null && modelId.length() > 0) {
             writer.print(" for ");
             writer.print(modelId);
         }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingException.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/ModelBuildingException.java
@@ -122,7 +122,7 @@ public class ModelBuildingException extends Exception {
         return Collections.unmodifiableList(result.getProblems());
     }
 
-    private static String toMessage(ModelBuildingResult result) {
+    public static String toMessage(ModelBuildingResult result) {
         if (result != null && !result.getModelIds().isEmpty()) {
             return toMessage(result.getModelIds().get(0), result.getProblems());
         }
@@ -137,7 +137,7 @@ public class ModelBuildingException extends Exception {
         writer.print(problems.size());
         writer.print((problems.size() == 1) ? " problem was " : " problems were ");
         writer.print("encountered while building the effective model");
-        if (modelId != null && modelId.length() > 0) {
+        if (modelId != null && !modelId.isEmpty()) {
             writer.print(" for ");
             writer.print(modelId);
         }

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -40,6 +40,7 @@ import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelProblemUtils;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
@@ -291,18 +292,19 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                 // ModelBuildingEx is thrown only on FATAL and ERROR severities, but we still can have WARNs
                 // that may lead to unexpected build failure, log them
                 if (!modelResult.getProblems().isEmpty()) {
+                    List<ModelProblem> problems = modelResult.getProblems();
+                    logger.warn(
+                            "{} {} encountered while building the effective model for {}",
+                            problems.size(),
+                            (problems.size() == 1) ? "problem was" : "problems were",
+                            request.getArtifact());
                     if (logger.isDebugEnabled()) {
-                        String message = ModelBuildingException.toMessage(modelResult);
-                        if (message != null) {
-                            logger.warn(message);
+                        for (ModelProblem problem : problems) {
+                            logger.warn(
+                                    "{} @ {}",
+                                    problem.getMessage(),
+                                    ModelProblemUtils.formatLocation(problem, null));
                         }
-                    } else {
-                        List<ModelProblem> problems = modelResult.getProblems();
-                        logger.warn(
-                                "{} {} encountered while building the effective model for {}",
-                                problems.size(),
-                                (problems.size() == 1) ? "problem was" : "problems were",
-                                request.getArtifact());
                     }
                 }
                 model = modelResult.getEffectiveModel();

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -37,6 +38,7 @@ import org.apache.maven.model.building.FileModelSource;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.eclipse.aether.RepositoryEvent;
@@ -67,6 +69,8 @@ import org.eclipse.aether.resolution.VersionResult;
 import org.eclipse.aether.spi.locator.Service;
 import org.eclipse.aether.spi.locator.ServiceLocator;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Benjamin Bentmann
@@ -90,6 +94,8 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
 
     private final ArtifactDescriptorReaderDelegate artifactDescriptorReaderDelegate =
             new ArtifactDescriptorReaderDelegate();
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Deprecated
     public DefaultArtifactDescriptorReader() {
@@ -281,7 +287,25 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                     modelRequest.setModelSource(new FileModelSource(pomArtifact.getFile()));
                 }
 
-                model = modelBuilder.build(modelRequest).getEffectiveModel();
+                ModelBuildingResult modelResult = modelBuilder.build(modelRequest);
+                // ModelBuildingEx is thrown only on FATAL and ERROR severities, but we still can have WARNs
+                // that may lead to unexpected build failure, log them
+                if (!modelResult.getProblems().isEmpty()) {
+                    if (logger.isDebugEnabled()) {
+                        String message = ModelBuildingException.toMessage(modelResult);
+                        if (message != null) {
+                            logger.warn(message);
+                        }
+                    } else {
+                        List<ModelProblem> problems = modelResult.getProblems();
+                        logger.warn(
+                                "{} {} encountered while building the effective model for {}",
+                                problems.size(),
+                                (problems.size() == 1) ? "problem was" : "problems were",
+                                request.getArtifact());
+                    }
+                }
+                model = modelResult.getEffectiveModel();
             } catch (ModelBuildingException e) {
                 for (ModelProblem problem : e.getProblems()) {
                     if (problem.getException() instanceof UnresolvableModelException) {


### PR DESCRIPTION
Fix and improvement in one PR as they are closely related.
First, this PR restores the ability (broken by MNG-8081) to calculate Profile activation for POMs with duplicate Profile ID.
Second, this PR improves UX by warning them about invalid models in their build.

The reproducer now looks like this:
https://gist.github.com/cstamas/165a610b233f4c03e381a0a2697903eb

Notice:
* WARNs issued about models (all Maven versions are mute about this)
* still, property `${javafx.platform}` properly evaluated just like in 3.9.6 (but not in 3.9.7)
* build succeeds (fails in 3.9.7)

---

https://issues.apache.org/jira/browse/MNG-8147
https://issues.apache.org/jira/browse/MNG-8141