### PR TITLE
[MNG-8341] Fix possible deadlock in ModelBuilder

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
@@ -921,7 +921,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             if (candidateSource == null) {
                 candidateSource = resolveReactorModel(parent.getGroupId(), parent.getArtifactId(), parent.getVersion());
             }
-            if (candidateSource == null) {
+            if (candidateSource == null && parentPath == null) {
                 candidateSource = request.getSource().resolve(modelProcessor::locateExistingPom, "..");
             }
 


### PR DESCRIPTION
The deadlock can happen when the root pom inherit from a parent which is a subproject, the subproject inheriting from an external parent.

JIRA issue: [MNG-8341](https://issues.apache.org/jira/browse/MNG-8341)
IT PR: https://github.com/apache/maven-integration-testing/pull/394

The reproducer project is https://github.com/apache/pdfbox.git master, but an IT would be a good idea.

