### PR TITLE
[MNG-8465] Add support for project.rootDirectory in repositories and fix other expressions

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelInterpolator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelInterpolator.java
@@ -211,7 +211,7 @@ public class DefaultModelInterpolator implements ModelInterpolator {
                 return projectDir.toAbsolutePath().toString();
             } else if (subExpr.startsWith("basedir.")) {
                 try {
-                    Object value = ReflectionValueExtractor.evaluate(subExpr, projectDir.toAbsolutePath(), false);
+                    Object value = ReflectionValueExtractor.evaluate(subExpr, projectDir.toAbsolutePath(), true);
                     if (value != null) {
                         return value.toString();
                     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -1343,7 +1343,14 @@ public class DefaultModelValidator implements ModelValidator {
                 // only allow ${basedir} and ${project.basedir}
                 Matcher m = EXPRESSION_NAME_PATTERN.matcher(repository.getUrl());
                 while (m.find()) {
-                    if (!("basedir".equals(m.group(1)) || "project.basedir".equals(m.group(1)))) {
+                    String expr = m.group(1);
+                    if (!("basedir".equals(expr)
+                            || "project.basedir".equals(expr)
+                            || expr.startsWith("project.basedir.")
+                            || "project.baseUri".equals(expr)
+                            || expr.startsWith("project.baseUri.")
+                            || "project.rootDirectory".equals(expr)
+                            || expr.startsWith("project.rootDirectory."))) {
                         validateStringNoExpression(
                                 prefix + prefix2 + "[" + repository.getId() + "].url",
                                 problems,

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -1355,7 +1355,7 @@ public class DefaultModelValidator implements ModelValidator {
                                 Version.V40,
                                 prefix + prefix2 + "[" + repository.getId() + "].url",
                                 null,
-                                "only expressions starting with 'project.basedir' or 'project.rootDirectory' are supported.",
+                                "contains an unsupported expression (only expressions starting with 'project.basedir' or 'project.rootDirectory' are supported).",
                                 repository);
                         break;
                     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelValidator.java
@@ -1347,16 +1347,15 @@ public class DefaultModelValidator implements ModelValidator {
                     if (!("basedir".equals(expr)
                             || "project.basedir".equals(expr)
                             || expr.startsWith("project.basedir.")
-                            || "project.baseUri".equals(expr)
-                            || expr.startsWith("project.baseUri.")
                             || "project.rootDirectory".equals(expr)
                             || expr.startsWith("project.rootDirectory."))) {
-                        validateStringNoExpression(
-                                prefix + prefix2 + "[" + repository.getId() + "].url",
+                        addViolation(
                                 problems,
                                 Severity.ERROR,
                                 Version.V40,
-                                repository.getUrl(),
+                                prefix + prefix2 + "[" + repository.getId() + "].url",
+                                null,
+                                "only expressions starting with 'project.basedir' or 'project.rootDirectory' are supported.",
                                 repository);
                         break;
                     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelValidatorTest.java
@@ -805,7 +805,7 @@ class DefaultModelValidatorTest {
         SimpleProblemCollector result = validateFile("raw-model/repository-with-expression.xml");
         assertViolations(result, 0, 1, 0);
         assertEquals(
-                "'repositories.repository.[repo].url' contains an expression but should be a constant.",
+                "'repositories.repository.[repo].url' contains an unsupported expression (only expressions starting with 'project.basedir' or 'project.rootDirectory' are supported).",
                 result.getErrors().get(0));
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
@@ -47,6 +47,6 @@ class MavenITmng8465RepositoryWithProjectDirTest extends AbstractMavenIntegratio
         List<String> urls = verifier.loadLogLines().stream()
                 .filter(s -> s.contains("<url>" + basedir.resolve("repo").toUri() + "</url>"))
                 .toList();
-        assertEquals(5, urls.size());
+        assertEquals(4, urls.size());
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
@@ -46,13 +46,8 @@ class MavenITmng8465RepositoryWithProjectDirTest extends AbstractMavenIntegratio
         verifier.addCliArgument("help:effective-pom");
         verifier.execute();
         List<String> urls = verifier.loadLogLines().stream()
-                .filter(s -> s.trim().startsWith("<url>"))
+                .filter(s -> s.trim().contains("<url>file://"))
                 .toList();
         assertEquals(4, urls.size());
-        for (String url : urls) {
-            Path repo = basedir.resolve("repo");
-            assertTrue(
-                    url.contains("file://" + repo) || url.contains(repo.toUri().toString()));
-        }
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8465">MNG-8465</a>.
+ */
+class MavenITmng8465RepositoryWithProjectDirTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8465RepositoryWithProjectDirTest() {
+        super("[4.0.0-rc-3-SNAPSHOT,)");
+    }
+
+    /**
+     *  Verify various supported repository URLs.
+     */
+    @Test
+    void testProjectDir() throws Exception {
+        Path basedir = extractResources("/mng-8465").getAbsoluteFile().toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("help:effective-pom");
+        verifier.execute();
+        List<String> urls = verifier.loadLogLines().stream()
+                .filter(s -> s.contains("<url>" + basedir.resolve("repo").toUri() + "</url>"))
+                .toList();
+        assertEquals(5, urls.size());
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8465">MNG-8465</a>.

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8465">MNG-8465</a>.
@@ -45,8 +46,13 @@ class MavenITmng8465RepositoryWithProjectDirTest extends AbstractMavenIntegratio
         verifier.addCliArgument("help:effective-pom");
         verifier.execute();
         List<String> urls = verifier.loadLogLines().stream()
-                .filter(s -> s.contains("<url>" + basedir.resolve("repo").toUri() + "</url>"))
+                .filter(s -> s.trim().startsWith("<url>"))
                 .toList();
         assertEquals(4, urls.size());
+        for (String url : urls) {
+            Path repo = basedir.resolve("repo");
+            assertTrue(url.contains("file://" + repo)
+                || url.contains(repo.toUri().toString()));
+        }
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8465RepositoryWithProjectDirTest.java
@@ -51,8 +51,8 @@ class MavenITmng8465RepositoryWithProjectDirTest extends AbstractMavenIntegratio
         assertEquals(4, urls.size());
         for (String url : urls) {
             Path repo = basedir.resolve("repo");
-            assertTrue(url.contains("file://" + repo)
-                || url.contains(repo.toUri().toString()));
+            assertTrue(
+                    url.contains("file://" + repo) || url.contains(repo.toUri().toString()));
         }
     }
 }

--- a/its/core-it-suite/src/test/resources/mng-8465/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8465/pom.xml
@@ -19,14 +19,10 @@
     </repository>
     <repository>
       <id>test3</id>
-      <url>${project.baseUri}repo</url>
-    </repository>
-    <repository>
-      <id>test4</id>
       <url>file://${project.rootDirectory}/repo</url>
     </repository>
     <repository>
-      <id>test5</id>
+      <id>test4</id>
       <url>${project.rootDirectory.uri}repo</url>
     </repository>
   </repositories>

--- a/its/core-it-suite/src/test/resources/mng-8465/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8465/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8465</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: MNG-8465</name>
+  <description>Test repositories can be defined using ${project.basedir} and ${project.rootDirectory}.</description>
+
+  <repositories>
+    <repository>
+      <id>test</id>
+      <url>file://${project.basedir}/repo</url>
+    </repository>
+    <repository>
+      <id>test2</id>
+      <url>${project.basedir.uri}repo</url>
+    </repository>
+    <repository>
+      <id>test3</id>
+      <url>${project.baseUri}repo</url>
+    </repository>
+    <repository>
+      <id>test4</id>
+      <url>file://${project.rootDirectory}/repo</url>
+    </repository>
+    <repository>
+      <id>test5</id>
+      <url>${project.rootDirectory.uri}repo</url>
+    </repository>
+  </repositories>
+</project>


### PR DESCRIPTION
Valid expressions in repositories are:
* `${project.basedir}`
* `${project.basedir.uri}`
* `${project.rootDirectory}`
* `${project.rootDirectory.uri}`

JIRA issues  [MNG-8465](https://issues.apache.org/jira/browse/MNG-8465)
