### PR TITLE
[MNG-8150] Backport TransferListener improvements for Maven 3.9.x

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/transfer/SimplexTransferListener.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/transfer/SimplexTransferListener.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.cli.transfer;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -129,7 +128,7 @@ public final class SimplexTransferListener extends AbstractTransferListener {
                             LOGGER.warn("Invalid TransferEvent.EventType={}; ignoring it", type);
                     }
                 } catch (TransferCancelledException e) {
-                    ongoing.put(transferEvent.getResource().getFile(), Boolean.FALSE);
+                    ongoing.put(new TransferResourceIdentifier(transferEvent.getResource()), Boolean.FALSE);
                 }
             });
         }
@@ -150,17 +149,17 @@ public final class SimplexTransferListener extends AbstractTransferListener {
         }
     }
 
-    private final ConcurrentHashMap<File, Boolean> ongoing = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<TransferResourceIdentifier, Boolean> ongoing = new ConcurrentHashMap<>();
 
     @Override
     public void transferInitiated(TransferEvent event) {
-        ongoing.putIfAbsent(event.getResource().getFile(), Boolean.TRUE);
+        ongoing.putIfAbsent(new TransferResourceIdentifier(event.getResource()), Boolean.TRUE);
         put(event, false);
     }
 
     @Override
     public void transferStarted(TransferEvent event) throws TransferCancelledException {
-        if (ongoing.get(event.getResource().getFile()) == Boolean.FALSE) {
+        if (ongoing.get(new TransferResourceIdentifier(event.getResource())) == Boolean.FALSE) {
             throw new TransferCancelledException();
         }
         put(event, false);
@@ -168,7 +167,7 @@ public final class SimplexTransferListener extends AbstractTransferListener {
 
     @Override
     public void transferProgressed(TransferEvent event) throws TransferCancelledException {
-        if (ongoing.get(event.getResource().getFile()) == Boolean.FALSE) {
+        if (ongoing.get(new TransferResourceIdentifier(event.getResource())) == Boolean.FALSE) {
             throw new TransferCancelledException();
         }
         put(event, false);
@@ -176,7 +175,7 @@ public final class SimplexTransferListener extends AbstractTransferListener {
 
     @Override
     public void transferCorrupted(TransferEvent event) throws TransferCancelledException {
-        if (ongoing.get(event.getResource().getFile()) == Boolean.FALSE) {
+        if (ongoing.get(new TransferResourceIdentifier(event.getResource())) == Boolean.FALSE) {
             throw new TransferCancelledException();
         }
         put(event, false);
@@ -184,13 +183,13 @@ public final class SimplexTransferListener extends AbstractTransferListener {
 
     @Override
     public void transferSucceeded(TransferEvent event) {
-        ongoing.remove(event.getResource().getFile());
+        ongoing.remove(new TransferResourceIdentifier(event.getResource()));
         put(event, ongoing.isEmpty());
     }
 
     @Override
     public void transferFailed(TransferEvent event) {
-        ongoing.remove(event.getResource().getFile());
+        ongoing.remove(new TransferResourceIdentifier(event.getResource()));
         put(event, ongoing.isEmpty());
     }
 

--- a/maven-embedder/src/main/java/org/apache/maven/cli/transfer/TransferResourceIdentifier.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/transfer/TransferResourceIdentifier.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.transfer;
+
+import java.io.File;
+import java.util.Objects;
+
+import org.eclipse.aether.transfer.TransferResource;
+import org.eclipse.sisu.Nullable;
+
+/**
+ * Immutable identifier of a {@link TransferResource}.
+ * The {@link TransferResource} is not immutable and does not implement {@code Objects#equals} and {@code Objects#hashCode} methods,
+ * making it not very suitable for usage in collections.
+ */
+final class TransferResourceIdentifier {
+
+    private final String repositoryId;
+    private final String repositoryUrl;
+    private final String resourceName;
+
+    @Nullable
+    private final File file;
+
+    private TransferResourceIdentifier(
+            String repositoryId, String repositoryUrl, String resourceName, @Nullable File file) {
+        this.repositoryId = repositoryId;
+        this.repositoryUrl = repositoryUrl;
+        this.resourceName = resourceName;
+        this.file = file;
+    }
+
+    TransferResourceIdentifier(TransferResource resource) {
+        this(resource.getRepositoryId(), resource.getRepositoryUrl(), resource.getResourceName(), resource.getFile());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        TransferResourceIdentifier that = (TransferResourceIdentifier) obj;
+        return Objects.equals(this.repositoryId, that.repositoryId)
+                && Objects.equals(this.repositoryUrl, that.repositoryUrl)
+                && Objects.equals(this.resourceName, that.resourceName)
+                && Objects.equals(this.file, that.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(repositoryId, repositoryUrl, resourceName, file);
+    }
+}


### PR DESCRIPTION
## Summary
Backporting https://github.com/apache/maven/pull/1575 to Maven 3.9.x.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)