### PR TITLE
Redirect the <sourceDirectory> element to <Source>

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Language.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Language.java
@@ -45,6 +45,19 @@ public interface Language extends ExtensibleEnum {
      */
     Language NONE = language("none");
 
+    /**
+     * The "resources" language. This is used for files such as images to provide in the output.
+     */
+    Language RESOURCES = language("resources");
+
+    /**
+     * The "script" language. Provided for compatibility with Maven 3.
+     *
+     * @deprecated Use {@link #RESOURCES} instead.
+     */
+    @Deprecated
+    Language SCRIPT = language("script");
+
     // TODO: this should be moved out from here to Java Support (builtin into core)
     Language JAVA_FAMILY = language("java");
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A root directory of source files.
+ * The sources may be Java main classes, test classes, resources or anything else identified by the scope.
+ */
+public interface SourceRoot {
+    /**
+     * {@return the root directory where the sources are stored}.
+     * The path is relative to the <abbr>POM</abbr> file.
+     */
+    Path directory();
+
+    /**
+     * {@return the list of pattern matchers for the files to include}.
+     * The default implementation returns an empty list, which means to apply a language-dependent pattern.
+     * For example, for the Java language, the pattern includes all files with the {@code .java} suffix.
+     */
+    default List<PathMatcher> includes() {
+        return List.of();
+    }
+
+    /**
+     * {@return the list of pattern matchers for the files to exclude}.
+     * The exclusions are applied after the inclusions.
+     * The default implementation returns an empty list.
+     */
+    default List<PathMatcher> excludes() {
+        return List.of();
+    }
+
+    /**
+     * {@return in which context the source files will be used}.
+     * The default value is {@link ProjectScope#MAIN}.
+     */
+    default ProjectScope scope() {
+        return ProjectScope.MAIN;
+    }
+
+    /**
+     * {@return the language of the source files}.
+     */
+    Language language();
+
+    /**
+     * {@return the name of the Java module (or other language-specific module) which is built by the sources}.
+     * The default value is empty.
+     */
+    default Optional<String> module() {
+        return Optional.empty();
+    }
+
+    /**
+     * {@return the version of the platform where the code will be executed}.
+     * In a Java environment, this is the value of the {@code --release} compiler option.
+     * The default value is empty.
+     */
+    default Optional<Version> targetVersion() {
+        return Optional.empty();
+    }
+
+    /**
+     * {@return an explicit target path, overriding the default value}.
+     * When a target path is explicitly specified, the values of the {@link #module()} and {@link #targetVersion()}
+     * elements are not used for inferring the path (they are still used as compiler options however).
+     * It means that for scripts and resources, the files below the path specified by {@link #directory()}
+     * are copied to the path specified by {@code targetPath()} with the exact same directory structure.
+     */
+    default Optional<Path> targetPath() {
+        return Optional.empty();
+    }
+
+    /**
+     * {@return whether resources are filtered to replace tokens with parameterized values}.
+     * The default value is {@code false}.
+     */
+    default boolean stringFiltering() {
+        return false;
+    }
+
+    /**
+     * {@return whether the directory described by this source element should be included in the build}.
+     * The default value is {@code true}.
+     */
+    default boolean enabled() {
+        return true;
+    }
+}

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -2041,7 +2041,7 @@
             ]]>
           </description>
           <type>String</type>
-          <defaultValue>main</defaultValue>
+          <defaultValue>java</defaultValue>
         </field>
         <field>
           <name>module</name>

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -775,7 +775,6 @@
           <type>String</type>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "main" scope and "resources" language -->
           <name>resources</name>
           <version>3.0.0+</version>
           <description>
@@ -783,6 +782,8 @@
             files associated with a project. These resources are often included in the final
             package.
             The default value is {@code src/main/resources}.
+
+            @deprecated Replaced by &lt;Source&gt; with "main" scope and "resources" language.
           </description>
           <association>
             <type>Resource</type>
@@ -790,13 +791,14 @@
           </association>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "test" scope and "resources" language -->
           <name>testResources</name>
           <version>4.0.0+</version>
           <description>
             This element describes all the classpath resources such as properties
             files associated with a project's unit tests.
             The default value is {@code src/test/resources}.
+
+            @deprecated Replaced by &lt;Source&gt; with "test" scope and "resources" language.
           </description>
           <association>
             <type>Resource</type>
@@ -874,7 +876,6 @@
           </association>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "main" scope. -->
           <name>sourceDirectory</name>
           <version>3.0.0+</version>
           <required>true</required>
