### PR TITLE
[MNG-8460] Implement flush()

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingOutputStream.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingOutputStream.java
@@ -56,6 +56,11 @@ public class LoggingOutputStream extends FilterOutputStream {
         }
     }
 
+    @Override
+    public void flush() throws IOException {
+        forceFlush();
+    }
+
     public void forceFlush() {
         if (buf.size() > 0) {
             String line = new String(buf.toByteArray(), 0, buf.size());


### PR DESCRIPTION
LoggingOutputStream used by default as sysout and syserr were NOT flushing (def method is empty), and flush happened only when EOL was printed.

Still, prompts and help:evaluate does print out unterminated strings.

---

https://issues.apache.org/jira/browse/MNG-8460
