### PR TITLE
[MNG-8360] Fix parent profiles not reported as activated

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
@@ -1199,9 +1199,13 @@ public class DefaultModelBuilder implements ModelBuilder {
 
             // profile injection
             List<Profile> activePomProfiles = getActiveProfiles(interpolatedProfiles, profileActivationContext);
-            result.setActivePomProfiles(activePomProfiles);
             model = profileInjector.injectProfiles(model, activePomProfiles, request, this);
             model = profileInjector.injectProfiles(model, activeExternalProfiles, request, this);
+
+            List<Profile> allProfiles = new ArrayList<>(parentActivePomProfiles.size() + activePomProfiles.size());
+            allProfiles.addAll(parentActivePomProfiles);
+            allProfiles.addAll(activePomProfiles);
+            result.setActivePomProfiles(allProfiles);
 
             // model interpolation
             Model resultModel = model;


### PR DESCRIPTION
JIRA issue: [MNG-8360](https://issues.apache.org/jira/browse/MNG-8360)
IT PR: https://github.com/apache/maven-integration-testing/pull/396

Fix parent profiles being activated but not reported as such.

