### PR TITLE
[MNG-8583] Missing SISU bean definitions from maven-resolver-provider

### DIFF
--- a/compat/maven-resolver-provider/pom.xml
+++ b/compat/maven-resolver-provider/pom.xml
@@ -170,6 +170,10 @@ under the License.
   <build>
     <plugins>
       <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/type/DefaultTypeProvider.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.repository.internal.type;
 
-import javax.inject.Named;
-
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -28,7 +26,6 @@ import org.apache.maven.api.Language;
 import org.apache.maven.api.Type;
 import org.apache.maven.api.spi.TypeProvider;
 
-@Named
 @Deprecated(since = "4.0.0")
 public class DefaultTypeProvider implements TypeProvider {
     @SuppressWarnings({"rawtypes", "unchecked"})


### PR DESCRIPTION
JIRA issue: [MNG-8583](https://issues.apache.org/jira/browse/MNG-8583)

The beans are not recognized by Sisu as the needed META-INF file is missing.