### PR TITLE
Guesswork II

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
@@ -184,22 +184,14 @@ public class DefaultProjectManager implements ProjectManager {
 
     @Override
     public List<RemoteRepository> getRemoteProjectRepositories(Project project) {
-        List<org.eclipse.aether.repository.RemoteRepository> remoteRepositories =
-                ((DefaultProject) project).getProject().getRemoteProjectRepositories();
-        if (remoteRepositories == null) {
-            return Collections.emptyList();
-        }
-        return Collections.unmodifiableList(new MappedList<>(remoteRepositories, session::getRemoteRepository));
+        return Collections.unmodifiableList(new MappedList<>(
+                ((DefaultProject) project).getProject().getRemoteProjectRepositories(), session::getRemoteRepository));
     }
 
     @Override
     public List<RemoteRepository> getRemotePluginRepositories(Project project) {
-        List<org.eclipse.aether.repository.RemoteRepository> remoteRepositories =
-                ((DefaultProject) project).getProject().getRemoteProjectRepositories();
-        if (remoteRepositories == null) {
-            return Collections.emptyList();
-        }
-        return Collections.unmodifiableList(new MappedList<>(remoteRepositories, session::getRemoteRepository));
+        return Collections.unmodifiableList(new MappedList<>(
+                ((DefaultProject) project).getProject().getRemotePluginRepositories(), session::getRemoteRepository));
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectManager.java
@@ -184,14 +184,22 @@ public class DefaultProjectManager implements ProjectManager {
 
     @Override
     public List<RemoteRepository> getRemoteProjectRepositories(Project project) {
-        return Collections.unmodifiableList(new MappedList<>(
-                ((DefaultProject) project).getProject().getRemoteProjectRepositories(), session::getRemoteRepository));
+        List<org.eclipse.aether.repository.RemoteRepository> remoteRepositories =
+                ((DefaultProject) project).getProject().getRemoteProjectRepositories();
+        if (remoteRepositories == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(new MappedList<>(remoteRepositories, session::getRemoteRepository));
     }
 
     @Override
     public List<RemoteRepository> getRemotePluginRepositories(Project project) {
-        return Collections.unmodifiableList(new MappedList<>(
-                ((DefaultProject) project).getProject().getRemotePluginRepositories(), session::getRemoteRepository));
+        List<org.eclipse.aether.repository.RemoteRepository> remoteRepositories =
+                ((DefaultProject) project).getProject().getRemoteProjectRepositories();
+        if (remoteRepositories == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(new MappedList<>(remoteRepositories, session::getRemoteRepository));
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -921,7 +921,6 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 project.setClassRealm(record.getRealm());
                 project.setExtensionDependencyFilter(record.getExtensionArtifactFilter());
             } catch (PluginResolutionException | PluginManagerException | PluginVersionResolutionException e) {
-
                 problems.add(Severity.ERROR, Version.BASE, "Unresolvable build extension: " + e.getMessage(), e);
             }
             projectBuildingHelper.selectProjectRealm(project);
@@ -936,6 +935,10 @@ public class DefaultProjectBuilder implements ProjectBuilder {
         }
         project.setRemoteArtifactRepositories(remoteRepositories);
 
-        return lifecycleBindingsInjector.injectLifecycleBindings(model3.getDelegate(), request, problems);
+        if (request.getRequestType() == ModelBuilderRequest.RequestType.BUILD_POM) {
+            return lifecycleBindingsInjector.injectLifecycleBindings(model3.getDelegate(), request, problems);
+        } else {
+            return model3.getDelegate();
+        }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -778,10 +778,16 @@ public class MavenProject implements Cloneable {
     }
 
     public List<RemoteRepository> getRemoteProjectRepositories() {
+        if (remoteProjectRepositories == null) {
+            this.remoteProjectRepositories = new ArrayList<>();
+        }
         return remoteProjectRepositories;
     }
 
     public List<RemoteRepository> getRemotePluginRepositories() {
+        if (remotePluginRepositories == null) {
+            this.remotePluginRepositories = new ArrayList<>();
+        }
         return remotePluginRepositories;
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
@@ -815,7 +815,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             resultModel = pluginManagementInjector.injectManagement(resultModel, request, this);
 
             // lifecycle bindings injection
-            if (request.getRequestType() != ModelBuilderRequest.RequestType.DEPENDENCY) {
+            if (request.getRequestType() == ModelBuilderRequest.RequestType.BUILD_POM) {
                 org.apache.maven.api.services.ModelTransformer lifecycleBindingsInjector =
                         request.getLifecycleBindingsInjector();
                 if (lifecycleBindingsInjector != null) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelBuilder.java
@@ -815,12 +815,10 @@ public class DefaultModelBuilder implements ModelBuilder {
             resultModel = pluginManagementInjector.injectManagement(resultModel, request, this);
 
             // lifecycle bindings injection
-            if (request.getRequestType() == ModelBuilderRequest.RequestType.BUILD_POM) {
-                org.apache.maven.api.services.ModelTransformer lifecycleBindingsInjector =
-                        request.getLifecycleBindingsInjector();
-                if (lifecycleBindingsInjector != null) {
-                    resultModel = lifecycleBindingsInjector.transform(resultModel, request, this);
-                }
+            org.apache.maven.api.services.ModelTransformer lifecycleBindingsInjector =
+                    request.getLifecycleBindingsInjector();
+            if (lifecycleBindingsInjector != null) {
+                resultModel = lifecycleBindingsInjector.transform(resultModel, request, this);
             }
 
             // dependency management import
@@ -1468,7 +1466,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 rawModel = transformFileToRaw(rawModel);
             }
 
-            for (var transformer : transformers) {
+            for (org.apache.maven.api.spi.ModelTransformer transformer : transformers) {
                 rawModel = transformer.transformRawModel(rawModel);
             }
 


### PR DESCRIPTION
Changes:
* ~project manager neglects lists of reposes may be nulls~ Nope, this is in fact maven project inconsistency.
* reverted logic: instead of "when not" use "when POM is build_pom" to inject lifecycle plugins
* always call inject lifecycle bindings as it injects not only that but reposes as well (maybe refactor it into separate method?)

Fixes https://issues.apache.org/jira/browse/MNG-8336

Let's see ITs