### PR TITLE
[MNG-8502] Embedded executor should obey MAVEN_ARGS env variable

### DIFF
--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/HelperImplTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/HelperImplTest.java
@@ -132,10 +132,11 @@ public class HelperImplTest {
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
-        assertEquals(
-                "aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
-                        + "aopalliance-1.0.jar",
-                path);
+        // split repository: assert "ends with" as split may introduce prefixes
+        assertTrue(
+                path.endsWith("aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
+                        + "aopalliance-1.0.jar"),
+                "path=" + path);
     }
 
     @ParameterizedTest
@@ -148,10 +149,11 @@ public class HelperImplTest {
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
-        assertEquals(
-                "aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
-                        + "aopalliance-1.0.jar",
-                path);
+        // split repository: assert "ends with" as split may introduce prefixes
+        assertTrue(
+                path.endsWith("aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
+                        + "aopalliance-1.0.jar"),
+                "path=" + path);
     }
 
     @ParameterizedTest
@@ -164,7 +166,8 @@ public class HelperImplTest {
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.metadataPath(helper.executorRequest(), "aopalliance", "someremote");
-        assertEquals("aopalliance" + File.separator + "maven-metadata-someremote.xml", path);
+        // split repository: assert "ends with" as split may introduce prefixes
+        assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
     }
 
     @ParameterizedTest
@@ -177,6 +180,7 @@ public class HelperImplTest {
                 EMBEDDED_MAVEN_EXECUTOR,
                 FORKED_MAVEN_EXECUTOR);
         String path = helper.metadataPath(helper.executorRequest(), "aopalliance", "someremote");
-        assertEquals("aopalliance" + File.separator + "maven-metadata-someremote.xml", path);
+        // split repository: assert "ends with" as split may introduce prefixes
+        assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
     }
 }


### PR DESCRIPTION
Salvaged from the "split repo for ITs" experiment. The experiment failed but this improvement is good to have, as makes the embedded executor behave more closely like forked executor.

Embedded so far did not obey MAVEN_ARGS env variable while forked did.

---

https://issues.apache.org/jira/browse/MNG-8502