### PR TITLE
[MNG-8395] Add a <Source> element in the model.

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -775,6 +775,7 @@
           <type>String</type>
         </field>
         <field>
+          <!-- TODO: replaced by <Source> with "resource" scope. -->
           <name>resources</name>
           <version>3.0.0+</version>
           <description>
@@ -789,6 +790,7 @@
           </association>
         </field>
         <field>
+          <!-- TODO: replaced by <Source> with "testResource" scope. -->
           <name>testResources</name>
           <version>4.0.0+</version>
           <description>
@@ -857,6 +859,22 @@
       </description>
       <fields>
         <field>
+          <name>sources</name>
+          <version>4.1.0+</version>
+          <description>
+            All the sources to compile and resources files to copy for a project or it's unit tests.
+            The sources can be Java source files, generated source files, scripts or resources for examples.
+            Each source is specified by a mandatory {@code directory} element, which is relative to the POM.
+            The kind of sources (codes to compile or resources to copy) and their usage (for the main code
+            or for the tests) is specified by the {@code scope} element together with each source directory.
+          </description>
+          <association>
+            <type>Source</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
+        <field>
+          <!-- TODO: replaced by <Source> with "main" scope. -->
           <name>sourceDirectory</name>
           <version>3.0.0+</version>
           <required>true</required>
@@ -869,6 +887,7 @@
           <type>String</type>
         </field>
         <field>
+          <!-- TODO: replaced by <Source> with "script" scope. -->
           <name>scriptSourceDirectory</name>
           <version>4.0.0+</version>
           <required>true</required>
@@ -882,6 +901,7 @@
           <type>String</type>
         </field>
         <field>
+          <!-- TODO: replaced by <Source> with "test" scope. -->
           <name>testSourceDirectory</name>
           <version>4.0.0+</version>
           <required>true</required>
@@ -1945,6 +1965,178 @@
       </codeSegments>
     </class>
     <class>
