### PR TITLE
Copy edits in comments, API doc, and messages

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
@@ -38,7 +38,7 @@ public interface Dependency extends Artifact {
     /**
      * {@return the type of the dependency}
      * A dependency can be a <abbr>JAR</abbr> file,
-     * a modular-<abbr>JAR</abbr> if it is intended to be placed on the module-path,
+     * a modular-<abbr>JAR</abbr> if it is intended to be placed on the module path,
      * a <abbr>JAR</abbr> containing test classes, <i>etc.</i>
      *
      * @see DependencyCoordinates#getType()

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyCoordinates.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyCoordinates.java
@@ -27,8 +27,8 @@ import org.apache.maven.api.annotations.Nullable;
 
 /**
  * {@code ArtifactCoordinates} completed with information about how the artifact will be used.
- * This information include the dependency type (main classes, test classes, <i>etc.</i>),
- * a scope (compile-time, run-time <i>etc.</i>), an obligation (whether the dependency
+ * This information includes the dependency type (main classes, test classes, <i>etc.</i>),
+ * a scope (compile, runtime <i>etc.</i>), an obligation (whether the dependency
  * is optional or mandatory), and possible exclusions for transitive dependencies.
  * The {@linkplain #getVersionConstraint() version} and the {@linkplain #getOptional() obligation}
  * may not be defined precisely.
@@ -41,7 +41,7 @@ public interface DependencyCoordinates extends ArtifactCoordinates {
     /**
      * {@return the type of the dependency}
      * A dependency can be a <abbr>JAR</abbr> file,
-     * a modular-<abbr>JAR</abbr> if it is intended to be placed on the module-path,
+     * a modular-<abbr>JAR</abbr> if it is intended to be placed on the module path,
      * a <abbr>JAR</abbr> containing test classes, <i>etc.</i>
      */
     @Nonnull
@@ -49,13 +49,13 @@ public interface DependencyCoordinates extends ArtifactCoordinates {
 
     /**
      * {@return the time at which the dependency will be used}
-     * If may be, for example, at compile time only, at run time or at test time.
+     * It may be, for example, at compile time only, at run time or at test time.
      */
     @Nonnull
     DependencyScope getScope();
 
     /**
-     * Returns whether the dependency is optional, mandatory or of unspecified obligation.
+     * Returns whether the dependency is optional, mandatory, or of unspecified obligation.
      *
      * @return the obligation, or {@code null} if unspecified
      */

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
@@ -33,7 +33,7 @@ import org.apache.maven.api.annotations.Nonnull;
 
 /**
  * The option of a Java command-line tool where to place the paths to some dependencies.
- * A {@code PathType} can identify the class-path, the module path, the patches for a specific module,
+ * A {@code PathType} can identify the class path, the module path, the patches for a specific module,
  * or another kind of path.
  *
  * <p>One path type is handled in a special way: unlike other options,
@@ -41,7 +41,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * This type is created by calls to {@link #patchModule(String)} and a new instance must be created for
  * every module to patch.</p>
  *
- * <p>Path types are often exclusive. For example, a dependency should not be both on the Java class-path
+ * <p>Path types are often exclusive. For example, a dependency should not be both on the Java class path
  * and on the Java module path.</p>
  *
  * <h2>Relationship with Java compiler standard location</h2>
@@ -63,16 +63,16 @@ public enum JavaPathType implements PathType {
      * The Java tools location is {@link StandardLocation#CLASS_PATH}.
      *
      * <h4>Context-sensitive interpretation</h4>
-     * A dependency with this path type will not necessarily be placed on the class-path.
+     * A dependency with this path type will not necessarily be placed on the class path.
      * There are two circumstances where the dependency may nevertheless be placed somewhere else:
      *
      * <ul>
      *   <li>If {@link #MODULES} path type is also set, then the dependency can be placed either on the
-     *       class-path or on the module path, but only one of those. The choice is up to the plugin,
+     *       class path or on the module path, but only one of those. The choice is up to the plugin,
      *       possibly using heuristic rules (Maven 3 behavior).</li>
      *   <li>If a {@link #patchModule(String)} is also set and the main JAR file is placed on the module path,
      *       then the test dependency will be placed on the Java {@code --patch-module} option instead of the
-     *       class-path.</li>
+     *       class path.</li>
      * </ul>
      */
     CLASSES(StandardLocation.CLASS_PATH, "--class-path"),
@@ -88,7 +88,7 @@ public enum JavaPathType implements PathType {
      *
      * <ul>
      *   <li>If {@link #CLASSES} path type is also set, then the dependency <em>should</em> be placed on the
-     *       module path, but is also compatible with placement on the class-path. Compatibility can
+     *       module path, but is also compatible with placement on the class path. Compatibility can
      *       be achieved, for example, by repeating in the {@code META-INF/services/} directory the services
      *       that are declared in the {@code module-info.class} file. In that case, the path type can be chosen
      *       by the plugin.</li>

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
@@ -33,7 +33,7 @@ import org.apache.maven.api.annotations.Nonnull;
 
 /**
  * The option of a Java command-line tool where to place the paths to some dependencies.
- * A {@code PathType} can identify the class-path, the module-path, the patches for a specific module,
+ * A {@code PathType} can identify the class-path, the module path, the patches for a specific module,
  * or another kind of path.
  *
  * <p>One path type is handled in a special way: unlike other options,
@@ -42,7 +42,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * every module to patch.</p>
  *
  * <p>Path types are often exclusive. For example, a dependency should not be both on the Java class-path
- * and on the Java module-path.</p>
+ * and on the Java module path.</p>
  *
  * <h2>Relationship with Java compiler standard location</h2>
  * This enumeration is closely related to the {@link JavaFileManager.Location} enumerations.
@@ -68,9 +68,9 @@ public enum JavaPathType implements PathType {
      *
      * <ul>
      *   <li>If {@link #MODULES} path type is also set, then the dependency can be placed either on the
-     *       class-path or on the module-path, but only one of those. The choice is up to the plugin,
+     *       class-path or on the module path, but only one of those. The choice is up to the plugin,
      *       possibly using heuristic rules (Maven 3 behavior).</li>
-     *   <li>If a {@link #patchModule(String)} is also set and the main JAR file is placed on the module-path,
+     *   <li>If a {@link #patchModule(String)} is also set and the main JAR file is placed on the module path,
      *       then the test dependency will be placed on the Java {@code --patch-module} option instead of the
      *       class-path.</li>
      * </ul>
@@ -83,16 +83,16 @@ public enum JavaPathType implements PathType {
      * The Java tools location is {@link StandardLocation#MODULE_PATH}.
      *
      * <h4>Context-sensitive interpretation</h4>
-     * A dependency with this flag will not necessarily be placed on the module-path.
+     * A dependency with this flag will not necessarily be placed on the module path.
      * There are two circumstances where the dependency may nevertheless be placed somewhere else:
      *
      * <ul>
      *   <li>If {@link #CLASSES} path type is also set, then the dependency <em>should</em> be placed on the
-     *       module-path, but is also compatible with placement on the class-path. Compatibility can
+     *       module path, but is also compatible with placement on the class-path. Compatibility can
      *       be achieved, for example, by repeating in the {@code META-INF/services/} directory the services
      *       that are declared in the {@code module-info.class} file. In that case, the path type can be chosen
      *       by the plugin.</li>
-     *   <li>If a {@link #patchModule(String)} is also set and the main JAR file is placed on the module-path,
+     *   <li>If a {@link #patchModule(String)} is also set and the main JAR file is placed on the module path,
      *       then the test dependency will be placed on the Java {@code --patch-module} option instead of the
      *       {@code --module-path} option.</li>
      * </ul>
@@ -151,8 +151,8 @@ public enum JavaPathType implements PathType {
      * one specific module. Used for compilation and execution among others.
      *
      * <h4>Context-sensitive interpretation</h4>
-     * This path type makes sense only when a main module is added on the module-path by another dependency.
-     * In no main module is found, the patch dependency may be added on the class-path or module-path
+     * This path type makes sense only when a main module is added on the module path by another dependency.
+     * In no main module is found, the patch dependency may be added on the class path or module path
      * depending on whether {@link #CLASSES} or {@link #MODULES} is present.
      *
      * @param moduleName name of the module on which to apply the path

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/PathType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/PathType.java
@@ -26,10 +26,10 @@ import org.apache.maven.api.annotations.Nonnull;
 
 /**
  * The option of a command-line tool where to place the paths to some dependencies.
- * A {@code PathType} can identify the Java class-path, the Java module-path,
+ * A {@code PathType} can identify the Java class-path, the Java module path,
  * or another kind of path for another programming language for example.
  * Path types are often exclusive. For example, a dependency should not be
- * both on the Java class-path and on the Java module-path.
+ * both on the Java class path and on the Java module path.
  *
  * @see org.apache.maven.api.services.DependencyResolverResult#getDispatchedPaths()
  *

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
@@ -54,21 +54,21 @@ public interface Type extends ExtensibleEnum {
     String BOM = "bom";
 
     /**
-     * Artifact type name for a JAR file that can be placed either on the class-path or on the module path.
+     * Artifact type name for a JAR file that can be placed either on the class path or on the module path.
      * The path (classes or modules) is chosen by the plugin, possibly using heuristic rules.
      * This is the behavior of Maven 3.
      */
     String JAR = "jar";
 
     /**
-     * Artifact type name for a fat-JAR file that can be only on the class-path.
+     * Artifact type name for a fat-JAR file that can be only on the class path.
      * The fat-JAR is a self-contained JAR and its transitive dependencies will not be resolved, if any.
      * This type is new in Maven 4.
      */
     String FATJAR = "fatjar";
 
     /**
-     * Artifact type name for a JAR file to unconditionally place on the class-path.
+     * Artifact type name for a JAR file to unconditionally place on the class path.
      * If the JAR is modular, its module information are ignored.
      * This type is new in Maven 4.
      */
@@ -82,7 +82,7 @@ public interface Type extends ExtensibleEnum {
     String MODULAR_JAR = "modular-jar";
 
     /**
-     * Artifact type name for a JAR file that can be placed either on the annotation processor class-path
+     * Artifact type name for a JAR file that can be placed either on the annotation processor class path
      * or module path. The path (classes or modules) is chosen by the plugin, possibly using heuristic rules.
      */
     String PROCESSOR = "processor";
@@ -115,8 +115,8 @@ public interface Type extends ExtensibleEnum {
     String MAVEN_PLUGIN = "maven-plugin";
 
     /**
-     * Artifact type name for a JAR file containing test classes. If the main artifact is placed on the class-path
-     * ({@value #JAR} or {@value #CLASSPATH_JAR} types), then the test artifact will also be placed on the class-path.
+     * Artifact type name for a JAR file containing test classes. If the main artifact is placed on the class path
+     * ({@value #JAR} or {@value #CLASSPATH_JAR} types), then the test artifact will also be placed on the class path.
      * Otherwise, if the main artifact is placed on the module path ({@value #JAR} or {@value #MODULAR_JAR} types),
      * then the test artifact will be added using {@code --patch-module} option.
      */
@@ -173,7 +173,7 @@ public interface Type extends ExtensibleEnum {
      * and no heuristic rule will be involved.
      *
      * <p>It is nevertheless common to specify two or more types of path. For example,
-     * a Java library may be compatible with either the class-path or the module-path,
+     * a Java library may be compatible with either the class path or the module path,
      * and the user may have provided no instruction about which type to use. In such
      * case, the plugin may apply rules for choosing a path. See for example
      * {@link JavaPathType#CLASSES} and {@link JavaPathType#MODULES}.</p>

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Type.java
@@ -32,7 +32,7 @@ import org.apache.maven.api.model.Dependency;
  * <p>
  * It provides information about the file type (or extension) of the associated artifact,
  * its default classifier, and how the artifact will be used in the build when creating
- * class-paths or module-paths.
+ * class paths or module paths.
  * <p>
  * For example, the type {@code java-source} has a {@code jar} extension and a
  * {@code sources} classifier. The artifact and its dependencies should be added
@@ -54,7 +54,7 @@ public interface Type extends ExtensibleEnum {
     String BOM = "bom";
 
     /**
-     * Artifact type name for a JAR file that can be placed either on the class-path or on the module-path.
+     * Artifact type name for a JAR file that can be placed either on the class-path or on the module path.
      * The path (classes or modules) is chosen by the plugin, possibly using heuristic rules.
      * This is the behavior of Maven 3.
      */
@@ -75,7 +75,7 @@ public interface Type extends ExtensibleEnum {
     String CLASSPATH_JAR = "classpath-jar";
 
     /**
-     * Artifact type name for a JAR file to unconditionally place on the module-path.
+     * Artifact type name for a JAR file to unconditionally place on the module path.
      * If the JAR is not modular, then it is loaded by Java as an unnamed module.
      * This type is new in Maven 4.
      */
@@ -83,18 +83,18 @@ public interface Type extends ExtensibleEnum {
 
     /**
      * Artifact type name for a JAR file that can be placed either on the annotation processor class-path
-     * or module-path. The path (classes or modules) is chosen by the plugin, possibly using heuristic rules.
+     * or module path. The path (classes or modules) is chosen by the plugin, possibly using heuristic rules.
      */
     String PROCESSOR = "processor";
 
     /**
-     * Artifact type name for a JAR file to unconditionally place on the annotation processor class-path.
+     * Artifact type name for a JAR file to unconditionally place on the annotation processor class path.
      * If the JAR is modular, its module information are ignored.
      */
     String CLASSPATH_PROCESSOR = "classpath-processor";
 
     /**
-     * Artifact type name for a JAR file to unconditionally place on the annotation processor module-path.
+     * Artifact type name for a JAR file to unconditionally place on the annotation processor module path.
      * If the JAR is not modular, then it is loaded by Java as an unnamed module.
      */
     String MODULAR_PROCESSOR = "modular-processor";
@@ -117,7 +117,7 @@ public interface Type extends ExtensibleEnum {
     /**
      * Artifact type name for a JAR file containing test classes. If the main artifact is placed on the class-path
      * ({@value #JAR} or {@value #CLASSPATH_JAR} types), then the test artifact will also be placed on the class-path.
-     * Otherwise, if the main artifact is placed on the module-path ({@value #JAR} or {@value #MODULAR_JAR} types),
+     * Otherwise, if the main artifact is placed on the module path ({@value #JAR} or {@value #MODULAR_JAR} types),
      * then the test artifact will be added using {@code --patch-module} option.
      */
     String TEST_JAR = "test-jar";

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverResult.java
@@ -69,8 +69,8 @@ public interface DependencyResolverResult {
 
     /**
      * Returns the file paths of all dependencies, regardless on which tool option those paths should be placed.
-     * The returned list may contain a mix of Java class-path, Java module-path, and other types of path elements.
-     * This collection has the same content than {@code getDependencies.values()} except that it does not contain
+     * The returned list may contain a mix of Java class path, Java module path, and other types of path elements.
+     * This collection has the same content as {@code getDependencies.values()} except that it does not contain
      * null elements.
      *
      * @return the paths of all dependencies
@@ -136,8 +136,8 @@ public interface DependencyResolverResult {
     Optional<ModuleDescriptor> getModuleDescriptor(@Nonnull Path dependency) throws IOException;
 
     /**
-     * If the module-path contains at least one filename-based auto-module, prepares a warning message.
-     * The module path is the collection of dependencies associated to {@link JavaPathType#MODULES}.
+     * If the module path contains at least one filename-based auto-module, prepares a warning message.
+     * The module path is the collection of dependencies associated with {@link JavaPathType#MODULES}.
      * It is caller's responsibility to send the message to a logger.
      *
      * @return warning message if at least one filename-based auto-module was found

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -340,12 +340,12 @@ public class MavenProject implements Cloneable {
     }
 
     /**
-     * Returns a filtered list of classpath elements. This method is invoked when the caller
-     * requested that all dependencies are placed on the classpath, with no module-path element.
+     * Returns a filtered list of class path elements. This method is invoked when the caller
+     * requested that all dependencies are placed on the class path, with no module path element.
      *
-     * @param scopeFilter a filter returning {@code true} for the artifact scopes to accept.
-     * @param includeTestDir whether to include the test directory in the classpath elements.
-     * @return paths of all artifacts placed on the classpath.
+     * @param scopeFilter a filter returning {@code true} for the artifact scopes to accept
+     * @param includeTestDir whether to include the test directory in the classpath elements
+     * @return paths of all artifacts placed on the classpath
      * @throws DependencyResolutionRequiredException if an artifact file is used, but has not been resolved
      */
     private List<String> getClasspathElements(final Predicate<String> scopeFilter, final boolean includeTestDir)

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolverResult.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolverResult.java
@@ -124,9 +124,9 @@ class DefaultDependencyResolverResult implements DependencyResolverResult {
 
     /**
      * Adds main and test output directories to the result. This method adds the main output directory
-     * to the module-path if it contains a {@code module-info.class}, or to the class-path otherwise.
+     * to the module path if it contains a {@code module-info.class}, or to the class-path otherwise.
      * For the test output directory, the rules are more complex and are governed by the fact that
-     * Java does not accept the placement of two modules of the same name on the module-path.
+     * Java does not accept the placement of two modules of the same name on the module path.
      * So the modular test output directory usually needs to be placed in a {@code --path-module} option.
      *
      * <ul>
@@ -134,21 +134,21 @@ class DefaultDependencyResolverResult implements DependencyResolverResult {
      *     <ul>
      *       <li>If a test module name is identical to a main module name,
      *           place the test directory in a {@code --patch-module} option.</li>
-     *       <li>Otherwise, place the test directory on the module-path. However, this case
+     *       <li>Otherwise, place the test directory on the module path. However, this case
      *           (a module existing only in test output, not in main output) should be uncommon.</li>
      *     </ul>
      *   </li>
      *   <li>Otherwise (test output contains no module information), then:
      *     <ul>
-     *       <li>If the main output is on the module-path, place the test output
+     *       <li>If the main output is on the module path, place the test output
      *           on a {@code --patch-module} option.</li>
-     *       <li>Otherwise (main output on the class-path), place the test output on the class-path too.</li>
+     *       <li>Otherwise (main output on the class path), place the test output on the class path too.</li>
      *     </ul>
      *   </li>
      * </ul>
      *
      * This method must be invoked before {@link #addDependency(Node, Dependency, Predicate, Path)}
-     * if output directories are desired on the class-path or module-path.
+     * if output directories are desired on the class path or module path.
      * This method can be invoked at most once.
      *
      * @param main the main output directory, or {@code null} if none

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolverResult.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/DefaultDependencyResolverResult.java
@@ -124,7 +124,7 @@ class DefaultDependencyResolverResult implements DependencyResolverResult {
 
     /**
      * Adds main and test output directories to the result. This method adds the main output directory
-     * to the module path if it contains a {@code module-info.class}, or to the class-path otherwise.
+     * to the module path if it contains a {@code module-info.class}, or to the class path otherwise.
      * For the test output directory, the rules are more complex and are governed by the fact that
      * Java does not accept the placement of two modules of the same name on the module path.
      * So the modular test output directory usually needs to be placed in a {@code --path-module} option.
@@ -235,7 +235,7 @@ class DefaultDependencyResolverResult implements DependencyResolverResult {
         }
         paths.add(path);
         /*
-         * Dispatch the dependency to class-path, module-path, patch-module path, etc.
+         * Dispatch the dependency to class path, module path, patch-module path, etc.
          * according the dependency properties. We need to process patch-module first,
          * because this type depends on whether a module of the same name has already
          * been added on the module-type.
@@ -255,7 +255,7 @@ class DefaultDependencyResolverResult implements DependencyResolverResult {
                 if (!containsModule(moduleName)) {
                     /*
                      * Not patching an existing module. This case should be unusual. If it nevertheless
-                     * happens, add on class-path or module-path if allowed, or keep patching otherwise.
+                     * happens, add to class path or module path if allowed, or keep patching otherwise.
                      * The latter case (keep patching) is okay if the main module will be defined later.
                      */
                     type = cache.selectPathType(pathTypes, filter, path).orElse(type);

--- a/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/PathModularizationCache.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/internal/impl/PathModularizationCache.java
@@ -181,7 +181,7 @@ class PathModularizationCache {
         String lineSeparator = System.lineSeparator();
         var joiner = new StringJoiner(
                 lineSeparator + "  - ",
-                "Filename-based automodules detected on the module-path: " + lineSeparator + "  - ",
+                "Filename-based automodules detected on the module path: " + lineSeparator + "  - ",
                 lineSeparator + "Please don't publish this project to a public artifact repository.");
         automodulesDetected.forEach(joiner::add);
         return Optional.of(joiner.toString());


### PR DESCRIPTION
In particular I've followed Oracle's usage of unhyphenated  "class path" and "module path" when referring to the concepts instead of the CLI argument. --module-path is still used when referring to the command line flags.