### PR TITLE
[MNG-8334] Fix output redirection

### DIFF
--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/Options.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/Options.java
@@ -18,10 +18,10 @@
  */
 package org.apache.maven.api.cli;
 
-import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;
@@ -202,14 +202,14 @@ public interface Options {
     /**
      * Emits warning messages if deprecated options are used.
      *
-     * @param printWriter the PrintWriter to use for output
+     * @param printWriter the string consumer to use for output
      */
-    default void warnAboutDeprecatedOptions(@Nonnull ParserRequest request, @Nonnull PrintWriter printWriter) {}
+    default void warnAboutDeprecatedOptions(@Nonnull ParserRequest request, @Nonnull Consumer<String> printWriter) {}
 
     /**
      * Displays help information for these options.
      *
-     * @param printWriter the PrintWriter to use for output
+     * @param printWriter the string consumer to use for output
      */
-    void displayHelp(@Nonnull ParserRequest request, @Nonnull PrintWriter printWriter);
+    void displayHelp(@Nonnull ParserRequest request, @Nonnull Consumer<String> printWriter);
 }

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -111,8 +111,8 @@ public abstract class BaseParser<O extends Options, R extends InvokerRequest<O>>
         List<O> parsedOptions = parseCliOptions(context);
 
         // warn about deprecated options
-        parsedOptions.forEach(o -> o.warnAboutDeprecatedOptions(
-                parserRequest, new PrintWriter(parserRequest.out() != null ? parserRequest.out() : System.out, true)));
+        PrintWriter printWriter = new PrintWriter(parserRequest.out() != null ? parserRequest.out() : System.out, true);
+        parsedOptions.forEach(o -> o.warnAboutDeprecatedOptions(parserRequest, printWriter::println));
 
         // assemble options if needed
         context.options = assembleOptions(parsedOptions);

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
@@ -91,7 +91,7 @@ public abstract class CommonsCliOptions implements Options {
 
     @Override
     public Optional<Boolean> verbose() {
-        if (commandLine.hasOption(CLIManager.VERBOSE) || commandLine.hasOption(CLIManager.DEBUG)) {
+        if (commandLine.hasOption(CLIManager.VERBOSE)) {
             return Optional.of(Boolean.TRUE);
         }
         return Optional.empty();

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LayeredOptions.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LayeredOptions.java
@@ -18,12 +18,12 @@
  */
 package org.apache.maven.cling.invoker;
 
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.maven.api.cli.Options;
@@ -138,10 +138,10 @@ public abstract class LayeredOptions<O extends Options> implements Options {
     }
 
     @Override
-    public void warnAboutDeprecatedOptions(ParserRequest request, PrintWriter printWriter) {}
+    public void warnAboutDeprecatedOptions(ParserRequest request, Consumer<String> printWriter) {}
 
     @Override
-    public void displayHelp(ParserRequest request, PrintWriter printWriter) {
+    public void displayHelp(ParserRequest request, Consumer<String> printWriter) {
         options.get(0).displayHelp(request, printWriter);
     }
 

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -327,6 +327,7 @@ public abstract class LookupInvoker<
                                 context.invokerRequest.in().orElse(null),
                                 context.invokerRequest.out().orElse(null))
                         .dumb(true)
+                        .systemOutput(TerminalBuilder.SystemOutput.ForcedSysOut)
                         .build(),
                 terminal -> doConfigureWithTerminal(context, terminal));
     }

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -320,6 +320,7 @@ public abstract class LookupInvoker<
                                 context.invokerRequest.in().orElse(null),
                                 context.invokerRequest.out().orElse(null))
                         .dumb(true)
