### PR TITLE
[MNG-8522] Deprecate maven-builder-support artifact and its classes

### DIFF
--- a/compat/maven-builder-support/pom.xml
+++ b/compat/maven-builder-support/pom.xml
@@ -35,6 +35,11 @@ under the License.
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/compat/maven-builder-support/pom.xml
+++ b/compat/maven-builder-support/pom.xml
@@ -30,7 +30,7 @@ under the License.
 
   <artifactId>maven-builder-support</artifactId>
 
-  <name>Maven Builder Support</name>
+  <name>Maven Builder Support (deprecated)</name>
   <description>Support for descriptor builders (model, setting, toolchains)</description>
 
   <dependencies>

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/DefaultProblem.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/DefaultProblem.java
@@ -23,7 +23,9 @@ package org.apache.maven.building;
  * thrown or a simple string message. In addition, a problem carries a hint about its source, e.g. the settings file
  * that exhibits the problem.
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 class DefaultProblem implements Problem {
 
     private final String source;

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/DefaultProblemCollector.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/DefaultProblemCollector.java
@@ -24,7 +24,9 @@ import java.util.List;
 /**
  * Collects problems that are encountered during settings building.
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 class DefaultProblemCollector implements ProblemCollector {
 
     private final List<Problem> problems;

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/FileSource.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/FileSource.java
@@ -28,7 +28,9 @@ import java.util.Objects;
 /**
  * Wraps an ordinary {@link File} as a source.
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 public class FileSource implements Source {
     private final Path path;
 

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/Problem.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/Problem.java
@@ -23,7 +23,9 @@ package org.apache.maven.building;
  * thrown or a simple string message. In addition, a problem carries a hint about its source, e.g. the settings file
  * that exhibits the problem.
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 public interface Problem {
 
     /**

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/ProblemCollector.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/ProblemCollector.java
@@ -23,7 +23,9 @@ import java.util.List;
 /**
  * Collects problems that are encountered during settings building.
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 public interface ProblemCollector {
 
     /**

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/ProblemCollectorFactory.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/ProblemCollectorFactory.java
@@ -23,7 +23,9 @@ import java.util.List;
 /**
  *
  * @since 3.3.0
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 public class ProblemCollectorFactory {
 
     /**

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/Source.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/Source.java
@@ -24,7 +24,9 @@ import java.io.InputStream;
 /**
  * Provides access to the contents of a source independently of the backing store (e.g. file system, database, memory).
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 public interface Source {
 
     /**

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/StringSource.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/StringSource.java
@@ -26,7 +26,9 @@ import java.nio.charset.StandardCharsets;
 /**
  * Wraps an ordinary {@link CharSequence} as a source.
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 public class StringSource implements Source {
     private final String content;
 

--- a/compat/maven-builder-support/src/main/java/org/apache/maven/building/UrlSource.java
+++ b/compat/maven-builder-support/src/main/java/org/apache/maven/building/UrlSource.java
@@ -26,7 +26,9 @@ import java.util.Objects;
 /**
  * Wraps an ordinary {@link URL} as a source.
  *
+ * @deprecated since 4.0.0, use {@link org.apache.maven.api.services} instead
  */
+@Deprecated(since = "4.0.0")
 public class UrlSource implements Source {
 
     private final URL url;


### PR DESCRIPTION
JIRA issue: [MNG-8522](https://issues.apache.org/jira/browse/MNG-8522)

The `maven-builder-support` contains classes shared between `maven-model-builder`, `maven-settings-builder` and `maven-toolchain-builder`, all of those subprojects being deprecated as they are part of the Maven 3 API.
This PR thus also deprecates this subproject and its classes.