### PR TITLE
[MNG-8575] Replace a list with O(N²) performance by O(N) at least during iteration.

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -149,7 +148,7 @@ public class MavenProject implements Cloneable {
     /**
      * All sources of this project, in the order they were added.
      */
-    private List<SourceRoot> sources = new CopyOnWriteArrayList<>();
+    private Set<SourceRoot> sources = new LinkedHashSet<>();
 
     @Deprecated
     private ArtifactRepository releaseArtifactRepository;
@@ -327,9 +326,7 @@ public class MavenProject implements Cloneable {
      * @since 4.0.0
      */
     public void addSourceRoot(SourceRoot source) {
-        if (!sources.contains(source)) {
-            sources.add(source);
-        }
+        sources.add(source);
     }
 
     /**
@@ -1324,7 +1321,7 @@ public class MavenProject implements Cloneable {
         // This property is not handled like others as we don't use public API.
         // The whole implementation of this `deepCopy` method may need revision,
         // but it would be the topic for a separated commit.
-        sources = new CopyOnWriteArrayList<>(project.sources);
+        sources = new LinkedHashSet<>(project.sources);
 
         if (project.getModel() != null) {
             setModel(project.getModel().clone());

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -745,18 +745,23 @@ public class MavenProject implements Cloneable {
 
     private List<Resource> getResources(final ProjectScope scope) {
         return new AbstractSequentialList<>() {
+            private Stream<SourceRoot> sources() {
+                return getEnabledSourceRoots(scope, Language.RESOURCES);
+            }
+
             @Override
             public ListIterator<Resource> listIterator(int index) {
-                return getEnabledSourceRoots(scope, Language.RESOURCES)
-                        .map(MavenProject::toResource)
-                        .toList()
-                        .listIterator(index);
+                return sources().map(MavenProject::toResource).toList().listIterator(index);
             }
 
             @Override
             public int size() {
-                return Math.toIntExact(
-                        getEnabledSourceRoots(scope, Language.RESOURCES).count());
+                return Math.toIntExact(sources().count());
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return sources().findAny().isEmpty();
             }
 
             @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -147,7 +147,7 @@ public class MavenProject implements Cloneable {
     private List<MavenProject> collectedProjects;
 
     /**
-     * All sources of this project. The map includes main and test codes for all languages.
+     * All sources of this project, in the order they were added.
      */
     private List<SourceRoot> sources = new CopyOnWriteArrayList<>();
 
@@ -318,13 +318,9 @@ public class MavenProject implements Cloneable {
     // ----------------------------------------------------------------------
 
     /**
-     * Adds the given source. If a source already exists for the given scope, language and directory,
-     * then this method either does nothing if all other properties are equal, or thrown
-     * {@linkplain IllegalArgumentException} otherwise.
+     * Adds the given source if not already present.
      *
      * @param source the source to add
-     * @throws IllegalArgumentException if a source exists for the given language, scope and directory
-     *         but with different values for the other properties.
      *
      * @see #getSourceRoots()
      *


### PR DESCRIPTION
JIRA issue: [MNG-8575](https://issues.apache.org/jira/browse/MNG-8575)

The use of `AbstractList` with an implementation that creates the whole list every time that `get(int)` is invoked implies that iterations over that list would have a performance cost of O(N²) where _N_ is the number of elements. Extending `AbstractSequentialList` instead brings back the performance cost to O(N) at least during iterations.