+                        .exec(false)
                         .systemOutput(TerminalBuilder.SystemOutput.ForcedSysOut)
                         .build(),
                 terminal -> doConfigureWithTerminal(context, terminal));

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -344,11 +344,10 @@ public abstract class LookupInvoker<
     }
 
     protected Consumer<String> determineWriter(C context) {
-        Consumer<String> writer = context.writer;
-        if (writer == null) {
+        if (context.writer == null) {
             context.writer = doDetermineWriter(context);
         }
-        return writer;
+        return context.writer;
     }
 
     protected Consumer<String> doDetermineWriter(C context) {

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -364,6 +364,7 @@ public abstract class LookupInvoker<
             Path logFile = context.cwdResolver.apply(options.logFile().get());
             try {
                 PrintWriter printWriter = new PrintWriter(Files.newBufferedWriter(logFile));
+                context.closeables.add(printWriter);
                 bel = new SimpleBuildEventListener(printWriter::println);
             } catch (IOException e) {
                 throw new MavenException("Unable to redirect logging to " + logFile, e);

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -74,10 +74,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.internal.impl.SettingsUtilsV4;
 import org.apache.maven.jline.FastTerminal;
 import org.apache.maven.jline.MessageUtils;
-import org.apache.maven.logging.BuildEventListener;
 import org.apache.maven.logging.LoggingOutputStream;
-import org.apache.maven.logging.ProjectBuildLogAppender;
-import org.apache.maven.logging.SimpleBuildEventListener;
 import org.apache.maven.logging.api.LogLevelRecorder;
 import org.apache.maven.slf4j.MavenSimpleLogger;
 import org.eclipse.aether.transfer.TransferListener;
@@ -155,7 +152,6 @@ public abstract class LookupInvoker<
         public Slf4jConfiguration.Level loggerLevel;
         public Terminal terminal;
         public Consumer<String> writer;
-        public BuildEventListener buildEventListener;
         public ClassLoader currentThreadContextClassLoader;
         public ContainerCapsule containerCapsule;
         public Lookup lookup;
@@ -314,11 +310,6 @@ public abstract class LookupInvoker<
         // so boot it asynchronously
         context.terminal = createTerminal(context);
         context.closeables.add(MessageUtils::systemUninstall);
-
-        // Create the build log appender
-        ProjectBuildLogAppender projectBuildLogAppender =
-                new ProjectBuildLogAppender(determineBuildEventListener(context));
-        context.closeables.add(projectBuildLogAppender);
     }
 
     protected Terminal createTerminal(C context) {
@@ -350,18 +341,6 @@ public abstract class LookupInvoker<
             System.setErr(new LoggingOutputStream(s -> stderr.warn("[stderr] " + s)).printStream());
             // no need to set them back, this is already handled by MessageUtils.systemUninstall() above
         }
-    }
-
-    protected BuildEventListener determineBuildEventListener(C context) {
-        if (context.buildEventListener == null) {
-            context.buildEventListener = doDetermineBuildEventListener(context);
-        }
-        return context.buildEventListener;
-    }
-
-    protected BuildEventListener doDetermineBuildEventListener(C context) {
-        Consumer<String> writer = determineWriter(context);
-        return new SimpleBuildEventListener(writer);
     }
 
     protected Consumer<String> determineWriter(C context) {

--- a/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -78,6 +78,7 @@ import org.apache.maven.logging.api.LogLevelRecorder;
 import org.apache.maven.slf4j.MavenSimpleLogger;
 import org.eclipse.aether.transfer.TransferListener;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.LocationAwareLogger;
@@ -320,6 +321,7 @@ public abstract class LookupInvoker<
                     builder.streams(
                             context.invokerRequest.in().orElse(null),
                             context.invokerRequest.out().orElse(null));
+                    builder.systemOutput(TerminalBuilder.SystemOutput.ForcedSysOut);
                     // The exec builder suffers from https://github.com/jline/jline3/issues/1098
                     // We could re-enable it when fixed to provide support for non-standard architectures,
                     // for which JLine does not provide any native library.

--- a/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
+++ b/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.jline;
 
+import java.util.function.Consumer;
+
 import org.apache.maven.api.services.MessageBuilder;
 import org.apache.maven.api.services.MessageBuilderFactory;
 import org.jline.jansi.AnsiConsole;
@@ -41,11 +43,26 @@ public class MessageUtils {
     }
 
     public static void systemInstall() {
+        systemInstall(null, null);
+    }
+
+    public static void systemInstall(Consumer<TerminalBuilder> builderConsumer, Consumer<Terminal> terminalConsumer) {
         MessageUtils.terminal = new FastTerminal(
-                () -> TerminalBuilder.builder().name("Maven").dumb(true).build(), terminal -> {
+                () -> {
+                    TerminalBuilder builder =
+                            TerminalBuilder.builder().name("Maven").dumb(true);
+                    if (builderConsumer != null) {
+                        builderConsumer.accept(builder);
+                    }
+                    return builder.build();
+                },
+                terminal -> {
                     MessageUtils.reader = createReader(terminal);
                     AnsiConsole.setTerminal(terminal);
                     AnsiConsole.systemInstall();
+                    if (terminalConsumer != null) {
+                        terminalConsumer.accept(terminal);
+                    }
                 });
     }
 


### PR DESCRIPTION
JIRA issue: [MNG-8334](https://issues.apache.org/jira/browse/MNG-8334)

- **Fix empty output when using -l or redirecting output**
- **Fix incomplete log in file**

Alternative PR to #1824 @cstamas, and it should fix both type of redirections (`-l` and shell stdout `>` redirection)

This PR is more in line with what I had in mind.
In particular, this would allow stuff like the multiplexed output from mvnd
where we display information to the terminal, but not the actual log output.

