### PR TITLE
[MNG-6113] Restore 'Maven Central Repository' name (lost with #1139)

### DIFF
--- a/apache-maven/src/assembly/maven/conf/settings.xml
+++ b/apache-maven/src/assembly/maven/conf/settings.xml
@@ -173,7 +173,7 @@ under the License.
   <repositories>
     <repository>
       <id>central</id>
-      <name>Central Repository</name>
+      <name>Maven Central Repository</name>
       <url>${maven.repo.central}</url>
       <snapshots>
         <enabled>false</enabled>
@@ -187,7 +187,7 @@ under the License.
   <pluginRepositories>
     <pluginRepository>
       <id>central</id>
-      <name>Central Repository</name>
+      <name>Maven Central Repository</name>
       <url>${maven.repo.central}</url>
       <snapshots>
         <enabled>false</enabled>


### PR DESCRIPTION
JIRA issue: [MNG-6113](https://issues.apache.org/jira/browse/MNG-6113)
