### PR TITLE
More readable formatting of the warning about automatic modules

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/PathModularizationCache.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/PathModularizationCache.java
@@ -178,10 +178,11 @@ class PathModularizationCache {
         if (automodulesDetected.isEmpty()) {
             return Optional.empty();
         }
+        String lineSeparator = System.lineSeparator();
         var joiner = new StringJoiner(
-                ", ",
-                "Filename-based automodules detected on the module-path: ",
-                "Please don't publish this project to a public artifact repository.");
+                lineSeparator + "  - ",
+                "Filename-based automodules detected on the module-path: " + lineSeparator + "  - ",
+                lineSeparator + "Please don't publish this project to a public artifact repository.");
         automodulesDetected.forEach(joiner::add);
         return Optional.of(joiner.toString());
     }


### PR DESCRIPTION
When Maven detects a non-modular JAR file on the module path, it produces a warning. However, the warning is currently not very readable. The message and all dependencies are put on the same line, and a space is missing between the last dependency and the rest of the message. This commit splits the message with each dependency on its own line.

Note: the relevance of this warning is questionable. This commit does not address the issue about whether we should just completely remove it.