### PR TITLE
[MNG-8484] Replace BaseRequest#unmodifiable with List.copyOf()

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployerRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactDeployerRequest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.api.services;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.RemoteRepository;
@@ -115,7 +116,7 @@ public interface ArtifactDeployerRequest {
                     int retryFailedDeploymentCount) {
                 super(session);
                 this.repository = requireNonNull(repository, "repository cannot be null");
-                this.artifacts = unmodifiable(requireNonNull(artifacts, "artifacts cannot be null"));
+                this.artifacts = List.copyOf(requireNonNull(artifacts, "artifacts cannot be null"));
                 this.retryFailedDeploymentCount = retryFailedDeploymentCount;
             }
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerRequest.java
@@ -20,6 +20,7 @@ package org.apache.maven.api.services;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Session;
@@ -89,7 +90,7 @@ public interface ArtifactInstallerRequest {
 
             DefaultArtifactInstallerRequest(@Nonnull Session session, @Nonnull Collection<ProducedArtifact> artifacts) {
                 super(session);
-                this.artifacts = unmodifiable(requireNonNull(artifacts, "artifacts cannot be null"));
+                this.artifacts = List.copyOf(requireNonNull(artifacts, "artifacts cannot be null"));
             }
 
             @Nonnull

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverRequest.java
@@ -119,7 +119,7 @@ public interface ArtifactResolverRequest {
                     @Nonnull Collection<? extends ArtifactCoordinates> coordinates,
                     @Nonnull List<RemoteRepository> repositories) {
                 super(session);
-                this.coordinates = unmodifiable(requireNonNull(coordinates, "coordinates cannot be null"));
+                this.coordinates = List.copyOf(requireNonNull(coordinates, "coordinates cannot be null"));
                 this.repositories = repositories;
             }
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/BaseRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/BaseRequest.java
@@ -18,10 +18,6 @@
  */
 package org.apache.maven.api.services;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-
 import org.apache.maven.api.ProtoSession;
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;
@@ -45,11 +41,5 @@ abstract class BaseRequest<S extends ProtoSession> {
     @Nonnull
     public S getSession() {
         return session;
-    }
-
-    protected static <T> Collection<T> unmodifiable(Collection<T> obj) {
-        return obj != null && !obj.isEmpty()
-                ? Collections.unmodifiableCollection(new ArrayList<>(obj))
-                : Collections.emptyList();
     }
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverRequest.java
@@ -400,9 +400,9 @@ public interface DependencyResolverRequest {
                 this.project = project;
                 this.rootArtifact = rootArtifact;
                 this.root = root;
-                this.dependencies = unmodifiable(requireNonNull(dependencies, "dependencies cannot be null"));
+                this.dependencies = List.copyOf(requireNonNull(dependencies, "dependencies cannot be null"));
                 this.managedDependencies =
-                        unmodifiable(requireNonNull(managedDependencies, "managedDependencies cannot be null"));
+                        List.copyOf(requireNonNull(managedDependencies, "managedDependencies cannot be null"));
                 this.verbose = verbose;
                 this.pathScope = requireNonNull(pathScope, "pathScope cannot be null");
                 this.pathTypeFilter = (pathTypeFilter != null) ? pathTypeFilter : (t) -> true;


### PR DESCRIPTION
`List.copyOf()` is exactly what we need to make a defensive copy of the input collection.  It also has the benefit of not doing anything if the input collection is already an immutable list.