### PR TITLE
Fix concurrency issue in DefaultModelValidator

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -1497,7 +1497,7 @@ public class DefaultModelValidator implements ModelValidator {
             String id,
             String sourceHint,
             InputLocationTracker tracker) {
-        if (validCoordinatesIds.contains(id)) {
+        if (id != null && validCoordinatesIds.contains(id)) {
             return true;
         }
         if (!validateStringNotEmpty(prefix, fieldName, problems, severity, version, id, sourceHint, tracker)) {

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -283,9 +284,9 @@ public class DefaultModelValidator implements ModelValidator {
         }
     }
 
-    private final Set<String> validCoordinatesIds = new HashSet<>();
+    private final Set<String> validCoordinatesIds = ConcurrentHashMap.newKeySet();
 
-    private final Set<String> validProfileIds = new HashSet<>();
+    private final Set<String> validProfileIds = ConcurrentHashMap.newKeySet();
 
     @Inject
     public DefaultModelValidator() {}

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -135,7 +135,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             }
         } catch (ArtifactDescriptorException e) {
             throw new PluginResolutionException(
-                    plugin, e.getResult().getExceptions(), logger.isDebugEnabled() ? e : null);
+                    plugin, e.getResult().getExceptions(), e);
         }
 
         try {
@@ -144,7 +144,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             pluginArtifact = repoSystem.resolveArtifact(session, request).getArtifact();
         } catch (ArtifactResolutionException e) {
             throw new PluginResolutionException(
-                    plugin, e.getResult().getExceptions(), logger.isDebugEnabled() ? e : null);
+                    plugin, e.getResult().getExceptions(), e);
         }
 
         return pluginArtifact;
@@ -234,7 +234,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             return repoSystem.resolveDependencies(session, depRequest);
         } catch (DependencyCollectionException e) {
             throw new PluginResolutionException(
-                    plugin, e.getResult().getExceptions(), logger.isDebugEnabled() ? e : null);
+                    plugin, e.getResult().getExceptions(), e);
         } catch (DependencyResolutionException e) {
             List<Exception> exceptions = Stream.concat(
                             e.getResult().getCollectExceptions().stream(),
@@ -242,7 +242,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                                     .filter(r -> !r.isResolved())
                                     .flatMap(r -> r.getExceptions().stream()))
                     .collect(Collectors.toList());
-            throw new PluginResolutionException(plugin, exceptions, logger.isDebugEnabled() ? e : null);
+            throw new PluginResolutionException(plugin, exceptions, e);
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -134,8 +134,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                 pluginArtifact = pluginArtifact.setProperties(props);
             }
         } catch (ArtifactDescriptorException e) {
-            throw new PluginResolutionException(
-                    plugin, e.getResult().getExceptions(), e);
+            throw new PluginResolutionException(plugin, e.getResult().getExceptions(), e);
         }
 
         try {
@@ -143,8 +142,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             request.setTrace(trace);
             pluginArtifact = repoSystem.resolveArtifact(session, request).getArtifact();
         } catch (ArtifactResolutionException e) {
-            throw new PluginResolutionException(
-                    plugin, e.getResult().getExceptions(), e);
+            throw new PluginResolutionException(plugin, e.getResult().getExceptions(), e);
         }
 
         return pluginArtifact;
@@ -233,8 +231,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             depRequest.setRoot(node);
             return repoSystem.resolveDependencies(session, depRequest);
         } catch (DependencyCollectionException e) {
-            throw new PluginResolutionException(
-                    plugin, e.getResult().getExceptions(), e);
+            throw new PluginResolutionException(plugin, e.getResult().getExceptions(), e);
         } catch (DependencyResolutionException e) {
             List<Exception> exceptions = Stream.concat(
                             e.getResult().getCollectExceptions().stream(),

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -160,9 +160,7 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
             result.setCollectionErrors(e.getResult().getExceptions());
 
             throw new DependencyResolutionException(
-                    result,
-                    "Could not collect dependencies for project " + project.getId(),
-                    e);
+                    result, "Could not collect dependencies for project " + project.getId(), e);
         }
 
         depRequest.setRoot(node);
@@ -192,9 +190,7 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
             process(result, e.getResult().getArtifactResults());
 
             throw new DependencyResolutionException(
-                    result,
-                    "Could not resolve dependencies for project " + project.getId(),
-                    e);
+                    result, "Could not resolve dependencies for project " + project.getId(), e);
         }
 
         return result;

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -162,7 +162,7 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
             throw new DependencyResolutionException(
                     result,
                     "Could not collect dependencies for project " + project.getId(),
-                    logger.isDebugEnabled() ? e : null);
+                    e);
         }
 
         depRequest.setRoot(node);
@@ -194,7 +194,7 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
             throw new DependencyResolutionException(
                     result,
                     "Could not resolve dependencies for project " + project.getId(),
-                    logger.isDebugEnabled() ? e : null);
+                    e);
         }
 
         return result;


### PR DESCRIPTION
This is one of the root cause for IT instability.
@slawekjaranowski I've also re-enabled full stack traces, as the causes are currently completely lost (only the first level of exceptions is kept in the message)