### PR TITLE
[MNG-8288] "path cannot be null"

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
@@ -1328,9 +1328,12 @@ public class DefaultModelBuilder implements ModelBuilder {
                 // defined on the root project.
                 Map<String, String> properties = new HashMap<>();
                 if (!Objects.equals(rootDirectory, model.getProjectDirectory())) {
-                    Model rootModel = derive(ModelSource.fromPath(modelProcessor.locateExistingPom(rootDirectory)))
-                            .readFileModel();
-                    properties.putAll(rootModel.getProperties());
+                    Path rootModelPath = modelProcessor.locateExistingPom(rootDirectory);
+                    if (rootModelPath != null) {
+                        Model rootModel =
+                                derive(ModelSource.fromPath(rootModelPath)).readFileModel();
+                        properties.putAll(rootModel.getProperties());
+                    }
                 } else {
                     properties.putAll(model.getProperties());
                 }


### PR DESCRIPTION
It seems Maven is eager to get POM from rootDirectory to support CI Friendly versions. This change makes it "best effort", as in if there is no POM, just walk away.

---

https://issues.apache.org/jira/browse/MNG-8288