### PR TITLE
[MNG-8165] Get rid of bashism creeped in

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -133,7 +133,7 @@ find_maven_basedir() {
       basedir=$wdir
       break
     fi
-    if [ "$wdir" == '/' ] ; then
+    if [ "$wdir" = '/' ] ; then
       break
     fi
     wdir=`cd "$wdir/.."; pwd`


### PR DESCRIPTION
Use of "==" is a bashism.

---

https://issues.apache.org/jira/browse/MNG-8165