### PR TITLE
IT: Move ITs off maven-shared-utils

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0108SnapshotUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0108SnapshotUpdateTest.java
@@ -20,14 +20,15 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
                 repository,
                 "org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-core-it-support-1.0-SNAPSHOT.jar");
         artifact.getParentFile().mkdirs();
-        FileUtils.fileWrite(artifact.getAbsolutePath(), "originalArtifact");
+        Files.writeString(artifact.getAbsoluteFile().toPath(), "originalArtifact");
 
         verifier.verifyArtifactNotPresent("org.apache.maven", "maven-core-it-support", "1.0-SNAPSHOT", "jar");
     }
@@ -86,7 +87,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
         // set in the past to ensure it is downloaded
         localRepoFile.setLastModified(System.currentTimeMillis() - TIME_OFFSET);
 
-        FileUtils.fileWrite(artifact.getAbsolutePath(), "updatedArtifact");
+        Files.writeString(artifact.getAbsoluteFile().toPath(), "updatedArtifact");
 
         verifier.addCliArgument("package");
         verifier.execute();
@@ -99,8 +100,9 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
     @Test
     public void testSnapshotUpdatedWithMetadata() throws Exception {
         File metadata = new File(repository, "org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        FileUtils.fileWrite(
-                metadata.getAbsolutePath(), constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
+        Files.writeString(
+                metadata.getAbsoluteFile().toPath(),
+                constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
 
         verifier.addCliArgument("package");
         verifier.execute();
@@ -109,9 +111,10 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
 
         verifyArtifactContent("originalArtifact");
 
-        FileUtils.fileWrite(artifact.getAbsolutePath(), "updatedArtifact");
+        Files.writeString(artifact.getAbsoluteFile().toPath(), "updatedArtifact");
         metadata = new File(repository, "org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        FileUtils.fileWrite(metadata.getAbsolutePath(), constructMetadata("2", System.currentTimeMillis(), true));
+        Files.writeString(
+                metadata.getAbsoluteFile().toPath(), constructMetadata("2", System.currentTimeMillis(), true));
 
         verifier.addCliArgument("package");
         verifier.execute();
@@ -130,8 +133,9 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
         localMetadata.getParentFile().mkdirs();
 
         File metadata = new File(repository, "org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        FileUtils.fileWrite(
-                metadata.getAbsolutePath(), constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
+        Files.writeString(
+                metadata.getAbsoluteFile().toPath(),
+                constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
 
         verifier.addCliArgument("package");
         verifier.execute();
@@ -141,9 +145,9 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
         verifyArtifactContent("originalArtifact");
         assertFalse(localMetadata.exists());
 
-        FileUtils.fileWrite(localRepoFile.getAbsolutePath(), "localArtifact");
-        FileUtils.fileWrite(
-                localMetadata.getAbsolutePath(),
+        Files.writeString(localRepoFile.getAbsoluteFile().toPath(), "localArtifact");
+        Files.writeString(
+                localMetadata.getAbsoluteFile().toPath(),
                 constructLocalMetadata("org.apache.maven", "maven-core-it-support", System.currentTimeMillis(), true));
         // update the remote file, but we shouldn't be looking
         artifact.setLastModified(System.currentTimeMillis());
@@ -157,11 +161,11 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
 
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.YEAR, -1);
-        FileUtils.fileWrite(
-                localMetadata.getAbsolutePath(),
+        Files.writeString(
+                localMetadata.getAbsoluteFile().toPath(),
                 constructLocalMetadata("org.apache.maven", "maven-core-it-support", cal.getTimeInMillis(), true));
-        FileUtils.fileWrite(
-                metadata.getAbsolutePath(), constructMetadata("2", System.currentTimeMillis() - 2000, true));
+        Files.writeString(
+                metadata.getAbsoluteFile().toPath(), constructMetadata("2", System.currentTimeMillis() - 2000, true));
         artifact.setLastModified(System.currentTimeMillis());
 
         verifier.addCliArgument("package");
@@ -175,8 +179,9 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
     @Test
     public void testSnapshotUpdatedWithMetadataUsingFileTimestamp() throws Exception {
         File metadata = new File(repository, "org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        FileUtils.fileWrite(
-                metadata.getAbsolutePath(), constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, false));
+        Files.writeString(
+                metadata.getAbsoluteFile().toPath(),
+                constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, false));
         metadata.setLastModified(System.currentTimeMillis() - TIME_OFFSET);
 
         verifier.addCliArgument("package");
@@ -186,9 +191,10 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
 
         verifyArtifactContent("originalArtifact");
 
-        FileUtils.fileWrite(artifact.getAbsolutePath(), "updatedArtifact");
+        Files.writeString(artifact.getAbsoluteFile().toPath(), "updatedArtifact");
         metadata = new File(repository, "org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        FileUtils.fileWrite(metadata.getAbsolutePath(), constructMetadata("2", System.currentTimeMillis(), false));
+        Files.writeString(
+                metadata.getAbsoluteFile().toPath(), constructMetadata("2", System.currentTimeMillis(), false));
 
         verifier.addCliArgument("package");
         verifier.execute();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
@@ -19,9 +19,9 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Properties;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -52,9 +52,9 @@ public class MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest extends Abst
         File dir = new File(testDir, "repo/org/apache/maven/its/mng1751/dep/0.1-SNAPSHOT");
         File templateMetadataFile = new File(dir, "template-metadata.xml");
         File metadataFile = new File(dir, "maven-metadata.xml");
-        FileUtils.copyFile(templateMetadataFile, metadataFile);
+        Files.copy(templateMetadataFile.toPath(), metadataFile.toPath());
         String checksum = ItUtils.calcHash(metadataFile, "SHA-1");
-        FileUtils.fileWrite(metadataFile.getPath() + ".sha1", checksum);
+        Files.writeString(metadataFile.toPath().getParent().resolve(metadataFile.getName() + ".sha1"), checksum);
 
         // phase 1: deploy a new snapshot, this should update the metadata despite its future timestamp
         Verifier verifier = newVerifier(new File(testDir, "dep").getAbsolutePath());

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Properties;
 
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
@@ -52,7 +53,7 @@ public class MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest extends Abst
         File dir = new File(testDir, "repo/org/apache/maven/its/mng1751/dep/0.1-SNAPSHOT");
         File templateMetadataFile = new File(dir, "template-metadata.xml");
         File metadataFile = new File(dir, "maven-metadata.xml");
-        Files.copy(templateMetadataFile.toPath(), metadataFile.toPath());
+        Files.copy(templateMetadataFile.toPath(), metadataFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         String checksum = ItUtils.calcHash(metadataFile, "SHA-1");
         Files.writeString(metadataFile.toPath().getParent().resolve(metadataFile.getName() + ".sha1"), checksum);
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2362DeployedPomEncodingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2362DeployedPomEncodingTest.java
@@ -19,8 +19,9 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -72,13 +73,13 @@ public class MavenITmng2362DeployedPomEncodingTest extends AbstractMavenIntegrat
     }
 
     private void assertPomUtf8(File pomFile) throws Exception {
-        String pom = FileUtils.fileRead(pomFile, "UTF-8");
+        String pom = Files.readString(pomFile.toPath());
         String chars = "\u00DF\u0131\u03A3\u042F\u05D0\u20AC";
         assertPom(pomFile, pom, chars);
     }
 
     private void assertPomLatin1(File pomFile) throws Exception {
-        String pom = FileUtils.fileRead(pomFile, "ISO-8859-1");
+        String pom = Files.readString(pomFile.toPath(), StandardCharsets.ISO_8859_1);
         String chars = "\u00C4\u00D6\u00DC\u00E4\u00F6\u00FC\u00DF";
         assertPom(pomFile, pom, chars);
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2790LastUpdatedMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2790LastUpdatedMetadataTest.java
@@ -19,11 +19,11 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -102,7 +102,7 @@ public class MavenITmng2790LastUpdatedMetadataTest extends AbstractMavenIntegrat
     }
 
     private Date getLastUpdated(File metadataFile) throws Exception {
-        String xml = FileUtils.fileRead(metadataFile, "UTF-8");
+        String xml = Files.readString(metadataFile.toPath());
         String timestamp = xml.replaceAll("(?s)\\A.*<lastUpdated>\\s*([0-9]++)\\s*</lastUpdated>.*\\z", "$1");
         SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
         format.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2820PomCommentsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2820PomCommentsTest.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -62,7 +62,7 @@ public class MavenITmng2820PomCommentsTest extends AbstractMavenIntegrationTestC
     }
 
     private void assertPomComments(File pomFile) throws Exception {
-        String pom = FileUtils.fileRead(pomFile, "UTF-8");
+        String pom = Files.readString(pomFile.toPath());
         assertPomComment(pom, "DOCUMENT-COMMENT-PRE-1");
         assertPomComment(pom, "DOCUMENT-COMMENT-PRE-2");
         assertPomComment(pom, "DOCUMENT-COMMENT-POST-1");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -261,7 +262,7 @@ public class MavenITmng3415JunkRepositoryMetadataTest extends AbstractMavenInteg
 
         System.out.println("Copying dependency POM\nfrom: " + pomSrc + "\nto: " + pom);
         Files.createDirectories(pom.toPath().getParent());
-        Files.copy(pomSrc.toPath(), pom.toPath());
+        Files.copy(pomSrc.toPath(), pom.toPath(), StandardCopyOption.REPLACE_EXISTING);
     }
 
     private File getMetadataFile(Verifier verifier) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
@@ -260,6 +260,7 @@ public class MavenITmng3415JunkRepositoryMetadataTest extends AbstractMavenInteg
         File pomSrc = new File(testDir, "dependency-pom.xml");
 
         System.out.println("Copying dependency POM\nfrom: " + pomSrc + "\nto: " + pom);
+        Files.createDirectories(pom.toPath().getParent());
         Files.copy(pomSrc.toPath(), pom.toPath());
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
@@ -23,11 +23,11 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -260,7 +260,7 @@ public class MavenITmng3415JunkRepositoryMetadataTest extends AbstractMavenInteg
         File pomSrc = new File(testDir, "dependency-pom.xml");
 
         System.out.println("Copying dependency POM\nfrom: " + pomSrc + "\nto: " + pom);
-        FileUtils.copyFile(pomSrc, pom);
+        Files.copy(pomSrc.toPath(), pom.toPath());
     }
 
     private File getMetadataFile(Verifier verifier) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3441MetadataUpdatedFromDeploymentRepositoryTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3441MetadataUpdatedFromDeploymentRepositoryTest.java
@@ -22,8 +22,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3503Xpp3ShadingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3503Xpp3ShadingTest.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +49,7 @@ public class MavenITmng3503Xpp3ShadingTest extends AbstractMavenIntegrationTestC
 
         verifier.verifyErrorFreeLog();
 
-        assertEquals("<root />", FileUtils.fileRead(new File(dir, "target/serialized.xml"), "UTF-8"));
+        assertEquals("<root />", Files.readString(new File(dir, "target/serialized.xml").toPath()));
     }
 
     @Test
@@ -62,6 +62,6 @@ public class MavenITmng3503Xpp3ShadingTest extends AbstractMavenIntegrationTestC
 
         verifier.verifyErrorFreeLog();
 
-        assertEquals("root", FileUtils.fileRead(new File(dir, "target/serialized.xml"), "UTF-8"));
+        assertEquals("root", Files.readString(new File(dir, "target/serialized.xml").toPath()));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3599useHttpProxyForWebDAVMk2Test.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3599useHttpProxyForWebDAVMk2Test.java
@@ -23,10 +23,10 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.StringUtils;
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -145,11 +145,11 @@ public class MavenITmng3599useHttpProxyForWebDAVMk2Test extends AbstractMavenInt
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        String settings = FileUtils.fileRead(new File(testDir, "settings-template.xml"));
+        String settings = Files.readString(new File(testDir, "settings-template.xml").toPath());
         settings = StringUtils.replace(settings, "@port@", Integer.toString(port));
         String newSettings = StringUtils.replace(settings, "@protocol@", "http");
 
-        FileUtils.fileWrite(new File(testDir, "settings.xml").getAbsolutePath(), newSettings);
+        Files.writeString(new File(testDir, "settings.xml").getAbsoluteFile().toPath(), newSettings);
 
         verifier = newVerifier(testDir.getAbsolutePath());
 
@@ -187,11 +187,11 @@ public class MavenITmng3599useHttpProxyForWebDAVMk2Test extends AbstractMavenInt
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        String settings = FileUtils.fileRead(new File(testDir, "settings-template.xml"));
+        String settings = Files.readString(new File(testDir, "settings-template.xml").toPath());
         settings = StringUtils.replace(settings, "@port@", Integer.toString(port));
         String newSettings = StringUtils.replace(settings, "@protocol@", "dav");
 
-        FileUtils.fileWrite(new File(testDir, "settings.xml").getAbsolutePath(), newSettings);
+        Files.writeString(new File(testDir, "settings.xml").getAbsoluteFile().toPath(), newSettings);
 
         verifier = newVerifier(testDir.getAbsolutePath());
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3693PomFileBasedirChangeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3693PomFileBasedirChangeTest.java
@@ -20,8 +20,8 @@ package org.apache.maven.it;
 
 import java.io.File;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3892ReleaseDeploymentTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3892ReleaseDeploymentTest.java
@@ -19,9 +19,9 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Locale;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -85,7 +85,7 @@ public class MavenITmng3892ReleaseDeploymentTest extends AbstractMavenIntegratio
     }
 
     private String readChecksum(File checksumFile) throws Exception {
-        String checksum = FileUtils.fileRead(checksumFile, "UTF-8").trim();
+        String checksum = Files.readString(checksumFile.toPath()).trim();
         if (checksum.indexOf(' ') >= 0) {
             checksum = checksum.substring(0, checksum.indexOf(' '));
         }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3940EnvVarInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3940EnvVarInterpolationTest.java
@@ -21,8 +21,8 @@ package org.apache.maven.it;
 import java.io.File;
 import java.util.Properties;
 
-import org.apache.maven.shared.utils.Os;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4309StrictChecksumValidationForMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4309StrictChecksumValidationForMetadataTest.java
@@ -20,9 +20,9 @@ package org.apache.maven.it;
 
 import java.io.File;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4368TimestampAwareArtifactInstallerTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4368TimestampAwareArtifactInstallerTest.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +69,7 @@ public class MavenITmng4368TimestampAwareArtifactInstallerTest extends AbstractM
         File installedPom =
                 new File(verifier.getArtifactPath("org.apache.maven.its.mng4368", "test", "0.1-SNAPSHOT", "pom"));
 
-        String pom = FileUtils.fileRead(installedPom, "UTF-8");
+        String pom = Files.readString(installedPom.toPath());
         assertTrue(pom.indexOf("Branch-A") > 0);
         assertFalse(pom.contains("Branch-B"));
 
@@ -84,7 +84,7 @@ public class MavenITmng4368TimestampAwareArtifactInstallerTest extends AbstractM
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        pom = FileUtils.fileRead(installedPom, "UTF-8");
+        pom = Files.readString(installedPom.toPath());
         assertFalse(pom.contains("Branch-A"));
         assertTrue(pom.indexOf("Branch-B") > 0);
     }
@@ -106,9 +106,9 @@ public class MavenITmng4368TimestampAwareArtifactInstallerTest extends AbstractM
         File bDir = new File(testDir, "branch-b");
         File bArtifact = new File(bDir, "artifact.jar");
 
-        FileUtils.fileWrite(aArtifact.getPath(), "UTF-8", "from Branch-A");
+        Files.writeString(aArtifact.toPath(), "from Branch-A");
         aArtifact.setLastModified(System.currentTimeMillis());
-        FileUtils.fileWrite(bArtifact.getPath(), "UTF-8", "from Branch-B");
+        Files.writeString(bArtifact.toPath(), "from Branch-B");
         bArtifact.setLastModified(aArtifact.lastModified() - 1000 * 60);
 
         Verifier verifier = newVerifier(aDir.getAbsolutePath());
@@ -122,7 +122,7 @@ public class MavenITmng4368TimestampAwareArtifactInstallerTest extends AbstractM
         File installedArtifact =
                 new File(verifier.getArtifactPath("org.apache.maven.its.mng4368", "test", "0.1-SNAPSHOT", "jar"));
 
-        String data = FileUtils.fileRead(installedArtifact, "UTF-8");
+        String data = Files.readString(installedArtifact.toPath());
         assertTrue(data.indexOf("Branch-A") > 0);
         assertFalse(data.contains("Branch-B"));
 
@@ -137,12 +137,12 @@ public class MavenITmng4368TimestampAwareArtifactInstallerTest extends AbstractM
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        data = FileUtils.fileRead(installedArtifact, "UTF-8");
+        data = Files.readString(installedArtifact.toPath());
         assertFalse(data.contains("Branch-A"));
         assertTrue(data.indexOf("Branch-B") > 0);
 
         long lastModified = installedArtifact.lastModified();
-        FileUtils.fileWrite(installedArtifact.getPath(), "UTF-8", "from Branch-C");
+        Files.writeString(installedArtifact.toPath(), "from Branch-C");
         installedArtifact.setLastModified(lastModified);
 
         verifier = newVerifier(bDir.getAbsolutePath());
@@ -153,7 +153,7 @@ public class MavenITmng4368TimestampAwareArtifactInstallerTest extends AbstractM
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        data = FileUtils.fileRead(installedArtifact, "UTF-8");
+        data = Files.readString(installedArtifact.toPath());
         assertFalse(data.contains("Branch-B"));
         assertTrue(data.indexOf("Branch-C") > 0);
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4554PluginPrefixMappingUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4554PluginPrefixMappingUpdateTest.java
@@ -28,8 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660OutdatedPackagedArtifact.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660OutdatedPackagedArtifact.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
@@ -84,7 +83,7 @@ public class MavenITmng4660OutdatedPackagedArtifact extends AbstractMavenIntegra
         final Path resourcesDirectory =
                 Files.createDirectories(Paths.get(testDir.toString(), "module-a", "src", "main", "resources"));
         final Path fileToWrite = resourcesDirectory.resolve("example.properties");
-        FileUtils.fileWrite(fileToWrite.toString(), "x=42");
+        Files.writeString(fileToWrite, "x=42");
 
         verifier2.setAutoclean(false);
         verifier2.addCliArgument("--projects");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4745PluginVersionUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4745PluginVersionUpdateTest.java
@@ -19,10 +19,10 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -163,6 +163,6 @@ public class MavenITmng4745PluginVersionUpdateTest extends AbstractMavenIntegrat
 
         File metadata = new File(testdir, "repo/org/apache/maven/its/mng4745/maven-it-plugin/maven-metadata.xml");
         metadata.getParentFile().mkdirs();
-        FileUtils.fileWrite(metadata.getAbsolutePath(), "UTF-8", content.toString());
+        Files.writeString(metadata.getAbsoluteFile().toPath(), content.toString());
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4874UpdateLatestPluginVersionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4874UpdateLatestPluginVersionTest.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +55,7 @@ public class MavenITmng4874UpdateLatestPluginVersionTest extends AbstractMavenIn
         verifier.verifyErrorFreeLog();
 
         File metadataFile = new File(testDir, "target/repo/org/apache/maven/its/mng4874/test/maven-metadata.xml");
-        String xml = FileUtils.fileRead(metadataFile, "UTF-8");
+        String xml = Files.readString(metadataFile.toPath());
         assertTrue(xml.matches("(?s).*<latest>0\\.1-SNAPSHOT</latest>.*"), xml);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4952MetadataReleaseInfoUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4952MetadataReleaseInfoUpdateTest.java
@@ -19,9 +19,9 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Map;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +69,7 @@ public class MavenITmng4952MetadataReleaseInfoUpdateTest extends AbstractMavenIn
         verifier.verifyErrorFreeLog();
 
         File metadataFile = new File(testDir, "target/repo/org/apache/maven/its/mng4952/test/maven-metadata.xml");
-        String xml = FileUtils.fileRead(metadataFile, "UTF-8");
+        String xml = Files.readString(metadataFile.toPath());
         assertTrue(xml.matches("(?s).*<release>2\\.0</release>.*"), xml);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5387ArtifactReplacementPlugin.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5387ArtifactReplacementPlugin.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ public class MavenITmng5387ArtifactReplacementPlugin extends AbstractMavenIntegr
         v0.verifyErrorFreeLog();
 
         String path = v0.getArtifactPath("org.apache.maven.its.mng5387", "mng5387-it", "0.0.1-SNAPSHOT", "txt", "c");
-        String contents = FileUtils.fileRead(new File(path), "utf-8");
+        String contents = Files.readString(new File(path).toPath());
         assertTrue(contents.contains("This is the second file"));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5742BuildExtensionClassloaderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5742BuildExtensionClassloaderTest.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +53,7 @@ public class MavenITmng5742BuildExtensionClassloaderTest extends AbstractMavenIn
         verifier.verifyErrorFreeLog();
         verifier.verifyFilePresent("target/execution-success.txt");
 
-        String actual = FileUtils.fileRead(new File(projectDir, "target/execution-success.txt"));
+        String actual = Files.readString(new File(projectDir, "target/execution-success.txt").toPath());
         assertEquals("executed", actual);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5753CustomMojoExecutionConfiguratorTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5753CustomMojoExecutionConfiguratorTest.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +61,7 @@ public class MavenITmng5753CustomMojoExecutionConfiguratorTest extends AbstractM
         // The <name/> element in the original configuration is "ORIGINAL". We want to assert that our
         // custom MojoExecutionConfigurator made the transformation of the element from "ORIGINAL" to "TRANSFORMED"
         //
-        String actual = FileUtils.fileRead(configurationFile);
+        String actual = Files.readString(configurationFile.toPath());
         assertEquals("TRANSFORMED", actual);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6127PluginExecutionConfigurationInterferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6127PluginExecutionConfigurationInterferenceTest.java
@@ -19,8 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -65,15 +65,15 @@ public class MavenITmng6127PluginExecutionConfigurationInterferenceTest extends 
         verifier.verifyErrorFreeLog();
 
         verifier.verifyFilePresent(modAconfigurationFile.getCanonicalPath());
-        String modAactual = FileUtils.fileRead(modAconfigurationFile);
+        String modAactual = Files.readString(modAconfigurationFile.toPath());
         assertEquals("name=mod-a, secondName=second from components.xml", modAactual);
 
         verifier.verifyFilePresent(modBconfigurationFile.getCanonicalPath());
-        String modBactual = FileUtils.fileRead(modBconfigurationFile);
+        String modBactual = Files.readString(modBconfigurationFile.toPath());
         assertEquals("name=mod-b, secondName=second from components.xml", modBactual);
 
         verifier.verifyFilePresent(modCconfigurationFile.getCanonicalPath());
-        String modCactual = FileUtils.fileRead(modCconfigurationFile);
+        String modCactual = Files.readString(modCconfigurationFile.toPath());
         assertEquals("secondName=second from components.xml", modCactual);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6386BaseUriPropertyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6386BaseUriPropertyTest.java
@@ -21,8 +21,8 @@ package org.apache.maven.it;
 import java.io.File;
 import java.util.Properties;
 
-import org.apache.maven.shared.utils.Os;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -110,7 +110,6 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
     }
 
     static void assertTextEquals(File file1, File file2) throws IOException {
-        // we need to ignore line endings
         assertEquals(
                 String.join("\n", Files.readAllLines(file1.toPath()).stream().map(String::trim).toList()),
                 String.join("\n", Files.readAllLines(file2.toPath()).stream().map(String::trim).toList()),

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -20,8 +20,8 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -111,8 +111,8 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
 
     static void assertTextEquals(File file1, File file2) throws IOException {
         assertEquals(
-                String.join("\n", FileUtils.loadFile(file1)),
-                String.join("\n", FileUtils.loadFile(file2)),
+                String.join("\n", Files.readString(file1.toPath())),
+                String.join("\n", Files.readString(file2.toPath())),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -111,8 +111,8 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
 
     static void assertTextEquals(File file1, File file2) throws IOException {
         assertEquals(
-                String.join("\n", Files.readString(file1.toPath())),
-                String.join("\n", Files.readString(file2.toPath())),
+                Files.readString(file1.toPath()),
+                Files.readString(file2.toPath()),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -112,8 +112,8 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
     static void assertTextEquals(File file1, File file2) throws IOException {
         // we need to ignore line endings
         assertEquals(
-                String.join("\n", Files.readAllLines(file1.toPath())),
-                String.join("\n", Files.readAllLines(file2.toPath())),
+                String.join("\n", Files.readAllLines(file1.toPath()).stream().map(String::trim).toList()),
+                String.join("\n", Files.readAllLines(file2.toPath()).stream().map(String::trim).toList()),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -111,8 +111,16 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
 
     static void assertTextEquals(File file1, File file2) throws IOException {
         assertEquals(
-                String.join("\n", Files.readAllLines(file1.toPath()).stream().map(String::trim).toList()),
-                String.join("\n", Files.readAllLines(file2.toPath()).stream().map(String::trim).toList()),
+                String.join(
+                        "\n",
+                        Files.readAllLines(file1.toPath()).stream()
+                                .map(String::trim)
+                                .toList()),
+                String.join(
+                        "\n",
+                        Files.readAllLines(file2.toPath()).stream()
+                                .map(String::trim)
+                                .toList()),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -110,9 +110,10 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
     }
 
     static void assertTextEquals(File file1, File file2) throws IOException {
+        // we need to ignore line endings
         assertEquals(
-                Files.readString(file1.toPath()),
-                Files.readString(file2.toPath()),
+                String.join("\n", Files.readAllLines(file1.toPath())),
+                String.join("\n", Files.readAllLines(file2.toPath())),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -136,8 +136,8 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
 
     static void assertTextEquals(File file1, File file2) throws IOException {
         assertEquals(
-                Files.readString(file1.toPath()),
-                Files.readString(file2.toPath()),
+                String.join("\n", Files.readAllLines(file1.toPath()).stream().map(String::trim).toList()),
+                String.join("\n", Files.readAllLines(file2.toPath()).stream().map(String::trim).toList()),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -20,8 +20,8 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
@@ -136,8 +136,8 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
 
     static void assertTextEquals(File file1, File file2) throws IOException {
         assertEquals(
-                String.join("\n", FileUtils.loadFile(file1)),
-                String.join("\n", FileUtils.loadFile(file2)),
+                String.join("\n", Files.readString(file1.toPath())),
+                String.join("\n", Files.readString(file2.toPath())),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -136,8 +136,16 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
 
     static void assertTextEquals(File file1, File file2) throws IOException {
         assertEquals(
-                String.join("\n", Files.readAllLines(file1.toPath()).stream().map(String::trim).toList()),
-                String.join("\n", Files.readAllLines(file2.toPath()).stream().map(String::trim).toList()),
+                String.join(
+                        "\n",
+                        Files.readAllLines(file1.toPath()).stream()
+                                .map(String::trim)
+                                .toList()),
+                String.join(
+                        "\n",
+                        Files.readAllLines(file2.toPath()).stream()
+                                .map(String::trim)
+                                .toList()),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -136,8 +136,8 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
 
     static void assertTextEquals(File file1, File file2) throws IOException {
         assertEquals(
-                String.join("\n", Files.readString(file1.toPath())),
-                String.join("\n", Files.readString(file2.toPath())),
+                Files.readString(file1.toPath()),
+                Files.readString(file2.toPath()),
                 "pom files differ " + file1 + " " + file2);
     }
 }


### PR DESCRIPTION
No dependency change yet, just remove all the use of `maven-shared-utils` from IT classes, as `plexus-utils` is anyway present. Also, Java alone has many of these utils now.