### PR TITLE
[MNG-8554] Fix UT suite for CLI

### DIFF
--- a/impl/maven-cli/pom.xml
+++ b/impl/maven-cli/pom.xml
@@ -169,7 +169,7 @@ under the License.
           </properties>
           <promoteUserPropertiesToSystemProperties>false</promoteUserPropertiesToSystemProperties>
           <systemPropertyVariables>
-            <maven.home>${maven.home}</maven.home>
+            <maven.home>${basedir}/src/test/resources/mavenHome</maven.home>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
@@ -20,7 +20,6 @@ package org.apache.maven.cling.invoker.mvn;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -31,7 +30,6 @@ import org.apache.maven.api.cli.Invoker;
 import org.apache.maven.api.cli.Parser;
 import org.apache.maven.api.cli.ParserRequest;
 import org.apache.maven.jline.JLineMessageBuilderFactory;
-import org.junit.jupiter.api.Assumptions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
@@ -88,13 +88,6 @@ public abstract class MavenInvokerTestSupport {
 
     protected Map<String, String> invoke(Path cwd, Path userHome, Collection<String> goals, Collection<String> args)
             throws Exception {
-        // works only in recent Maven4
-        Assumptions.assumeTrue(
-                Files.isRegularFile(Paths.get(System.getProperty("maven.home"))
-                        .resolve("conf")
-                        .resolve("maven.properties")),
-                "${maven.home}/conf/maven.properties must be a file");
-
         Files.createDirectories(cwd.resolve(".mvn"));
         Path pom = cwd.resolve("pom.xml").toAbsolutePath();
         Files.writeString(pom, POM_STRING);

--- a/impl/maven-cli/src/test/resources/mavenHome/conf/maven.properties
+++ b/impl/maven-cli/src/test/resources/mavenHome/conf/maven.properties
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Maven user properties
+#
+# The properties defined in this file will be made available through
+# user properties at the very beginning of Maven's boot process.
+#
+
+maven.installation.conf = ${maven.home}/conf
+maven.user.conf         = ${user.home}/.m2
+maven.project.conf      = ${session.rootDirectory}/.mvn
+
+# Comma-separated list of files to include.
+# Each item may be enclosed in quotes to gracefully include spaces. Items are trimmed before being loaded.
+# If the first character of an item is a question mark, the load will silently fail if the file does not exist.
+${includes} = ?"${maven.user.conf}/maven.properties", \
+              ?"${maven.project.conf}/maven.properties"
+
+#
+# Settings
+#
+# Define the default three levels for settings.
+# The '-is' flag will override the 'maven.installation.settings' property.
+# The '-ps' flag will override the 'maven.project.settings' property.
+# The '-s' flag will override the 'maven.user.settings' property.
+maven.installation.settings = ${maven.installation.conf}/settings.xml
+maven.project.settings      = ${maven.project.conf}/settings.xml
+maven.user.settings         = ${maven.user.conf}/settings.xml
+
+#
+# Toolchains
+#
+# Define the default three levels for toolchains.
+# The '-it' flag will override the 'maven.installation.toolchains' property.
+# The '-t' flag will override the 'maven.user.toolchains' property.
+maven.installation.toolchains = ${maven.installation.conf}/toolchains.xml
+maven.user.toolchains         = ${maven.user.conf}/toolchains.xml
+
+#
+# Extensions
+#
+maven.installation.extensions = ${maven.installation.conf}/extensions.xml
+maven.project.extensions      = ${maven.project.conf}/extensions.xml
+maven.user.extensions         = ${maven.user.conf}/extensions.xml
+
+#
+# Maven central repository URL.
+#
+maven.repo.central = ${env.MAVEN_REPO_CENTRAL:-https://repo.maven.apache.org/maven2}


### PR DESCRIPTION
The whole UT suite was written to rely on maven.properties of the "outer build", hence UTs were not even running when built with Maven 3. Latest changes made it simply fail.

Fix the UT suite, as BasePasrser is depending on maven.properties being loaded, so provide one in a fake maven.home. Now the UT is always running, irrelevant of Maven being built with.

---

https://issues.apache.org/jira/browse/MNG-8554