+      <name>Source</name>
+      <description>
+        <![CDATA[
+        Description of the sources associated with a project main code or unit tests.
+        The sources can be Java source files, generated source files, scripts or resources for examples.
+        A source is specified by a mandatory {@code directory} element, which is relative to the POM.
+        The directory content can optionally by reduced to a subset with the {@code includes} and
+        {@code excludes} elements. The kind of sources (codes, resources, <i>etc.</i>) and their
+        usage (main code, tests, <i>etc.</i>) is specified by the {@code scope} element.
+
+        <h2>Default source directories</h2>
+        If no source directories are specified, the defaults are {@code src/${scope}/${lang}} where
+        {@code ${scope}} is the value of the {@link #scope} element (typically {@code main} or {@code test}) and
+        {@code ${lang}} is the value of the {@link #lang} element (typically {@code java} or {@code resources}).
+        ]]>
+      </description>
+      <version>4.1.0+</version>
+      <superClass>FileSet</superClass>
+      <fields>
+        <field>
+          <name>scope</name>
+          <version>4.1.0+</version>
+          <description>
+            <![CDATA[
+            Specifies in which context the source files will be used - typically {@code main} or {@code test}.
+
+            <p>The <b>main</b> scope is used for specifying a directory containing the source of the project.
+            The generated build system will compile the sources from this directory when the project is built.
+            The path given in the {@code directory} field is relative to the project descriptor.
+            The default directory for the default language (Java) is {@code "src/main/java"}.</p>
+
+            <p>The <b>test</b> scope is used for specifying a directory containing the unit test source of the project.
+            The generated build system will compile these directories when the project is being tested.
+            The path given in the {@code directory} field is relative to the project descriptor.
+            The default directory for the default language (Java) is {@code "src/test/java"}.</p>
+
+            <p>If no scope is specified, the default is {@code main}.</p>
+            ]]>
+          </description>
+          <type>String</type>
+          <defaultValue>main</defaultValue>
+        </field>
+        <field>
+          <name>lang</name>
+          <version>4.1.0+</version>
+          <description>
+            <![CDATA[
+            Specifies the language of the source files - typically {@code java} or {@code resources}.
+            Resources is used as a generic term for scripting languages (e.g., JavaScript or Python)
+            or markup languages (e.g. properties file, <abbr>JSON</abbr> or <abbr>XML</abbr>).
+
+            <p>The <b>java</b> language is used for specifying a directory containing the Java sources of the project.
+            The generated build system will compile the sources from this directory using the Java compiler when the
+            project is built. The path given in the {@code directory} field is relative to the project descriptor.
+            The default directory for the main Java sources is {@code "src/main/java"}.</p>
+
+            <p>The <b>resources</b> language is used for specifying a directory containing the class-path
+            or module-path resources such as properties files or scripts associated with a project.
+            This directory is meant to be different from the main source directory,
+            in that its contents will be copied to the output directory in most cases
+            (since scripts are interpreted rather than compiled).
+            The default directory for the main resources is {@code "src/main/resources"}.</p>
+
+            <p>If no language is specified, the default is {@code java}.</p>
+            ]]>
+          </description>
+          <type>String</type>
+          <defaultValue>main</defaultValue>
+        </field>
+        <field>
+          <name>module</name>
+          <version>4.1.0+</version>
+          <description>
+            <![CDATA[
+            Name of the Java module (or other language-specific module) which is built by the sources.
+            This element can be specified in a Maven project containing multiple Java modules.
+            It is generally not needed for non-modular projects, or for modular projects having only one module.
+
+            <p>If a module name is specified for resources or script files,
+            then this value modifies the directory where the files will be copied.
+            For example, if a Java module name is "foo.biz", then the {@code foo/bar.properties}
+            resource file will be copied as {@code foo.biz/foo/bar.properties}.</p>
+
+            <p>This element can be combined with the {@code targetVersion} element for specifying sources,
+            scripts or resources that are specific to both a particular module and a target version.</p>
+            ]]>
+          </description>
+          <type>String</type>
+        </field>
+        <field>
+          <name>targetVersion</name>
+          <version>4.1.0+</version>
+          <description>
+            <![CDATA[
+            The version of the platform where the code will be executed.
+            In a Java environment, this is the value of the {@code --release} compiler option.
+            If a Java project contains multiple main sources with different target versions,
+            then a multi-version <abbr>JAR</abbr> file will be created.
+            If this element is omitted, then the default target version is the compiler default value,
+            which is usually the version of the Java environment running Maven.
+
+            <p>If a target version is specified for resources or script files,
+            then this value modifies the directory where the files will be copied.
+            For example, if {@code targetVersion} is 17, then the {@code foo/bar.properties}
+            resource file will be copied as {@code META-INF/versions/17/foo/bar.properties}.</p>
+
+            <p>This element can be combined with the {@code module} element for specifying sources,
+            scripts or resources that are specific to both a particular module and a target version.</p>
+            ]]>
+          </description>
+          <type>String</type>
+        </field>
+        <field>
+          <name>targetPath</name>
+          <version>4.1.0+</version>
+          <description>
+            <![CDATA[
+            Specifies an explicit target path, overriding the default value.
+            The path is relative to the {@code ${project.build.outputDirectory}} directory,
+            which is typically {@code target/classes} in a Java project.
+
+            <p>When a target path is explicitly specified, the values of the {@code module} and {@code targetVersion}
+            elements are not used for inferring the path (they are still used as compiler options however).
+            It means that for scripts and resources, the files below the path specified by {@code directory}
+            are copied to the path specified by {@code targetPath} with the exact same directory structure.
+            It is user's responsibility to put module and version components in the {@code targetPath} if needed.</p>
+
+            <p>Note that for Java source files, a directory with the module name may still be generated despite
+            above statement about {@code module} being ignored, because that directory is generated by the Java
+            compiler rather than Maven.</p>
+            ]]>
+          </description>
+          <type>String</type>
+        </field>
+        <field>
+          <name>filtering</name>
+          <version>4.1.0+</version>
+          <description>
+            <![CDATA[
+            Whether resources are filtered to replace tokens with parameterized values.
+            The values are taken from the {@code properties} element and from the properties
+            in the files listed in the {@code filters} element.
+
+            <p>This filtering should not be confused with the filtering of paths done by the
+            {@code includes} and {@code excludes} patterns.</p>
+
+            <p>The default value is {@code false}.</p>
+            ]]>
+          </description>
+          <type>boolean</type>
+          <defaultValue>false</defaultValue>
+        </field>
+        <field>
+          <name>enabled</name>
+          <version>4.1.0+</version>
+          <description>
+            <![CDATA[
+            Whether the directory described by this source element should be included in the build.
+            This flag provides an easy way to include or exclude some sources depending, for example,
+            o property values defined in profiles. A use case is including optional resources only
+            when the user confirmed a license agreement.
+
+            <p>The default value is {@code true}.</p>
+            ]]>
+          </description>
+          <type>boolean</type>
+          <defaultValue>true</defaultValue>
+        </field>
+      </fields>
+    </class>
+    <class>
+      <!-- TODO: Replaced by <Source>. -->
       <name>Resource</name>
       <description>This element describes all of the classpath resources associated with a project
         or unit tests.</description>

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -775,7 +775,7 @@
           <type>String</type>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "resource" scope. -->
+          <!-- TODO: replaced by <Source> with "main" scope and "resources" language -->
           <name>resources</name>
           <version>3.0.0+</version>
           <description>
@@ -790,7 +790,7 @@
           </association>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "testResource" scope. -->
+          <!-- TODO: replaced by <Source> with "test" scope and "resources" language -->
           <name>testResources</name>
           <version>4.0.0+</version>
           <description>
@@ -887,7 +887,7 @@
           <type>String</type>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "script" scope. -->
+          <!-- TODO: replaced by <Source> with "script" language -->
           <name>scriptSourceDirectory</name>
           <version>4.0.0+</version>
           <required>true</required>
@@ -2134,7 +2134,7 @@
       </fields>
     </class>
     <class>
-      <!-- TODO: Replaced by <Source>. -->
+      <!-- TODO: Replaced by <Source> with "resources" language. -->
       <name>Resource</name>
       <description>This element describes all of the classpath resources associated with a project
         or unit tests.</description>

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -2062,11 +2062,12 @@
             The version of the platform where the code will be executed.
             In a Java environment, this is the value of the {@code --release} compiler option.
             If a Java project contains multiple main sources with different target versions,
-            then a multi-version <abbr>JAR</abbr> file will be created.
+            then a multi-version <abbr>JAR</abbr> file will be created
+            with the lowest version taken as the <dfn>base version</dfn>.
             If this element is omitted, then the default target version is the compiler default value,
             which is usually the version of the Java environment running Maven.
 
-            <p>If a target version is specified for resources or script files,
+            <p>If a target version, different from the base version, is specified for resources or script files,
             then this value modifies the directory where the files will be copied.
             For example, if {@code targetVersion} is 17, then the {@code foo/bar.properties}
             resource file will be copied as {@code META-INF/versions/17/foo/bar.properties}.</p>
@@ -2100,16 +2101,13 @@
           <type>String</type>
         </field>
         <field>
-          <name>filtering</name>
+          <name>stringFiltering</name>
           <version>4.1.0+</version>
           <description>
             <![CDATA[
             Whether resources are filtered to replace tokens with parameterized values.
             The values are taken from the {@code properties} element and from the properties
             in the files listed in the {@code filters} element.
-
-            <p>This filtering should not be confused with the filtering of paths done by the
-            {@code includes} and {@code excludes} patterns.</p>
 
             <p>The default value is {@code false}.</p>
             ]]>

--- a/src/mdo/reader-stax.vm
+++ b/src/mdo/reader-stax.vm
@@ -435,19 +435,19 @@ public class ${className} {
      * @return ${root.name}
      */
 #if ( $locationTracking )
-    public ${root.name} read(Reader reader, boolean strict, InputSource source) throws XMLStreamException {
+    public ${root.name} read(Reader reader, boolean strict, InputSource inputSrc) throws XMLStreamException {
 #else
     public ${root.name} read(Reader reader, boolean strict) throws XMLStreamException {
 #end
 #if ( $locationTracking )
-        StreamSource streamSource = new StreamSource(reader, source != null ? source.getLocation() : null);
+        StreamSource streamSource = new StreamSource(reader, inputSrc != null ? inputSrc.getLocation() : null);
 #else
         StreamSource streamSource = new StreamSource(reader);
 #end
         XMLInputFactory factory = getXMLInputFactory();
         XMLStreamReader parser = factory.createXMLStreamReader(streamSource);
 #if ( $locationTracking )
-        return read(parser, strict, source);
+        return read(parser, strict, inputSrc);
 #else
     return read(parser, strict);
 #end
@@ -471,19 +471,19 @@ public class ${className} {
      * @return ${root.name}
      */
 #if ( $locationTracking )
-    public ${root.name} read(InputStream in, boolean strict, InputSource source) throws XMLStreamException {
+    public ${root.name} read(InputStream in, boolean strict, InputSource inputSrc) throws XMLStreamException {
 #else
     public ${root.name} read(InputStream in, boolean strict) throws XMLStreamException {
 #end
 #if ( $locationTracking )
-        StreamSource streamSource = new StreamSource(in, source != null ? source.getLocation() : null);
+        StreamSource streamSource = new StreamSource(in, inputSrc != null ? inputSrc.getLocation() : null);
 #else
         StreamSource streamSource = new StreamSource(in);
 #end
         XMLInputFactory factory = getXMLInputFactory();
         XMLStreamReader parser = factory.createXMLStreamReader(streamSource);
 #if ( $locationTracking )
-        return read(parser, strict, source);
+        return read(parser, strict, inputSrc);
 #else
         return read(parser, strict);
 #end
@@ -499,7 +499,7 @@ public class ${className} {
      * @return ${root.name}
      */
 #if ( $locationTracking )
-    public ${root.name} read(XMLStreamReader parser, boolean strict, InputSource source) throws XMLStreamException {
+    public ${root.name} read(XMLStreamReader parser, boolean strict, InputSource inputSrc) throws XMLStreamException {
 #else
     public ${root.name} read(XMLStreamReader parser, boolean strict) throws XMLStreamException {
 #end
@@ -518,7 +518,7 @@ public class ${className} {
                     throw new XMLStreamException("Duplicated tag: '${rootTag}'", parser.getLocation(), null);
                 }
 #if ( $locationTracking )
-                $rootLcapName = parse${rootUcapName}(parser, strict, source);
+                $rootLcapName = parse${rootUcapName}(parser, strict, inputSrc);
 #elseif ( $needXmlContext )
                 $rootLcapName = parse${rootUcapName}(parser, strict, context);
 #else
@@ -541,7 +541,7 @@ public class ${className} {
   #set ( $ancestors = $Helper.ancestors( $class ) )
   #set ( $allFields = $Helper.xmlFields( $class ) )
   #if ( $locationTracking )
-    private ${classUcapName} parse${classUcapName}(XMLStreamReader parser, boolean strict, InputSource source) throws XMLStreamException {
+    private ${classUcapName} parse${classUcapName}(XMLStreamReader parser, boolean strict, InputSource inputSrc) throws XMLStreamException {
   #elseif ( $needXmlContext )
     private ${classUcapName} parse${classUcapName}(XMLStreamReader parser, boolean strict, Deque<Object> context) throws XMLStreamException {
   #else
@@ -551,7 +551,7 @@ public class ${className} {
         ${classUcapName}.Builder ${classLcapName} = ${classUcapName}.newBuilder(true);
   #if ( $locationTracking )
         if (addLocationInformation) {
-            ${classLcapName}.location("", new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), source));
+            ${classLcapName}.location("", new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), inputSrc));
         }
   #end
         for (int i = parser.getAttributeCount() - 1; i >= 0; i--) {
@@ -574,7 +574,7 @@ public class ${className} {
             } else if ("$fieldTagName".equals(name)) {
       #if ( $locationTracking )
                 if (addLocationInformation) {
-                    ${classLcapName}.location(name, new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), source));
+                    ${classLcapName}.location(name, new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), inputSrc));
                 }
       #end
       #if ( $field.type == "String" )
@@ -632,7 +632,7 @@ public class ${className} {
                     break;
       #elseif ( $field.type == "DOM" )
         #if ( $locationTracking )
-                    ${classLcapName}.${field.name}(buildXmlNode(parser, source));
+                    ${classLcapName}.${field.name}(buildXmlNode(parser, inputSrc));
         #else
                     ${classLcapName}.${field.name}(buildXmlNode(parser));
         #end
@@ -646,7 +646,7 @@ public class ${className} {
                         if ("${Helper.singular($fieldTagName)}".equals(parser.getLocalName())) {
         #if ( $locationTracking )
                             if (addLocationInformation) {
-                                locations.put(Integer.valueOf(locations.size()), new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), source));
+                                locations.put(Integer.valueOf(locations.size()), new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), inputSrc));
                             }
         #end
                             ${field.name}.add(interpolatedTrimmed(nextText(parser, strict), "${fieldTagName}"));
@@ -666,7 +666,7 @@ public class ${className} {
                         String value = nextText(parser, strict).trim();
         #if ( $locationTracking )
                         if (addLocationInformation) {
-                            locations.put(key, new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), source));
+                            locations.put(key, new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), inputSrc));
                         }
         #end
                         ${field.name}.put(key, value);
@@ -675,7 +675,7 @@ public class ${className} {
                     break;
       #elseif ( $field.to && $field.multiplicity == "1" )
         #if ( $locationTracking )
-                    ${classLcapName}.${field.name}(parse${field.toClass.name}(parser, strict, source));
+                    ${classLcapName}.${field.name}(parse${field.toClass.name}(parser, strict, inputSrc));
         #elseif ( $needXmlContext )
                     ${classLcapName}.${field.name}(parse${field.toClass.name}(parser, strict, context));
         #else
@@ -684,7 +684,7 @@ public class ${className} {
                     break;
       #elseif ( $field.to && $field.multiplicity == "*" && $Helper.isFlatItems( $field ) )
         #if ( $locationTracking )
-                    ${field.name}.add(parse${field.toClass.name}(parser, strict, source));
+                    ${field.name}.add(parse${field.toClass.name}(parser, strict, inputSrc));
         #elseif ( $needXmlContext )
                     ${field.name}.add(parse${field.toClass.name}(parser, strict, context));
         #else
@@ -696,7 +696,7 @@ public class ${className} {
                     while (parser.nextTag() == XMLStreamReader.START_ELEMENT) {
                         if ("${Helper.singular($fieldTagName)}".equals(parser.getLocalName())) {
         #if ( $locationTracking )
-                            ${field.name}.add(parse${field.toClass.name}(parser, strict, source));
+                            ${field.name}.add(parse${field.toClass.name}(parser, strict, inputSrc));
         #elseif ( $needXmlContext )
                             ${field.name}.add(parse${field.toClass.name}(parser, strict, context));
         #else
@@ -723,7 +723,7 @@ public class ${className} {
             }
   #if ( $locationTracking )
             if (addLocationInformation) {
-                ${classLcapName}.location(childName, new InputLocation(line, column, source, locations));
+                ${classLcapName}.location(childName, new InputLocation(line, column, inputSrc, locations));
             }
   #end
         }
@@ -923,10 +923,10 @@ public class ${className} {
     }
 
 #if ( $locationTracking )
-    private XmlNode buildXmlNode(XMLStreamReader parser, InputSource source) throws XMLStreamException {
+    private XmlNode buildXmlNode(XMLStreamReader parser, InputSource inputSrc) throws XMLStreamException {
         return XmlNodeStaxBuilder.build(parser,
                 addLocationInformation
-                        ? p -> new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), source)
+                        ? p -> new InputLocation(parser.getLocation().getLineNumber(), parser.getLocation().getColumnNumber(), inputSrc)
                         : null);
     }
 #else
@@ -993,12 +993,12 @@ public class ${className} {
     public static interface ContentTransformer {
         /**
          * Interpolate the value read from the xpp3 document
-         * @param source The source value
+         * @param inputSrc The input source value
          * @param fieldName A description of the field being interpolated. The implementation may use this to
          *                           log stuff.
          * @return The interpolated value.
          */
-        String transform(String source, String fieldName);
+        String transform(String inputSrc, String fieldName);
     }
 
 }


### PR DESCRIPTION
JIRA issue: [MNG-8395](https://issues.apache.org/jira/browse/MNG-8395)

Add a `<Source>` element in the model. Properties are:

- `directory` (inherited from `FileSet`)
- `includes`  (inherited from `PatternSet`)
- `excludes`  (inherited from `PatternSet`)
- `scope`
- `lang`
- `module`
- `targetVersion`
- `targetPath` (taken from `<Resource>`)
- `filtering` (taken from `<Resource>`)
- `enabled`

This commit also renames `source` parameter value in `reader-stax.vm` for avoiding name collision with the new `Source` model element.