### PR TITLE
[MNG-8189] Warn about plugin versions not pinned for all lifecycles

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
+import org.apache.maven.api.model.InputLocation;
+import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.model.Plugin;
 import org.apache.maven.api.services.LifecycleRegistry;
 import org.apache.maven.api.services.LookupException;
@@ -79,6 +81,13 @@ import static org.apache.maven.internal.impl.Lifecycles.plugin;
 public class DefaultLifecycleRegistry implements LifecycleRegistry {
 
     private static final String MAVEN_PLUGINS = "org.apache.maven.plugins:";
+
+    public static final String DEFAULT_LIFECYCLE_MODELID = "org.apache.maven:maven-core:"
+            + DefaultLifecycleRegistry.class.getPackage().getImplementationVersion()
+            + ":default-lifecycle-bindings";
+
+    public static final InputLocation DEFAULT_LIFECYCLE_INPUT_LOCATION =
+            new InputLocation(new InputSource(DEFAULT_LIFECYCLE_MODELID, null));
 
     private final List<LifecycleProvider> providers;
 

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultPackagingRegistry.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultPackagingRegistry.java
@@ -35,7 +35,6 @@ import org.apache.maven.api.Packaging;
 import org.apache.maven.api.Type;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.InputLocation;
-import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.model.Plugin;
 import org.apache.maven.api.model.PluginContainer;
 import org.apache.maven.api.model.PluginExecution;
@@ -43,7 +42,6 @@ import org.apache.maven.api.services.Lookup;
 import org.apache.maven.api.services.PackagingRegistry;
 import org.apache.maven.api.services.TypeRegistry;
 import org.apache.maven.api.spi.PackagingProvider;
-import org.apache.maven.lifecycle.internal.DefaultLifecyclePluginAnalyzer;
 import org.apache.maven.lifecycle.mapping.LifecycleMapping;
 import org.apache.maven.lifecycle.mapping.LifecycleMojo;
 import org.apache.maven.lifecycle.mapping.LifecyclePhase;
@@ -105,9 +103,7 @@ public class DefaultPackagingRegistry
     }
 
     static void parseLifecyclePhaseDefinitions(Map<String, Plugin> plugins, String phase, LifecyclePhase goals) {
-        InputSource inputSource =
-                new InputSource(DefaultLifecyclePluginAnalyzer.DEFAULTLIFECYCLEBINDINGS_MODELID, null);
-        InputLocation location = new InputLocation(-1, -1, inputSource, 0);
+        InputLocation location = DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION;
 
         List<LifecycleMojo> mojos = goals.getMojos();
         if (mojos != null) {

--- a/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
@@ -76,7 +76,15 @@ public class Lifecycles {
                         .id("default-" + c[3])
                         .phase(phase)
                         .goals(Collections.singletonList(c[3]))
+                        .location("", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
+                        .location("id", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
+                        .location("phase", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
+                        .location("goals", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
                         .build()))
+                .location("", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
+                .location("groupId", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
+                .location("artifactId", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
+                .location("version", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
                 .build();
     }
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.apache.maven.api.services.Lookup;
 import org.apache.maven.api.xml.XmlNode;
+import org.apache.maven.internal.impl.DefaultLifecycleRegistry;
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.LifeCyclePluginAnalyzer;
 import org.apache.maven.lifecycle.Lifecycle;
@@ -54,9 +55,6 @@ import static java.util.Objects.requireNonNull;
 @Singleton
 @Named
 public class DefaultLifecyclePluginAnalyzer implements LifeCyclePluginAnalyzer {
-    public static final String DEFAULTLIFECYCLEBINDINGS_MODELID = "org.apache.maven:maven-core:"
-            + DefaultLifecyclePluginAnalyzer.class.getPackage().getImplementationVersion()
-            + ":default-lifecycle-bindings";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -131,7 +129,7 @@ public class DefaultLifecyclePluginAnalyzer implements LifeCyclePluginAnalyzer {
 
     private void parseLifecyclePhaseDefinitions(Map<Plugin, Plugin> plugins, String phase, LifecyclePhase goals) {
         InputSource inputSource = new InputSource();
-        inputSource.setModelId(DEFAULTLIFECYCLEBINDINGS_MODELID);
+        inputSource.setModelId(DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_MODELID);
         InputLocation location = new InputLocation(-1, -1, inputSource);
         location.setLocation(0, location);
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/BuilderCommon.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/BuilderCommon.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.BuildFailure;
@@ -32,11 +31,11 @@ import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.internal.MultilineMessageHelper;
+import org.apache.maven.internal.impl.DefaultLifecycleRegistry;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.lifecycle.LifecycleNotFoundException;
 import org.apache.maven.lifecycle.LifecyclePhaseNotFoundException;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
-import org.apache.maven.lifecycle.internal.DefaultLifecyclePluginAnalyzer;
 import org.apache.maven.lifecycle.internal.ExecutionEventCatapult;
 import org.apache.maven.lifecycle.internal.LifecycleDebugLogger;
 import org.apache.maven.lifecycle.internal.LifecycleExecutionPlanCalculator;
@@ -139,7 +138,7 @@ public class BuilderCommon {
             }
         }
 
-        final String defaulModelId = DefaultLifecyclePluginAnalyzer.DEFAULTLIFECYCLEBINDINGS_MODELID;
+        final String defaulModelId = DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_MODELID;
 
         List<String> unversionedPlugins = executionPlan.getMojoExecutions().stream()
                 .map(MojoExecution::getPlugin)
@@ -149,7 +148,7 @@ public class BuilderCommon {
                                 p.getLocation("version").getSource().getModelId()))
                 .distinct()
                 .map(Plugin::getArtifactId) // managed by us, groupId is always o.a.m.plugins
-                .collect(Collectors.toList());
+                .toList();
 
         if (!unversionedPlugins.isEmpty()) {
             logger.warn("Version not locked for default bindings plugins " + unversionedPlugins

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -53,6 +53,7 @@ import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.execution.ProjectExecutionEvent;
 import org.apache.maven.execution.ProjectExecutionListener;
 import org.apache.maven.internal.MultilineMessageHelper;
+import org.apache.maven.internal.impl.DefaultLifecycleRegistry;
 import org.apache.maven.internal.impl.util.PhasingExecutor;
 import org.apache.maven.internal.transformation.ConsumerPomArtifactTransformer;
 import org.apache.maven.internal.xml.XmlNodeImpl;
@@ -62,7 +63,6 @@ import org.apache.maven.lifecycle.LifecyclePhaseNotFoundException;
 import org.apache.maven.lifecycle.MojoExecutionConfigurator;
 import org.apache.maven.lifecycle.internal.BuildThreadFactory;
 import org.apache.maven.lifecycle.internal.CompoundProjectExecutionListener;
-import org.apache.maven.lifecycle.internal.DefaultLifecyclePluginAnalyzer;
 import org.apache.maven.lifecycle.internal.ExecutionEventCatapult;
 import org.apache.maven.lifecycle.internal.GoalTask;
 import org.apache.maven.lifecycle.internal.LifecycleTask;
@@ -238,7 +238,7 @@ public class BuildPlanExecutor {
         }
 
         private void checkUnboundVersions(BuildPlan buildPlan) {
-            String defaulModelId = DefaultLifecyclePluginAnalyzer.DEFAULTLIFECYCLEBINDINGS_MODELID;
+            String defaulModelId = DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_MODELID;
             List<String> unversionedPlugins = buildPlan
                     .allSteps()
                     .flatMap(step -> step.mojos.values().stream().flatMap(map -> map.values().stream()))

--- a/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecycleExecutionPlanCalculatorStub.java
+++ b/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecycleExecutionPlanCalculatorStub.java
@@ -25,12 +25,12 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.internal.impl.DefaultLifecycleRegistry;
 import org.apache.maven.internal.xml.XmlNodeImpl;
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.LifecycleNotFoundException;
 import org.apache.maven.lifecycle.LifecyclePhaseNotFoundException;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
-import org.apache.maven.lifecycle.internal.DefaultLifecyclePluginAnalyzer;
 import org.apache.maven.lifecycle.internal.ExecutionPlanItem;
 import org.apache.maven.lifecycle.internal.LifecycleExecutionPlanCalculator;
 import org.apache.maven.lifecycle.internal.ProjectBuildList;
@@ -210,7 +210,7 @@ public class LifecycleExecutionPlanCalculatorStub implements LifecycleExecutionP
 
     private static MojoExecution createMojoExecution(String goal, String executionId, MojoDescriptor mojoDescriptor) {
         InputSource defaultBindings = new InputSource();
-        defaultBindings.setModelId(DefaultLifecyclePluginAnalyzer.DEFAULTLIFECYCLEBINDINGS_MODELID);
+        defaultBindings.setModelId(DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_MODELID);
 
         final Plugin plugin = mojoDescriptor.getPluginDescriptor().getPlugin();
         plugin.setLocation("version", new InputLocation(12, 34, defaultBindings));


### PR DESCRIPTION
Also move the default location into DefaultLifecycleRegistry as the DefaultLifecyclePluginAnalizer is not used anymore

---

JIRA issue: [MNG-8189](https://issues.apache.org/jira/browse/MNG-8189)
