### PR TITLE
Renaming of `ArtifactCoordinate.getVersion()` + documentation

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
@@ -24,7 +24,8 @@ import org.apache.maven.api.annotations.Nonnull;
 
 /**
  * Pointer to a resolved resource such as a <abbr>JAR</abbr> file or <abbr>WAE</abbr> application.
- * {@code Artifact} instances are created when <dfn>resolving</dfn> {@link Artifact} instances.
+ * Each {@code Artifact} instance is basically a pointer to a file in the Maven repository.
+ * {@code Artifact} instances are created when <dfn>resolving</dfn> {@link ArtifactCoordinate} instances.
  * Resolving is the process that selects a {@linkplain #getVersion() particular version}
  * and downloads the artifact in the local repository.
  * The download may be deferred to the first time that the file is needed.
@@ -72,6 +73,8 @@ public interface Artifact {
     /**
      * {@return the version of the artifact}. Contrarily to {@link ArtifactCoordinate},
      * each {@code Artifact} is associated to a specific version instead of a range of versions.
+     * If the {@linkplain #getBaseVersion() base version} contains a meta-version such as {@code LATEST},
+     * {@code RELEASE} or {@code SNAPSHOT}, those keywords are replaced by, for example, the actual timestamp.
      *
      * @see ArtifactCoordinate#getVersionConstraint()
      */
