### PR TITLE
[MNG-8389] MavenExReq lacks u/p/i settings file paths

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
@@ -83,6 +83,11 @@ public class LookupContext implements AutoCloseable {
     public ContainerCapsule containerCapsule;
     public Lookup lookup;
 
+    // paths user can override from CLI, and we need to set on MavenExReq
+    public Path installationSettingsPath;
+    public Path projectSettingsPath;
+    public Path userSettingsPath;
+
     public boolean interactive;
     public Path localRepositoryPath;
     public Settings effectiveSettings;

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -434,8 +434,8 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
 
     protected void settings(C context, SettingsBuilder settingsBuilder) throws Exception {
         Options mavenOptions = context.invokerRequest.options();
-        Path userSettingsFile = null;
 
+        Path userSettingsFile = null;
         if (mavenOptions.altUserSettings().isPresent()) {
             userSettingsFile =
                     context.cwdResolver.apply(mavenOptions.altUserSettings().get());
@@ -452,7 +452,6 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
         }
 
         Path projectSettingsFile = null;
-
         if (mavenOptions.altProjectSettings().isPresent()) {
             projectSettingsFile =
                     context.cwdResolver.apply(mavenOptions.altProjectSettings().get());
@@ -470,7 +469,6 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
         }
 
         Path installationSettingsFile = null;
-
         if (mavenOptions.altInstallationSettings().isPresent()) {
             installationSettingsFile = context.cwdResolver.apply(
                     mavenOptions.altInstallationSettings().get());
@@ -486,6 +484,10 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
                 installationSettingsFile = context.installationResolver.apply(installationSettingsFileStr);
             }
         }
+
+        context.installationSettingsPath = installationSettingsFile;
+        context.projectSettingsPath = projectSettingsFile;
+        context.userSettingsPath = userSettingsFile;
 
         Function<String, String> interpolationSource = Interpolator.chain(
                 context.protoSession.getUserProperties()::get, context.protoSession.getSystemProperties()::get);
@@ -591,6 +593,12 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
         request.setBaseDirectory(context.invokerRequest.topDirectory().toFile());
         request.setSystemProperties(toProperties(context.protoSession.getSystemProperties()));
         request.setUserProperties(toProperties(context.protoSession.getUserProperties()));
+
+        request.setInstallationSettingsFile(
+                context.installationSettingsPath != null ? context.installationSettingsPath.toFile() : null);
+        request.setProjectSettingsFile(
+                context.projectSettingsPath != null ? context.projectSettingsPath.toFile() : null);
+        request.setUserSettingsFile(context.userSettingsPath != null ? context.userSettingsPath.toFile() : null);
 
         request.setTopDirectory(context.invokerRequest.topDirectory());
         if (context.invokerRequest.rootDirectory().isPresent()) {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
@@ -171,14 +171,14 @@ public abstract class MavenInvoker<C extends MavenContext> extends LookupInvoker
     }
 
     @Override
-    protected void customizeSettingsRequest(C context, SettingsBuilderRequest settingsBuilderRequest) {
+    protected void customizeSettingsRequest(C context, SettingsBuilderRequest settingsBuilderRequest) throws Exception {
         if (context.eventSpyDispatcher != null) {
             context.eventSpyDispatcher.onEvent(settingsBuilderRequest);
         }
     }
 
     @Override
-    protected void customizeSettingsResult(C context, SettingsBuilderResult settingsBuilderResult) {
+    protected void customizeSettingsResult(C context, SettingsBuilderResult settingsBuilderResult) throws Exception {
         if (context.eventSpyDispatcher != null) {
             context.eventSpyDispatcher.onEvent(settingsBuilderResult);
         }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
@@ -178,7 +178,7 @@ public abstract class MavenInvoker<C extends MavenContext> extends LookupInvoker
     }
 
     @Override
-    protected void customizeSettingsResult(C context, SettingsBuilderResult settingsBuilderResult) throws Exception {
+    protected void customizeSettingsResult(C context, SettingsBuilderResult settingsBuilderResult) {
         if (context.eventSpyDispatcher != null) {
             context.eventSpyDispatcher.onEvent(settingsBuilderResult);
         }
@@ -186,7 +186,6 @@ public abstract class MavenInvoker<C extends MavenContext> extends LookupInvoker
 
     protected void toolchains(C context, MavenExecutionRequest request) throws Exception {
         Path userToolchainsFile = null;
-
         if (context.invokerRequest.options().altUserToolchains().isPresent()) {
             userToolchainsFile = context.cwdResolver.apply(
                     context.invokerRequest.options().altUserToolchains().get());
@@ -204,7 +203,6 @@ public abstract class MavenInvoker<C extends MavenContext> extends LookupInvoker
         }
 
         Path installationToolchainsFile = null;
-
         if (context.invokerRequest.options().altInstallationToolchains().isPresent()) {
             installationToolchainsFile = context.cwdResolver.apply(
                     context.invokerRequest.options().altInstallationToolchains().get());


### PR DESCRIPTION
The "effective" paths for 3 settings file was not set on MavenExecutionRequest.

---

https://issues.apache.org/jira/browse/MNG-8389