### PR TITLE
Probable bug: method that nullifies model

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelPathTranslator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelPathTranslator.java
@@ -107,7 +107,7 @@ public class DefaultModelPathTranslator implements ModelPathTranslator {
 
     private Resource alignToBaseDirectory(Resource resource, Path basedir) {
         if (resource != null) {
-            String newDir = alignToBaseDirectory(resource.getDirectory(), basedir);
+            String newDir = mayAlignToBaseDirectoryOrNull(resource.getDirectory(), basedir);
             if (newDir != null) {
                 return resource.withDirectory(newDir);
             }
@@ -116,6 +116,17 @@ public class DefaultModelPathTranslator implements ModelPathTranslator {
     }
 
     private String alignToBaseDirectory(String path, Path basedir) {
+        String newPath = mayAlignToBaseDirectoryOrNull(path, basedir);
+        if (newPath != null) {
+            return newPath;
+        }
+        return path;
+    }
+
+    /**
+     * Returns aligned path or {@code null} if no need for change.
+     */
+    private String mayAlignToBaseDirectoryOrNull(String path, Path basedir) {
         String newPath = pathTranslator.alignToBaseDirectory(path, basedir);
         return Objects.equals(path, newPath) ? null : newPath;
     }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/path/DefaultModelPathTranslator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/path/DefaultModelPathTranslator.java
@@ -126,7 +126,10 @@ public class DefaultModelPathTranslator implements ModelPathTranslator {
 
     private String alignToBaseDirectory(String path, Path basedir) {
         String newPath = mayAlignToBaseDirectoryOrNull(path, basedir);
-        return Objects.equals(path, newPath) ? path : newPath;
+        if (newPath != null) {
+            return newPath;
+        }
+        return path;
     }
 
     /**

--- a/maven-model-builder/src/main/java/org/apache/maven/model/path/DefaultModelPathTranslator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/path/DefaultModelPathTranslator.java
@@ -116,7 +116,7 @@ public class DefaultModelPathTranslator implements ModelPathTranslator {
 
     private Resource alignToBaseDirectory(Resource resource, Path basedir) {
         if (resource != null) {
-            String newDir = alignToBaseDirectory(resource.getDirectory(), basedir);
+            String newDir = mayAlignToBaseDirectoryOrNull(resource.getDirectory(), basedir);
             if (newDir != null) {
                 return resource.withDirectory(newDir);
             }
@@ -125,6 +125,14 @@ public class DefaultModelPathTranslator implements ModelPathTranslator {
     }
 
     private String alignToBaseDirectory(String path, Path basedir) {
+        String newPath = mayAlignToBaseDirectoryOrNull(path, basedir);
+        return Objects.equals(path, newPath) ? path : newPath;
+    }
+
+    /**
+     * Returns aligned path or {@code null} if no need for change.
+     */
+    private String mayAlignToBaseDirectoryOrNull(String path, Path basedir) {
         String newPath = pathTranslator.alignToBaseDirectory(path, basedir);
         return Objects.equals(path, newPath) ? null : newPath;
     }


### PR DESCRIPTION
As discovered by @desruisseaux , this method is once used for "change detection" (if result is not null, apply change), and once directly where it -- probably by mistake -- nullifies the field value.

@gnodet 