### PR TITLE
[MNG-8241] Test comparing letters to numbers

### DIFF
--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -251,13 +251,13 @@ class ComparableVersionTest {
     void testLexicographicOrder() {
         ComparableVersion aardvark = new ComparableVersion("aardvark");
         ComparableVersion zebra = new ComparableVersion("zebra");
-        assertTrue(zebra.compareTo( aardvark ) > 0);
+        assertTrue(zebra.compareTo(aardvark) > 0);
         assertTrue(aardvark.compareTo(zebra) < 0);
 
         // Greek zebra
-        ComparableVersion ζέβρα = new ComparableVersion( "ζέβρα" );
-        assertTrue(ζέβρα.compareTo( zebra ) > 0);
-        assertTrue(zebra.compareTo( ζέβρα ) < 0);
+        ComparableVersion ζέβρα = new ComparableVersion("ζέβρα");
+        assertTrue(ζέβρα.compareTo(zebra) > 0);
+        assertTrue(zebra.compareTo(ζέβρα) < 0);
     }
 
     /**

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -236,6 +236,17 @@ class ComparableVersionTest {
         assertEquals("0.2", version2.getCanonical());
     }
 
+    @Test
+    void testCompareDigitToLetter() {
+        ComparableVersion c1 = new ComparableVersion("7");
+        ComparableVersion c2 = new ComparableVersion("J");
+        ComparableVersion c3 = new ComparableVersion("c");
+        assertTrue(c1.compareTo(c2) > 0, "expected 7 > J");
+        assertTrue(c2.compareTo(c1) < 0, "expected J < 1");
+        assertTrue(c1.compareTo(c3) > 0, "expected 7 > c");
+        assertTrue(c3.compareTo(c1) < 0, "expected c < 7");
+    }
+
     /**
      * Test <a href="https://issues.apache.org/jira/browse/MNG-5568">MNG-5568</a> edge case
      * which was showing transitive inconsistency: since A &gt; B and B &gt; C then we should have A &gt; C

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -247,6 +247,19 @@ class ComparableVersionTest {
         assertTrue(c3.compareTo(c1) < 0, "expected c < 7");
     }
 
+    @Test
+    void testLexicographicOrder() {
+        ComparableVersion aardvark = new ComparableVersion("aardvark");
+        ComparableVersion zebra = new ComparableVersion("zebra");
+        assertTrue(zebra.compareTo( aardvark ) > 0);
+        assertTrue(aardvark.compareTo(zebra) < 0);
+
+        // Greek zebra
+        ComparableVersion ζέβρα = new ComparableVersion( "ζέβρα" );
+        assertTrue(ζέβρα.compareTo( zebra ) > 0);
+        assertTrue(zebra.compareTo( ζέβρα ) < 0);
+    }
+
     /**
      * Test <a href="https://issues.apache.org/jira/browse/MNG-5568">MNG-5568</a> edge case
      * which was showing transitive inconsistency: since A &gt; B and B &gt; C then we should have A &gt; C


### PR DESCRIPTION
This is a characterization test for existing behavior with ASCII characters. I'm going to add this to the docs as well but that's in a separate repo. 