### PR TITLE
MNG-8479 - Use 'ejb' not 'ejb3' as type in ReactorReader artifact resolution for compile phase

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -70,7 +70,7 @@ class ReactorReader implements MavenWorkspaceReader {
     public static final String PROJECT_LOCAL_REPO = "project-local-repo";
 
     private static final Collection<String> COMPILE_PHASE_TYPES = new HashSet<>(
-            Arrays.asList("jar", "ejb-client", "war", "rar", "ejb3", "par", "sar", "wsr", "har", "app-client"));
+            Arrays.asList("jar", "ejb-client", "war", "rar", "ejb", "par", "sar", "wsr", "har", "app-client"));
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReactorReader.class);
 


### PR DESCRIPTION
### DESCRIPTION

Use 'ejb' not 'ejb3' as type in ReactorReader artifact resolution for compile phase

I left this as a Draft to reflect the fact that I don't really understand this layer of code, but had just guess and confirmed that it seemed to fix the problem.

Hopefully more discussion can occur on the issue at: 
https://issues.apache.org/jira/browse/MNG-8479

---

### CHECKLIST

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [x] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