@@ -79,8 +82,10 @@ public interface Artifact {
     Version getVersion();
 
     /**
-     * {@return the base version of the artifact}.
-     * TODO: this javadoc is not helpful.
+     * {@return the version or meta-version of the artifact}.
+     * A meta-version is a version suffixed with {@code LATEST}, {@code RELEASE} or {@code SNAPSHOT} keyword.
+     * Meta-versions are represented in a base version by their symbols (e.g., {@code SNAPSHOT}),
+     * while they are replaced by, for example, the actual timestamp in the {@linkplain #getVersion() version}.
      */
     @Nonnull
     Version getBaseVersion();

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
@@ -73,8 +73,8 @@ public interface Artifact {
     /**
      * {@return the version of the artifact}. Contrarily to {@link ArtifactCoordinate},
      * each {@code Artifact} is associated to a specific version instead of a range of versions.
-     * If the {@linkplain #getBaseVersion() base version} contains a meta-version such as {@code LATEST},
-     * {@code RELEASE} or {@code SNAPSHOT}, those keywords are replaced by, for example, the actual timestamp.
+     * If the {@linkplain #getBaseVersion() base version} contains a meta-version such as {@code SNAPSHOT},
+     * those keywords are replaced by, for example, the actual timestamp.
      *
      * @see ArtifactCoordinate#getVersionConstraint()
      */
@@ -83,7 +83,7 @@ public interface Artifact {
 
     /**
      * {@return the version or meta-version of the artifact}.
-     * A meta-version is a version suffixed with {@code LATEST}, {@code RELEASE} or {@code SNAPSHOT} keyword.
+     * A meta-version is a version suffixed with the {@code SNAPSHOT} keyword.
      * Meta-versions are represented in a base version by their symbols (e.g., {@code SNAPSHOT}),
      * while they are replaced by, for example, the actual timestamp in the {@linkplain #getVersion() version}.
      */

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
@@ -23,76 +23,83 @@ import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * An artifact points to a resource such as a jar file or war application.
+ * Pointer to a resolved resource such as a <abbr>JAR</abbr> file or <abbr>WAE</abbr> application.
+ * {@code Artifact} instances are created when <dfn>resolving</dfn> {@link Artifact} instances.
+ * Resolving is the process that selects a {@linkplain #getVersion() particular version}
+ * and downloads the artifact in the local repository.
+ * The download may be deferred to the first time that the file is needed.
  *
  * @since 4.0.0
  */
 @Experimental
 @Immutable
 public interface Artifact {
-
     /**
-     * Returns a unique identifier for this artifact.
+     * {@return a unique identifier for this artifact}.
      * The identifier is composed of groupId, artifactId, extension, classifier, and version.
      *
-     * @return the unique identifier
+     * @see ArtifactCoordinate#getId()
      */
     @Nonnull
     default String key() {
+        String c = getClassifier();
         return getGroupId()
                 + ':'
                 + getArtifactId()
                 + ':'
                 + getExtension()
-                + (getClassifier().isEmpty() ? "" : ":" + getClassifier())
+                + (c.isEmpty() ? "" : ":" + c)
                 + ':'
                 + getVersion();
     }
 
     /**
-     * The groupId of the artifact.
+     * {@return the group identifier of the artifact}.
      *
-     * @return the groupId
+     * @see ArtifactCoordinate#getGroupId()
      */
     @Nonnull
     String getGroupId();
 
     /**
-     * The artifactId of the artifact.
+     * {@return the identifier of the artifact}.
      *
-     * @return the artifactId
+     * @see ArtifactCoordinate#getArtifactId()
      */
     @Nonnull
     String getArtifactId();
 
     /**
-     * The version of the artifact.
+     * {@return the version of the artifact}. Contrarily to {@link ArtifactCoordinate},
+     * each {@code Artifact} is associated to a specific version instead of a range of versions.
      *
-     * @return the version
+     * @see ArtifactCoordinate#getVersionConstraint()
      */
     @Nonnull
     Version getVersion();
 
     /**
-     * The base version of the artifact.
-     *
-     * @return the version
+     * {@return the base version of the artifact}.
+     * TODO: this javadoc is not helpful.
      */
     @Nonnull
     Version getBaseVersion();
 
     /**
-     * The classifier of the artifact.
+     * Returns the classifier of the artifact.
      *
      * @return the classifier or an empty string if none, never {@code null}
+     * @see ArtifactCoordinate#getClassifier()
      */
     @Nonnull
     String getClassifier();
 
     /**
-     * The file extension of the artifact.
+     * Returns the file extension of the artifact.
+     * The dot separator is <em>not</em> included in the returned string.
      *
-     * @return the extension
+     * @return the file extension or an empty string if none, never {@code null}
+     * @see ArtifactCoordinate#getExtension()
      */
     @Nonnull
     String getExtension();
@@ -106,9 +113,9 @@ public interface Artifact {
     boolean isSnapshot();
 
     /**
-     * Shortcut for {@code session.createArtifactCoordinate(artifact)}
+     * {@return coordinate with the same identifiers as this artifact}.
+     * This is a shortcut for {@code session.createArtifactCoordinate(artifact)}.
      *
-     * @return an {@link ArtifactCoordinate}
      * @see org.apache.maven.api.Session#createArtifactCoordinate(Artifact)
      */
     @Nonnull

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
@@ -54,7 +54,7 @@ public interface ArtifactCoordinate {
 
     /**
      * {@return the specific version, range of versions or meta-version of the artifact}.
-     * A meta-version is a version suffixed with {@code LATEST}, {@code RELEASE} or {@code SNAPSHOT} keyword.
+     * A meta-version is a version suffixed with the {@code SNAPSHOT} keyword.
      */
     @Nonnull
     VersionConstraint getVersionConstraint();

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
@@ -23,33 +23,29 @@ import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * The {@code Coordinate} object is used to point to an {@link Artifact}
- * but the version may be specified as a range instead of an exact version.
+ * Point to an {@link Artifact} but with the version specified as a range instead of an exact version.
+ * Each {@code ArtifactCoordinate} instance is basically a pointer to a file in the Maven repository,
+ * except that the version may not be defined precisely.
  *
  * @since 4.0.0
  */
 @Experimental
 @Immutable
 public interface ArtifactCoordinate {
-
     /**
-     * The groupId of the artifact.
-     *
-     * @return the groupId
+     * {@return the group identifier of the artifact}.
      */
     @Nonnull
     String getGroupId();
 
     /**
-     * The artifactId of the artifact.
-     *
-     * @return the artifactId
+     * {@return the identifier of the artifact}.
      */
     @Nonnull
     String getArtifactId();
 
     /**
-     * The classifier of the artifact.
+     * Returns the classifier of the artifact.
      *
      * @return the classifier or an empty string if none, never {@code null}
      */
@@ -57,30 +53,38 @@ public interface ArtifactCoordinate {
     String getClassifier();
 
     /**
-     * The version of the artifact.
-     *
-     * @return the version
+     * {@return the range of versions of the artifact}.
      */
     @Nonnull
-    VersionConstraint getVersion();
+    VersionConstraint getVersionConstraint();
 
     /**
-     * The extension of the artifact.
+     * Returns the file extension of the artifact.
+     * The dot separator is <em>not</em> included in the returned string.
      *
-     * @return the extension or an empty string if none, never {@code null}
+     * @return the file extension or an empty string if none, never {@code null}
      */
     @Nonnull
     String getExtension();
 
     /**
-     * Unique id identifying this artifact
+     * {@return a unique string representation identifying this artifact}.
+     * The default implementation returns a colon-separated list of group
+     * identifier, artifact identifier, extension, classifier and version.
+     *
+     * @see Artifact#key()
      */
     @Nonnull
     default String getId() {
+        String c = getClassifier();
         return getGroupId()
-                + ":" + getArtifactId()
-                + ":" + getExtension()
-                + (getClassifier().isEmpty() ? "" : ":" + getClassifier())
-                + ":" + getVersion();
+                + ':'
+                + getArtifactId()
+                + ':'
+                + getExtension()
+                + ':'
+                + c
+                + (c.isEmpty() ? "" : ":")
+                + getVersionConstraint();
     }
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinate.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * Point to an {@link Artifact} but with the version specified as a range instead of an exact version.
+ * Identification of an ensemble of {@code Artifact}s in a range of versions.
  * Each {@code ArtifactCoordinate} instance is basically a pointer to a file in the Maven repository,
  * except that the version may not be defined precisely.
  *
@@ -53,7 +53,8 @@ public interface ArtifactCoordinate {
     String getClassifier();
 
     /**
-     * {@return the range of versions of the artifact}.
+     * {@return the specific version, range of versions or meta-version of the artifact}.
+     * A meta-version is a version suffixed with {@code LATEST}, {@code RELEASE} or {@code SNAPSHOT} keyword.
      */
     @Nonnull
     VersionConstraint getVersionConstraint();

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
@@ -23,30 +23,45 @@ import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
+ * Result of resolving a {@code DependencyCoordinate}.
+ * Resolving is the process that clarifies the obligation (optional or mandatory status),
+ * selects a particular version and downloads the artifact in the local repository.
  *
  * @since 4.0.0
  */
 @Experimental
 @Immutable
 public interface Dependency extends Artifact {
-
     /**
-     * The dependency type.
+     * {@return the type of the dependency}. A dependency can be a <abbr>JAR</abbr> file,
+     * a modular-<abbr>JAR</abbr> if it is intended to be placed on the module-path,
+     * a <abbr>JAR</abbr> containing test classes, <i>etc.</i>
      *
-     * @return the dependency type, never {@code null}
+     * @see DependencyCoordinate#getType()
      */
     @Nonnull
     Type getType();
 
+    /**
+     * {@return the time at which the dependency will be used}.
+     * If may be, for example, at compile time only, at run time or at test time.
+     *
+     * @see DependencyCoordinate#getScope()
+     */
     @Nonnull
     DependencyScope getScope();
 
+    /**
+     * Returns whether the dependency is optional or mandatory.
+     * Contrarily to {@link DependencyCoordinate}, the obligation of a dependency cannot be unspecified.
+     *
+     * @return {@code true} if the dependency is optional, or {@code false} if mandatory
+     * @see DependencyCoordinate#getOptional()
+     */
     boolean isOptional();
 
     /**
-     * Creates a {@code DependencyCoordinate} based on this {@code Dependency}.
-     *
-     * @return a {@link DependencyCoordinate}
+     * {@return coordinate with the same identifiers as this dependency}.
      */
     @Nonnull
     @Override

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
@@ -23,9 +23,12 @@ import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * Result of resolving a {@code DependencyCoordinate}.
- * Resolving is the process that clarifies the obligation (optional or mandatory status),
- * selects a particular version and downloads the artifact in the local repository.
+ * A result of collecting, flattening and resolving {@code DependencyCoordinate}s.
+ * Dependency is the output of the <dfn>collection</dfn> process, which builds the graph of dependencies,
+ * followed by <dfn>flattening</dfn> and <dfn>resolution</dfn>.
+ * The version selection is done for each dependency during the collection phase.
+ * The flatten phase will keep only a single version per ({@code groupId}, {@code artifactId}) pair.
+ * The resolution will actually download the dependencies (or artifacts) that have been computed.
  *
  * @since 4.0.0
  */
@@ -53,7 +56,8 @@ public interface Dependency extends Artifact {
 
     /**
      * Returns whether the dependency is optional or mandatory.
-     * Contrarily to {@link DependencyCoordinate}, the obligation of a dependency cannot be unspecified.
+     * Contrarily to {@link DependencyCoordinate}, the obligation of a {@code Dependency} is always present.
+     * The value is computed during the dependencies collection phase.
      *
      * @return {@code true} if the dependency is optional, or {@code false} if mandatory
      * @see DependencyCoordinate#getOptional()

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyCoordinate.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyCoordinate.java
@@ -26,6 +26,11 @@ import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.annotations.Nullable;
 
 /**
+ * {@code ArtifactCoordinate} completed with information about how the artifact will be used.
+ * Those information include the dependency type (main classes, test classes, <i>etc.</i>),
+ * a scope (compile-time, run-time <i>etc.</i>), and an obligation (whether the dependency
+ * is optional or mandatory). The {@linkplain #getVersionConstraint() version}
+ * and the {@linkplain #getOptional() obligation} may not be defined precisely.
  *
  * @since 4.0.0
  */
@@ -33,19 +38,31 @@ import org.apache.maven.api.annotations.Nullable;
 @Immutable
 public interface DependencyCoordinate extends ArtifactCoordinate {
     /**
-     * The type of the artifact.
-     *
-     * @return the type
+     * {@return the type of the dependency}. A dependency can be a <abbr>JAR</abbr> file,
+     * a modular-<abbr>JAR</abbr> if it is intended to be placed on the module-path,
+     * a <abbr>JAR</abbr> containing test classes, <i>etc.</i>
      */
     @Nonnull
     Type getType();
 
+    /**
+     * {@return the time at which the dependency will be used}.
+     * If may be, for example, at compile time only, at run time or at test time.
+     */
     @Nonnull
     DependencyScope getScope();
 
+    /**
+     * Returns whether the dependency is optional, mandatory or of unspecified obligation.
+     *
+     * @return the obligation, or {@code null} if unspecified
+     */
     @Nullable
     Boolean getOptional();
 
+    /**
+     * {@return transitive dependencies to exclude}.
+     */
     @Nonnull
     Collection<Exclusion> getExclusions();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
@@ -28,9 +28,9 @@ import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * Dependency scope.
- * This represents at which time the dependency will be used, for example, at compile time only,
- * at run time or at test time.  For a given dependency, the scope is directly derived from the
+ * Represents at which time the dependency will be used.
+ * If may be, for example, at compile time only, at run time or at test time.
+ * For a given dependency, the scope is directly derived from the
  * {@link org.apache.maven.api.model.Dependency#getScope()} and will be used when using {@link PathScope}
  * and the {@link org.apache.maven.api.services.DependencyResolver}.
  *

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
@@ -28,8 +28,8 @@ import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * Represents at which time the dependency will be used.
- * If may be, for example, at compile time only, at run time or at test time.
+ * Indicates when the dependency will be used.
+ * For example, it may be at compile time only, at runtime, or at test time.
  * For a given dependency, the scope is directly derived from the
  * {@link org.apache.maven.api.model.Dependency#getScope()} and will be used when using {@link PathScope}
  * and the {@link org.apache.maven.api.services.DependencyResolver}.

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
@@ -613,8 +613,8 @@ public interface Session {
             @Nonnull Project project, @Nonnull PathScope scope, @Nonnull Collection<PathType> desiredTypes);
 
     /**
-     * Resolves an artifact's meta version (if any) to a concrete version. For example, resolves "1.0-SNAPSHOT"
-     * to "1.0-20090208.132618-23" or "RELEASE"/"LATEST" to "2.0".
+     * Resolves an artifact's meta version (if any) to a concrete version.
+     * For example, resolves "1.0-SNAPSHOT" to "1.0-20090208.132618-23".
      * <p>
      * Shortcut for {@code getService(VersionResolver.class).resolve(...)}
      *

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Version.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Version.java
@@ -22,7 +22,9 @@ import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * A version usually parsed using the {@link org.apache.maven.api.services.VersionParser} service.
+ * A version or meta-version of an artifact or a dependency.
+ * A meta-version is a version suffixed with {@code LATEST}, {@code RELEASE} or {@code SNAPSHOT} keyword.
+ * Version is usually parsed using the {@link org.apache.maven.api.services.VersionParser} service.
  *
  * @since 4.0.0
  * @see org.apache.maven.api.services.VersionParser#parseVersion(String)

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Version.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Version.java
@@ -23,7 +23,7 @@ import org.apache.maven.api.annotations.Nonnull;
 
 /**
  * A version or meta-version of an artifact or a dependency.
- * A meta-version is a version suffixed with {@code LATEST}, {@code RELEASE} or {@code SNAPSHOT} keyword.
+ * A meta-version is a version suffixed with the {@code SNAPSHOT} keyword.
  * Version is usually parsed using the {@link org.apache.maven.api.services.VersionParser} service.
  *
  * @since 4.0.0

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/package-info.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/package-info.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Core API for Maven plugins.
+ *
+ * <h2>Dependency management</h2>
+ * <p>{@link org.apache.maven.api.ArtifactCoordinate} instances are used to locate artifacts in a repository.
+ * Each instance is basically a pointer to a file in the Maven repository, except that the version may not be
+ * defined precisely.</p>
+ *
+ * <p>{@link org.apache.maven.api.Artifact} instances are the pointed artifacts in the repository.
+ * They are created when <dfn>resolving</dfn> an {@code ArtifactCoordinate}. Resolving is the process
+ * that selects a particular version and downloads the artifact in the local repository.
+ * The download may be deferred to the first time that the file is needed.</p>
+ *
+ * <p>{@link org.apache.maven.api.DependencyCoordinate} instances are used to express a dependency.
+ * They are an {@code ArtifactCoordinate} completed with information about how the artifact will be used:
+ * type, scope and obligation (whether the dependency is optional or mandatory).
+ * The version and the obligation may not be defined precisely.</p>
+ *
+ * <p>{@link org.apache.maven.api.Dependency} instances are the pointed dependencies in the repository.
+ * They are created when <dfn>resolving</dfn> a {@code DependencyCoordinate}.
+ * Resolving is the process that clarifies the obligation (optional or mandatory status),
+ * selects a particular version and downloads the artifact in the local repository.</p>
+ *
+ * <p>{@link org.apache.maven.api.Node} is the main output of the <dfn>dependency collection</dfn> process.
+ * it's the graph of dependencies. The above-cited {@code Dependency} instances are the outputs of the
+ * collection process, part of the graph computed from one or more {@code DependencyCoordinate}s.</p>
+ */
+package org.apache.maven.api;

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/package-info.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/package-info.java
@@ -20,6 +20,14 @@
 /**
  * Core API for Maven plugins.
  *
+ * <h2>Definitions of terms</h2>
+ * <p><dfn>Artifact resolution</dfn> is the process of {@linkplain org.apache.maven.api.services.VersionResolver
+ * resolving the version} and then downloading the file.</p>
+ *
+ * <p><dfn>Dependency resolution</dfn> is the process of collecting dependencies, flattening the graph,
+ * and then downloading the file. The flattening phase removes branches of the graph so that one artifact
+ * per ({@code groupId}, {@code artifactId}) pair is present.</p>
+ *
  * <h2>Dependency management</h2>
  * <p>{@link org.apache.maven.api.ArtifactCoordinate} instances are used to locate artifacts in a repository.
  * Each instance is basically a pointer to a file in the Maven repository, except that the version may not be

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactCoordinateFactoryRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactCoordinateFactoryRequest.java
@@ -100,7 +100,7 @@ public interface ArtifactCoordinateFactoryRequest {
                 .groupId(nonNull(coordinate, "coordinate").getGroupId())
                 .artifactId(coordinate.getArtifactId())
                 .classifier(coordinate.getClassifier())
-                .version(coordinate.getVersion().asString())
+                .version(coordinate.getVersionConstraint().asString())
                 .extension(coordinate.getExtension())
                 .build();
     }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinateFactoryRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinateFactoryRequest.java
@@ -74,7 +74,7 @@ public interface DependencyCoordinateFactoryRequest extends ArtifactCoordinateFa
                 .session(nonNull(session, "session cannot be null"))
                 .groupId(nonNull(coordinate, "coordinate cannot be null").getGroupId())
                 .artifactId(coordinate.getArtifactId())
-                .version(coordinate.getVersion().asString())
+                .version(coordinate.getVersionConstraint().asString())
                 .classifier(coordinate.getClassifier())
                 .extension(coordinate.getExtension())
                 .build();

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionResolver.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionResolver.java
@@ -35,8 +35,8 @@ import org.apache.maven.api.annotations.Nonnull;
 public interface VersionResolver extends Service {
 
     /**
-     * Resolves an artifact's meta version (if any) to a concrete version. For example, resolves "1.0-SNAPSHOT"
-     * to "1.0-20090208.132618-23" or "RELEASE"/"LATEST" to "2.0".
+     * Resolves an artifact's meta version (if any) to a concrete version.
+     * For example, resolves "1.0-SNAPSHOT" to "1.0-20090208.132618-23".
      *
      * @param session The repository session, must not be {@code null}.
      * @param artifactCoordinate The artifact coordinate for which the version needs to be resolved, must not be {@code null}
@@ -50,8 +50,8 @@ public interface VersionResolver extends Service {
     }
 
     /**
-     * Resolves an artifact's meta version (if any) to a concrete version. For example, resolves "1.0-SNAPSHOT"
-     * to "1.0-20090208.132618-23" or "RELEASE"/"LATEST" to "2.0".
+     * Resolves an artifact's meta version (if any) to a concrete version.
+     * For example, resolves "1.0-SNAPSHOT" to "1.0-20090208.132618-23".
      *
      * @param request The version request, must not be {@code null}.
      * @return The version result, never {@code null}.

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/AbstractSession.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/AbstractSession.java
@@ -306,7 +306,7 @@ public abstract class AbstractSession implements InternalSession {
                             dependency.getArtifactId(),
                             dependency.getClassifier(),
                             type.getExtension(),
-                            dependency.getVersion().toString(),
+                            dependency.getVersionConstraint().toString(),
                             Map.of("type", type.id()),
                             (ArtifactType) null),
                     dependency.getScope().id(),
@@ -357,7 +357,7 @@ public abstract class AbstractSession implements InternalSession {
                 coord.getArtifactId(),
                 coord.getClassifier(),
                 coord.getExtension(),
-                coord.getVersion().toString(),
+                coord.getVersionConstraint().toString(),
                 null,
                 (File) null);
     }

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/DefaultArtifactCoordinate.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/DefaultArtifactCoordinate.java
@@ -57,7 +57,7 @@ public class DefaultArtifactCoordinate implements ArtifactCoordinate {
 
     @Nonnull
     @Override
-    public VersionConstraint getVersion() {
+    public VersionConstraint getVersionConstraint() {
         return session.parseVersionConstraint(coordinate.getVersion());
     }
 
@@ -83,13 +83,13 @@ public class DefaultArtifactCoordinate implements ArtifactCoordinate {
         DefaultArtifactCoordinate that = (DefaultArtifactCoordinate) o;
         return Objects.equals(this.getGroupId(), that.getGroupId())
                 && Objects.equals(this.getArtifactId(), that.getArtifactId())
-                && Objects.equals(this.getVersion(), that.getVersion())
+                && Objects.equals(this.getVersionConstraint(), that.getVersionConstraint())
                 && Objects.equals(this.getClassifier(), that.getClassifier());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getGroupId(), getArtifactId(), getVersion(), getClassifier());
+        return Objects.hash(getGroupId(), getArtifactId(), getVersionConstraint(), getClassifier());
     }
 
     @Override

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/DefaultDependencyCoordinate.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/DefaultDependencyCoordinate.java
@@ -33,7 +33,7 @@ public class DefaultDependencyCoordinate extends AetherDependencyWrapper impleme
     }
 
     @Override
-    public VersionConstraint getVersion() {
+    public VersionConstraint getVersionConstraint() {
         return session.parseVersionConstraint(dependency.getArtifact().getVersion());
     }
 

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/resolver/DefaultModelResolver.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/resolver/DefaultModelResolver.java
@@ -50,8 +50,8 @@ public class DefaultModelResolver implements ModelResolver {
             throws ModelResolverException {
         try {
             ArtifactCoordinate coord = session.createArtifactCoordinate(groupId, artifactId, version, "pom");
-            if (coord.getVersion().getVersionRange() != null
-                    && coord.getVersion().getVersionRange().getUpperBoundary() == null) {
+            if (coord.getVersionConstraint().getVersionRange() != null
+                    && coord.getVersionConstraint().getVersionRange().getUpperBoundary() == null) {
                 // Message below is checked for in the MNG-2199 core IT.
                 throw new ModelResolverException(
                         String.format("The requested version range '%s' does not specify an upper bound", version),

--- a/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
+++ b/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
@@ -37,8 +37,10 @@ import org.apache.maven.artifact.versioning.VersionRange;
  */
 public interface Artifact extends Comparable<Artifact> {
 
+    @Deprecated(since = "4.0.0")
     String RELEASE_VERSION = "RELEASE";
 
+    @Deprecated(since = "4.0.0")
     String LATEST_VERSION = "LATEST";
 
     String SNAPSHOT_VERSION = "SNAPSHOT";

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManager.java
@@ -60,6 +60,7 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
 
     private static final String TOUCHFILE_NAME = "resolver-status.properties";
 
+    @Override
     public boolean isUpdateRequired(Artifact artifact, ArtifactRepository repository) {
         File file = artifact.getFile();
 
@@ -98,6 +99,7 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
         return (lastCheckDate == null) || policy.checkOutOfDate(lastCheckDate);
     }
 
+    @Override
     public boolean isUpdateRequired(RepositoryMetadata metadata, ArtifactRepository repository, File file) {
         // Here, we need to determine which policy to use. Release updateInterval will be used when
         // the metadata refers to a release artifact or meta-version, and snapshot updateInterval will be used when
@@ -141,11 +143,13 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
         return readLastUpdated(touchfile, key);
     }
 
+    @Override
     public String getError(Artifact artifact, ArtifactRepository repository) {
         File touchFile = getTouchfile(artifact);
         return getError(touchFile, getRepositoryKey(repository));
     }
 
+    @Override
     public void touch(Artifact artifact, ArtifactRepository repository, String error) {
         File file = artifact.getFile();
 
@@ -158,6 +162,7 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
         }
     }
 
+    @Override
     public void touch(RepositoryMetadata metadata, ArtifactRepository repository, File file) {
         File touchfile = getTouchfile(metadata, file);
 

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/ReleaseArtifactTransformation.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/resolver/transform/ReleaseArtifactTransformation.java
@@ -40,6 +40,7 @@ import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 @Deprecated
 public class ReleaseArtifactTransformation extends AbstractVersionTransformation {
 
+    @Override
     public void transformForResolve(Artifact artifact, RepositoryRequest request)
             throws ArtifactResolutionException, ArtifactNotFoundException {
         if (Artifact.RELEASE_VERSION.equals(artifact.getVersion())) {
@@ -58,12 +59,14 @@ public class ReleaseArtifactTransformation extends AbstractVersionTransformation
         }
     }
 
+    @Override
     public void transformForInstall(Artifact artifact, ArtifactRepository localRepository) {
         ArtifactMetadata metadata = createMetadata(artifact);
 
         artifact.addMetadata(metadata);
     }
 
+    @Override
     public void transformForDeployment(
             Artifact artifact, ArtifactRepository remoteRepository, ArtifactRepository localRepository) {
         ArtifactMetadata metadata = createMetadata(artifact);
@@ -84,6 +87,7 @@ public class ReleaseArtifactTransformation extends AbstractVersionTransformation
         return new ArtifactRepositoryMetadata(artifact, versioning);
     }
 
+    @Override
     protected String constructVersion(Versioning versioning, String baseVersion) {
         return versioning.getRelease();
     }

--- a/maven-compat/src/test/java/org/apache/maven/repository/TestRepositorySystem.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/TestRepositorySystem.java
@@ -78,6 +78,7 @@ public class TestRepositorySystem implements RepositorySystem {
         this.artifactFactory = artifactFactory;
     }
 
+    @Override
     public ArtifactRepository buildArtifactRepository(Repository repository) throws InvalidRepositoryException {
         return new MavenArtifactRepository(
                 repository.getId(),
@@ -87,14 +88,17 @@ public class TestRepositorySystem implements RepositorySystem {
                 new ArtifactRepositoryPolicy());
     }
 
+    @Override
     public Artifact createArtifact(String groupId, String artifactId, String version, String packaging) {
         return createArtifact(groupId, artifactId, version, null, packaging);
     }
 
+    @Override
     public Artifact createArtifact(String groupId, String artifactId, String version, String scope, String type) {
         return new DefaultArtifact(groupId, artifactId, version, scope, type, null, new TestArtifactHandler(type));
     }
 
+    @Override
     public ArtifactRepository createArtifactRepository(
             String id,
             String url,
@@ -104,16 +108,19 @@ public class TestRepositorySystem implements RepositorySystem {
         return new MavenArtifactRepository(id, url, repositoryLayout, snapshots, releases);
     }
 
+    @Override
     public Artifact createArtifactWithClassifier(
             String groupId, String artifactId, String version, String type, String classifier) {
         return new DefaultArtifact(groupId, artifactId, version, null, type, classifier, new TestArtifactHandler(type));
     }
 
+    @Override
     public ArtifactRepository createDefaultLocalRepository() throws InvalidRepositoryException {
         return createLocalRepository(
                 new File(System.getProperty("basedir", "."), "target/local-repo").getAbsoluteFile());
     }
 
+    @Override
     public ArtifactRepository createDefaultRemoteRepository() throws InvalidRepositoryException {
         return new MavenArtifactRepository(
                 DEFAULT_REMOTE_REPO_ID,
@@ -127,6 +134,7 @@ public class TestRepositorySystem implements RepositorySystem {
                 new ArtifactRepositoryPolicy());
     }
 
+    @Override
     public Artifact createDependencyArtifact(Dependency dependency) {
         Artifact artifact = new DefaultArtifact(
                 dependency.getGroupId(),
@@ -145,6 +153,7 @@ public class TestRepositorySystem implements RepositorySystem {
         return artifact;
     }
 
+    @Override
     public ArtifactRepository createLocalRepository(File localRepository) throws InvalidRepositoryException {
         return new MavenArtifactRepository(
                 MavenRepositorySystem.DEFAULT_LOCAL_REPO_ID,
@@ -154,6 +163,7 @@ public class TestRepositorySystem implements RepositorySystem {
                 new ArtifactRepositoryPolicy());
     }
 
+    @Override
     public Artifact createPluginArtifact(Plugin plugin) {
         VersionRange versionRange;
         try {
@@ -169,24 +179,31 @@ public class TestRepositorySystem implements RepositorySystem {
         return artifactFactory.createPluginArtifact(plugin.getGroupId(), plugin.getArtifactId(), versionRange);
     }
 
+    @Override
     public Artifact createProjectArtifact(String groupId, String artifactId, String version) {
         return createArtifact(groupId, artifactId, version, "pom");
     }
 
+    @Override
     public List<ArtifactRepository> getEffectiveRepositories(List<ArtifactRepository> repositories) {
         return repositories;
     }
 
+    @Override
     public Mirror getMirror(ArtifactRepository repository, List<Mirror> mirrors) {
         return null;
     }
 
+    @Override
     public void injectAuthentication(List<ArtifactRepository> repositories, List<Server> servers) {}
 
+    @Override
     public void injectMirror(List<ArtifactRepository> repositories, List<Mirror> mirrors) {}
 
+    @Override
     public void injectProxy(List<ArtifactRepository> repositories, List<Proxy> proxies) {}
 
+    @Override
     public void publish(
             ArtifactRepository repository, File source, String remotePath, ArtifactTransferListener transferListener)
             throws ArtifactTransferFailedException {
@@ -194,6 +211,7 @@ public class TestRepositorySystem implements RepositorySystem {
 
     }
 
+    @Override
     public ArtifactResolutionResult resolve(ArtifactResolutionRequest request) {
         ArtifactResolutionResult result = new ArtifactResolutionResult();
 
@@ -283,6 +301,7 @@ public class TestRepositorySystem implements RepositorySystem {
         artifact.setResolved(true);
     }
 
+    @Override
     public void retrieve(
             ArtifactRepository repository,
             File destination,
@@ -293,9 +312,12 @@ public class TestRepositorySystem implements RepositorySystem {
 
     }
 
+    @Override
     public void injectMirror(RepositorySystemSession session, List<ArtifactRepository> repositories) {}
 
+    @Override
     public void injectProxy(RepositorySystemSession session, List<ArtifactRepository> repositories) {}
 
+    @Override
     public void injectAuthentication(RepositorySystemSession session, List<ArtifactRepository> repositories) {}
 }

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
@@ -188,7 +188,7 @@ public class DefaultProject implements Project {
             }
 
             @Override
-            public VersionConstraint getVersion() {
+            public VersionConstraint getVersionConstraint() {
                 return session.parseVersionConstraint(dependency.getVersion());
             }
 


### PR DESCRIPTION
The pull request contains two changes:

* Documentation on `Artifact`, `ArtifactCoordinate`, `Dependency` and `DependencyCoordinate`.
* Renaming of `ArtifactCoordinate.getVersion()` as `getVersionConstraint()`.

This pull request is located after #1621 for avoiding merge conflict. It would be easier to merge (if accepted) #1621 before to merge this one.