### PR TITLE
[MNG-8311] empty but existing <localRepository/> in settings.xml

### DIFF
--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -621,7 +621,7 @@ public abstract class LookupInvoker<
         }
         // settings
         userDefinedLocalRepo = context.effectiveSettings.getLocalRepository();
-        if (userDefinedLocalRepo != null) {
+        if (userDefinedLocalRepo != null && !userDefinedLocalRepo.isEmpty()) {
             return context.userResolver.apply(userDefinedLocalRepo);
         }
         // defaults


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/MNG-8311, I reported the issue that an empty `<localRepository/>` element in the settings.xml uses the current working directory or home directory for the local repository.

This PR fixes that issue by adding a check for the empty `String`.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

