### PR TITLE
Add license header to m2.conf

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -151,7 +151,6 @@ under the License.
           <artifactId>apache-rat-plugin</artifactId>
           <configuration>
             <excludes combine.children="append">
-              <exclude>src/assembly/maven/bin/m2.conf</exclude>
               <!-- these are partial scripts, resulting in mvn scripts -->
               <exclude>src/assembly/shared/init</exclude>
               <exclude>src/assembly/shared/init.cmd</exclude>

--- a/apache-maven/src/assembly/maven/bin/m2.conf
+++ b/apache-maven/src/assembly/maven/bin/m2.conf
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 main is org.apache.maven.cli.MavenCli from plexus.core
 
 set maven.conf default ${maven.home}/conf


### PR DESCRIPTION
...just found no reason not adding it, as all other scripts/shell have added, and this file format actually can accept \# comments...