### PR TITLE
[MNG-8141] Aftermath, and tidy up

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -464,12 +463,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 }
             }
         }
-        HashSet<String> profileIds = new HashSet<>();
         for (Profile profile : interpolatedActivations) {
-            if (!profileIds.add(profile.getId())) {
-                problems.add(new ModelProblemCollectorRequest(Severity.WARNING, ModelProblem.Version.BASE)
-                        .setMessage("Duplicate activation for profile " + profile.getId()));
-            }
             Activation activation = profile.getActivation();
             Optional<Activation> a = Optional.ofNullable(activation);
             a.map(Activation::getFile).ifPresent(fa -> {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -95,6 +95,7 @@ public class DefaultModelValidator implements ModelValidator {
         this.versionProcessor = versionProcessor;
     }
 
+    @SuppressWarnings("checkstyle:methodlength")
     @Override
     public void validateRawModel(Model m, ModelBuildingRequest request, ModelProblemCollector problems) {
         Parent parent = m.getParent();
@@ -132,7 +133,22 @@ public class DefaultModelValidator implements ModelValidator {
             }
         }
 
-        if (request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
+        if (request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL) {
+            // profiles: they are essential for proper model building (may contribute profiles, dependencies...)
+            HashSet<String> minProfileIds = new HashSet<>();
+            for (Profile profile : m.getProfiles()) {
+                if (!minProfileIds.add(profile.getId())) {
+                    addViolation(
+                            problems,
+                            Severity.WARNING,
+                            Version.BASE,
+                            "profiles.profile.id",
+                            null,
+                            "Duplicate activation for profile " + profile.getId(),
+                            profile);
+                }
+            }
+        } else if (request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
             Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
             // [MNG-6074] Maven should produce an error if no model version has been set in a POM file used to build an


### PR DESCRIPTION
No (logic) change, merely moved the new code to proper place (validation) to not piggy back onto processing: this is much cleaner.

---

https://issues.apache.org/jira/browse/MNG-8141

Inspired by suggestions in master PR https://github.com/apache/maven/pull/1569