### PR TITLE
[MNG-8378] Upgrade to Resolver 2.0.4

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--Daether.transport.jdk.httpVersion=HTTP_1_1

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@ under the License.
     <plexusInterpolationVersion>1.27</plexusInterpolationVersion>
     <plexusTestingVersion>1.4.0</plexusTestingVersion>
     <plexusXmlVersion>4.0.4</plexusXmlVersion>
-    <resolverVersion>2.0.3</resolverVersion>
+    <resolverVersion>2.0.4</resolverVersion>
     <securityDispatcherVersion>4.0.2</securityDispatcherVersion>
     <sisuVersion>0.9.0.M3</sisuVersion>
     <slf4jVersion>2.0.16</slf4jVersion>


### PR DESCRIPTION
Use latest Resolver with bugfixes and enhancements. Also, downgrades default JDK Transport to HTTP/1.1.
https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12320628&version=12355229

---

https://issues.apache.org/jira/browse/MNG-8378