### PR TITLE
[MNG-8252] Fully infer the parent coordinates if the location points to a valid model

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -301,37 +301,6 @@ public class DefaultModelValidator implements ModelValidator {
     public void validateFileModel(Model m, ModelBuilderRequest request, ModelProblemCollector problems) {
 
         Parent parent = m.getParent();
-        if (parent != null) {
-            validateStringNotEmpty(
-                    "parent.groupId", problems, Severity.FATAL, Version.BASE, parent.getGroupId(), parent);
-
-            validateStringNotEmpty(
-                    "parent.artifactId", problems, Severity.FATAL, Version.BASE, parent.getArtifactId(), parent);
-
-            if (equals(parent.getGroupId(), m.getGroupId()) && equals(parent.getArtifactId(), m.getArtifactId())) {
-                addViolation(
-                        problems,
-                        Severity.FATAL,
-                        Version.BASE,
-                        "parent.artifactId",
-                        null,
-                        "must be changed"
-                                + ", the parent element cannot have the same groupId:artifactId as the project.",
-                        parent);
-            }
-
-            if (equals("LATEST", parent.getVersion()) || equals("RELEASE", parent.getVersion())) {
-                addViolation(
-                        problems,
-                        Severity.WARNING,
-                        Version.BASE,
-                        "parent.version",
-                        null,
-                        "is either LATEST or RELEASE (both of them are being deprecated)",
-                        parent);
-            }
-        }
-
         if (request.getValidationLevel() == ModelBuilderRequest.VALIDATION_LEVEL_MINIMAL) {
             // profiles: they are essential for proper model building (may contribute profiles, dependencies...)
             HashSet<String> minProfileIds = new HashSet<>();
@@ -553,7 +522,36 @@ public class DefaultModelValidator implements ModelValidator {
 
         if (parent != null) {
             validateStringNotEmpty(
+                    "parent.groupId", problems, Severity.FATAL, Version.BASE, parent.getGroupId(), parent);
+
+            validateStringNotEmpty(
+                    "parent.artifactId", problems, Severity.FATAL, Version.BASE, parent.getArtifactId(), parent);
+
+            validateStringNotEmpty(
                     "parent.version", problems, Severity.FATAL, Version.BASE, parent.getVersion(), parent);
+
+            if (equals(parent.getGroupId(), m.getGroupId()) && equals(parent.getArtifactId(), m.getArtifactId())) {
+                addViolation(
+                        problems,
+                        Severity.FATAL,
+                        Version.BASE,
+                        "parent.artifactId",
+                        null,
+                        "must be changed"
+                                + ", the parent element cannot have the same groupId:artifactId as the project.",
+                        parent);
+            }
+
+            if (equals("LATEST", parent.getVersion()) || equals("RELEASE", parent.getVersion())) {
+                addViolation(
+                        problems,
+                        Severity.WARNING,
+                        Version.BASE,
+                        "parent.version",
+                        null,
+                        "is either LATEST or RELEASE (both of them are being deprecated)",
+                        parent);
+            }
         }
     }
 


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-8252
IT PR: https://github.com/apache/maven-integration-testing/pull/360

A simple empty parent should be sufficient if the parent is located in the parent directory:
```
<project xmlns="http://maven.apache.org/POM/4.1.0">
    <parent />
    <artifactId>maven-resolver-util</artifactId>

     ...
</project>
```

If the parent is in a different location,
 ```
<project xmlns="http://maven.apache.org/POM/4.1.0">
    <parent>
        <location>../parent/</location>
    </parent>
    <artifactId>maven-resolver-util</artifactId>

     ...
</project>
```
