### PR TITLE
Make sure user properties are pushed to system properties early

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -124,6 +124,7 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
 
     protected int doInvoke(C context) throws Exception {
         pushCoreProperties(context);
+        pushUserProperties(context);
         validate(context);
         prepare(context);
         configureLogging(context);


### PR DESCRIPTION
Ideally, the logging system would use user properties instead of system properties...
Also we now push the properties twice, which would be needed in case the `PropertyContributor` extension point has done any modification to the properties in the meantime, but we need to ensure that the second call actually does something (as we avoid pushing properties if they are in the session's system properties).