### PR TITLE
[MNG-8469] Fix interpolation precedence order

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelInterpolator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/model/DefaultModelInterpolator.java
@@ -169,6 +169,10 @@ public class DefaultModelInterpolator implements ModelInterpolator {
             ModelBuilderRequest request,
             ModelProblemCollector problems,
             String expression) {
+        // basedir (the prefixed combos are handled below)
+        if ("basedir".equals(expression)) {
+            return projectProperty(model, projectDir, expression, false);
+        }
         // timestamp
         if ("build.timestamp".equals(expression) || "maven.build.timestamp".equals(expression)) {
             return new MavenBuildTimestamp(request.getSession().getStartTime(), model.getProperties())
@@ -184,12 +188,8 @@ public class DefaultModelInterpolator implements ModelInterpolator {
                 }
             }
         }
-        // un-prefixed model reflection
-        String value = projectProperty(model, projectDir, expression, false);
         // user properties
-        if (value == null) {
-            value = request.getUserProperties().get(expression);
-        }
+        String value = request.getUserProperties().get(expression);
         // model properties
         if (value == null) {
             value = model.getProperties().get(expression);
@@ -201,6 +201,10 @@ public class DefaultModelInterpolator implements ModelInterpolator {
         // environment variables
         if (value == null) {
             value = request.getSystemProperties().get("env." + expression);
+        }
+        // un-prefixed model reflection
+        if (value == null) {
+            value = projectProperty(model, projectDir, expression, false);
         }
         return value;
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelInterpolatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelInterpolatorTest.java
@@ -565,7 +565,7 @@ class DefaultModelInterpolatorTest {
 
         assertCollectorState(0, 1, 0, collector);
         assertEquals(
-                "recursive variable reference: someBasedir",
+                "recursive variable reference: basedir",
                 collector.getErrors().get(0));
     }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelInterpolatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelInterpolatorTest.java
@@ -565,8 +565,7 @@ class DefaultModelInterpolatorTest {
 
         assertCollectorState(0, 1, 0, collector);
         assertEquals(
-                "recursive variable reference: basedir",
-                collector.getErrors().get(0));
+                "recursive variable reference: basedir", collector.getErrors().get(0));
     }
 
     @Test

--- a/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelInterpolatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/internal/impl/model/DefaultModelInterpolatorTest.java
@@ -53,6 +53,7 @@ import org.apache.maven.api.services.model.RootLocator;
 import org.apache.maven.internal.impl.model.profile.SimpleProblemCollector;
 import org.apache.maven.internal.impl.standalone.ApiRunner;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -549,6 +550,7 @@ class DefaultModelInterpolatorTest {
         assertTrue(collector.getErrors().get(0).contains("recursive variable reference"));
     }
 
+    @Disabled("per def cannot be recursive: ${basedir} is immediately going for project.basedir")
     @Test
     public void testRecursiveExpressionCycleBaseDir() throws Exception {
         Map<String, String> props = new HashMap<>();
@@ -563,7 +565,8 @@ class DefaultModelInterpolatorTest {
 
         assertCollectorState(0, 1, 0, collector);
         assertEquals(
-                "recursive variable reference: basedir", collector.getErrors().get(0));
+                "recursive variable reference: someBasedir",
+                collector.getErrors().get(0));
     }
 
     @Test

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8469InterpolationPrecendenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8469InterpolationPrecendenceTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8469">MNG-8469</a>.
+ */
+class MavenITmng8469InterpolationPrecendenceTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8469InterpolationPrecendenceTest() {
+        super("[4.0.0-rc-3-SNAPSHOT,)");
+    }
+
+    /**
+     *  Verify project is buildable.
+     */
+    @Test
+    void testIt() throws Exception {
+        Path basedir = extractResources("/mng-8469").getAbsoluteFile().toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("help:effective-pom");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // 4.0.0-rc-2 fails as
+        // [ERROR] Some problems were encountered while processing the POMs
+        // [ERROR] The build could not read 1 project -> [Help 1]
+        // [ERROR]
+        // [ERROR]   The project org.apache.maven.its.mng8469:test:1.0 (...pom.xml) has 1 error
+        // [ERROR]     recursive variable reference: scm.connection
+
+        verifier.verifyTextInLog("<connection>foobar</connection>");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -100,6 +100,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8469InterpolationPrecendenceTest.class);
         suite.addTestSuite(MavenITmng8414ConsumerPomWithNewFeaturesTest.class);
         suite.addTestSuite(MavenITmng8245BeforePhaseCliTest.class);
         suite.addTestSuite(MavenITmng8244PhaseAllTest.class);

--- a/its/core-it-suite/src/test/resources/mng-8469/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8469/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8469</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: MNG-8469</name>
+  <description>Test interpolation considers prefix-less model last</description>
+
+  <scm>
+    <!-- Maven 4.0.0-rc-2 (MNG-8469) would fail on this POM -->
+    <connection>${scm.connection}</connection>
+  </scm>
+
+  <properties>
+    <scm.connection>foobar</scm.connection>
+  </properties>
+</project>


### PR DESCRIPTION
Restore precedence as it was in Maven3:
- basedir
- buildTime
- prefixed model
- user props
- model props
- system props
- env
- prefixless model

---

https://issues.apache.org/jira/browse/MNG-8469
