### PR TITLE
[MNG-8177] Add contextual info for model warnings

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -294,10 +294,11 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                 if (!modelResult.getProblems().isEmpty()) {
                     List<ModelProblem> problems = modelResult.getProblems();
                     logger.warn(
-                            "{} {} encountered while building the effective model for {}",
+                            "{} {} encountered while building the effective model for {}; trace: {}",
                             problems.size(),
                             (problems.size() == 1) ? "problem was" : "problems were",
-                            request.getArtifact());
+                            request.getArtifact(),
+                            RequestTraceHelper.interpretTrace(true, request.getTrace()));
                     if (logger.isDebugEnabled()) {
                         for (ModelProblem problem : problems) {
                             logger.warn(

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -42,6 +42,7 @@ import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelProblemUtils;
 import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
 import org.eclipse.aether.RepositoryException;
@@ -295,19 +296,21 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                 if (!modelResult.getProblems().isEmpty()) {
                     List<ModelProblem> problems = modelResult.getProblems();
                     if (logger.isDebugEnabled()) {
-                        logger.warn(
-                                "{} {} encountered while building the effective model for {} during {}",
+                        String problem = (problems.size() == 1) ? "problem" : "problems";
+                        String problemPredicate = problem + ((problems.size() == 1) ? " was" : " were");
+                        String message = String.format(
+                                "%s %s encountered while building the effective model for %s during %s\n",
                                 problems.size(),
-                                (problems.size() == 1) ? "problem was" : "problems were",
+                                problemPredicate,
                                 request.getArtifact(),
                                 RequestTraceHelper.interpretTrace(true, request.getTrace()));
-                        logger.warn("Problems encountered:");
-                        for (ModelProblem problem : problems) {
-                            logger.warn(
-                                    "* {} @ {}",
-                                    problem.getMessage(),
-                                    ModelProblemUtils.formatLocation(problem, null));
+                        message += StringUtils.capitalizeFirstLetter(problem);
+                        for (ModelProblem modelProblem : problems) {
+                            message += String.format(
+                                    "\n* %s @ %s",
+                                    modelProblem.getMessage(), ModelProblemUtils.formatLocation(modelProblem, null));
                         }
+                        logger.warn(message);
                     } else {
                         logger.warn(
                                 "{} {} encountered while building the effective model for {} during {} (use -X to see details)",

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -294,11 +294,11 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                 if (!modelResult.getProblems().isEmpty()) {
                     List<ModelProblem> problems = modelResult.getProblems();
                     logger.warn(
-                            "{} {} encountered while building the effective model for {}; trace: {}",
+                            "{} {} encountered while building the effective model for {} during {}",
                             problems.size(),
                             (problems.size() == 1) ? "problem was" : "problems were",
                             request.getArtifact(),
-                            RequestTraceHelper.interpretTrace(true, request.getTrace()));
+                            RequestTraceHelper.interpretTrace(logger.isDebugEnabled(), request.getTrace()));
                     if (logger.isDebugEnabled()) {
                         for (ModelProblem problem : problems) {
                             logger.warn(

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -195,6 +195,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         return result;
     }
 
+    @SuppressWarnings("MethodLength")
     private Model loadPom(
             RepositorySystemSession session, ArtifactDescriptorRequest request, ArtifactDescriptorResult result)
             throws ArtifactDescriptorException {
@@ -293,17 +294,27 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
                 // that may lead to unexpected build failure, log them
                 if (!modelResult.getProblems().isEmpty()) {
                     List<ModelProblem> problems = modelResult.getProblems();
-                    logger.warn(
-                            "{} {} encountered while building the effective model for {} during {}",
-                            problems.size(),
-                            (problems.size() == 1) ? "problem was" : "problems were",
-                            request.getArtifact(),
-                            RequestTraceHelper.interpretTrace(logger.isDebugEnabled(), request.getTrace()));
                     if (logger.isDebugEnabled()) {
+                        logger.warn(
+                                "{} {} encountered while building the effective model for {} during {}",
+                                problems.size(),
+                                (problems.size() == 1) ? "problem was" : "problems were",
+                                request.getArtifact(),
+                                RequestTraceHelper.interpretTrace(true, request.getTrace()));
+                        logger.warn("Problems encountered:");
                         for (ModelProblem problem : problems) {
                             logger.warn(
-                                    "{} @ {}", problem.getMessage(), ModelProblemUtils.formatLocation(problem, null));
+                                    "* {} @ {}",
+                                    problem.getMessage(),
+                                    ModelProblemUtils.formatLocation(problem, null));
                         }
+                    } else {
+                        logger.warn(
+                                "{} {} encountered while building the effective model for {} during {} (use -X to see details)",
+                                problems.size(),
+                                (problems.size() == 1) ? "problem was" : "problems were",
+                                request.getArtifact(),
+                                RequestTraceHelper.interpretTrace(false, request.getTrace()));
                     }
                 }
                 model = modelResult.getEffectiveModel();

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RequestTraceHelper.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RequestTraceHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.repository.internal;
+
+import java.util.stream.Collectors;
+
+import org.apache.maven.model.Plugin;
+import org.eclipse.aether.RequestTrace;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectStepData;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.DependencyRequest;
+
+/**
+ * Helper class to manage {@link RequestTrace} for better error logging.
+ *
+ * @since 3.9.9
+ */
+public final class RequestTraceHelper {
+
+    /**
+     * Method that creates some informational string based on passed in {@link RequestTrace}. The contents of request
+     * trace can literally be anything, but this class tries to cover "most common" cases that are happening in Maven.
+     */
+    public static String interpretTrace(boolean explain, RequestTrace requestTrace) {
+        while (requestTrace != null) {
+            Object data = requestTrace.getData();
+            if (data instanceof DependencyRequest) {
+                DependencyRequest request = (DependencyRequest) data;
+                return (explain ? "dependency request for " : "") + request;
+            } else if (data instanceof CollectRequest) {
+                CollectRequest request = (CollectRequest) data;
+                return (explain ? "collect request for " : "") + request;
+            } else if (data instanceof CollectStepData) {
+                CollectStepData stepData = (CollectStepData) data;
+                return (explain ? "collect path " : "")
+                        + stepData.getPath().stream().map(Object::toString).collect(Collectors.joining(" -> "));
+            } else if (data instanceof ArtifactDescriptorRequest) {
+                ArtifactDescriptorRequest request = (ArtifactDescriptorRequest) data;
+                return (explain ? "artifact descriptor request for " : "") + request.getArtifact();
+            } else if (data instanceof ArtifactRequest) {
+                ArtifactRequest request = (ArtifactRequest) data;
+                return (explain ? "artifact request for " : "") + request.getArtifact();
+            } else if (data instanceof Plugin) {
+                Plugin plugin = (Plugin) data;
+                return (explain ? "plugin " : "") + plugin.getId();
+            }
+            requestTrace = requestTrace.getParent();
+        }
+
+        return "n/a";
+    }
+}

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RequestTraceHelper.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RequestTraceHelper.java
@@ -52,11 +52,11 @@ public final class RequestTraceHelper {
                 CollectStepData stepData = (CollectStepData) data;
                 String msg = "dependency collection step for " + stepData.getContext();
                 if (detailed) {
-                    msg += "\n";
-                    msg += "Path to offending node from root:\n";
+                    msg += ". Path to offending node from root:\n";
                     msg += stepData.getPath().stream()
                             .map(n -> " -> " + n.toString())
                             .collect(Collectors.joining("\n"));
+                    msg += "\n => " + stepData.getNode();
                 }
                 return msg;
             } else if (data instanceof ArtifactDescriptorRequest) {

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RequestTraceHelper.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/RequestTraceHelper.java
@@ -39,28 +39,35 @@ public final class RequestTraceHelper {
      * Method that creates some informational string based on passed in {@link RequestTrace}. The contents of request
      * trace can literally be anything, but this class tries to cover "most common" cases that are happening in Maven.
      */
-    public static String interpretTrace(boolean explain, RequestTrace requestTrace) {
+    public static String interpretTrace(boolean detailed, RequestTrace requestTrace) {
         while (requestTrace != null) {
             Object data = requestTrace.getData();
             if (data instanceof DependencyRequest) {
                 DependencyRequest request = (DependencyRequest) data;
-                return (explain ? "dependency request for " : "") + request;
+                return "dependency resolution for " + request;
             } else if (data instanceof CollectRequest) {
                 CollectRequest request = (CollectRequest) data;
-                return (explain ? "collect request for " : "") + request;
+                return "dependency collection for " + request;
             } else if (data instanceof CollectStepData) {
                 CollectStepData stepData = (CollectStepData) data;
-                return (explain ? "collect path " : "")
-                        + stepData.getPath().stream().map(Object::toString).collect(Collectors.joining(" -> "));
+                String msg = "dependency collection step for " + stepData.getContext();
+                if (detailed) {
+                    msg += "\n";
+                    msg += "Path to offending node from root:\n";
+                    msg += stepData.getPath().stream()
+                            .map(n -> " -> " + n.toString())
+                            .collect(Collectors.joining("\n"));
+                }
+                return msg;
             } else if (data instanceof ArtifactDescriptorRequest) {
                 ArtifactDescriptorRequest request = (ArtifactDescriptorRequest) data;
-                return (explain ? "artifact descriptor request for " : "") + request.getArtifact();
+                return "artifact descriptor request for " + request.getArtifact();
             } else if (data instanceof ArtifactRequest) {
                 ArtifactRequest request = (ArtifactRequest) data;
-                return (explain ? "artifact request for " : "") + request.getArtifact();
+                return "artifact request for " + request.getArtifact();
             } else if (data instanceof Plugin) {
                 Plugin plugin = (Plugin) data;
-                return (explain ? "plugin " : "") + plugin.getId();
+                return "plugin request " + plugin.getId();
             }
             requestTrace = requestTrace.getParent();
         }


### PR DESCRIPTION
As they really can come from anywhere. In case of this issue even from some eliminated POM that was read while collecting dirty tree, and was later eliminated. So confusing for users.

---

https://issues.apache.org/jira/browse/MNG-8177