@@ -883,11 +884,12 @@
             generated build system will compile the sources from this directory when the project is
             built. The path given is relative to the project descriptor.
             The default value is {@code src/main/java}.
+
+            @deprecated Replaced by &lt;Source&gt; with "main" scope.
           </description>
           <type>String</type>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "script" language -->
           <name>scriptSourceDirectory</name>
           <version>4.0.0+</version>
           <required>true</required>
@@ -897,11 +899,12 @@
             contents will be copied to the output directory in most cases (since scripts are
             interpreted rather than compiled).
             The default value is {@code src/main/scripts}.
+
+            @deprecated Replaced by &lt;Source&gt; with "script" language.
           </description>
           <type>String</type>
         </field>
         <field>
-          <!-- TODO: replaced by <Source> with "test" scope. -->
           <name>testSourceDirectory</name>
           <version>4.0.0+</version>
           <required>true</required>
@@ -910,6 +913,8 @@
             project. The generated build system will compile these directories when the project is
             being tested. The path given is relative to the project descriptor.
             The default value is {@code src/test/java}.
+
+            @deprecated Replaced by &lt;Source&gt; with "test" scope.
           </description>
           <type>String</type>
         </field>
@@ -2143,7 +2148,6 @@
       </fields>
     </class>
     <class>
-      <!-- TODO: Replaced by <Source> with "resources" language. -->
       <name>Resource</name>
       <description>This element describes all of the classpath resources associated with a project
         or unit tests.</description>
@@ -2161,6 +2165,8 @@
             element with this value: {@code org/apache/maven/messages}.
             This is not required if you simply put the resources in that directory
             structure at the source, however.
+
+            @deprecated Replaced by &lt;Source&gt; with "resources" language.
           </description>
           <type>String</type>
         </field>

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -46,6 +46,8 @@ import java.util.stream.Stream;
 
 import org.apache.maven.ProjectCycleException;
 import org.apache.maven.RepositoryUtils;
+import org.apache.maven.api.Language;
+import org.apache.maven.api.ProjectScope;
 import org.apache.maven.api.SessionData;
 import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.Dependency;
@@ -73,6 +75,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.bridge.MavenRepositorySystem;
+import org.apache.maven.impl.DefaultSourceRoot;
 import org.apache.maven.impl.InternalSession;
 import org.apache.maven.impl.resolver.ArtifactDescriptorUtils;
 import org.apache.maven.model.building.DefaultModelProblem;
