### PR TITLE
[MNG-8295] Dependency Manager Transitivity (now default) handles dependency management inconsistently

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/resolver/MavenSessionBuilderSupplier.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/resolver/MavenSessionBuilderSupplier.java
@@ -43,6 +43,7 @@ import org.eclipse.aether.internal.impl.scope.ScopeManagerImpl;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.util.artifact.DefaultArtifactTypeRegistry;
 import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
+import org.eclipse.aether.util.graph.manager.TransitiveDependencyManager;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
@@ -84,7 +85,10 @@ public class MavenSessionBuilderSupplier implements Supplier<SessionBuilder> {
     }
 
     public DependencyManager getDependencyManager(boolean transitive) {
-        return new ClassicDependencyManager(transitive, getScopeManager());
+        if (transitive) {
+            return new TransitiveDependencyManager(getScopeManager());
+        }
+        return new ClassicDependencyManager(getScopeManager());
     }
 
     protected DependencySelector getDependencySelector() {


### PR DESCRIPTION
IT PR: https://github.com/apache/maven-integration-testing/pull/384
JIRA issue: [MNG-8295](https://issues.apache.org/jira/browse/MNG-8295)
-----
From @DidierLoiseau 

Actually use TransitiveDependencyManager when maven.resolver.dependencyManagerTransitivity=true, instead of ClassicDependencyManager(true, …) as per https://github.com/apache/maven/pull/1357.

This fixes [MNG-8295](https://issues.apache.org/jira/browse/MNG-8295) and the integration tests proposed in https://github.com/apache/maven-integration-testing/pull/384.

I thought that, since the change is trivial, it doesn’t cost much to create a PR for it already – even if the consensus turns out to be something else in the end.

------

Supersedes https://github.com/apache/maven/pull/1785 to align branch names