### PR TITLE
Delete unused mode constants

### DIFF
--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
@@ -28,7 +28,7 @@ import org.apache.maven.api.annotations.Nullable;
 import org.apache.maven.api.annotations.ThreadSafe;
 
 /**
- * An immutable xml node.
+ * An immutable XML node.
  *
  * @since 4.0.0
  */
@@ -39,15 +39,11 @@ public interface XmlNode {
 
     String CHILDREN_COMBINATION_MODE_ATTRIBUTE = "combine.children";
 
-    String CHILDREN_COMBINATION_MERGE = "merge";
-
     String CHILDREN_COMBINATION_APPEND = "append";
 
     String SELF_COMBINATION_MODE_ATTRIBUTE = "combine.self";
 
     String SELF_COMBINATION_OVERRIDE = "override";
-
-    String SELF_COMBINATION_MERGE = "merge";
 
     String SELF_COMBINATION_REMOVE = "remove";
 

--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
@@ -43,13 +43,6 @@ public interface XmlNode {
 
     String CHILDREN_COMBINATION_APPEND = "append";
 
-    /**
-     * This default mode for combining children DOMs during merge means that where element names match, the process will
-     * try to merge the element data, rather than putting the dominant and recessive elements (which share the same
-     * element name) as siblings in the resulting DOM.
-     */
-    String DEFAULT_CHILDREN_COMBINATION_MODE = CHILDREN_COMBINATION_MERGE;
-
     String SELF_COMBINATION_MODE_ATTRIBUTE = "combine.self";
 
     String SELF_COMBINATION_OVERRIDE = "override";
@@ -68,14 +61,6 @@ public interface XmlNode {
      * This is a comma separated list of attribute names.
      */
     String KEYS_COMBINATION_MODE_ATTRIBUTE = "combine.keys";
-
-    /**
-     * This default mode for combining a DOM node during merge means that where element names match, the process will
-     * try to merge the element attributes and values, rather than overriding the recessive element completely with the
-     * dominant one. This means that wherever the dominant element doesn't provide the value or a particular attribute,
-     * that value or attribute will be set from the recessive DOM node.
-     */
-    String DEFAULT_SELF_COMBINATION_MODE = SELF_COMBINATION_MERGE;
 
     @Nonnull
     String getName();


### PR DESCRIPTION
We can always add these later if we need them, but right now their existence implies things about the code that aren't true.