### PR TITLE
Align Toolbox versions

### DIFF
--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -155,10 +155,10 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
         Map<String, String> logs = invoke(
                 cwd,
                 userHome,
-                List.of("eu.maveniverse.maven.plugins:toolbox:0.6.1:help"),
+                List.of("eu.maveniverse.maven.plugins:toolbox:0.6.2:help"),
                 List.of("--force-interactive"));
 
-        String log = logs.get("eu.maveniverse.maven.plugins:toolbox:0.6.1:help");
+        String log = logs.get("eu.maveniverse.maven.plugins:toolbox:0.6.2:help");
         assertTrue(log.contains("https://repo1.maven.org/maven2"), log);
         assertFalse(log.contains("https://repo.maven.apache.org/maven2"), log);
     }

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
  * @see <a href="https://github.com/maveniverse/toolbox">Maveniverse Toolbox</a>
  */
 public class ToolboxTool implements ExecutorTool {
-    private static final String TOOLBOX = "eu.maveniverse.maven.plugins:toolbox:0.5.2:";
+    private static final String TOOLBOX = "eu.maveniverse.maven.plugins:toolbox:0.6.2:";
 
     private final ExecutorHelper helper;
 

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
@@ -76,7 +76,7 @@ public abstract class MavenExecutorTestSupport {
                 List.of(mvn3ExecutorRequestBuilder()
                         .cwd(cwd)
                         .userHomeDirectory(userHome)
-                        .argument("eu.maveniverse.maven.plugins:toolbox:0.5.2:gav-dump")
+                        .argument("eu.maveniverse.maven.plugins:toolbox:0.6.2:gav-dump")
                         .argument("-l")
                         .argument(logfile)
                         .build()));
@@ -95,7 +95,7 @@ public abstract class MavenExecutorTestSupport {
                 List.of(mvn4ExecutorRequestBuilder()
                         .cwd(cwd)
                         .userHomeDirectory(userHome)
-                        .argument("eu.maveniverse.maven.plugins:toolbox:0.5.2:gav-dump")
+                        .argument("eu.maveniverse.maven.plugins:toolbox:0.6.2:gav-dump")
                         .argument("-l")
                         .argument(logfile)
                         .build()));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -56,7 +56,7 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
         Verifier verifier = newVerifier(basedir.toString(), null);
         verifier.addCliArgument("-DasProperties");
         verifier.addCliArgument("-DtoFile=dump.properties");
-        verifier.addCliArgument("eu.maveniverse.maven.plugins:toolbox:0.5.2:gav-dump");
+        verifier.addCliArgument("eu.maveniverse.maven.plugins:toolbox:0.6.2:gav-dump");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 


### PR DESCRIPTION
As they are used in various tests and test supporting code. Just to lessen download (once, and reuse same).