### PR TITLE
[MNG-8256] FilteredProjectDependencyGraph fix for non-transitive case

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -120,8 +120,7 @@ public class DefaultGraphBuilder implements GraphBuilder {
         Result<ProjectDependencyGraph> result = null;
 
         if (session.getProjectDependencyGraph() != null || session.getProjects() != null) {
-            final ProjectDependencyGraph graph =
-                    new DefaultProjectDependencyGraph(session.getAllProjects(), session.getProjects());
+            final ProjectDependencyGraph graph = new DefaultProjectDependencyGraph(session.getAllProjects());
 
             result = Result.success(graph);
         }

--- a/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -120,7 +120,10 @@ public class DefaultGraphBuilder implements GraphBuilder {
         Result<ProjectDependencyGraph> result = null;
 
         if (session.getProjectDependencyGraph() != null || session.getProjects() != null) {
-            final ProjectDependencyGraph graph = new DefaultProjectDependencyGraph(session.getAllProjects());
+            ProjectDependencyGraph graph = new DefaultProjectDependencyGraph(session.getAllProjects());
+            if (session.getProjects() != null) {
+                graph = new FilteredProjectDependencyGraph(graph, session.getProjects());
+            }
 
             result = Result.success(graph);
         }

--- a/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
@@ -88,11 +88,11 @@ class FilteredProjectDependencyGraph implements ProjectDependencyGraph {
         for (MavenProject project : projects) {
             if (whiteList.containsKey(project)) {
                 filtered.add(project);
-            } else {
+            } else if (!transitive) {
                 filtered.addAll(
                         upstream
-                                ? getUpstreamProjects(project, transitive)
-                                : getDownstreamProjects(project, transitive));
+                                ? getUpstreamProjects(project, false)
+                                : getDownstreamProjects(project, false));
             }
         }
         return filtered;

--- a/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
@@ -89,10 +89,7 @@ class FilteredProjectDependencyGraph implements ProjectDependencyGraph {
             if (whiteList.containsKey(project)) {
                 filtered.add(project);
             } else if (!transitive) {
-                filtered.addAll(
-                        upstream
-                                ? getUpstreamProjects(project, false)
-                                : getDownstreamProjects(project, false));
+                filtered.addAll(upstream ? getUpstreamProjects(project, false) : getDownstreamProjects(project, false));
             }
         }
         return filtered;

--- a/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
@@ -82,6 +82,16 @@ class FilteredProjectDependencyGraph implements ProjectDependencyGraph {
         return applyFilter(projectDependencyGraph.getUpstreamProjects(project, transitive), transitive, true);
     }
 
+    /**
+     * Filter out whitelisted projects with a big twist:
+     * Assume we have all projects {@code a, b, c} while active are {@code a, c} and relation among all projects
+     * is {@code a -> b -> c}. This method handles well the case for transitive list. But, for non-transitive we need
+     * to "pull in" transitive dependencies of eliminated projects, as for case above, the properly filtered list would
+     * be {@code a -> c}.
+     * <p>
+     * Original code would falsely report {@code a} project as "without dependencies", basically would lose link due
+     * filtering. This causes build ordering issues in concurrent builders.
+     */
     private List<MavenProject> applyFilter(
             Collection<? extends MavenProject> projects, boolean transitive, boolean upstream) {
         List<MavenProject> filtered = new ArrayList<>(projects.size());

--- a/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
+++ b/maven-core/src/main/java/org/apache/maven/graph/FilteredProjectDependencyGraph.java
@@ -34,11 +34,11 @@ import org.apache.maven.project.MavenProject;
  */
 class FilteredProjectDependencyGraph implements ProjectDependencyGraph {
 
-    private ProjectDependencyGraph projectDependencyGraph;
+    private final ProjectDependencyGraph projectDependencyGraph;
 
-    private Map<MavenProject, ?> whiteList;
+    private final Map<MavenProject, ?> whiteList;
 
-    private List<MavenProject> sortedProjects;
+    private final List<MavenProject> sortedProjects;
 
     /**
      * Creates a new project dependency graph from the specified graph.
@@ -50,46 +50,43 @@ class FilteredProjectDependencyGraph implements ProjectDependencyGraph {
             ProjectDependencyGraph projectDependencyGraph, Collection<? extends MavenProject> whiteList) {
         this.projectDependencyGraph =
                 Objects.requireNonNull(projectDependencyGraph, "projectDependencyGraph cannot be null");
-
         this.whiteList = new IdentityHashMap<>();
-
         for (MavenProject project : whiteList) {
             this.whiteList.put(project, null);
         }
+        this.sortedProjects = applyFilter(projectDependencyGraph.getSortedProjects());
     }
 
     /**
      * @since 3.5.0
      */
+    @Override
     public List<MavenProject> getAllProjects() {
         return this.projectDependencyGraph.getAllProjects();
     }
 
+    @Override
     public List<MavenProject> getSortedProjects() {
-        if (sortedProjects == null) {
-            sortedProjects = applyFilter(projectDependencyGraph.getSortedProjects());
-        }
-
         return new ArrayList<>(sortedProjects);
     }
 
+    @Override
     public List<MavenProject> getDownstreamProjects(MavenProject project, boolean transitive) {
         return applyFilter(projectDependencyGraph.getDownstreamProjects(project, transitive));
     }
 
+    @Override
     public List<MavenProject> getUpstreamProjects(MavenProject project, boolean transitive) {
         return applyFilter(projectDependencyGraph.getUpstreamProjects(project, transitive));
     }
 
     private List<MavenProject> applyFilter(Collection<? extends MavenProject> projects) {
         List<MavenProject> filtered = new ArrayList<>(projects.size());
-
         for (MavenProject project : projects) {
             if (whiteList.containsKey(project)) {
                 filtered.add(project);
             }
         }
-
         return filtered;
     }
 

--- a/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
@@ -61,7 +61,7 @@ class DefaultProjectDependencyGraphTest {
         assertEquals(aProject, sortedProjects.get(0));
         assertEquals(cProject, sortedProjects.get(1));
 
-        assertTrue(graph.getDownstreamProjects(aProject, true).contains(cProject));
+        assertTrue(graph.getDownstreamProjects(aProject, false).contains(cProject));
     }
 
     @Test

--- a/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
@@ -53,7 +53,7 @@ class DefaultProjectDependencyGraphTest {
     private final MavenProject transitiveOnly = createProject(Arrays.asList(toDependency(depender3)), "depender5");
 
     @Test
-    void myTheory() throws DuplicateProjectException, CycleDetectedException {
+    void testNonTransitiveFiltering() throws DuplicateProjectException, CycleDetectedException {
         ProjectDependencyGraph graph = new FilteredProjectDependencyGraph(
                 new DefaultProjectDependencyGraph(Arrays.asList(aProject, bProject, cProject)),
                 Arrays.asList(aProject, cProject));

--- a/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
@@ -29,12 +29,17 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  */
 class DefaultProjectDependencyGraphTest {
 
     private final MavenProject aProject = createA();
+
+    private final MavenProject bProject = createProject(Arrays.asList(toDependency(aProject)), "bProject");
+
+    private final MavenProject cProject = createProject(Arrays.asList(toDependency(bProject)), "cProject");
 
     private final MavenProject depender1 = createProject(Arrays.asList(toDependency(aProject)), "depender1");
 
@@ -46,6 +51,18 @@ class DefaultProjectDependencyGraphTest {
             createProject(Arrays.asList(toDependency(aProject), toDependency(depender3)), "depender4");
 
     private final MavenProject transitiveOnly = createProject(Arrays.asList(toDependency(depender3)), "depender5");
+
+    @Test
+    void myTheory() throws DuplicateProjectException, CycleDetectedException {
+        ProjectDependencyGraph graph = new FilteredProjectDependencyGraph(
+                new DefaultProjectDependencyGraph(Arrays.asList(aProject, bProject, cProject)),
+                Arrays.asList(aProject, cProject));
+        final List<MavenProject> sortedProjects = graph.getSortedProjects();
+        assertEquals(aProject, sortedProjects.get(0));
+        assertEquals(cProject, sortedProjects.get(1));
+
+        assertTrue(graph.getDownstreamProjects(aProject, true).contains(cProject));
+    }
 
     @Test
     void testGetSortedProjects() throws DuplicateProjectException, CycleDetectedException {


### PR DESCRIPTION
The `FilteredProjectDependencyGraph` class fix for non-transitive case and an UT. Also contains some improvement in classes, making them immutable as intended.

---

https://issues.apache.org/jira/browse/MNG-8256