### PR TITLE
[MNG-8558] Move JavaToolchain

### DIFF
--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/DefaultToolchain.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/DefaultToolchain.java
@@ -32,7 +32,9 @@ import org.slf4j.Logger;
  * to avoid rewriting usual code.
  *
  * @since 2.0.9
+ * @deprecated Use {@link org.apache.maven.api.Toolchain} instead.
  */
+@Deprecated(since = "4.0.0")
 public abstract class DefaultToolchain // should have been AbstractToolchain...
 implements Toolchain, ToolchainPrivate {
     private final Logger logger;

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/MisconfiguredToolchainException.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/MisconfiguredToolchainException.java
@@ -21,6 +21,7 @@ package org.apache.maven.toolchain;
 /**
  *
  */
+@Deprecated(since = "4.0.0")
 public class MisconfiguredToolchainException extends Exception {
 
     public MisconfiguredToolchainException(String message) {

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/RequirementMatcher.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/RequirementMatcher.java
@@ -21,6 +21,7 @@ package org.apache.maven.toolchain;
 /**
  *
  */
+@Deprecated(since = "4.0.0")
 public interface RequirementMatcher {
 
     boolean matches(String requirement);

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
@@ -25,6 +25,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 /**
  *
  */
+@Deprecated(since = "4.0.0")
 public final class RequirementMatcherFactory {
     private RequirementMatcherFactory() {}
 

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/Toolchain.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/Toolchain.java
@@ -22,7 +22,9 @@ package org.apache.maven.toolchain;
  * Toolchain interface.
  *
  * @since 2.0.9
+ * @deprecated Use {@link org.apache.maven.api.Toolchain} instead.
  */
+@Deprecated(since = "4.0.0")
 public interface Toolchain {
 
     /**

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainFactory.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainFactory.java
@@ -24,7 +24,9 @@ import org.apache.maven.toolchain.model.ToolchainModel;
  * Internal toolchain factory, to prepare toolchains instances.
  *
  * @since 2.0.9
+ * @deprecated Use {@link org.apache.maven.api.services.ToolchainFactory} instead.
  */
+@Deprecated(since = "4.0.0")
 public interface ToolchainFactory {
     /**
      * Create instance of toolchain.

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManager.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManager.java
@@ -27,7 +27,9 @@ import org.apache.maven.execution.MavenSession;
  * Public API for a toolchain-aware plugin to get expected toolchain instance.
  *
  * @since 2.0.9
+ * @deprecated Use {@link org.apache.maven.api.services.ToolchainManager} instead.
  */
+@Deprecated(since = "4.0.0")
 public interface ToolchainManager {
 
     // NOTE: Some plugins like Surefire access this field directly!

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
@@ -115,7 +115,7 @@ public class ToolchainManagerFactory {
         return new org.apache.maven.impl.DefaultToolchainManager(allFactories, logger) {};
     }
 
-    class DefaultToolchainManagerV4 implements org.apache.maven.api.services.ToolchainManager {
+    public class DefaultToolchainManagerV4 implements org.apache.maven.api.services.ToolchainManager {
         @Nonnull
         @Override
         public List<org.apache.maven.api.Toolchain> getToolchains(
@@ -145,7 +145,7 @@ public class ToolchainManagerFactory {
         }
     }
 
-    class DefaultToolchainManagerV3 implements ToolchainManager, ToolchainManagerPrivate {
+    public class DefaultToolchainManagerV3 implements ToolchainManager, ToolchainManagerPrivate {
 
         @Override
         public Toolchain getToolchainFromBuildContext(String type, MavenSession session) {

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 @Named
 @Singleton
 @Deprecated(since = "4.0.0")
-class ToolchainManagerFactory {
+public class ToolchainManagerFactory {
 
     private final Lookup lookup;
     private final Logger logger;

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
@@ -60,6 +60,7 @@ class ToolchainManagerFactory {
 
     @Provides
     @Typed({ToolchainManager.class, ToolchainManagerPrivate.class})
+    @Named // qualifier is required for SiduDIBridge to work
     DefaultToolchainManagerV3 v3Manager() {
         return new DefaultToolchainManagerV3();
     }

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerFactory.java
@@ -23,12 +23,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.maven.api.Session;
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Priority;
+import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
+import org.apache.maven.api.di.Typed;
 import org.apache.maven.api.services.Lookup;
 import org.apache.maven.api.services.ToolchainFactoryException;
+import org.apache.maven.api.services.ToolchainManagerException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.impl.MappedList;
 import org.apache.maven.toolchain.model.ToolchainModel;
@@ -36,19 +42,33 @@ import org.slf4j.Logger;
 
 @Named
 @Singleton
-public class DefaultToolchainManager implements ToolchainManager, ToolchainManagerPrivate {
+@Deprecated(since = "4.0.0")
+class ToolchainManagerFactory {
 
     private final Lookup lookup;
     private final Logger logger;
 
     @Inject
-    public DefaultToolchainManager(Lookup lookup) {
+    ToolchainManagerFactory(Lookup lookup) {
         this(lookup, null);
     }
 
-    protected DefaultToolchainManager(Lookup lookup, Logger logger) {
+    protected ToolchainManagerFactory(Lookup lookup, Logger logger) {
         this.lookup = lookup;
         this.logger = logger;
+    }
+
+    @Provides
+    @Typed({ToolchainManager.class, ToolchainManagerPrivate.class})
+    DefaultToolchainManagerV3 v3Manager() {
+        return new DefaultToolchainManagerV3();
+    }
+
+    @Provides
+    @Priority(10)
+    @Typed(org.apache.maven.api.services.ToolchainManager.class)
+    DefaultToolchainManagerV4 v4Manager() {
+        return new DefaultToolchainManagerV4();
     }
 
     private org.apache.maven.impl.DefaultToolchainManager getDelegate() {
@@ -86,7 +106,7 @@ public class DefaultToolchainManager implements ToolchainManager, ToolchainManag
                 public Optional<org.apache.maven.api.Toolchain> createDefaultToolchain()
                         throws ToolchainFactoryException {
                     return Optional.ofNullable(v3Factory.createDefaultToolchain())
-                            .map(DefaultToolchainManager.this::getToolchainV4);
+                            .map(ToolchainManagerFactory.this::getToolchainV4);
                 }
             });
         }
@@ -94,35 +114,72 @@ public class DefaultToolchainManager implements ToolchainManager, ToolchainManag
         return new org.apache.maven.impl.DefaultToolchainManager(allFactories, logger) {};
     }
 
-    @Override
-    public Toolchain getToolchainFromBuildContext(String type, MavenSession session) {
-        return getDelegate()
-                .getToolchainFromBuildContext(session.getSession(), type)
-                .map(this::getToolchainV3)
-                .orElse(null);
-    }
+    class DefaultToolchainManagerV4 implements org.apache.maven.api.services.ToolchainManager {
+        @Nonnull
+        @Override
+        public List<org.apache.maven.api.Toolchain> getToolchains(
+                @Nonnull Session session, @Nonnull String type, @Nullable Map<String, String> requirements)
+                throws ToolchainManagerException {
+            return getDelegate().getToolchains(session, type, requirements);
+        }
 
-    @Override
-    public List<Toolchain> getToolchains(MavenSession session, String type, Map<String, String> requirements) {
-        return new MappedList<>(
-                getDelegate().getToolchains(session.getSession(), type, requirements), this::getToolchainV3);
-    }
+        @Nonnull
+        @Override
+        public Optional<org.apache.maven.api.Toolchain> getToolchainFromBuildContext(
+                @Nonnull Session session, @Nonnull String type) throws ToolchainManagerException {
+            return getDelegate().getToolchainFromBuildContext(session, type);
+        }
 
-    @Override
-    public ToolchainPrivate[] getToolchainsForType(String type, MavenSession session)
-            throws MisconfiguredToolchainException {
-        try {
-            List<org.apache.maven.api.Toolchain> toolchains = getDelegate().getToolchains(session.getSession(), type);
-            return toolchains.stream().map(this::getToolchainV3).toArray(ToolchainPrivate[]::new);
-        } catch (org.apache.maven.api.services.ToolchainManagerException e) {
-            throw new MisconfiguredToolchainException(e.getMessage(), e);
+        @Override
+        public void storeToolchainToBuildContext(
+                @Nonnull Session session, @Nonnull org.apache.maven.api.Toolchain toolchain) {
+            getDelegate().storeToolchainToBuildContext(session, toolchain);
+        }
+
+        @Nonnull
+        @Override
+        public List<org.apache.maven.api.Toolchain> getToolchains(@Nonnull Session session, @Nonnull String type)
+                throws ToolchainManagerException {
+            return getDelegate().getToolchains(session, type);
         }
     }
 
-    @Override
-    public void storeToolchainToBuildContext(ToolchainPrivate toolchain, MavenSession session) {
-        org.apache.maven.api.Toolchain tc = getToolchainV4(toolchain);
-        getDelegate().storeToolchainToBuildContext(session.getSession(), tc);
+    class DefaultToolchainManagerV3 implements ToolchainManager, ToolchainManagerPrivate {
+
+        @Override
+        public Toolchain getToolchainFromBuildContext(String type, MavenSession session) {
+            return getDelegate()
+                    .getToolchainFromBuildContext(session.getSession(), type)
+                    .map(ToolchainManagerFactory.this::getToolchainV3)
+                    .orElse(null);
+        }
+
+        @Override
+        public List<Toolchain> getToolchains(MavenSession session, String type, Map<String, String> requirements) {
+            return new MappedList<>(
+                    getDelegate().getToolchains(session.getSession(), type, requirements),
+                    ToolchainManagerFactory.this::getToolchainV3);
+        }
+
+        @Override
+        public ToolchainPrivate[] getToolchainsForType(String type, MavenSession session)
+                throws MisconfiguredToolchainException {
+            try {
+                List<org.apache.maven.api.Toolchain> toolchains =
+                        getDelegate().getToolchains(session.getSession(), type);
+                return toolchains.stream()
+                        .map(ToolchainManagerFactory.this::getToolchainV3)
+                        .toArray(ToolchainPrivate[]::new);
+            } catch (org.apache.maven.api.services.ToolchainManagerException e) {
+                throw new MisconfiguredToolchainException(e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public void storeToolchainToBuildContext(ToolchainPrivate toolchain, MavenSession session) {
+            org.apache.maven.api.Toolchain tc = getToolchainV4(toolchain);
+            getDelegate().storeToolchainToBuildContext(session.getSession(), tc);
+        }
     }
 
     private org.apache.maven.api.Toolchain getToolchainV4(ToolchainPrivate toolchain) {

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerPrivate.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainManagerPrivate.java
@@ -29,7 +29,9 @@ import org.apache.maven.execution.MavenSession;
  *
  * @since 2.0.9
  * @see ToolchainManager#getToolchainFromBuildContext(String, MavenSession)
+ * @deprecated Use {@link org.apache.maven.api.services.ToolchainManager} instead.
  */
+@Deprecated(since = "4.0.0")
 public interface ToolchainManagerPrivate {
 
     /**

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainPrivate.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/ToolchainPrivate.java
@@ -24,7 +24,10 @@ import org.apache.maven.toolchain.model.ToolchainModel;
 
 /**
  * a private contract between the toolchains plugin and the components.
+ *
+ * @deprecated Use {@link org.apache.maven.api.Toolchain} instead.
  */
+@Deprecated(since = "4.0.0")
 public interface ToolchainPrivate extends Toolchain {
 
     /**

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/java/JavaToolchain.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/java/JavaToolchain.java
@@ -24,7 +24,9 @@ import org.apache.maven.toolchain.Toolchain;
  * JDK toolchain interface.
  *
  * @since 2.0.9, renamed from JavaToolChain in 3.2.4
+ * @deprecated Use {@link org.apache.maven.api.JavaToolchain} instead.
  */
+@Deprecated(since = "4.0.0")
 public interface JavaToolchain extends Toolchain {
     //    /**
     //     * Returns a list of {@link java.io.File}s which represents the bootstrap libraries for the

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/java/JavaToolchainFactory.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/java/JavaToolchainFactory.java
@@ -18,9 +18,6 @@
  */
 package org.apache.maven.toolchain.java;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,9 +40,9 @@ import org.slf4j.LoggerFactory;
  * <code>jdk</code> hint.
  *
  * @since 2.0.9, renamed from <code>DefaultJavaToolchainFactory</code> in 3.2.4
+ * @deprecated Use {@link org.apache.maven.api.services.ToolchainFactory} instead.
  */
-@Named("jdk")
-@Singleton
+@Deprecated(since = "4.0.0")
 public class JavaToolchainFactory implements ToolchainFactory {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/java/JavaToolchainImpl.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/java/JavaToolchainImpl.java
@@ -31,7 +31,9 @@ import org.slf4j.Logger;
  * JDK toolchain implementation.
  *
  * @since 2.0.9, renamed from DefaultJavaToolChain in 3.2.4
+ * @deprecated Use {@link org.apache.maven.api.services.ToolchainFactory} instead.
  */
+@Deprecated(since = "4.0.0")
 public class JavaToolchainImpl extends DefaultToolchain implements JavaToolchain {
     private String javaHome;
 

--- a/compat/maven-compat/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
@@ -54,7 +54,7 @@ class DefaultToolchainManagerTest {
     @Mock
     private Logger logger;
 
-    private DefaultToolchainManager toolchainManager;
+    private ToolchainManagerFactory.DefaultToolchainManagerV3 toolchainManager;
 
     @Mock
     private ToolchainFactory toolchainFactory_basicType;
@@ -77,7 +77,7 @@ class DefaultToolchainManagerTest {
         when(lookup.lookupMap(org.apache.maven.toolchain.ToolchainFactory.class))
                 .thenReturn(Map.of());
 
-        toolchainManager = new DefaultToolchainManager(lookup, logger);
+        toolchainManager = new ToolchainManagerFactory(lookup, logger).v3Manager();
     }
 
     @Test

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultJavaToolchainFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultJavaToolchainFactory.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.maven.api.JavaToolchain;
+import org.apache.maven.api.Toolchain;
+import org.apache.maven.api.Version;
+import org.apache.maven.api.VersionConstraint;
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.di.Inject;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Singleton;
+import org.apache.maven.api.services.ToolchainFactory;
+import org.apache.maven.api.services.ToolchainFactoryException;
+import org.apache.maven.api.services.VersionParser;
+import org.apache.maven.api.services.VersionParserException;
+import org.apache.maven.api.toolchain.ToolchainModel;
+import org.apache.maven.api.xml.XmlNode;
+import org.apache.maven.impl.util.Os;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named("jdk")
+@Singleton
+public class DefaultJavaToolchainFactory implements ToolchainFactory {
+
+    public static final String KEY_JAVAHOME = "jdkHome"; // NOI18N
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultJavaToolchainFactory.class);
+
+    final VersionParser versionParser;
+
+    @Inject
+    public DefaultJavaToolchainFactory(VersionParser versionParser) {
+        this.versionParser = versionParser;
+    }
+
+    @Nonnull
+    @Override
+    public JavaToolchain createToolchain(@Nonnull ToolchainModel model) {
+        // populate the provides section
+        Map<String, Predicate<String>> matchers = model.getProvides().entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    if (value == null) {
+                        throw new ToolchainFactoryException(
+                                "Provides token '" + key + "' doesn't have any value configured.");
+                    }
+                    return "version".equals(key) ? new VersionMatcher(versionParser, value) : new ExactMatcher(value);
+                }));
+
+        // compute and normalize the java home
+        XmlNode dom = model.getConfiguration();
+        XmlNode javahome = dom != null ? dom.getChild(KEY_JAVAHOME) : null;
+        if (javahome == null || javahome.getValue() == null) {
+            throw new ToolchainFactoryException(
+                    "Java toolchain without the " + KEY_JAVAHOME + " configuration element.");
+        }
+        Path normal = Paths.get(javahome.getValue()).normalize();
+        if (!Files.exists(normal)) {
+            throw new ToolchainFactoryException("Non-existing JDK home configuration at " + normal.toAbsolutePath());
+        }
+        String javaHome = normal.toString();
+
+        return new DefaultJavaToolchain(model, javaHome, matchers);
+    }
+
+    @Nonnull
+    @Override
+    public Optional<Toolchain> createDefaultToolchain() {
+        return Optional.empty();
+    }
+
+    static class DefaultJavaToolchain implements JavaToolchain {
+
+        final ToolchainModel model;
+        final String javaHome;
+        final Map<String, Predicate<String>> matchers;
+
+        DefaultJavaToolchain(ToolchainModel model, String javaHome, Map<String, Predicate<String>> matchers) {
+            this.model = model;
+            this.javaHome = javaHome;
+            this.matchers = matchers;
+        }
+
+        @Override
+        public String getJavaHome() {
+            return javaHome;
+        }
+
+        @Override
+        public String getType() {
+            return "jdk";
+        }
+
+        @Override
+        public ToolchainModel getModel() {
+            return model;
+        }
+
+        @Override
+        public String findTool(String toolName) {
+            Path toRet = findTool(toolName, Paths.get(getJavaHome()).normalize());
+            if (toRet != null) {
+                return toRet.toAbsolutePath().toString();
+            }
+            return null;
+        }
+
+        private static Path findTool(String toolName, Path installDir) {
+            Path bin = installDir.resolve("bin"); // NOI18N
+            if (Files.isDirectory(bin)) {
+                if (Os.IS_WINDOWS) {
+                    Path tool = bin.resolve(toolName + ".exe");
+                    if (Files.exists(tool)) {
+                        return tool;
+                    }
+                }
+                Path tool = bin.resolve(toolName);
+                if (Files.exists(tool)) {
+                    return tool;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public boolean matchesRequirements(Map<String, String> requirements) {
+            for (Map.Entry<String, String> requirement : requirements.entrySet()) {
+                String key = requirement.getKey();
+
+                Predicate<String> matcher = matchers.get(key);
+
+                if (matcher == null) {
+                    LOGGER.debug("Toolchain {} is missing required property: {}", this, key);
+                    return false;
+                }
+                if (!matcher.test(requirement.getValue())) {
+                    LOGGER.debug("Toolchain {} doesn't match required property: {}", this, key);
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    static final class ExactMatcher implements Predicate<String> {
+
+        final String provides;
+
+        ExactMatcher(String provides) {
+            this.provides = provides;
+        }
+
+        @Override
+        public boolean test(String requirement) {
+            return provides.equalsIgnoreCase(requirement);
+        }
+
+        @Override
+        public String toString() {
+            return provides;
+        }
+    }
+
+    static final class VersionMatcher implements Predicate<String> {
+
+        final VersionParser versionParser;
+        final Version version;
+
+        VersionMatcher(VersionParser versionParser, String version) {
+            this.versionParser = versionParser;
+            this.version = versionParser.parseVersion(version);
+        }
+
+        @Override
+        public boolean test(String requirement) {
+            try {
+                VersionConstraint constraint = versionParser.parseVersionConstraint(requirement);
+                return constraint.contains(version);
+            } catch (VersionParserException ex) {
+                return false;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return version.toString();
+        }
+    }
+}


### PR DESCRIPTION
JIRA issue: [MNG-8558](http://issues.apache.org/jira/projects/MNG/issues/MNG-8558)

* move JavaToolchain support to maven-impl
* deprecate Maven 3 toolchain support classes
* add a factory to create toolchain managers wrapping both v3 and v4 toolchains
