### PR TITLE
[MNG-8485] Remove unused, untested, experimental version methods

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionRangeResolverResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionRangeResolverResult.java
@@ -40,19 +40,5 @@ public interface VersionRangeResolverResult {
     List<Version> getVersions();
 
     @Nonnull
-    default Optional<Version> getLowerVersion() {
-        return getVersions().isEmpty()
-                ? Optional.empty()
-                : Optional.of(getVersions().get(0));
-    }
-
-    @Nonnull
-    default Optional<Version> getHigherVersion() {
-        return getVersions().isEmpty()
-                ? Optional.empty()
-                : Optional.of(getVersions().get(getVersions().size() - 1));
-    }
-
-    @Nonnull
     Optional<Repository> getRepository(Version version);
 }


### PR DESCRIPTION
YAGNI.
If it turns out we do need these, they should be renamed getLowestVersion and getHighestVersion.