### PR TITLE
[MNG-8461] Initial settings method must restore context state

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -501,8 +501,12 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
      * If there are Maven3 passwords presents in settings, this results in doubled warnings emitted. So Plexus DI
      * creation call keeps "emitSettingsWarnings" false. If there are fatal issues, it will anyway "die" at that
      * spot before warnings would be emitted.
+     * <p>
+     * The method returns a "cleaner" runnable, as during extension loading the context needs to be "cleaned", restored
+     * to previous state (as it was before extension loading).
      */
-    protected void settings(C context, boolean emitSettingsWarnings, SettingsBuilder settingsBuilder) throws Exception {
+    protected Runnable settings(C context, boolean emitSettingsWarnings, SettingsBuilder settingsBuilder)
+            throws Exception {
         Options mavenOptions = context.invokerRequest.options();
 
         Path userSettingsFile = null;
@@ -612,6 +616,14 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
             }
             context.logger.info("");
         }
+        return () -> {
+            context.installationSettingsPath = null;
+            context.projectSettingsPath = null;
+            context.userSettingsPath = null;
+            context.effectiveSettings = null;
+            context.interactive = true;
+            context.localRepositoryPath = null;
+        };
     }
 
     protected void customizeSettingsRequest(C context, SettingsBuilderRequest settingsBuilderRequest)


### PR DESCRIPTION
Effective settings are (should be) created twice, once for "early boot" of Plexus when extensions are loaded up, and then again when Maven "boots".

Bug was that early call "corrupted" (inited settings) in context causing that 2nd required call (due spy) was omitted. This resulted in lack of settings related spy events firing (as we do have IT for spy but it does not test settings events).

---

https://issues.apache.org/jira/browse/MNG-8461

Related: https://github.com/alextu/maven4-reproducer/issues/1