### PR TITLE
[MNG-8349] Avoid exceptions with invalid modelVersion

### DIFF
--- a/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/maven-api-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -1963,13 +1963,20 @@ public class DefaultModelValidator implements ModelValidator {
         String[] firstSegments = first.split("\\.");
         String[] secondSegments = second.split("\\.");
         for (int i = 0; i < Math.max(firstSegments.length, secondSegments.length); i++) {
-            int result = Long.valueOf(i < firstSegments.length ? firstSegments[i] : "0")
-                    .compareTo(Long.valueOf(i < secondSegments.length ? secondSegments[i] : "0"));
+            int result = asLong(i, firstSegments).compareTo(asLong(i, secondSegments));
             if (result != 0) {
                 return result;
             }
         }
         return 0;
+    }
+
+    private static Long asLong(int index, String[] segments) {
+        try {
+            return Long.valueOf(index < segments.length ? segments[index] : "0");
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 
     @SuppressWarnings("checkstyle:parameternumber")


### PR DESCRIPTION
JIRA issue: [MNG-8349](https://issues.apache.org/jira/browse/MNG-8349)

The output is now the expected one (albeit duplicated):
```
[INFO] Scanning for projects...
[ERROR] Some problems were encountered while processing the POMs
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.test:foo:jar:1.0-SNAPSHOT (/Users/gnodet/tmp/MNG-8189/pom.xml) has 2 errors
[ERROR]     'modelVersion' must be one of [4.0.0, 4.1.0] but is '4..0.0'. @ org.test:foo:1.0-SNAPSHOT, file:///Users/gnodet/tmp/MNG-8189/pom.xml, line 2, column 3
[ERROR]     'modelVersion' must be one of [4.0.0, 4.1.0] but is '4..0.0'. @ org.test:foo:1.0-SNAPSHOT, file:///Users/gnodet/tmp/MNG-8189/pom.xml, line 2, column 3
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the '-e' switch
[ERROR] Re-run Maven using the '-X' switch to enable verbose output
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
```
