### PR TITLE
[MNG-8344] Support multiple operators in variable expansion

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultInterpolator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultInterpolator.java
@@ -268,7 +268,8 @@ public class DefaultInterpolator implements Interpolator {
         String variable = val.substring(startDelim + DELIM_START.length(), stopDelim);
         String org = variable;
 
-        String substValue = processSubstitution(variable, org, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
+        String substValue = processSubstitution(
+                variable, org, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
 
         // Append the leading characters, the substituted value of
         // the variable, and the trailing characters to get the new
@@ -308,7 +309,8 @@ public class DefaultInterpolator implements Interpolator {
                 // No more operators, process the final variable
                 if (substValue == null) {
                     currentVar = variable.substring(startIdx);
-                    substValue = resolveVariable(currentVar, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
+                    substValue = resolveVariable(
+                            currentVar, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
                 }
                 break;
             }
@@ -316,7 +318,8 @@ public class DefaultInterpolator implements Interpolator {
             // Get the current variable part before the operator
             String varPart = variable.substring(startIdx, idx);
             if (substValue == null) {
-                substValue = resolveVariable(varPart, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
+                substValue =
+                        resolveVariable(varPart, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
             }
 
             // Find the end of the current operator's value
@@ -328,7 +331,8 @@ public class DefaultInterpolator implements Interpolator {
             String opValue = variable.substring(idx + 2, nextIdx >= 0 ? nextIdx : variable.length());
 
             // Process the operator value through substitution if it contains variables
-            String processedOpValue = doSubstVars(opValue, org, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
+            String processedOpValue =
+                    doSubstVars(opValue, org, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
 
             // Apply the operator
             if (":+".equals(op)) {
@@ -377,7 +381,8 @@ public class DefaultInterpolator implements Interpolator {
         }
         if (substValue == null && !variable.isEmpty() && callback != null) {
             String s1 = callback.apply(variable);
-            String s2 = doSubstVars(s1, variable, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
+            String s2 =
+                    doSubstVars(s1, variable, cycleMap, configProps, callback, postprocessor, defaultsToEmptyString);
             substValue = postprocessor != null ? postprocessor.apply(variable, s2) : s2;
         }
 

--- a/maven-api-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultInterpolatorTest.java
+++ b/maven-api-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultInterpolatorTest.java
@@ -170,6 +170,30 @@ class DefaultInterpolatorTest {
         assertEquals("", props.get("c_cp"));
     }
 
+    @Test
+    void testXdg() {
+        Map<String, String> props = new LinkedHashMap<>();
+        props.put("user.home", "/Users/gnodet");
+        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}}:-${user.home}/.m2}");
+        performSubstitution(props);
+        assertEquals("/users/gnodet/.m2", props.get("maven.user.config"));
+
+        props = new LinkedHashMap<>();
+        props.put("user.home", "/Users/gnodet");
+        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}}:-${user.home}/.m2}");
+        props.put("env.MAVEN_XDG", "");
+        performSubstitution(props);
+        assertEquals("/users/gnodet/.config/maven", props.get("maven.user.config"));
+
+        props = new LinkedHashMap<>();
+        props.put("user.home", "/Users/gnodet");
+        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config}/maven}:-${user.home}/.m2}");
+        props.put("env.MAVEN_XDG", "");
+        props.put("env.XDG_CONFIG_HOME", "/Users/gnodet/.xdg/maven");
+        performSubstitution(props);
+        assertEquals("/users/gnodet/.xdg/maven", props.get("maven.user.config"));
+    }
+
     private void performSubstitution(Map<String, String> props) {
         performSubstitution(props, null);
     }

--- a/maven-api-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultInterpolatorTest.java
+++ b/maven-api-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultInterpolatorTest.java
@@ -176,20 +176,26 @@ class DefaultInterpolatorTest {
 
         props = new LinkedHashMap<>();
         props.put("user.home", "/Users/gnodet");
-        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
+        props.put(
+                "maven.user.config",
+                "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
         performSubstitution(props);
         assertEquals("/Users/gnodet/.m2", props.get("maven.user.config"));
 
         props = new LinkedHashMap<>();
         props.put("user.home", "/Users/gnodet");
-        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
+        props.put(
+                "maven.user.config",
+                "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
         props.put("env.MAVEN_XDG", "true");
         performSubstitution(props);
         assertEquals("/Users/gnodet/.config/maven", props.get("maven.user.config"));
 
         props = new LinkedHashMap<>();
         props.put("user.home", "/Users/gnodet");
-        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
+        props.put(
+                "maven.user.config",
+                "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
         props.put("env.MAVEN_XDG", "true");
         props.put("env.XDG_CONFIG_HOME", "/Users/gnodet/.xdg/maven");
         performSubstitution(props);

--- a/maven-api-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultInterpolatorTest.java
+++ b/maven-api-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultInterpolatorTest.java
@@ -172,26 +172,28 @@ class DefaultInterpolatorTest {
 
     @Test
     void testXdg() {
-        Map<String, String> props = new LinkedHashMap<>();
-        props.put("user.home", "/Users/gnodet");
-        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}}:-${user.home}/.m2}");
-        performSubstitution(props);
-        assertEquals("/users/gnodet/.m2", props.get("maven.user.config"));
+        Map<String, String> props;
 
         props = new LinkedHashMap<>();
         props.put("user.home", "/Users/gnodet");
-        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}}:-${user.home}/.m2}");
-        props.put("env.MAVEN_XDG", "");
+        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
         performSubstitution(props);
-        assertEquals("/users/gnodet/.config/maven", props.get("maven.user.config"));
+        assertEquals("/Users/gnodet/.m2", props.get("maven.user.config"));
 
         props = new LinkedHashMap<>();
         props.put("user.home", "/Users/gnodet");
-        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config}/maven}:-${user.home}/.m2}");
-        props.put("env.MAVEN_XDG", "");
+        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
+        props.put("env.MAVEN_XDG", "true");
+        performSubstitution(props);
+        assertEquals("/Users/gnodet/.config/maven", props.get("maven.user.config"));
+
+        props = new LinkedHashMap<>();
+        props.put("user.home", "/Users/gnodet");
+        props.put("maven.user.config", "${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config/maven}:-${user.home}/.m2}");
+        props.put("env.MAVEN_XDG", "true");
         props.put("env.XDG_CONFIG_HOME", "/Users/gnodet/.xdg/maven");
         performSubstitution(props);
-        assertEquals("/users/gnodet/.xdg/maven", props.get("maven.user.config"));
+        assertEquals("/Users/gnodet/.xdg/maven", props.get("maven.user.config"));
     }
 
     private void performSubstitution(Map<String, String> props) {


### PR DESCRIPTION
JIRA issue: [MNG-8344](https://issues.apache.org/jira/browse/MNG-8344)

----

The goal is to enhance the supported syntax for operators in variable expansion, so that we can use those as a ternary operator:
```
maven.user.config = ${env.MAVEN_XDG:+${env.XDG_CONFIG_HOME:-${user.home}/.config}/maven}:-${user.home}/.m2}
```