### PR TITLE
[MNG-8394] Event bridge and properties fix

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -72,6 +73,8 @@ public class LookupContext implements AutoCloseable {
 
     // this one "evolves" as process progresses (instance is immutable but instances are replaced)
     public ProtoSession protoSession;
+    // here we track which user properties we pushed to Java System Properties (internal only)
+    public Set<String> pushedUserProperties;
 
     public Logger logger;
     public ILoggerFactory loggerFactory;

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/ExecutionEvent.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/ExecutionEvent.java
@@ -29,6 +29,9 @@ public interface ExecutionEvent {
 
     /**
      * The possible types of execution events.
+     *
+     * Note: do not modify this enum, or, make sure that this enum and
+     * {@link org.apache.maven.api.EventType} have same elements in same order.
      */
     enum Type {
         ProjectDiscoveryStarted,

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultEvent.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultEvent.java
@@ -30,15 +30,17 @@ import org.apache.maven.execution.ExecutionEvent;
 public class DefaultEvent implements Event {
     private final InternalMavenSession session;
     private final ExecutionEvent delegate;
+    private final EventType eventType;
 
-    public DefaultEvent(InternalMavenSession session, ExecutionEvent delegate) {
+    public DefaultEvent(InternalMavenSession session, ExecutionEvent delegate, EventType eventType) {
         this.session = session;
         this.delegate = delegate;
+        this.eventType = eventType;
     }
 
     @Override
     public EventType getType() {
-        return EventType.valueOf(delegate.getType().name());
+        return eventType;
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/EventSpyImpl.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/EventSpyImpl.java
@@ -55,7 +55,7 @@ public class EventSpyImpl implements EventSpy {
     }
 
     /**
-     * Simple "conversion" from Maven3 event type enum to Maven4 enum,
+     * Simple "conversion" from Maven3 event type enum to Maven4 enum.
      */
     protected EventType convert(ExecutionEvent.Type type) {
         return EventType.values()[type.ordinal()];


### PR DESCRIPTION
JIRA issue: [MNG-8394](https://issues.apache.org/jira/browse/MNG-8394)

Changes:
* The event type conversion is wrong (mvn3-mvn4 event bridge).
* The user properties were pushed too late for logging configuration. Now we push user properties two times, immediately (only those keys that does not exists), and 2nd time after property contributor we "refresh" all we pushed.