### PR TITLE
[MNG-8582] Keep stdout/stderr functioning

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -284,11 +284,6 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
         context.slf4jConfiguration.setRootLoggerLevel(context.loggerLevel);
         // else fall back to default log level specified in conf
         // see https://issues.apache.org/jira/browse/MNG-2570
-
-        // Create the build log appender; also sets MavenSimpleLogger sink
-        ProjectBuildLogAppender projectBuildLogAppender =
-                new ProjectBuildLogAppender(determineBuildEventListener(context));
-        context.closeables.add(projectBuildLogAppender);
     }
 
     protected BuildEventListener determineBuildEventListener(C context) {
@@ -305,6 +300,11 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
 
     protected void createTerminal(C context) {
         if (context.terminal == null) {
+            // Create the build log appender; also sets MavenSimpleLogger sink
+            ProjectBuildLogAppender projectBuildLogAppender =
+                    new ProjectBuildLogAppender(determineBuildEventListener(context));
+            context.closeables.add(projectBuildLogAppender);
+
             MessageUtils.systemInstall(
                     builder -> {
                         if (context.invokerRequest.embedded()) {


### PR DESCRIPTION
This call has severe implications (re-ties logger, and in case is invoked multiple times, causes "loop").
Make sure it happens only once, This changes does not affect mvn and mvnd (it installs own stdout/stderr), but does affects mvnsh and resident maven,

---

https://issues.apache.org/jira/browse/MNG-8582