### PR TITLE
[MNG-8487] Completely isolate UTs

### DIFF
--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -52,15 +52,18 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
     }
 
     @Test
-    void defaultFs(@TempDir(cleanup = CleanupMode.ON_SUCCESS) Path tempDir) throws Exception {
-        invoke(tempDir, Arrays.asList("clean", "verify"));
+    void defaultFs(
+            @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path cwd,
+            @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path userHome)
+            throws Exception {
+        invoke(cwd, userHome, Arrays.asList("clean", "verify"));
     }
 
     @Disabled("Until we move off fully from File")
     @Test
     void jimFs() throws Exception {
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
-            invoke(fs.getPath("/"), Arrays.asList("clean", "verify"));
+            invoke(fs.getPath("/cwd"), fs.getPath("/home"), Arrays.asList("clean", "verify"));
         }
     }
 }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
@@ -80,7 +80,7 @@ public abstract class MavenInvokerTestSupport {
             }
             """;
 
-    protected void invoke(Path cwd, Collection<String> goals) throws Exception {
+    protected void invoke(Path cwd, Path userHome, Collection<String> goals) throws Exception {
         // works only in recent Maven4
         Assumptions.assumeTrue(
                 Files.isRegularFile(Paths.get(System.getProperty("maven.home"))
@@ -104,6 +104,7 @@ public abstract class MavenInvokerTestSupport {
                                 new ProtoLogger(),
                                 new JLineMessageBuilderFactory())
                         .cwd(cwd)
+                        .userHome(userHome)
                         .build()));
                 String log = Files.readString(logFile);
                 System.out.println(log);

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvokerTest.java
@@ -55,15 +55,18 @@ public class ResidentMavenInvokerTest extends MavenInvokerTestSupport {
     }
 
     @Test
-    void defaultFs(@TempDir(cleanup = CleanupMode.ON_SUCCESS) Path tempDir) throws Exception {
-        invoke(tempDir, Arrays.asList("clean", "verify"));
+    void defaultFs(
+            @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path cwd,
+            @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path userHome)
+            throws Exception {
+        invoke(cwd, userHome, Arrays.asList("clean", "verify"));
     }
 
     @Disabled("Until we move off fully from File")
     @Test
     void jimFs() throws Exception {
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
-            invoke(fs.getPath("/"), Arrays.asList("clean", "verify"));
+            invoke(fs.getPath("/cwd"), fs.getPath("/home"), Arrays.asList("clean", "verify"));
         }
     }
 }

--- a/impl/maven-executor/src/main/java/org/apache/maven/api/cli/ExecutorRequest.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/api/cli/ExecutorRequest.java
@@ -163,7 +163,9 @@ public interface ExecutorRequest {
                 MVN,
                 null,
                 getCanonicalPath(Paths.get(System.getProperty("user.dir"))),
-                installationDirectory != null ? getCanonicalPath(installationDirectory) : discoverMavenHome(),
+                installationDirectory != null
+                        ? getCanonicalPath(installationDirectory)
+                        : discoverInstallationDirectory(),
                 getCanonicalPath(Paths.get(System.getProperty("user.home"))),
                 null,
                 null,
@@ -430,12 +432,21 @@ public interface ExecutorRequest {
     }
 
     @Nonnull
-    static Path discoverMavenHome() {
+    static Path discoverInstallationDirectory() {
         String mavenHome = System.getProperty("maven.home");
         if (mavenHome == null) {
             throw new ExecutorException("requires maven.home Java System Property set");
         }
         return getCanonicalPath(Paths.get(mavenHome));
+    }
+
+    @Nonnull
+    static Path discoverUserHomeDirectory() {
+        String userHome = System.getProperty("user.home");
+        if (userHome == null) {
+            throw new ExecutorException("requires user.home Java System Property set");
+        }
+        return getCanonicalPath(Paths.get(userHome));
     }
 
     @Nonnull

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
@@ -39,16 +39,25 @@ import static java.util.Objects.requireNonNull;
 public class HelperImpl implements ExecutorHelper {
     private final Mode defaultMode;
     private final Path installationDirectory;
+    private final Path userHomeDirectory;
     private final ExecutorTool executorTool;
     private final HashMap<Mode, Executor> executors;
 
     private final ConcurrentHashMap<String, String> cache;
 
-    public HelperImpl(Mode defaultMode, @Nullable Path installationDirectory, Executor embedded, Executor forked) {
+    public HelperImpl(
+            Mode defaultMode,
+            @Nullable Path installationDirectory,
+            @Nullable Path userHomeDirectory,
+            Executor embedded,
+            Executor forked) {
         this.defaultMode = requireNonNull(defaultMode);
         this.installationDirectory = installationDirectory != null
                 ? ExecutorRequest.getCanonicalPath(installationDirectory)
-                : ExecutorRequest.discoverMavenHome();
+                : ExecutorRequest.discoverInstallationDirectory();
+        this.userHomeDirectory = userHomeDirectory != null
+                ? ExecutorRequest.getCanonicalPath(userHomeDirectory)
+                : ExecutorRequest.discoverUserHomeDirectory();
         this.executorTool = new ToolboxTool(this);
         this.executors = new HashMap<>();
 
@@ -64,7 +73,7 @@ public class HelperImpl implements ExecutorHelper {
 
     @Override
     public ExecutorRequest.Builder executorRequest() {
-        return ExecutorRequest.mavenBuilder(installationDirectory);
+        return ExecutorRequest.mavenBuilder(installationDirectory).userHomeDirectory(userHomeDirectory);
     }
 
     @Override

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/HelperImplTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/HelperImplTest.java
@@ -19,6 +19,8 @@
 package org.apache.maven.cling.executor.impl;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,6 +30,7 @@ import org.apache.maven.cling.executor.ExecutorHelper;
 import org.apache.maven.cling.executor.embedded.EmbeddedMavenExecutor;
 import org.apache.maven.cling.executor.forked.ForkedMavenExecutor;
 import org.apache.maven.cling.executor.internal.HelperImpl;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -37,8 +40,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HelperImplTest {
+    private static final Path FAKE_USER_HOME;
+
+    static {
+        try {
+            FAKE_USER_HOME = Files.createTempDirectory("fake");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     private static final EmbeddedMavenExecutor EMBEDDED_MAVEN_EXECUTOR = new EmbeddedMavenExecutor();
     private static final ForkedMavenExecutor FORKED_MAVEN_EXECUTOR = new ForkedMavenExecutor();
+
+    @TempDir
+    private Path userHome;
 
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
@@ -46,6 +62,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         Map<String, String> dump = helper.dump(helper.executorRequest());
@@ -58,6 +75,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         Map<String, String> dump = helper.dump(helper.executorRequest());
@@ -70,6 +88,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         assertEquals(System.getProperty("maven3version"), helper.mavenVersion());
@@ -81,6 +100,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         assertEquals(System.getProperty("maven4version"), helper.mavenVersion());
@@ -92,6 +112,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String localRepository = helper.localRepository(helper.executorRequest());
@@ -105,6 +126,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String localRepository = helper.localRepository(helper.executorRequest());
@@ -118,6 +140,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
@@ -133,6 +156,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
@@ -148,6 +172,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.metadataPath(helper.executorRequest(), "aopalliance", "someremote");
@@ -160,6 +185,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
+                FAKE_USER_HOME,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.metadataPath(helper.executorRequest(), "aopalliance", "someremote");

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/HelperImplTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/HelperImplTest.java
@@ -19,8 +19,6 @@
 package org.apache.maven.cling.executor.impl;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,16 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HelperImplTest {
-    private static final Path FAKE_USER_HOME;
-
-    static {
-        try {
-            FAKE_USER_HOME = Files.createTempDirectory("fake");
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
     private static final EmbeddedMavenExecutor EMBEDDED_MAVEN_EXECUTOR = new EmbeddedMavenExecutor();
     private static final ForkedMavenExecutor FORKED_MAVEN_EXECUTOR = new ForkedMavenExecutor();
 
@@ -62,7 +50,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         Map<String, String> dump = helper.dump(helper.executorRequest());
@@ -75,7 +63,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         Map<String, String> dump = helper.dump(helper.executorRequest());
@@ -88,7 +76,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         assertEquals(System.getProperty("maven3version"), helper.mavenVersion());
@@ -100,7 +88,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         assertEquals(System.getProperty("maven4version"), helper.mavenVersion());
@@ -112,7 +100,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String localRepository = helper.localRepository(helper.executorRequest());
@@ -126,7 +114,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String localRepository = helper.localRepository(helper.executorRequest());
@@ -140,7 +128,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
@@ -156,7 +144,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
@@ -172,7 +160,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.metadataPath(helper.executorRequest(), "aopalliance", "someremote");
@@ -185,7 +173,7 @@ public class HelperImplTest {
         ExecutorHelper helper = new HelperImpl(
                 mode,
                 mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                FAKE_USER_HOME,
+                userHome,
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.metadataPath(helper.executorRequest(), "aopalliance", "someremote");

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -140,6 +140,7 @@ public class Verifier {
             this.executorHelper = new HelperImpl(
                     VERIFIER_FORK_MODE,
                     Paths.get(System.getProperty("maven.home")),
+                    this.userHomeDirectory,
                     EMBEDDED_MAVEN_EXECUTOR,
                     FORKED_MAVEN_EXECUTOR);
             this.defaultCliArguments =


### PR DESCRIPTION
UTs were using real user home, and in case user had user-wide extensions.xml, it resulted in failure. Goal: make sure all UTs are properly protected and isolated from user env, by providing "fake" user home (to not have user-wide extensions in real user home affect test outcome).

---

https://issues.apache.org/jira/browse/MNG-8487