### PR TITLE
[MNG-8210] Replace Maven "module" term by "subproject" in documentation

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Mojo.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/annotations/Mojo.java
@@ -76,8 +76,8 @@ public @interface Mojo {
     boolean projectRequired() default true;
 
     /**
-     * if the Mojo uses the Maven project and its child modules.
-     * @return uses the Maven project and its child modules
+     * if the Mojo uses the Maven project and its subprojects.
+     * @return uses the Maven project and its subprojectss
      */
     boolean aggregator() default false;
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelSource.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelSource.java
@@ -27,7 +27,7 @@ import static org.apache.maven.api.services.BaseRequest.nonNull;
 
 /**
  * A Source specific to load POMs.  The {@link #resolve(ModelLocator, String)} method
- * will be used to find POMs for children modules.
+ * will be used to find POMs for subprojects.
  *
  * @since 4.0.0
  */

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -528,10 +528,10 @@
         <field xdoc.separator="blank">
           <name>modules</name>
           <version>4.0.0+</version>
-          <description>The modules (sometimes called subprojects) to build as a part of this
-            project. Each module listed is a relative path to the directory containing the module.
-            To be consistent with the way default urls are calculated from parent, it is recommended
-            to have module names match artifact ids.</description>
+          <description>The subprojects (formerly called modules) to build as a part of this
+            project. Each subproject listed is a relative path to the directory containing the subproject.
+            To be consistent with the way default URLs are calculated from parent, it is recommended
+            to have subproject names match artifact ids.</description>
           <association>
             <type>String</type>
             <multiplicity>*</multiplicity>
@@ -755,8 +755,8 @@
           <name>defaultGoal</name>
           <version>3.0.0+</version>
           <description>The default goal (or phase in Maven 2) to execute when none is specified for
-            the project. Note that in case of a multi-module build, only the default goal of the top-level
-            project is relevant, i.e. the default goals of child modules are ignored. Since Maven 3,
+            the project. Note that in case of a build with subprojects, only the default goal of the top-level
+            project is relevant, i.e. the default goals of subprojects are ignored. Since Maven 3,
             multiple goals/phases can be separated by whitespace.</description>
           <type>String</type>
         </field>


### PR DESCRIPTION
Replace Maven "module" term by "subproject" in documentation for avoiding confusion with JPMS modules. This commit was initially part of #1625 and moved to a separated PR for allowing inclusion with [MNG-8210](https://issues.apache.org/jira/browse/MNG-8210) instead of [MNG-8195](https://issues.apache.org/jira/browse/MNG-8195).