### PR TITLE
[MNG-8141] Model Builder report issues during build

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -33,7 +34,9 @@ import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelProblemUtils;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
@@ -61,6 +64,8 @@ import org.eclipse.aether.resolution.VersionRequest;
 import org.eclipse.aether.resolution.VersionResolutionException;
 import org.eclipse.aether.resolution.VersionResult;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default artifact descriptor reader.
@@ -77,6 +82,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
     private final ModelCacheFactory modelCacheFactory;
     private final Map<String, MavenArtifactRelocationSource> artifactRelocationSources;
     private final ArtifactDescriptorReaderDelegate delegate;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject
     public DefaultArtifactDescriptorReader(
@@ -220,7 +226,24 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                             pomArtifact.getVersion()));
                 }
 
-                model = modelBuilder.build(modelRequest).getEffectiveModel();
+                ModelBuildingResult modelResult = modelBuilder.build(modelRequest);
+                // ModelBuildingEx is thrown only on FATAL and ERROR severities, but we still can have WARNs
+                // that may lead to unexpected build failure, log them
+                if (!modelResult.getProblems().isEmpty()) {
+                    List<ModelProblem> problems = modelResult.getProblems();
+                    logger.warn(
+                            "{} {} encountered while building the effective model for {}",
+                            problems.size(),
+                            (problems.size() == 1) ? "problem was" : "problems were",
+                            request.getArtifact());
+                    if (logger.isDebugEnabled()) {
+                        for (ModelProblem problem : problems) {
+                            logger.warn(
+                                    "{} @ {}", problem.getMessage(), ModelProblemUtils.formatLocation(problem, null));
+                        }
+                    }
+                }
+                model = modelResult.getEffectiveModel();
             } catch (ModelBuildingException e) {
                 for (ModelProblem problem : e.getProblems()) {
                     if (problem.getException() instanceof UnresolvableModelException) {


### PR DESCRIPTION
And ArtifactDescriptorReader should not "toss away" but report WARNings (as in case of ERROR or FATAL MB throws).

Part 1: port ArtifactDescriptorReader to not loose WARNs

---

https://issues.apache.org/jira/browse/MNG-8141