### PR TITLE
No issue, no change

### DIFF
--- a/maven-embedder/src/main/resources/META-INF/maven/slf4j-configuration.properties
+++ b/maven-embedder/src/main/resources/META-INF/maven/slf4j-configuration.properties
@@ -17,7 +17,7 @@
 
 # key = Slf4j effective logger factory implementation
 # value = corresponding o.a.m.cli.logging.Slf4jConfiguration class
-org.slf4j.impl.SimpleLoggerFactory org.apache.maven.cli.logging.impl.Slf4jSimpleConfiguration
-org.apache.maven.slf4j.MavenLoggerFactory org.apache.maven.cli.logging.impl.Slf4jSimpleConfiguration
-org.apache.logging.slf4j.Log4jLoggerFactory org.apache.maven.cli.logging.impl.Log4j2Configuration
-ch.qos.logback.classic.LoggerContext org.apache.maven.cli.logging.impl.LogbackConfiguration
+org.slf4j.impl.SimpleLoggerFactory=org.apache.maven.cli.logging.impl.Slf4jSimpleConfiguration
+org.apache.maven.slf4j.MavenLoggerFactory=org.apache.maven.cli.logging.impl.Slf4jSimpleConfiguration
+org.apache.logging.slf4j.Log4jLoggerFactory=org.apache.maven.cli.logging.impl.Log4j2Configuration
+ch.qos.logback.classic.LoggerContext=org.apache.maven.cli.logging.impl.LogbackConfiguration


### PR DESCRIPTION
Just a simple PR to make properties file a "properties file" as majority would expect. According to spec '=', ':', or white space can be delimiter and this file IS valid, but still, users my be surprised, or tools like IDEs may misinterpret this, otherwise valid Java Properties File.