### PR TITLE
[MNG-8211] Fail the build if project effective version has expression

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -704,10 +704,8 @@ public class DefaultModelValidator implements ModelValidator {
             if (hasExpression(m.getVersion())) {
                 Severity versionExpressionSeverity = Severity.ERROR;
                 if (m.getProperties() != null
-                        && Boolean.parseBoolean(m.getProperties()
-                                .getOrDefault(
-                                        BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION,
-                                        Boolean.FALSE.toString()))) {
+                        && Boolean.parseBoolean(
+                                m.getProperties().get(BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION))) {
                     versionExpressionSeverity = Severity.WARNING;
                 }
                 addViolation(

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -699,6 +699,16 @@ public class DefaultModelValidator implements ModelValidator {
             validateBannedCharacters(
                     EMPTY, "version", problems, errOn31, Version.V20, m.getVersion(), null, m, ILLEGAL_VERSION_CHARS);
             validate20ProperSnapshotVersion("version", problems, errOn31, Version.V20, m.getVersion(), null, m);
+            if (hasExpression(m.getVersion())) {
+                addViolation(
+                        problems,
+                        Severity.ERROR,
+                        Version.V20,
+                        "version",
+                        null,
+                        "must be a constant version but is '" + m.getVersion() + "'.",
+                        m);
+            }
 
             Build build = m.getBuild();
             if (build != null) {

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -78,6 +78,8 @@ import org.apache.maven.model.v4.MavenTransformer;
 @Named
 @Singleton
 public class DefaultModelValidator implements ModelValidator {
+    public static final String BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION =
+            "maven.build.allowExpressionInEffectiveProjectVersion";
 
     public static final List<String> VALID_MODEL_VERSIONS =
             Collections.unmodifiableList(Arrays.asList("4.0.0", "4.1.0"));
@@ -700,9 +702,17 @@ public class DefaultModelValidator implements ModelValidator {
                     EMPTY, "version", problems, errOn31, Version.V20, m.getVersion(), null, m, ILLEGAL_VERSION_CHARS);
             validate20ProperSnapshotVersion("version", problems, errOn31, Version.V20, m.getVersion(), null, m);
             if (hasExpression(m.getVersion())) {
+                Severity versionExpressionSeverity = Severity.ERROR;
+                if (m.getProperties() != null
+                        && Boolean.parseBoolean(m.getProperties()
+                                .getOrDefault(
+                                        BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION,
+                                        Boolean.FALSE.toString()))) {
+                    versionExpressionSeverity = Severity.WARNING;
+                }
                 addViolation(
                         problems,
-                        Severity.ERROR,
+                        versionExpressionSeverity,
                         Version.V20,
                         "version",
                         null,

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -691,6 +691,16 @@ public class DefaultModelValidator implements ModelValidator {
             validateBannedCharacters(
                     EMPTY, "version", problems, errOn31, Version.V20, m.getVersion(), null, m, ILLEGAL_VERSION_CHARS);
             validate20ProperSnapshotVersion("version", problems, errOn31, Version.V20, m.getVersion(), null, m);
+            if (hasExpression(m.getVersion())) {
+                addViolation(
+                        problems,
+                        Severity.ERROR,
+                        Version.V20,
+                        "version",
+                        null,
+                        "must be a constant version but is '" + m.getVersion() + "'.",
+                        m);
+            }
 
             Build build = m.getBuild();
             if (build != null) {

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -80,6 +80,8 @@ import org.apache.maven.model.v4.MavenTransformer;
 @Named
 @Singleton
 public class DefaultModelValidator implements ModelValidator {
+    public static final String BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION =
+            "maven.build.allowExpressionInEffectiveProjectVersion";
 
     public static final List<String> VALID_MODEL_VERSIONS =
             Collections.unmodifiableList(Arrays.asList("4.0.0", "4.1.0"));
@@ -692,9 +694,17 @@ public class DefaultModelValidator implements ModelValidator {
                     EMPTY, "version", problems, errOn31, Version.V20, m.getVersion(), null, m, ILLEGAL_VERSION_CHARS);
             validate20ProperSnapshotVersion("version", problems, errOn31, Version.V20, m.getVersion(), null, m);
             if (hasExpression(m.getVersion())) {
+                Severity versionExpressionSeverity = Severity.ERROR;
+                if (m.getProperties() != null
+                        && Boolean.parseBoolean(m.getProperties()
+                                .getOrDefault(
+                                        BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION,
+                                        Boolean.FALSE.toString()))) {
+                    versionExpressionSeverity = Severity.WARNING;
+                }
                 addViolation(
                         problems,
-                        Severity.ERROR,
+                        versionExpressionSeverity,
                         Version.V20,
                         "version",
                         null,

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -696,10 +696,8 @@ public class DefaultModelValidator implements ModelValidator {
             if (hasExpression(m.getVersion())) {
                 Severity versionExpressionSeverity = Severity.ERROR;
                 if (m.getProperties() != null
-                        && Boolean.parseBoolean(m.getProperties()
-                                .getOrDefault(
-                                        BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION,
-                                        Boolean.FALSE.toString()))) {
+                        && Boolean.parseBoolean(
+                                m.getProperties().get(BUILD_ALLOW_EXPRESSION_IN_EFFECTIVE_PROJECT_VERSION))) {
                     versionExpressionSeverity = Severity.WARNING;
                 }
                 addViolation(


### PR DESCRIPTION
As this is almost always source of confusion. If feature is used and there is no proper value set, fail the build, as users for sure does not plan to deploy artifacts with version `${revision}` (or any expression in project.version).

Still, to not be disruptive, the old behaviour can be achieved by setting `maven.build.allowExpressionInEffectiveProjectVersion`=true project property.

---

https://issues.apache.org/jira/browse/MNG-8211