@@ -576,9 +579,43 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             // only set those on 2nd phase, ignore on 1st pass
             if (project.getFile() != null) {
                 Build build = project.getBuild().getDelegate();
-                project.addScriptSourceRoot(build.getScriptSourceDirectory());
-                project.addCompileSourceRoot(build.getSourceDirectory());
-                project.addTestCompileSourceRoot(build.getTestSourceDirectory());
+                List<org.apache.maven.api.model.Source> sources = build.getSources();
+                Path baseDir = project.getBaseDirectory();
+                InternalSession s = InternalSession.from(session);
+                boolean hasScript = false;
+                boolean hasMain = false;
+                boolean hasTest = false;
+                for (var source : sources) {
+                    var src = new DefaultSourceRoot(s, baseDir, source);
+                    project.addSourceRoot(src);
+                    Language language = src.language();
+                    if (Language.JAVA_FAMILY.equals(language)) {
+                        ProjectScope scope = src.scope();
+                        if (ProjectScope.MAIN.equals(scope)) {
+                            hasMain = true;
+                        } else {
+                            hasTest |= ProjectScope.TEST.equals(scope);
+                        }
+                    } else {
+                        hasScript |= Language.SCRIPT.equals(language);
+                    }
+                }
+                /*
+                 * `sourceDirectory`, `testSourceDirectory` and `scriptSourceDirectory`
+                 * are ignored if the POM file contains at least one <source> element
+                 * for the corresponding scope and langiage. This rule exists because
+                 * Maven provides default values for those elements which may conflict
+                 * with user's configuration.
+                 */
+                if (!hasScript) {
+                    project.addScriptSourceRoot(build.getScriptSourceDirectory());
+                }
+                if (!hasMain) {
+                    project.addCompileSourceRoot(build.getSourceDirectory());
+                }
+                if (!hasTest) {
+                    project.addTestCompileSourceRoot(build.getTestSourceDirectory());
+                }
             }
 
             project.setActiveProfiles(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -33,8 +33,12 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.apache.maven.RepositoryUtils;
+import org.apache.maven.api.Language;
+import org.apache.maven.api.ProjectScope;
+import org.apache.maven.api.SourceRoot;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -42,6 +46,7 @@ import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.impl.DefaultSourceRoot;
 import org.apache.maven.lifecycle.internal.DefaultProjectArtifactFactory;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.CiManagement;
@@ -121,8 +126,10 @@ public class MavenProject implements Cloneable {
 
     private Set<Artifact> pluginArtifacts;
 
+    @Deprecated
     private List<ArtifactRepository> remoteArtifactRepositories;
 
+    @Deprecated
     private List<ArtifactRepository> pluginArtifactRepositories;
 
     private List<RemoteRepository> remoteProjectRepositories;
@@ -135,20 +142,52 @@ public class MavenProject implements Cloneable {
 
     private List<MavenProject> collectedProjects;
 
-    private List<String> compileSourceRoots = new ArrayList<>();
+    /**
+     * A tuple of {@link SourceRoot} properties for which we decide that no duplicated value should exist in a project.
+     * The set of properties that we choose to put in this record may be modified in any future Maven version.
+     * The intend is to detect some configuration errors.
+     */
+    private static record SourceKey(ProjectScope scope, Language language, Path directory) {
+        /**
+         * Converts this key into a source root.
+         * Used for adding a new source when no other information is available.
+         *
+         * @return the source root for the properties of this key.
+         */
+        SourceRoot createSource() {
+            return new DefaultSourceRoot(scope, language, directory);
+        }
 
-    private List<String> testCompileSourceRoots = new ArrayList<>();
+        /**
+         * {@return an error message to report when a conflict is detected}.
+         *
+         * @param baseDir value of {@link #getBaseDirectory()}, in order to make the message shorter
+         */
+        String conflictMessage(Path baseDir) {
+            return "Directory " + baseDir.relativize(directory)
+                    + " is specified twice for the scope \"" + scope.id()
+                    + "\" and language \"" + language.id() + "\".";
+        }
+    }
 
-    private List<String> scriptSourceRoots = new ArrayList<>();
+    /**
+     * All sources of this project. The map includes main and test codes for all languages.
+     * However, we put some restrictions on what information can be repeated.
+     * Those restrictions are expressed in {@link SourceKey}.
+     */
+    private HashMap<SourceKey, SourceRoot> sources = new LinkedHashMap<>(); // Need access to the `clone()` method.
 
+    @Deprecated
     private ArtifactRepository releaseArtifactRepository;
 
+    @Deprecated
     private ArtifactRepository snapshotArtifactRepository;
 
     private List<Profile> activeProfiles = new ArrayList<>();
 
     private Map<String, List<String>> injectedProfileIds = new LinkedHashMap<>();
 
+    @Deprecated
     private Set<Artifact> dependencyArtifacts;
 
     private Artifact artifact;
@@ -160,12 +199,16 @@ public class MavenProject implements Cloneable {
 
     private Map<String, Artifact> pluginArtifactMap;
 
+    @Deprecated
     private Set<Artifact> reportArtifacts;
 
+    @Deprecated
     private Map<String, Artifact> reportArtifactMap;
 
+    @Deprecated
     private Set<Artifact> extensionArtifacts;
 
+    @Deprecated
     private Map<String, Artifact> extensionArtifactMap;
 
     private Map<String, Artifact> managedVersionMap;
@@ -266,8 +309,22 @@ public class MavenProject implements Cloneable {
         this.file = file;
     }
 
+    /**
+     * @deprecated Replaced by {@link #getBaseDirectory()} for migrating from {@code File} to {@code Path}.
+     */
+    @Deprecated(since = "4.0.0")
     public File getBasedir() {
         return basedir;
+    }
+
+    /**
+     * {@return the base directory of this project}.
+     * All source files are relative to this directory, unless they were specified as absolute paths.
+     *
+     * @since 4.0.0
+     */
+    public Path getBaseDirectory() {
+        return getBasedir().toPath();
     }
 
     public void setDependencies(List<Dependency> dependencies) {
@@ -286,40 +343,129 @@ public class MavenProject implements Cloneable {
     // Test and compile source roots.
     // ----------------------------------------------------------------------
 
-    private void addPath(List<String> paths, String path) {
-        if (path != null) {
-            path = path.trim();
-            if (!path.isEmpty()) {
-                File file = new File(path);
-                if (file.isAbsolute()) {
-                    path = file.getAbsolutePath();
-                } else if (".".equals(path)) {
-                    path = getBasedir().getAbsolutePath();
-                } else {
-                    path = new File(getBasedir(), path).getAbsolutePath();
-                }
+    /**
+     * Adds the given source. If a source already exists for the given scope, language and directory,
+     * then this method either does nothing if all other properties are equal, or thrown
+     * {@linkplain IllegalArgumentException} otherwise.
+     *
+     * @param source the source to add
+     * @throws IllegalArgumentException if a source exists for the given language, scope and directory
+     *         but with different values for the other properties.
+     *
+     * @since 4.0.0
+     */
+    public void addSourceRoot(SourceRoot source) {
+        var key = new SourceKey(source.scope(), source.language(), source.directory());
+        SourceRoot current = sources.putIfAbsent(key, source);
+        if (current != null && !current.equals(source)) {
+            throw new IllegalArgumentException(key.conflictMessage(getBaseDirectory()));
+        }
+    }
 
-                if (!paths.contains(path)) {
-                    paths.add(path);
-                }
+    /**
+     * Resolves and adds the given directory as a source with the given scope and language.
+     * First, this method resolves the given root against the {@linkplain #getBaseDirectory() base directory},
+     * then normalizes the path. If a source already exists for the same scope, language and normalized directory,
+     * this method does nothing. Otherwise, the normalized directory is added as a new {@link SourceRoot} element.
+     *
+     * @param scope scope (main or test) of the directory to add
+     * @param language language of the files contained in the directory to add
+     * @param directory the directory to add if not already present in the source
+     *
+     * @since 4.0.0
+     */
+    public void addSourceRoot(ProjectScope scope, Language language, Path directory) {
+        directory = getBaseDirectory().resolve(directory).normalize();
+        var key = new SourceKey(scope, language, directory);
+        sources.computeIfAbsent(key, SourceKey::createSource);
+    }
+
+    /**
+     * Resolves and adds the given directory as a source with the given scope and language.
+     * If the given directory is null, blank or already in the sources, then this method does nothing.
+     * Otherwise, the directory is converted to a path, resolved, normalized and finally added as a new
+     * {@link SourceRoot} element if no source exists for these scope, language and normalized directory.
+     *
+     * @param scope scope (main or test) of the directory to add
+     * @param language language of the files contained in the directory to add
+     * @param directory the directory to add if not already present in the source, or null
+     *
+     * @since 4.0.0
+     */
+    public void addSourceRoot(ProjectScope scope, Language language, String directory) {
+        if (directory != null) {
+            directory = directory.trim();
+            if (!directory.isBlank()) {
+                Path path = getBaseDirectory().resolve(directory).normalize();
+                var key = new SourceKey(scope, language, path);
+                sources.computeIfAbsent(key, SourceKey::createSource);
             }
         }
     }
 
+    /**
+     * @deprecated Replaced by {@code addSourceRoot(ProjectScope.MAIN, Language.JAVA_FAMILY, path)}.
+     */
+    @Deprecated(since = "4.0.0")
     public void addCompileSourceRoot(String path) {
-        addPath(getCompileSourceRoots(), path);
+        addSourceRoot(ProjectScope.MAIN, Language.JAVA_FAMILY, path);
     }
 
+    /**
+     * @deprecated Replaced by {@code addSourceRoot(ProjectScope.TEST, Language.JAVA_FAMILY, path)}.
+     */
+    @Deprecated(since = "4.0.0")
     public void addTestCompileSourceRoot(String path) {
-        addPath(getTestCompileSourceRoots(), path);
+        addSourceRoot(ProjectScope.TEST, Language.JAVA_FAMILY, path);
     }
 
+    /**
+     * {@return all sources that provide files in the given language for the given scope}.
+     * If the given scope is {@code null}, then this method returns the sources for all scopes.
+     * If the given language is {@code null}, then this method returns the sources for all languages.
+     *
+     * @param scope the scope of the sources to return, or {@code null} for all scopes
+     * @param language the language of the sources to return, or {@code null} for all languages
+     *
+     * @since 4.0.0
+     */
+    public Stream<SourceRoot> getSourceRoots(ProjectScope scope, Language language) {
+        Stream<SourceRoot> s = sources.values().stream();
+        if (scope != null) {
+            s = s.filter((source) -> scope.equals(source.scope()));
+        }
+        if (language != null) {
+            s = s.filter((source) -> language.equals(source.language()));
+        }
+        return s;
+    }
+
+    /**
+     * Returns a list of paths for the given scope.
+     *
+     * @deprecated Used only for the implementation of deprecated methods.
+     */
+    @Deprecated
+    private List<String> getSourceRootDirs(ProjectScope scope, Language language) {
+        return getSourceRoots(scope, language)
+                .map((source) -> source.directory().toString())
+                .toList();
+    }
+
+    /**
+     * @deprecated Replaced by {@code getSourceRoots(ProjectScope.MAIN, Language.JAVA_FAMILY)}.
+     */
+    @Deprecated(since = "4.0.0")
     public List<String> getCompileSourceRoots() {
-        return compileSourceRoots;
+        return getSourceRootDirs(ProjectScope.MAIN, Language.JAVA_FAMILY);
     }
 
+    /**
+     * @deprecated Replaced by {@code getSourceRoots(ProjectScope.TEST, Language.JAVA_FAMILY)}.
+     */
+    @Deprecated(since = "4.0.0")
     public List<String> getTestCompileSourceRoots() {
-        return testCompileSourceRoots;
+        return getSourceRootDirs(ProjectScope.TEST, Language.JAVA_FAMILY);
     }
 
     // TODO let the scope handler deal with this
@@ -600,20 +746,38 @@ public class MavenProject implements Cloneable {
         return getModelBuild();
     }
 
+    /**
+     * @deprecated Replaced by {@code getSourceRoots(ProjectScope.MAIN, Language.RESOURCES)}.
+     */
+    @Deprecated(since = "4.0.0")
     public List<Resource> getResources() {
         return getBuild().getResources();
     }
 
+    /**
+     * @deprecated Replaced by {@code getSourceRoots(ProjectScope.TEST, Language.RESOURCES)}.
+     */
+    @Deprecated(since = "4.0.0")
     public List<Resource> getTestResources() {
         return getBuild().getTestResources();
     }
 
+    /**
+     * @deprecated {@link Resource} is replaced by {@link SourceRoot}.
+     */
+    @Deprecated(since = "4.0.0")
     public void addResource(Resource resource) {
         getBuild().addResource(resource);
+        addSourceRoot(new DefaultSourceRoot(getBaseDirectory(), ProjectScope.MAIN, resource.getDelegate()));
     }
 
+    /**
+     * @deprecated {@link Resource} is replaced by {@link SourceRoot}.
+     */
+    @Deprecated(since = "4.0.0")
     public void addTestResource(Resource testResource) {
         getBuild().addTestResource(testResource);
+        addSourceRoot(new DefaultSourceRoot(getBaseDirectory(), ProjectScope.TEST, testResource.getDelegate()));
     }
 
     public void setLicenses(List<License> licenses) {
@@ -737,11 +901,13 @@ public class MavenProject implements Cloneable {
         return build;
     }
 
+    @Deprecated
     public void setRemoteArtifactRepositories(List<ArtifactRepository> remoteArtifactRepositories) {
         this.remoteArtifactRepositories = remoteArtifactRepositories;
         this.remoteProjectRepositories = RepositoryUtils.toRepos(getRemoteArtifactRepositories());
     }
 
+    @Deprecated
     public List<ArtifactRepository> getRemoteArtifactRepositories() {
         if (remoteArtifactRepositories == null) {
             remoteArtifactRepositories = new ArrayList<>();
@@ -750,6 +916,7 @@ public class MavenProject implements Cloneable {
         return remoteArtifactRepositories;
     }
 
+    @Deprecated
     public void setPluginArtifactRepositories(List<ArtifactRepository> pluginArtifactRepositories) {
         this.pluginArtifactRepositories = pluginArtifactRepositories;
         this.remotePluginRepositories = RepositoryUtils.toRepos(getPluginArtifactRepositories());
@@ -759,6 +926,7 @@ public class MavenProject implements Cloneable {
      * @return a list of ArtifactRepository objects constructed from the Repository objects returned by
      *         getPluginRepositories.
      */
+    @Deprecated
     public List<ArtifactRepository> getPluginArtifactRepositories() {
         if (pluginArtifactRepositories == null) {
             pluginArtifactRepositories = new ArrayList<>();
@@ -767,6 +935,7 @@ public class MavenProject implements Cloneable {
         return pluginArtifactRepositories;
     }
 
+    @Deprecated
     public ArtifactRepository getDistributionManagementArtifactRepository() {
         return getArtifact().isSnapshot() && (getSnapshotArtifactRepository() != null)
                 ? getSnapshotArtifactRepository()
@@ -912,10 +1081,12 @@ public class MavenProject implements Cloneable {
         this.dependencyArtifacts = dependencyArtifacts;
     }
 
+    @Deprecated
     public void setReleaseArtifactRepository(ArtifactRepository releaseArtifactRepository) {
         this.releaseArtifactRepository = releaseArtifactRepository;
     }
 
+    @Deprecated
     public void setSnapshotArtifactRepository(ArtifactRepository snapshotArtifactRepository) {
         this.snapshotArtifactRepository = snapshotArtifactRepository;
     }
@@ -1043,12 +1214,32 @@ public class MavenProject implements Cloneable {
         this.attachedArtifacts = attachedArtifacts;
     }
 
-    protected void setCompileSourceRoots(List<String> compileSourceRoots) {
-        this.compileSourceRoots = compileSourceRoots;
+    /**
+     * @deprecated Used only for the implementation of deprecated methods.
+     */
+    @Deprecated
+    private void setSourceRootDirs(ProjectScope scope, Language language, List<String> roots) {
+        sources.values().removeIf((source) -> scope.equals(source.scope()) && language.equals(source.language()));
+        Path directory = getBaseDirectory();
+        for (String root : roots) {
+            addSourceRoot(new DefaultSourceRoot(scope, language, directory.resolve(root)));
+        }
     }
 
+    /**
+     * @deprecated Replaced by {@link #addSourceRoot(ProjectScope, Language, String)}.
+     */
+    @Deprecated(since = "4.0.0")
+    protected void setCompileSourceRoots(List<String> compileSourceRoots) {
+        setSourceRootDirs(ProjectScope.MAIN, Language.JAVA_FAMILY, compileSourceRoots);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #addSourceRoot(ProjectScope, Language, String)}.
+     */
+    @Deprecated(since = "4.0.0")
     protected void setTestCompileSourceRoots(List<String> testCompileSourceRoots) {
-        this.testCompileSourceRoots = testCompileSourceRoots;
+        setSourceRootDirs(ProjectScope.TEST, Language.JAVA_FAMILY, testCompileSourceRoots);
     }
 
     protected ArtifactRepository getReleaseArtifactRepository() {
@@ -1111,18 +1302,10 @@ public class MavenProject implements Cloneable {
             setAttachedArtifacts(new ArrayList<>(project.getAttachedArtifacts()));
         }
 
-        if (project.getCompileSourceRoots() != null) {
-            // clone source roots
-            setCompileSourceRoots((new ArrayList<>(project.getCompileSourceRoots())));
-        }
-
-        if (project.getTestCompileSourceRoots() != null) {
-            setTestCompileSourceRoots((new ArrayList<>(project.getTestCompileSourceRoots())));
-        }
-
-        if (project.getScriptSourceRoots() != null) {
-            setScriptSourceRoots((new ArrayList<>(project.getScriptSourceRoots())));
-        }
+        // This property is not handled like others as we don't use public API.
+        // The whole implementation of this `deepCopy` method may need revision,
+        // but it would be the topic for a separated commit.
+        sources = (HashMap<SourceKey, SourceRoot>) project.sources.clone();
 
         if (project.getModel() != null) {
             setModel(project.getModel().clone());
@@ -1346,24 +1529,17 @@ public class MavenProject implements Cloneable {
 
     @Deprecated
     protected void setScriptSourceRoots(List<String> scriptSourceRoots) {
-        this.scriptSourceRoots = scriptSourceRoots;
+        setSourceRootDirs(ProjectScope.MAIN, Language.SCRIPT, scriptSourceRoots);
     }
 
     @Deprecated
     public void addScriptSourceRoot(String path) {
-        if (path != null) {
-            path = path.trim();
-            if (path.length() != 0) {
-                if (!getScriptSourceRoots().contains(path)) {
-                    getScriptSourceRoots().add(path);
-                }
-            }
-        }
+        addSourceRoot(ProjectScope.MAIN, Language.SCRIPT, path);
     }
 
     @Deprecated
     public List<String> getScriptSourceRoots() {
-        return scriptSourceRoots;
+        return getSourceRootDirs(ProjectScope.MAIN, Language.SCRIPT);
     }
 
     @Deprecated
@@ -1590,7 +1766,6 @@ public class MavenProject implements Cloneable {
     @Deprecated
     public void setExtensionArtifacts(Set<Artifact> extensionArtifacts) {
         this.extensionArtifacts = extensionArtifacts;
-
         extensionArtifactMap = null;
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.maven.api.Language;
+import org.apache.maven.api.ProjectScope;
+import org.apache.maven.api.Session;
+import org.apache.maven.api.SourceRoot;
+import org.apache.maven.api.Version;
+import org.apache.maven.api.model.Resource;
+import org.apache.maven.api.model.Source;
+
+/**
+ * A default implementation of {@code SourceRoot} built from the model.
+ */
+public final class DefaultSourceRoot implements SourceRoot {
+    private final Path directory;
+
+    private final List<PathMatcher> includes;
+
+    private final List<PathMatcher> excludes;
+
+    private final ProjectScope scope;
+
+    private final Language language;
+
+    private final String moduleName;
+
+    private final Version targetVersion;
+
+    private final Path targetPath;
+
+    private final boolean stringFiltering;
+
+    private final boolean enabled;
+
+    /**
+     * Creates a new instance from the given model.
+     *
+     * @param session the session of resolving extensible enumerations
+     * @param baseDir the base directory for resolving relative paths
+     * @param source a source element from the model
+     */
+    public DefaultSourceRoot(final Session session, final Path baseDir, final Source source) {
+        String value = nonBlank(source.getDirectory());
+        if (value == null) {
+            throw new IllegalArgumentException("Source declaration without directory value.");
+        }
+        directory = baseDir.resolve(value);
+        FileSystem fs = directory.getFileSystem();
+        includes = matchers(fs, source.getIncludes());
+        excludes = matchers(fs, source.getExcludes());
+        stringFiltering = source.isStringFiltering();
+        enabled = source.isEnabled();
+        moduleName = nonBlank(source.getModule());
+
+        value = nonBlank(source.getScope());
+        scope = (value != null) ? session.requireProjectScope(value) : ProjectScope.MAIN;
+
+        value = nonBlank(source.getLang());
+        language = (value != null) ? session.requireLanguage(value) : Language.JAVA_FAMILY;
+
+        value = nonBlank(source.getTargetVersion());
+        targetVersion = (value != null) ? session.parseVersion(value) : null;
+
+        value = nonBlank(source.getTargetPath());
+        targetPath = (value != null) ? baseDir.resolve(value) : null;
+    }
+
+    /**
+     * Creates a new instance from the given resource.
+     * This is used for migration from the previous way of declaring resources.
+     *
+     * @param baseDir the base directory for resolving relative paths
+     * @param scope the scope of the resource (main or test)
+     * @param resource a resource element from the model
+     */
+    public DefaultSourceRoot(final Path baseDir, ProjectScope scope, Resource resource) {
+        String value = nonBlank(resource.getDirectory());
+        if (value == null) {
+            throw new IllegalArgumentException("Source declaration without directory value.");
+        }
+        directory = baseDir.resolve(value).normalize();
+        FileSystem fs = directory.getFileSystem();
+        includes = matchers(fs, resource.getIncludes());
+        excludes = matchers(fs, resource.getExcludes());
+        stringFiltering = Boolean.parseBoolean(resource.getFiltering());
+        enabled = true;
+        moduleName = null;
+        this.scope = scope;
+        language = Language.RESOURCES;
+        targetVersion = null;
+        targetPath = null;
+    }
+
+    /**
+     * Creates a new instance for the given directory and scope. The language is assumed Java.
+     *
+     * @param scope scope of source code (main or test)
+     * @param language language of the source code
+     * @param directory directory of the source code
+     */
+    public DefaultSourceRoot(final ProjectScope scope, final Language language, final Path directory) {
+        this.scope = Objects.requireNonNull(scope);
+        this.language = language;
+        this.directory = Objects.requireNonNull(directory);
+        includes = List.of();
+        excludes = List.of();
+        moduleName = null;
+        targetVersion = null;
+        targetPath = null;
+        stringFiltering = false;
+        enabled = true;
+    }
+
+    /**
+     * {@return the given value as a trimmed non-blank string, or null otherwise}.
+     */
+    private static String nonBlank(String value) {
+        if (value != null) {
+            value = value.trim();
+            if (value.isBlank()) {
+                value = null;
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Creates a path matcher for each pattern.
+     * The path separator is {@code /} on all platforms, including Windows.
+     * The prefix before the {@code :} character is the syntax.
+     * If no syntax is specified, {@code "glob"} is assumed.
+     *
+     * @param fs the file system of the root directory
+     * @param patterns the patterns for which to create path matcher
+     * @return a path matcher for each pattern
+     */
+    private static List<PathMatcher> matchers(FileSystem fs, List<String> patterns) {
+        final var matchers = new PathMatcher[patterns.size()];
+        for (int i = 0; i < matchers.length; i++) {
+            String pattern = patterns.get(i);
+            if (pattern.indexOf(':') < 0) {
+                pattern = "glob:" + pattern;
+            }
+            matchers[i] = fs.getPathMatcher(pattern);
+        }
+        return List.of(matchers);
+    }
+
+    /**
+     * {@return the root directory where the sources are stored}.
+     */
+    @Override
+    public Path directory() {
+        return directory;
+    }
+
+    /**
+     * {@return the list of pattern matchers for the files to include}.
+     */
+    @Override
+    @SuppressWarnings("ReturnOfCollectionOrArrayField") // Safe because unmodifiable
+    public List<PathMatcher> includes() {
+        return includes;
+    }
+
+    /**
+     * {@return the list of pattern matchers for the files to exclude}.
+     */
+    @Override
+    @SuppressWarnings("ReturnOfCollectionOrArrayField") // Safe because unmodifiable
+    public List<PathMatcher> excludes() {
+        return excludes;
+    }
+
+    /**
+     * {@return in which context the source files will be used}.
+     */
+    @Override
+    public ProjectScope scope() {
+        return scope;
+    }
+
+    /**
+     * {@return the language of the source files}.
+     */
+    @Override
+    public Language language() {
+        return language;
+    }
+
+    /**
+     * {@return the name of the Java module (or other language-specific module) which is built by the sources}.
+     */
+    @Override
+    public Optional<String> module() {
+        return Optional.ofNullable(moduleName);
+    }
+
+    /**
+     * {@return the version of the platform where the code will be executed}.
+     */
+    @Override
+    public Optional<Version> targetVersion() {
+        return Optional.ofNullable(targetVersion);
+    }
+
+    /**
+     * {@return an explicit target path, overriding the default value}.
+     */
+    @Override
+    public Optional<Path> targetPath() {
+        return Optional.ofNullable(targetPath);
+    }
+
+    /**
+     * {@return whether resources are filtered to replace tokens with parameterized values}.
+     */
+    @Override
+    public boolean stringFiltering() {
+        return stringFiltering;
+    }
+
+    /**
+     * {@return whether the directory described by this source element should be included in the build}.
+     */
+    @Override
+    public boolean enabled() {
+        return enabled;
+    }
+
+    /**
+     * {@return a hash code value computed from all properties}.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                directory,
+                includes,
+                excludes,
+                scope,
+                language,
+                moduleName,
+                targetVersion,
+                targetPath,
+                stringFiltering,
+                enabled);
+    }
+
+    /**
+     * {@return whether the two objects are of the same class with equal property values}.
+     *
+     * @param obj the other object to compare with this object, or {@code null}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DefaultSourceRoot other) {
+            return directory.equals(other.directory)
+                    && includes.equals(other.includes)
+                    && excludes.equals(other.excludes)
+                    && Objects.equals(scope, other.scope)
+                    && Objects.equals(language, other.language)
+                    && Objects.equals(moduleName, other.moduleName)
+                    && Objects.equals(targetVersion, other.targetVersion)
+                    && stringFiltering == other.stringFiltering
+                    && enabled == other.enabled;
+        }
+        return false;
+    }
+}

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/ExtensibleEnumRegistries.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/ExtensibleEnumRegistries.java
@@ -80,7 +80,7 @@ public class ExtensibleEnumRegistries {
 
         @Inject
         public DefaultLanguageRegistry(List<LanguageProvider> providers) {
-            super(providers, Language.NONE, Language.JAVA_FAMILY);
+            super(providers, Language.NONE, Language.RESOURCES, Language.SCRIPT, Language.JAVA_FAMILY);
         }
     }
 


### PR DESCRIPTION
Notable changes:

* Add a `SourceRoot` interface for the properties declared in the POM's `<Source>` element.
* In the POM, deprecate the `sourceDirectory`, `testSourceDirectory`, `scriptSourceDirectory`, `resources`, `testResources` elements and the `Resource` structure. They are replaced by `<source>` elements.
* In the `MavenProject` class, replace the `compileSourceRoots`, `testCompileSourceRoots` and `scriptSourceRoots` fields by redirections to the new `sources` field with paths wrapped in `SourceRoot` objects. The resource fields are not completely replaced, information are duplicated.
* The getters and setters methods for above-cited fields are deprecated.
* This commit contains other opportunistic deprecations on methods which were receiving or returning instances of types that were already deprecated.

In the POM file, the above-cited deprecated properties are ignored if a corresponding `<source>` element exists. For example, if there is a source with `<scope>main</scope>` and `<lang>java</lang>`, then `<sourceDirectory>` is ignored. This rule exits because Maven sets default values to those fields, which can interfere with user's setting.

**Note:** the `SourceRoot` API uses method names without the `get` prefix in anticipation for possible use of records in the future.