### PR TITLE
[MNG-8347] Resolver 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -667,21 +667,6 @@ under the License.
   </dependencies>
   -->
 
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-        <checksumPolicy>fail</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>maven-2236</id>
-      <url>https://repository.apache.org/content/repositories/maven-2236</url>
-    </repository>
-  </repositories>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Last PR in series, to be merged once Resolver 2.0.3 is released and synced to Maven Central.

This PR fails today, as Resolver 2.0.3 is not in MC.