### PR TITLE
[MNG-8477] Fix problems with file activation being wrongly cached

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8477MultithreadedFileActivationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8477MultithreadedFileActivationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8477">MNG-8477</a>.
+ */
+class MavenITmng8477MultithreadedFileActivationTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8477MultithreadedFileActivationTest() {
+        super("[4.0.0-rc-3-SNAPSHOT,)");
+    }
+
+    /**
+     *  Verify project is buildable.
+     */
+    @Test
+    void testIt() throws Exception {
+        Path basedir = extractResources("/mng-8477").getAbsoluteFile().toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArguments("help:active-profiles", "-Dmaven.modelBuilder.parallelism=1");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        verifier.verifyTextInLog("- xxx (source: test:m2:jar:1)");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -100,6 +100,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8477MultithreadedFileActivationTest.class);
         suite.addTestSuite(MavenITmng8469InterpolationPrecendenceTest.class);
         suite.addTestSuite(MavenITmng8461SpySettingsEventTest.class);
         suite.addTestSuite(MavenITmng8414ConsumerPomWithNewFeaturesTest.class);

--- a/its/core-it-suite/src/test/resources/mng-8477/m1/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8477/m1/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>project</artifactId>
+    <version>1</version>
+  </parent>
+  <groupId>test</groupId>
+  <artifactId>m1</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8477/m2/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8477/m2/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>project</artifactId>
+    <version>1</version>
+  </parent>
+  <groupId>test</groupId>
+  <artifactId>m2</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8477/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8477/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>project</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>m1</module>
+    <module>m2</module>
+  </modules>
+  <profiles>
+    <profile>
+      <id>xxx</id>
+      <activation>
+        <file>
+          <exists>src/io.properties</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.0</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
JIRA issue: [MNG-8477](https://issues.apache.org/jira/browse/MNG-8477)

Disable profile activation interpolation before checking profile activations.
The interpolated activations are cached and lead to wrong evaluations.
Given the activations are interpolated anyway during activation, there's
no need to do that before.

