### PR TITLE
[MNG-8400] Make sure base parser uses canonical maven.home

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -221,6 +221,8 @@ public abstract class BaseParser implements Parser {
 
         Properties buildProperties = CLIReportingUtils.getBuildProperties();
 
+        // TODO
+
         String mavenVersion = buildProperties.getProperty(CLIReportingUtils.BUILD_VERSION_PROPERTY);
         systemProperties.setProperty("maven.version", mavenVersion);
 

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -221,7 +221,10 @@ public abstract class BaseParser implements Parser {
 
         Properties buildProperties = CLIReportingUtils.getBuildProperties();
 
-        // TODO
+        // the three canonical directories (that may change due canonical paths vs symlinks)
+        systemProperties.setProperty(Constants.MAVEN_HOME, context.installationDirectory.toString());
+        systemProperties.setProperty("user.home", context.userHomeDirectory.toString());
+        systemProperties.setProperty("user.dir", context.cwd.toString());
 
         String mavenVersion = buildProperties.getProperty(CLIReportingUtils.BUILD_VERSION_PROPERTY);
         systemProperties.setProperty("maven.version", mavenVersion);

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -50,8 +51,6 @@ import org.apache.maven.properties.internal.EnvironmentUtils;
 import org.apache.maven.properties.internal.SystemProperties;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.maven.api.Constants.MAVEN_HOME;
-import static org.apache.maven.api.Constants.MAVEN_INSTALLATION_CONF;
 import static org.apache.maven.cling.invoker.Utils.getCanonicalPath;
 import static org.apache.maven.cling.invoker.Utils.or;
 import static org.apache.maven.cling.invoker.Utils.prefix;
@@ -140,23 +139,26 @@ public abstract class BaseParser implements Parser {
             context.systemPropertiesOverrides.put("user.dir", result.toString());
             return result;
         } else {
-            return getCanonicalPath(Paths.get(System.getProperty("user.dir")));
+            Path result = getCanonicalPath(Paths.get(System.getProperty("user.dir")));
+            mayOverrideDirectorySystemProperty(context, "user.dir", result);
+            return result;
         }
     }
 
     protected Path getInstallationDirectory(LocalContext context) throws ParserException {
-        Path result;
         if (context.parserRequest.mavenHome() != null) {
-            result = getCanonicalPath(context.parserRequest.mavenHome());
-            context.systemPropertiesOverrides.put(MAVEN_HOME, result.toString());
+            Path result = getCanonicalPath(context.parserRequest.mavenHome());
+            context.systemPropertiesOverrides.put(Constants.MAVEN_HOME, result.toString());
+            return result;
         } else {
             String mavenHome = System.getProperty(Constants.MAVEN_HOME);
             if (mavenHome == null) {
                 throw new ParserException("local mode requires " + Constants.MAVEN_HOME + " Java System Property set");
             }
-            result = getCanonicalPath(Paths.get(mavenHome));
+            Path result = getCanonicalPath(Paths.get(mavenHome));
+            mayOverrideDirectorySystemProperty(context, Constants.MAVEN_HOME, result);
+            return result;
         }
-        return result;
     }
 
     protected Path getUserHomeDirectory(LocalContext context) throws ParserException {
@@ -165,7 +167,20 @@ public abstract class BaseParser implements Parser {
             context.systemPropertiesOverrides.put("user.home", result.toString());
             return result;
         } else {
-            return getCanonicalPath(Paths.get(System.getProperty("user.home")));
+            Path result = getCanonicalPath(Paths.get(System.getProperty("user.home")));
+            mayOverrideDirectorySystemProperty(context, "user.home", result);
+            return result;
+        }
+    }
+
+    /**
+     * This method is needed to "align" values used later on for interpolations and path calculations.
+     * We enforce "canonical" paths, so IF key and canonical path value disagree, let override it.
+     */
+    protected void mayOverrideDirectorySystemProperty(LocalContext context, String javaSystemPropertyKey, Path value) {
+        String valueString = value.toString();
+        if (!Objects.equals(System.getProperty(javaSystemPropertyKey), valueString)) {
+            context.systemPropertiesOverrides.put(javaSystemPropertyKey, valueString);
         }
     }
 
@@ -221,11 +236,6 @@ public abstract class BaseParser implements Parser {
 
         Properties buildProperties = CLIReportingUtils.getBuildProperties();
 
-        // the three canonical directories (that may change due canonical paths vs symlinks)
-        systemProperties.setProperty(Constants.MAVEN_HOME, context.installationDirectory.toString());
-        systemProperties.setProperty("user.home", context.userHomeDirectory.toString());
-        systemProperties.setProperty("user.dir", context.cwd.toString());
-
         String mavenVersion = buildProperties.getProperty(CLIReportingUtils.BUILD_VERSION_PROPERTY);
         systemProperties.setProperty("maven.version", mavenVersion);
 
@@ -257,13 +267,14 @@ public abstract class BaseParser implements Parser {
                 or(paths::get, prefix("cli.", userSpecifiedProperties::get), context.systemProperties::get);
 
         Path mavenConf;
-        if (context.systemProperties.get(MAVEN_INSTALLATION_CONF) != null) {
-            mavenConf = context.installationDirectory.resolve(context.systemProperties.get(MAVEN_INSTALLATION_CONF));
+        if (context.systemProperties.get(Constants.MAVEN_INSTALLATION_CONF) != null) {
+            mavenConf = context.installationDirectory.resolve(
+                    context.systemProperties.get(Constants.MAVEN_INSTALLATION_CONF));
         } else if (context.systemProperties.get("maven.conf") != null) {
             mavenConf = context.installationDirectory.resolve(context.systemProperties.get("maven.conf"));
-        } else if (context.systemProperties.get(MAVEN_HOME) != null) {
+        } else if (context.systemProperties.get(Constants.MAVEN_HOME) != null) {
             mavenConf = context.installationDirectory
-                    .resolve(context.systemProperties.get(MAVEN_HOME))
+                    .resolve(context.systemProperties.get(Constants.MAVEN_HOME))
                     .resolve("conf");
         } else {
             mavenConf = context.installationDirectory.resolve("");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -18,15 +18,15 @@
  */
 package org.apache.maven.it;
 
-import org.apache.maven.shared.verifier.util.ResourceExtractor;
-import org.junit.jupiter.api.Test;
-
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,7 +45,8 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
     @Test
     void testIt() throws Exception {
         Path basedir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-8400")
-                .getAbsoluteFile().toPath();
+                .getAbsoluteFile()
+                .toPath();
         Path tempDir = basedir.resolve("tmp");
         Files.createDirectories(tempDir);
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -62,6 +62,8 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
         verifier.addCliArgument("-DforceStdout");
         verifier.addCliArgument("-DasProperties");
         verifier.addCliArgument("eu.maveniverse.maven.plugins:toolbox:0.5.2:gav-dump");
+        // TODO: fork until new entry point CLIng is used
+        verifier.setForkJvm(true);
         verifier.execute();
 
         String dump = verifier.loadLogContent();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8400">MNG-8400</a>.
+ */
+class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8400CanonicalMavenHomeTest() {
+        super("[4.0.0-rc-1,)");
+    }
+
+    /**
+     *  Verify that properties are aligned (all use canonical maven home)
+     */
+    @Test
+    void testIt() throws Exception {
+        Path basedir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-8400")
+                .getAbsoluteFile().toPath();
+        Path tempDir = basedir.resolve("tmp");
+        Files.createDirectories(tempDir);
+
+        Path linkedMavenHome = tempDir.resolve("linked-maven-home");
+
+        Path mavenHome = Paths.get(System.getProperty("maven.home"));
+        Files.createSymbolicLink(linkedMavenHome, mavenHome);
+
+        System.setProperty("maven.home", linkedMavenHome.toString());
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("--raw-streams");
+        verifier.addCliArgument("--quiet");
+        verifier.addCliArgument("-DforceStdout");
+        verifier.addCliArgument("-DasProperties");
+        verifier.addCliArgument("eu.maveniverse.maven.plugins:toolbox:0.5.2:gav-dump");
+        verifier.execute();
+
+        String dump = verifier.loadLogContent();
+        Properties props = new Properties();
+        props.load(new ByteArrayInputStream(dump.getBytes(StandardCharsets.UTF_8)));
+
+        Path installationSettingsXml = Paths.get(props.getProperty("maven.settings"));
+        Path installationToolchainsXml = Paths.get(props.getProperty("maven.toolchains"));
+
+        assertEquals(installationToolchainsXml.getParent(), installationSettingsXml.getParent());
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -52,10 +52,10 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
 
         Path linkedMavenHome = tempDir.resolve("linked-maven-home");
 
-        Path mavenHome = Paths.get(System.getProperty("maven.home"));
-        Files.createSymbolicLink(linkedMavenHome, mavenHome);
-
+        Path oldMavenHome = Paths.get(System.getProperty("maven.home"));
+        Files.createSymbolicLink(linkedMavenHome, oldMavenHome);
         System.setProperty("maven.home", linkedMavenHome.toString());
+
         Verifier verifier = newVerifier(basedir.toString(), null);
         verifier.addCliArgument("--raw-streams");
         verifier.addCliArgument("--quiet");
@@ -72,7 +72,9 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
 
         Path installationSettingsXml = Paths.get(props.getProperty("maven.settings"));
         Path installationToolchainsXml = Paths.get(props.getProperty("maven.toolchains"));
+        Path mavenHome = Paths.get(props.getProperty("maven.home"));
 
-        assertEquals(installationToolchainsXml.getParent(), installationSettingsXml.getParent());
+        assertEquals(mavenHome, installationSettingsXml.getParent().getParent()); // remove conf
+        assertEquals(mavenHome, installationToolchainsXml.getParent().getParent()); // remove conf
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -56,7 +56,7 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
         Files.createSymbolicLink(linkedMavenHome, mavenHome);
 
         System.setProperty("maven.home", linkedMavenHome.toString());
-        Verifier verifier = newVerifier(basedir.toString());
+        Verifier verifier = newVerifier(basedir.toString(), null);
         verifier.addCliArgument("--raw-streams");
         verifier.addCliArgument("--quiet");
         verifier.addCliArgument("-DforceStdout");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -100,6 +100,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8400CanonicalMavenHomeTest.class);
         suite.addTestSuite(MavenITmng8385PropertyContributoSPITest.class);
         suite.addTestSuite(MavenITmng8383UnknownTypeDependenciesTest.class);
         suite.addTestSuite(MavenITmng8379SettingsDecryptTest.class);


### PR DESCRIPTION
As currently it is mixing canonical paths with non-canonical ones.

---

https://issues.apache.org/jira/browse/MNG-8400