### PR TITLE
[MNG-8165] top/root/multimodule mixup

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
+++ b/maven-core/src/main/java/org/apache/maven/execution/MavenExecutionRequest.java
@@ -433,12 +433,16 @@ public interface MavenExecutionRequest {
 
     /**
      * @since 3.3.0
+     * @deprecated
      */
+    @Deprecated
     void setMultiModuleProjectDirectory(File file);
 
     /**
      * @since 3.3.0
+     * @deprecated
      */
+    @Deprecated
     File getMultiModuleProjectDirectory();
 
     /**

--- a/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CliRequest.java
@@ -39,6 +39,7 @@ public class CliRequest {
 
     String workingDirectory;
 
+    @Deprecated
     File multiModuleProjectDirectory;
 
     Path rootDirectory;

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -321,7 +321,7 @@ public class MavenCli {
         // the -f/--file option.  However, the command line isn't parsed yet, so
         // we need to iterate through the args to find it and act upon it.
         Path cwd = Paths.get(cliRequest.workingDirectory);
-        // MavenCliTest extensively use MULTIMODULE_PROJECT_DIRECTORY
+        // MavenCliTest extensively uses MULTIMODULE_PROJECT_DIRECTORY
         Path topDirectory = cliRequest.multiModuleProjectDirectory.toPath();
         boolean isAltFile = false;
         for (String arg : cliRequest.args) {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -321,6 +321,7 @@ public class MavenCli {
         // the -f/--file option.  However, the command line isn't parsed yet, so
         // we need to iterate through the args to find it and act upon it.
         Path cwd = Paths.get(cliRequest.workingDirectory);
+        // MavenCliTest extensively use MULTIMODULE_PROJECT_DIRECTORY
         Path topDirectory = cliRequest.multiModuleProjectDirectory.toPath();
         boolean isAltFile = false;
         for (String arg : cliRequest.args) {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -30,6 +30,7 @@ import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -319,12 +320,13 @@ public class MavenCli {
         // We need to locate the top level project which may be pointed at using
         // the -f/--file option.  However, the command line isn't parsed yet, so
         // we need to iterate through the args to find it and act upon it.
+        Path cwd = Paths.get(cliRequest.workingDirectory);
         Path topDirectory = cliRequest.multiModuleProjectDirectory.toPath();
         boolean isAltFile = false;
         for (String arg : cliRequest.args) {
             if (isAltFile) {
                 // this is the argument following -f/--file
-                Path path = topDirectory.resolve(stripLeadingAndTrailingQuotes(arg));
+                Path path = cwd.resolve(stripLeadingAndTrailingQuotes(arg));
                 if (Files.isDirectory(path)) {
                     topDirectory = path;
                 } else if (Files.isRegularFile(path)) {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1335,7 +1335,7 @@ public class MavenCli {
                 .setUpdateSnapshots(updateSnapshots) // default: false
                 .setNoSnapshotUpdates(noSnapshotUpdates) // default: false
                 .setGlobalChecksumPolicy(globalChecksumPolicy) // default: warn
-                .setMultiModuleProjectDirectory(rootOrTopDirectory(cliRequest).toFile());
+                .setMultiModuleProjectDirectory(cliRequest.multiModuleProjectDirectory);
 
         if (alternatePomFile != null) {
             File pom = resolveFile(new File(alternatePomFile), workingDirectory);
@@ -1545,14 +1545,6 @@ public class MavenCli {
 
         String mavenBuildVersion = CLIReportingUtils.createMavenVersionString(buildProperties);
         systemProperties.setProperty("maven.build.version", mavenBuildVersion);
-    }
-
-    protected Path rootOrTopDirectory(CliRequest request) {
-        if (request.rootDirectory != null) {
-            return request.rootDirectory;
-        } else {
-            return request.topDirectory;
-        }
     }
 
     protected boolean isAcceptableRootDirectory(Path path) {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -130,6 +130,7 @@ import static org.apache.maven.shared.utils.logging.MessageUtils.buffer;
 public class MavenCli {
     public static final String LOCAL_REPO_PROPERTY = "maven.repo.local";
 
+    @Deprecated
     public static final String MULTIMODULE_PROJECT_DIRECTORY = "maven.multiModuleProjectDirectory";
 
     public static final String USER_HOME = System.getProperty("user.home");
@@ -320,14 +321,12 @@ public class MavenCli {
         // We need to locate the top level project which may be pointed at using
         // the -f/--file option.  However, the command line isn't parsed yet, so
         // we need to iterate through the args to find it and act upon it.
-        Path cwd = Paths.get(cliRequest.workingDirectory);
-        // MavenCliTest extensively uses MULTIMODULE_PROJECT_DIRECTORY
-        Path topDirectory = cliRequest.multiModuleProjectDirectory.toPath();
+        Path topDirectory = Paths.get(cliRequest.workingDirectory);
         boolean isAltFile = false;
         for (String arg : cliRequest.args) {
             if (isAltFile) {
                 // this is the argument following -f/--file
-                Path path = cwd.resolve(stripLeadingAndTrailingQuotes(arg));
+                Path path = topDirectory.resolve(stripLeadingAndTrailingQuotes(arg));
                 if (Files.isDirectory(path)) {
                     topDirectory = path;
                 } else if (Files.isRegularFile(path)) {

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -33,6 +33,7 @@ import org.apache.maven.toolchain.building.ToolchainsBuildingResult;
 import org.codehaus.plexus.PlexusContainer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.mockito.InOrder;
@@ -95,9 +96,9 @@ public class MavenCliTest {
 
     @Test
     public void testMavenConfig() throws Exception {
-        System.setProperty(
-                MavenCli.MULTIMODULE_PROJECT_DIRECTORY, new File("src/test/projects/config").getCanonicalPath());
-        CliRequest request = new CliRequest(new String[0], null);
+        String rootDirectory = new File("src/test/projects/config").getCanonicalPath();
+        System.setProperty(MavenCli.MULTIMODULE_PROJECT_DIRECTORY, rootDirectory);
+        CliRequest request = new CliRequest(new String[] {"-f", rootDirectory}, null);
 
         // read .mvn/maven.config
         cli.initialize(request);
@@ -113,10 +114,9 @@ public class MavenCliTest {
 
     @Test
     public void testMavenConfigInvalid() throws Exception {
-        System.setProperty(
-                MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
-                new File("src/test/projects/config-illegal").getCanonicalPath());
-        CliRequest request = new CliRequest(new String[0], null);
+        String rootDirectory = new File("src/test/projects/config-illegal").getCanonicalPath();
+        System.setProperty(MavenCli.MULTIMODULE_PROJECT_DIRECTORY, rootDirectory);
+        CliRequest request = new CliRequest(new String[] {"-f", rootDirectory}, null);
 
         cli.initialize(request);
         try {
@@ -142,10 +142,9 @@ public class MavenCliTest {
      */
     @Test
     public void testMVNConfigurationThreadCanBeOverwrittenViaCommandLine() throws Exception {
-        System.setProperty(
-                MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
-                new File("src/test/projects/mavenConfigProperties").getCanonicalPath());
-        CliRequest request = new CliRequest(new String[] {"-T", "5"}, null);
+        String rootDirectory = new File("src/test/projects/mavenConfigProperties").getCanonicalPath();
+        System.setProperty(MavenCli.MULTIMODULE_PROJECT_DIRECTORY, rootDirectory);
+        CliRequest request = new CliRequest(new String[] {"-f", rootDirectory, "-T", "5"}, null);
 
         cli.initialize(request);
         // read .mvn/maven.config
@@ -169,10 +168,9 @@ public class MavenCliTest {
      */
     @Test
     public void testMVNConfigurationDefinedPropertiesCanBeOverwrittenViaCommandLine() throws Exception {
-        System.setProperty(
-                MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
-                new File("src/test/projects/mavenConfigProperties").getCanonicalPath());
-        CliRequest request = new CliRequest(new String[] {"-Drevision=8.1.0"}, null);
+        String rootDirectory = new File("src/test/projects/mavenConfigProperties").getCanonicalPath();
+        System.setProperty(MavenCli.MULTIMODULE_PROJECT_DIRECTORY, rootDirectory);
+        CliRequest request = new CliRequest(new String[] {"-f", rootDirectory, "-Drevision=8.1.0"}, null);
 
         cli.initialize(request);
         // read .mvn/maven.config
@@ -198,10 +196,10 @@ public class MavenCliTest {
      */
     @Test
     public void testMVNConfigurationCLIRepeatedPropertiesLastWins() throws Exception {
-        System.setProperty(
-                MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
-                new File("src/test/projects/mavenConfigProperties").getCanonicalPath());
-        CliRequest request = new CliRequest(new String[] {"-Drevision=8.1.0", "-Drevision=8.2.0"}, null);
+        String rootDirectory = new File("src/test/projects/mavenConfigProperties").getCanonicalPath();
+        System.setProperty(MavenCli.MULTIMODULE_PROJECT_DIRECTORY, rootDirectory);
+        CliRequest request =
+                new CliRequest(new String[] {"-f", rootDirectory, "-Drevision=8.1.0", "-Drevision=8.2.0"}, null);
 
         cli.initialize(request);
         // read .mvn/maven.config
@@ -226,6 +224,7 @@ public class MavenCliTest {
      * @throws Exception
      */
     @Test
+    @Ignore("This UT plays with multiModuleProjectDirectory and -f should not be possible")
     public void testMVNConfigurationFunkyArguments() throws Exception {
         System.setProperty(
                 MavenCli.MULTIMODULE_PROJECT_DIRECTORY,


### PR DESCRIPTION
This is a bug how in Maven different paths are detected and handled.

Maven 4 is not affected.

## What is happening?

Properties/paths in play:
* `cliRequest.multiModuleProjectDirectory`, an ancient (and deprecated) path that is calculated in `mvn` script and passed to JVM as Java System Property: contains the calculated location of `.mvn` directory (but does not bubble up to root)
* `cliRequest,topDirectory`, new path since 3.9.x, that is basically "cwd adjusted for `-f`"
* `cliRequest.rootDirectory`, new path since 3.9.x, that is nullable (does not have to exists). that is recursively searched for, from topDirectory by bubbling up to parent. It is searching for a directory that contains `.mvn` sub-directory, and is `null` if none found.

In this respect, `rootDirectory` and `multiModuleProjectDirectory` are usually similar (same), and `topDirectory` is similar to `basedir`.

For start, `mvn` script stops when it arrives to FS root (`/`), hence `multiModuleProjectDirectory` will NOT point at root, even if `.mvn` directory present in it. The other two are fine in this respect.

But config and extensions were still loaded up from `multiModuleProjectDirectory` despite what `rootDirectory` was set to.

Removal of `multiModuleProjectDirectory` in Maven 3 is not possible, but is deprecated and it's use is highly discouraged.

---

https://issues.apache.org/jira/browse/MNG-8165