### PR TITLE
[MNG-8252] Fully infer the parent coordinates if the location points to a valid model (#1706)

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/BuildModelTransformer.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/BuildModelTransformer.java
@@ -20,7 +20,6 @@ package org.apache.maven.internal.impl.model;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -58,34 +57,13 @@ public class BuildModelTransformer implements ModelTransformer {
     void handleParent(ModelTransformerContext context, Model model, Path pomFile, Model.Builder builder) {
         Parent parent = model.getParent();
         if (parent != null) {
-            String groupId = parent.getGroupId();
-            String artifactId = parent.getArtifactId();
             String version = parent.getVersion();
-            String path = Optional.ofNullable(parent.getRelativePath()).orElse("..");
-            if (version == null && !path.isEmpty()) {
-                Optional<RelativeProject> resolvedParent = resolveRelativePath(
-                        pomFile, context, Paths.get(path), parent.getGroupId(), parent.getArtifactId());
-                if (resolvedParent.isPresent()) {
-                    RelativeProject project = resolvedParent.get();
-                    if (groupId == null
-                            || groupId.equals(project.getGroupId()) && artifactId == null
-                            || artifactId.equals(project.getArtifactId())) {
-                        groupId = project.getGroupId();
-                        artifactId = project.getArtifactId();
-                        version = resolvedParent.get().getVersion();
-                    }
-                }
-            }
 
             // CI Friendly version for parent
             String modVersion = replaceCiFriendlyVersion(context, version);
 
             // Update parent
-            builder.parent(parent.with()
-                    .groupId(groupId)
-                    .artifactId(artifactId)
-                    .version(modVersion)
-                    .build());
+            builder.parent(parent.with().version(modVersion).build());
         }
     }
 

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/MavenModelMerger.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/MavenModelMerger.java
@@ -231,6 +231,37 @@ public class MavenModelMerger extends MavenMerger {
         }
     }
 
+    @Override
+    protected void mergeModelBase_Subprojects(
+            ModelBase.Builder builder,
+            ModelBase target,
+            ModelBase source,
+            boolean sourceDominant,
+            Map<Object, Object> context) {
+        List<String> src = source.getSubprojects();
+        if (!src.isEmpty() && sourceDominant) {
+            List<Integer> indices = new ArrayList<>();
+            List<String> tgt = target.getSubprojects();
+            Set<String> excludes = new LinkedHashSet<>(tgt);
+            List<String> merged = new ArrayList<>(tgt.size() + src.size());
+            merged.addAll(tgt);
+            for (int i = 0, n = tgt.size(); i < n; i++) {
+                indices.add(i);
+            }
+            for (int i = 0, n = src.size(); i < n; i++) {
+                String s = src.get(i);
+                if (!excludes.contains(s)) {
+                    merged.add(s);
+                    indices.add(~i);
+                }
+            }
+            builder.subprojects(merged);
+            builder.location(
+                    "subprojects",
+                    InputLocation.merge(target.getLocation("subprojects"), source.getLocation("subprojects"), indices));
+        }
+    }
+
     /*
      * TODO: The order of the merged list could be controlled by an attribute in the model association: target-first,
      * source-first, dominant-first, recessive-first


### PR DESCRIPTION
Fix things
The original PR was passing UT and IT, but to sure how it worked
Anyway, this aims at fixing the computation. Using the `BuildModelTransformer` is not a good option: when the full reactor is loaded, we parse file models and expect them to have valid groupId/artifactId, so the processing has to be done during file model loading.