### PR TITLE
[MNG-8132] Fix BOM dependency exclusions

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
@@ -1288,12 +1288,18 @@ public class DefaultModelBuilder implements ModelBuilder {
             // Dependency excluded from import.
             List<Dependency> dependencies = importMgmt.getDependencies().stream()
                     .filter(candidate -> exclusions.stream().noneMatch(exclusion -> match(exclusion, candidate)))
-                    .map(candidate -> candidate.withExclusions(exclusions))
+                    .map(candidate -> addExclusions(candidate, exclusions))
                     .collect(Collectors.toList());
             importMgmt = importMgmt.withDependencies(dependencies);
         }
 
         return importMgmt;
+    }
+
+    private static org.apache.maven.api.model.Dependency addExclusions(
+            org.apache.maven.api.model.Dependency candidate, List<Exclusion> exclusions) {
+        return candidate.withExclusions(Stream.concat(candidate.getExclusions().stream(), exclusions.stream())
+                .toList());
     }
 
     private boolean match(Exclusion exclusion, Dependency candidate) {


### PR DESCRIPTION
Fix for MNG-8132.
The original patch from MNG-5600 had not been ported to the new model builder
