### PR TITLE
[MNG-8401] Reference global Maven download page

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -43,7 +43,7 @@ under the License.
       <item name="Source Xref" href="xref/index.html"/>
       <!--item name="FAQ" href="faq.html"/-->
       <item name="License" href="https://www.apache.org/licenses/"/>
-      <item name="Download" href="/download.html"/>
+      <item name="Download" href="../../download.cgi"/>
     </menu>
 
     <menu inherit="bottom" name="Descriptors Reference">


### PR DESCRIPTION
Otherwise the ASF default template is used due to global redirects from */downloads.html -> */downloads.cgi (in
https://svn.apache.org/repos/asf/maven/website/content/.htaccess) -> /var/www/dyn/closer.lua (in
https://github.com/apache/infrastructure-p6/blob/0a8ee96efb418bb75a4256dd331085471211dfd5/modules/closer_cgi/files/closer-cgi.conf#L6C21-L6C44)

The ASF default template does not work for the Maven Website (maven.apache.org)
