### PR TITLE
[MNG-8302] Warn when appropriate

### DIFF
--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
@@ -125,13 +125,14 @@ public interface InvokerRequest<O extends Options> {
     Path topDirectory();
 
     /**
-     * Returns the root directory of the Maven invocation.
-     * This is determined by the presence of a .mvn directory or a POM with the root="true" property.
+     * Returns the root directory of the Maven invocation, if found. This is determined by the presence of a
+     * {@code .mvn} directory or a POM with the root="true" property but is not always applicable (ie invocation
+     * from outside a checkout).
      *
-     * @return the root directory path
+     * @return the root directory path, if present
      */
     @Nonnull
-    Path rootDirectory();
+    Optional<Path> rootDirectory();
 
     /**
      * Returns the input stream for the Maven execution, if running in embedded mode.

--- a/maven-api-impl/src/main/java/org/apache/maven/api/services/model/RootLocator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/api/services/model/RootLocator.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 
 import org.apache.maven.api.Service;
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
 
 /**
  * Interface used to locate the root directory for a given project.
@@ -39,6 +40,9 @@ public interface RootLocator extends Service {
     String UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE = "Unable to find the root directory. "
             + "Create a .mvn directory in the root directory or add the root=\"true\""
             + " attribute on the root project's model to identify it.";
+
+    @Nullable
+    Path findRoot(@Nonnull Path basedir);
 
     @Nonnull
     Path findMandatoryRoot(@Nonnull Path basedir);

--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/rootlocator/DefaultRootLocator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/rootlocator/DefaultRootLocator.java
@@ -46,13 +46,19 @@ public class DefaultRootLocator implements RootLocator {
                 .toList();
     }
 
-    @Nonnull
-    public Path findMandatoryRoot(@Nonnull Path basedir) {
+    @Override
+    public Path findRoot(Path basedir) {
         requireNonNull(basedir, "basedir is null");
         Path rootDirectory = basedir;
         while (rootDirectory != null && !isRootDirectory(rootDirectory)) {
             rootDirectory = rootDirectory.getParent();
         }
+        return rootDirectory;
+    }
+
+    @Nonnull
+    public Path findMandatoryRoot(@Nonnull Path basedir) {
+        Path rootDirectory = findRoot(basedir);
         Optional<Path> rdf = getRootDirectoryFallback();
         if (rootDirectory == null) {
             rootDirectory = rdf.orElseThrow(() -> new IllegalStateException(getNoRootMessage()));

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseInvokerRequest.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseInvokerRequest.java
@@ -114,8 +114,8 @@ public abstract class BaseInvokerRequest<T extends Options> implements InvokerRe
     }
 
     @Override
-    public Path rootDirectory() {
-        return rootDirectory;
+    public Optional<Path> rootDirectory() {
+        return Optional.ofNullable(rootDirectory);
     }
 
     @Override

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -643,11 +643,13 @@ public abstract class LookupInvoker<
         request.setBaseDirectory(context.invokerRequest.topDirectory().toFile());
         request.setSystemProperties(toProperties(context.invokerRequest.systemProperties()));
         request.setUserProperties(toProperties(context.invokerRequest.userProperties()));
-        request.setMultiModuleProjectDirectory(
-                context.invokerRequest.rootDirectory().toFile());
 
-        request.setRootDirectory(context.invokerRequest.rootDirectory());
         request.setTopDirectory(context.invokerRequest.topDirectory());
+        if (context.invokerRequest.rootDirectory().isPresent()) {
+            request.setMultiModuleProjectDirectory(
+                    context.invokerRequest.rootDirectory().get().toFile());
+            request.setRootDirectory(context.invokerRequest.rootDirectory().get());
+        }
 
         request.addPluginGroup("org.apache.maven.plugins");
         request.addPluginGroup("org.codehaus.mojo");

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/Utils.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/Utils.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.annotations.Nullable;
-import org.apache.maven.api.cli.ParserException;
 import org.apache.maven.api.services.model.RootLocator;
 import org.apache.maven.cli.logging.Slf4jConfiguration;
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -48,6 +47,7 @@ import static java.util.Objects.requireNonNull;
 public final class Utils {
     private Utils() {}
 
+    @Nullable
     public static File toFile(Path path) {
         if (path != null) {
             return path.toFile();
@@ -55,6 +55,7 @@ public final class Utils {
         return null;
     }
 
+    @Nonnull
     public static String stripLeadingAndTrailingQuotes(String str) {
         requireNonNull(str, "str");
         final int length = str.length();
@@ -67,6 +68,7 @@ public final class Utils {
         return str;
     }
 
+    @Nonnull
     public static Path getCanonicalPath(Path path) {
         requireNonNull(path, "path");
         try {
@@ -76,6 +78,7 @@ public final class Utils {
         }
     }
 
+    @Nonnull
     public static Map<String, String> toMap(Properties properties) {
         requireNonNull(properties, "properties");
         HashMap<String, String> map = new HashMap<>();
@@ -85,6 +88,7 @@ public final class Utils {
         return map;
     }
 
+    @Nonnull
     public static Properties toProperties(Map<String, String> properties) {
         requireNonNull(properties, "properties");
         Properties map = new Properties();
@@ -94,6 +98,7 @@ public final class Utils {
         return map;
     }
 
+    @Nonnull
     public static BasicInterpolator createInterpolator(Collection<Map<String, String>> properties) {
         StringSearchInterpolator interpolator = new StringSearchInterpolator();
         interpolator.addValueSource(new AbstractValueSource(false) {
@@ -111,6 +116,7 @@ public final class Utils {
         return interpolator;
     }
 
+    @Nonnull
     public static Function<String, String> prefix(String prefix, Function<String, String> cb) {
         return s -> {
             String v = null;
@@ -122,6 +128,7 @@ public final class Utils {
     }
 
     @SafeVarargs
+    @Nonnull
     public static Function<String, String> or(Function<String, String>... callbacks) {
         return s -> {
             for (Function<String, String> cb : callbacks) {
@@ -153,7 +160,7 @@ public final class Utils {
     }
 
     @Nullable
-    public static Path findRoot(Path topDirectory) throws ParserException {
+    public static Path findRoot(Path topDirectory) {
         requireNonNull(topDirectory, "topDirectory");
         Path rootDirectory =
                 ServiceLoader.load(RootLocator.class).iterator().next().findRoot(topDirectory);
@@ -164,7 +171,7 @@ public final class Utils {
     }
 
     @Nonnull
-    public static Path findMandatoryRoot(Path topDirectory) throws ParserException {
+    public static Path findMandatoryRoot(Path topDirectory) {
         requireNonNull(topDirectory, "topDirectory");
         return getCanonicalPath(Optional.ofNullable(
                         ServiceLoader.load(RootLocator.class).iterator().next().findMandatoryRoot(topDirectory))

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/Utils.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/Utils.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.function.Function;
@@ -154,15 +155,8 @@ public final class Utils {
     @Nullable
     public static Path findRoot(Path topDirectory) throws ParserException {
         requireNonNull(topDirectory, "topDirectory");
-        Path rootDirectory = null;
-        for (RootLocator rootLocator : ServiceLoader.load(RootLocator.class).stream()
-                .map(ServiceLoader.Provider::get)
-                .toList()) {
-            rootDirectory = rootLocator.findRoot(topDirectory);
-            if (rootDirectory != null) {
-                break;
-            }
-        }
+        Path rootDirectory =
+                ServiceLoader.load(RootLocator.class).iterator().next().findRoot(topDirectory);
         if (rootDirectory != null) {
             return getCanonicalPath(rootDirectory);
         }
@@ -172,15 +166,8 @@ public final class Utils {
     @Nonnull
     public static Path findMandatoryRoot(Path topDirectory) throws ParserException {
         requireNonNull(topDirectory, "topDirectory");
-        Path rootDirectory;
-        for (RootLocator rootLocator : ServiceLoader.load(RootLocator.class).stream()
-                .map(ServiceLoader.Provider::get)
-                .toList()) {
-            rootDirectory = rootLocator.findMandatoryRoot(topDirectory);
-            if (rootDirectory != null) {
-                return getCanonicalPath(rootDirectory);
-            }
-        }
-        throw new IllegalStateException("how did we get here?");
+        return getCanonicalPath(Optional.ofNullable(
+                        ServiceLoader.load(RootLocator.class).iterator().next().findMandatoryRoot(topDirectory))
+                .orElseThrow());
     }
 }

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/BaseMavenParser.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/BaseMavenParser.java
@@ -42,8 +42,8 @@ public abstract class BaseMavenParser<O extends MavenOptions, R extends MavenInv
         // CLI args
         result.add(parseMavenCliOptions(context.parserRequest.args()));
         // maven.config; if exists
-        Path mavenConfig = context.rootDirectory.resolve(".mvn/maven.config");
-        if (Files.isRegularFile(mavenConfig)) {
+        Path mavenConfig = context.rootDirectory != null ? context.rootDirectory.resolve(".mvn/maven.config") : null;
+        if (mavenConfig != null && Files.isRegularFile(mavenConfig)) {
             result.add(parseMavenConfigOptions(mavenConfig));
         }
         return result;

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/DefaultMavenInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/DefaultMavenInvoker.java
@@ -260,6 +260,12 @@ public abstract class DefaultMavenInvoker<
     @Override
     protected void populateRequest(C context, MavenExecutionRequest request) throws Exception {
         super.populateRequest(context, request);
+        if (context.invokerRequest.rootDirectory().isEmpty()) {
+            // now warn about "no root found"
+            Path rootDirectory = Utils.findMandatoryRoot(context.invokerRequest.topDirectory());
+            request.setMultiModuleProjectDirectory(rootDirectory.toFile());
+            request.setRootDirectory(rootDirectory);
+        }
 
         MavenOptions options = context.invokerRequest.options();
         request.setNoSnapshotUpdates(options.suppressSnapshotUpdates().orElse(false));
@@ -273,12 +279,6 @@ public abstract class DefaultMavenInvoker<
         Path pom = determinePom(context);
         request.setPom(pom != null ? pom.toFile() : null);
         if (pom != null) {
-            if (request.getRootDirectory() == null) {
-                // now warn about "no root found"
-                Path rootDirectory = Utils.findMandatoryRoot(context.invokerRequest.topDirectory());
-                request.setMultiModuleProjectDirectory(rootDirectory.toFile());
-                request.setRootDirectory(rootDirectory);
-            }
             if (pom.getParent() != null) {
                 request.setBaseDirectory(pom.getParent().toFile());
             }

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/DefaultMavenInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/DefaultMavenInvoker.java
@@ -261,7 +261,6 @@ public abstract class DefaultMavenInvoker<
     protected void populateRequest(C context, MavenExecutionRequest request) throws Exception {
         super.populateRequest(context, request);
         if (context.invokerRequest.rootDirectory().isEmpty()) {
-            // now warn about "no root found"
             Path rootDirectory = Utils.findMandatoryRoot(context.invokerRequest.topDirectory());
             request.setMultiModuleProjectDirectory(rootDirectory.toFile());
             request.setRootDirectory(rootDirectory);
@@ -277,8 +276,8 @@ public abstract class DefaultMavenInvoker<
         request.setGlobalChecksumPolicy(determineGlobalChecksumPolicy(context));
 
         Path pom = determinePom(context);
-        request.setPom(pom != null ? pom.toFile() : null);
         if (pom != null) {
+            request.setPom(pom.toFile());
             if (pom.getParent() != null) {
                 request.setBaseDirectory(pom.getParent().toFile());
             }

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/DefaultMavenInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/DefaultMavenInvoker.java
@@ -261,9 +261,10 @@ public abstract class DefaultMavenInvoker<
     protected void populateRequest(C context, MavenExecutionRequest request) throws Exception {
         super.populateRequest(context, request);
         if (context.invokerRequest.rootDirectory().isEmpty()) {
-            Path rootDirectory = Utils.findMandatoryRoot(context.invokerRequest.topDirectory());
-            request.setMultiModuleProjectDirectory(rootDirectory.toFile());
-            request.setRootDirectory(rootDirectory);
+            // maven requires this to be set; so default it (and see below at POM)
+            request.setMultiModuleProjectDirectory(
+                    context.invokerRequest.topDirectory().toFile());
+            request.setRootDirectory(context.invokerRequest.topDirectory());
         }
 
         MavenOptions options = context.invokerRequest.options();
@@ -280,6 +281,13 @@ public abstract class DefaultMavenInvoker<
             request.setPom(pom.toFile());
             if (pom.getParent() != null) {
                 request.setBaseDirectory(pom.getParent().toFile());
+            }
+
+            // project present, but we could not determine rootDirectory: extra work needed
+            if (context.invokerRequest.rootDirectory().isEmpty()) {
+                Path rootDirectory = Utils.findMandatoryRoot(context.invokerRequest.topDirectory());
+                request.setMultiModuleProjectDirectory(rootDirectory.toFile());
+                request.setRootDirectory(rootDirectory);
             }
         }
 


### PR DESCRIPTION
First, `rootDirectory` is nullable, CLIng code was not assuming this, fixed.
Second, emit the "no root found" warning ONLY when appropriate (when we have a POM in picture).

---

https://issues.apache.org/jira/browse/MNG-8302
