### PR TITLE
[MNG-8591] Fix default value for plugin resolution (which has always been null)

### DIFF
--- a/api/maven-api-plugin/src/main/mdo/plugin.mdo
+++ b/api/maven-api-plugin/src/main/mdo/plugin.mdo
@@ -212,7 +212,6 @@ under the License.
           <name>requiresDependencyResolution</name>
           <version>1.0.0/1.1.0</version>
           <type>String</type>
-          <defaultValue>runtime</defaultValue>
           <description>
             Flags this Mojo as requiring the dependencies in the specified class path to be resolved before it can
             execute: {@code compile}, {@code runtime}, {@code test},
@@ -223,7 +222,6 @@ under the License.
           <name>dependencyResolution</name>
           <version>2.0.0+</version>
           <type>String</type>
-          <defaultValue>runtime</defaultValue>
           <description>
             Flags this Mojo as requiring the dependencies in the specified class path to be resolved before it can
             execute: {@code compile}, {@code runtime}, {@code test},


### PR DESCRIPTION
JIRA issue: [MNG-8591](https://issues.apache.org/jira/browse/MNG-8591)
Fixes https://github.com/apache/maven-clean-plugin/issues/104

The cause is that Maven 3 has a hand-written parser for the plugin.xml. So while the schema was specifying a default value of `runtime`, this was not the one actually used, as the code was [only setting the value when something was specified in the xml](https://github.com/apache/maven/blob/4d00ebee3777c6567119d3a9baf035b13ba859de/maven-plugin-api/src/main/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilder.java#L178-L188).  Maven 4 now uses a modello generated reader which actually uses the default value which leads to the problem reported above.  Removing the default value from the schema will fix the problem and align the schema with the actual behavior in Maven 3.