### PR TITLE
[MNG-8342] Add command line and terminal information when verbose

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
@@ -49,6 +49,10 @@ public final class CLIReportingUtils {
     public static final String BUILD_VERSION_PROPERTY = "version";
 
     public static String showVersion() {
+        return showVersion(null, null);
+    }
+
+    public static String showVersion(String commandLine, String terminal) {
         final String ls = System.lineSeparator();
         Properties properties = getBuildProperties();
         StringBuilder version = new StringBuilder(256);
@@ -78,6 +82,13 @@ public final class CLIReportingUtils {
                 .append("\", family: \"")
                 .append(Os.OS_FAMILY)
                 .append('\"');
+        // Add process information using modern Java API
+        if (commandLine != null) {
+            version.append(ls).append("Command line: ").append(commandLine);
+        }
+        if (terminal != null) {
+            version.append(ls).append("Terminal: ").append(terminal);
+        }
         return version.toString();
     }
 


### PR DESCRIPTION
JIRA issue: [MNG-8342](https://issues.apache.org/jira/browse/MNG-8342)

----


Output is the following:
```
➜  maven git:(MNG-8342) ✗ ~/work/git/maven/apache-maven/target/apache-maven-4.0.0-beta-6-SNAPSHOT/bin/mvn --verbose -v
Apache Maven 4.0.0-beta-6-SNAPSHOT (3425b4dd08fa4dd416e0e16c39c5dc8c6d80b6cc)
Maven home: /Users/gnodet/work/git/maven/apache-maven/target/apache-maven-4.0.0-beta-6-SNAPSHOT
Java version: 22.0.2, vendor: Eclipse Adoptium, runtime: /Users/gnodet/.sdkman/candidates/java/22.0.2-tem
Default locale: en_FR, platform encoding: UTF-8
OS name: "mac os x", version: "15.0.1", arch: "aarch64", family: "mac"
Command line: /Users/gnodet/.sdkman/candidates/java/22/bin/java -DtrimStackTrace=false --enable-native-access=ALL-UNNAMED -classpath /Users/gnodet/work/git/maven/apache-maven/target/apache-maven-4.0.0-beta-6-SNAPSHOT/boot/plexus-classworlds-2.8.0.jar -Dclassworlds.conf=/Users/gnodet/work/git/maven/apache-maven/target/apache-maven-4.0.0-beta-6-SNAPSHOT/bin/m2.conf -Dmaven.home=/Users/gnodet/work/git/maven/apache-maven/target/apache-maven-4.0.0-beta-6-SNAPSHOT -Dmaven.mainClass=org.apache.maven.cling.MavenCling -Dlibrary.jansi.path=/Users/gnodet/work/git/maven/apache-maven/target/apache-maven-4.0.0-beta-6-SNAPSHOT/lib/jansi-native -Dmaven.multiModuleProjectDirectory=/Users/gnodet/work/git/maven org.codehaus.plexus.classworlds.launcher.Launcher --verbose -v
Terminal: PosixSysTerminal (type=xterm-256color, provider=ffm, pty=org.jline.terminal.impl.ffm.FfmNativePty)
```