### PR TITLE
[MNG-8211] Fail the build if CI Friendly revision used without value

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator.java
@@ -30,9 +30,7 @@ import java.util.Properties;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.ModelBuildingRequest;
-import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelProblemCollector;
-import org.apache.maven.model.building.ModelProblemCollectorRequest;
 import org.apache.maven.model.path.PathTranslator;
 import org.apache.maven.model.path.UrlNormalizer;
 import org.codehaus.plexus.interpolation.AbstractValueSource;
@@ -160,16 +158,6 @@ public abstract class AbstractStringBasedModelInterpolator implements ModelInter
         // Overwrite existing values in model properties. Otherwise it's not possible
         // to define them via command line e.g.: mvn -Drevision=6.5.7 ...
         versionProcessor.overwriteModelProperties(modelProperties, config);
-        String version = model.getVersion();
-        if (version != null && version.startsWith("${") && version.endsWith("}")) {
-            String property = version.substring(2, version.length() - 1);
-            if (!modelProperties.containsKey(property)) {
-                problems.add(new ModelProblemCollectorRequest(ModelProblem.Severity.FATAL, ModelProblem.Version.BASE)
-                        .setMessage("Model '" + model.getId() + "' uses CI Friendly Versions expression '${" + property
-                                + "}' without value being set")
-                        .setLocation(model.getLocation("")));
-            }
-        }
         valueSources.add(new MapBasedValueSource(modelProperties));
 
         valueSources.add(new MapBasedValueSource(config.getSystemProperties()));

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -476,7 +476,14 @@ public class DefaultModelValidator implements ModelValidator {
 
         validateStringNotEmpty("version", problems, Severity.ERROR, Version.BASE, m.getVersion(), m);
         if (hasExpression(m.getVersion())) {
-            addViolation(problems, Severity.ERROR, Version.BASE, "version", null, "must be a constant version but is '" + m.getVersion() + "'.", m);
+            addViolation(
+                    problems,
+                    Severity.ERROR,
+                    Version.BASE,
+                    "version",
+                    null,
+                    "must be a constant version but is '" + m.getVersion() + "'.",
+                    m);
         }
 
         Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -475,16 +475,6 @@ public class DefaultModelValidator implements ModelValidator {
         }
 
         validateStringNotEmpty("version", problems, Severity.ERROR, Version.BASE, m.getVersion(), m);
-        if (hasExpression(m.getVersion())) {
-            addViolation(
-                    problems,
-                    Severity.ERROR,
-                    Version.BASE,
-                    "version",
-                    null,
-                    "must be a constant version but is '" + m.getVersion() + "'.",
-                    m);
-        }
 
         Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
@@ -516,6 +506,16 @@ public class DefaultModelValidator implements ModelValidator {
             validateBannedCharacters(
                     EMPTY, "version", problems, errOn31, Version.V20, m.getVersion(), null, m, ILLEGAL_VERSION_CHARS);
             validate20ProperSnapshotVersion("version", problems, errOn31, Version.V20, m.getVersion(), null, m);
+            if (hasExpression(m.getVersion())) {
+                addViolation(
+                        problems,
+                        Severity.ERROR,
+                        Version.V20,
+                        "version",
+                        null,
+                        "must be a constant version but is '" + m.getVersion() + "'.",
+                        m);
+            }
 
             Build build = m.getBuild();
             if (build != null) {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -475,6 +475,9 @@ public class DefaultModelValidator implements ModelValidator {
         }
 
         validateStringNotEmpty("version", problems, Severity.ERROR, Version.BASE, m.getVersion(), m);
+        if (hasExpression(m.getVersion())) {
+            addViolation(problems, Severity.ERROR, Version.BASE, "version", null, "must be a constant version but is '" + m.getVersion() + "'.", m);
+        }
 
         Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -510,8 +510,8 @@ public class DefaultModelValidator implements ModelValidator {
             validate20ProperSnapshotVersion("version", problems, errOn31, Version.V20, m.getVersion(), null, m);
             if (hasExpression(m.getVersion())) {
                 Severity versionExpressionSeverity = Severity.ERROR;
-                if (Boolean.parseBoolean(m.getProperties()
-                        .getProperty(BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION, Boolean.FALSE.toString()))) {
+                if (Boolean.parseBoolean(
+                        m.getProperties().getProperty(BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION))) {
                     versionExpressionSeverity = Severity.WARNING;
                 }
                 addViolation(

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -74,6 +74,8 @@ import org.codehaus.plexus.util.StringUtils;
 @Named
 @Singleton
 public class DefaultModelValidator implements ModelValidator {
+    public static final String BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION =
+            "maven.build.allowExpressionInEffectiveProjectVersion";
 
     private static final Pattern CI_FRIENDLY_EXPRESSION = Pattern.compile("\\$\\{(.+?)}");
     private static final Pattern EXPRESSION_PROJECT_NAME_PATTERN = Pattern.compile("\\$\\{(project.+?)}");
@@ -507,9 +509,14 @@ public class DefaultModelValidator implements ModelValidator {
                     EMPTY, "version", problems, errOn31, Version.V20, m.getVersion(), null, m, ILLEGAL_VERSION_CHARS);
             validate20ProperSnapshotVersion("version", problems, errOn31, Version.V20, m.getVersion(), null, m);
             if (hasExpression(m.getVersion())) {
+                Severity versionExpressionSeverity = Severity.ERROR;
+                if (Boolean.parseBoolean(m.getProperties()
+                        .getProperty(BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION, Boolean.FALSE.toString()))) {
+                    versionExpressionSeverity = Severity.WARNING;
+                }
                 addViolation(
                         problems,
-                        Severity.ERROR,
+                        versionExpressionSeverity,
                         Version.V20,
                         "version",
                         null,


### PR DESCRIPTION
As this is almost always source of confusion. If feature is used and there is no proper value set, fail the build, as users for sure does not plan to deploy artifacts with version `${revision}` (or any expression in project.version).

Still, to not be disruptive, the old behaviour can be achieved by setting `maven.build.allowExpressionInEffectiveProjectVersion`=true project property.

---

https://issues.apache.org/jira/browse/MNG-8211