### PR TITLE
[MNG-8178] Fall back to system properties for missing profile activation context properties

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivator.java
@@ -22,7 +22,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.Locale;
-import java.util.Map;
 
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.ActivationOS;
@@ -42,14 +41,6 @@ public class OperatingSystemProfileActivator implements ProfileActivator {
 
     private static final String REGEX_PREFIX = "regex:";
 
-    private static String systemProperty(Map<String, String> map, String key) {
-        String v = map.get(key);
-        if (v == null) {
-            v = System.getProperty(key, "");
-        }
-        return v;
-    }
-
     @Override
     public boolean isActive(Profile profile, ProfileActivationContext context, ModelProblemCollector problems) {
         Activation activation = profile.getActivation();
@@ -66,12 +57,15 @@ public class OperatingSystemProfileActivator implements ProfileActivator {
 
         boolean active = ensureAtLeastOneNonNull(os);
 
-        String actualOsName =
-                systemProperty(context.getSystemProperties(), "os.name").toLowerCase(Locale.ENGLISH);
-        String actualOsArch =
-                systemProperty(context.getSystemProperties(), "os.arch").toLowerCase(Locale.ENGLISH);
-        String actualOsVersion =
-                systemProperty(context.getSystemProperties(), "os.version").toLowerCase(Locale.ENGLISH);
+        String actualOsName = context.getSystemProperties()
+                .getOrDefault("os.name", Os.OS_NAME)
+                .toLowerCase(Locale.ENGLISH);
+        String actualOsArch = context.getSystemProperties()
+                .getOrDefault("os.arch", Os.OS_ARCH)
+                .toLowerCase(Locale.ENGLISH);
+        String actualOsVersion = context.getSystemProperties()
+                .getOrDefault("os.version", Os.OS_VERSION)
+                .toLowerCase(Locale.ENGLISH);
 
         if (active && os.getFamily() != null) {
             active = determineFamilyMatch(os.getFamily(), actualOsName);

--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivator.java
@@ -22,6 +22,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.ActivationOS;
@@ -41,6 +42,14 @@ public class OperatingSystemProfileActivator implements ProfileActivator {
 
     private static final String REGEX_PREFIX = "regex:";
 
+    private static String systemProperty(Map<String, String> map, String key) {
+        String v = map.get(key);
+        if (v == null) {
+            v = System.getProperty(key, "");
+        }
+        return v;
+    }
+
     @Override
     public boolean isActive(Profile profile, ProfileActivationContext context, ModelProblemCollector problems) {
         Activation activation = profile.getActivation();
@@ -57,9 +66,12 @@ public class OperatingSystemProfileActivator implements ProfileActivator {
 
         boolean active = ensureAtLeastOneNonNull(os);
 
-        String actualOsName = context.getSystemProperties().get("os.name").toLowerCase(Locale.ENGLISH);
-        String actualOsArch = context.getSystemProperties().get("os.arch").toLowerCase(Locale.ENGLISH);
-        String actualOsVersion = context.getSystemProperties().get("os.version").toLowerCase(Locale.ENGLISH);
+        String actualOsName =
+                systemProperty(context.getSystemProperties(), "os.name").toLowerCase(Locale.ENGLISH);
+        String actualOsArch =
+                systemProperty(context.getSystemProperties(), "os.arch").toLowerCase(Locale.ENGLISH);
+        String actualOsVersion =
+                systemProperty(context.getSystemProperties(), "os.version").toLowerCase(Locale.ENGLISH);
 
         if (active && os.getFamily() != null) {
             active = determineFamilyMatch(os.getFamily(), actualOsName);


### PR DESCRIPTION
- **[MNG-8178] Fall back to System.getProperty for missing context props**
- **Use Os class to grab values instead**

Forward port of https://github.com/apache/maven/pull/1603
