### PR TITLE
[MNG-8165] Align mvn.sh script with mvn.cmd

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -127,9 +127,13 @@ find_maven_basedir() {
 (
   basedir=`find_file_argument_basedir "$@"`
   wdir="${basedir}"
-  while [ "$wdir" != '/' ] ; do
+  while :
+  do
     if [ -d "$wdir"/.mvn ] ; then
       basedir=$wdir
+      break
+    fi
+    if [ "$wdir" == '/' ] ; then
       break
     fi
     wdir=`cd "$wdir/.."; pwd`


### PR DESCRIPTION
As one does check for .mvn directory in FS root while other does not, stops one level before.

---

https://issues.apache.org/jira/browse/MNG-8165