### PR TITLE
[MNG-8256] FilteredProjectDependencyGraph fix for non-transitive case

### DIFF
--- a/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
+++ b/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
@@ -35,6 +35,10 @@ public class DefaultProjectDependencyGraphTest extends TestCase {
 
     private final MavenProject aProject = createA();
 
+    private final MavenProject bProject = createProject(Arrays.asList(toDependency(aProject)), "bProject");
+
+    private final MavenProject cProject = createProject(Arrays.asList(toDependency(bProject)), "cProject");
+
     private final MavenProject depender1 = createProject(Arrays.asList(toDependency(aProject)), "depender1");
 
     private final MavenProject depender2 = createProject(Arrays.asList(toDependency(aProject)), "depender2");
@@ -45,6 +49,17 @@ public class DefaultProjectDependencyGraphTest extends TestCase {
             createProject(Arrays.asList(toDependency(aProject), toDependency(depender3)), "depender4");
 
     private final MavenProject transitiveOnly = createProject(Arrays.asList(toDependency(depender3)), "depender5");
+
+    public void testNonTransitiveFiltering() throws DuplicateProjectException, CycleDetectedException {
+        ProjectDependencyGraph graph = new FilteredProjectDependencyGraph(
+                new DefaultProjectDependencyGraph(Arrays.asList(aProject, bProject, cProject)),
+                Arrays.asList(aProject, cProject));
+        final List<MavenProject> sortedProjects = graph.getSortedProjects();
+        assertEquals(aProject, sortedProjects.get(0));
+        assertEquals(cProject, sortedProjects.get(1));
+
+        assertTrue(graph.getDownstreamProjects(aProject, false).contains(cProject));
+    }
 
     public void testGetSortedProjects() throws DuplicateProjectException, CycleDetectedException {
         ProjectDependencyGraph graph = new DefaultProjectDependencyGraph(Arrays.asList(depender1, aProject));


### PR DESCRIPTION
The `FilteredProjectDependencyGraph` class fix for non-transitive case and an UT. Also contains some improvement in classes, making them immutable as intended.

---

https://issues.apache.org/jira/browse/MNG-8256