### PR TITLE
Get rid of slf4j warning

### DIFF
--- a/maven-docgen/pom.xml
+++ b/maven-docgen/pom.xml
@@ -78,11 +78,6 @@
 
     <!-- Not needed during compile -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.17.0</version>


### PR DESCRIPTION
maven-docgen module warns about multiple providers being on classpath. As Maven logging that is a slf4j provider already present, simple not needed.