### PR TITLE
[MNG-8595] Bump slf4jVersion from 2.0.16 to 2.0.17

### DIFF
--- a/apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
+++ b/apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
@@ -24,7 +24,7 @@ subject to the terms and conditions of the following licenses:
 ##
 #set ( $apacheMavenGroupIds = [ "org.apache.maven", "org.apache.maven.wagon", "org.apache.maven.resolver",
                                 "org.apache.maven.shared" ] )
-#set ( $MITLicenseNames = [ "MIT License", "MIT license", "The MIT License" ] )
+#set ( $MITLicenseNames = [ "MIT License", "MIT license", "The MIT License", "MIT" ] )
 #foreach ( $project in $projects )
 #**##foreach ( $license in $project.licenses )
 #*  *##set ( $groupId = $project.artifact.groupId )

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@ under the License.
     <resolverVersion>2.0.6</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
     <sisuVersion>0.9.0.M3</sisuVersion>
-    <slf4jVersion>2.0.16</slf4jVersion>
+    <slf4jVersion>2.0.17</slf4jVersion>
     <stax2ApiVersion>4.2.2</stax2ApiVersion>
     <wagonVersion>3.5.3</wagonVersion>
     <woodstoxVersion>7.1.0</woodstoxVersion>


### PR DESCRIPTION
Also adjust distro packaging, as license name changed from "MIT License" to "MIT".

---

https://issues.apache.org/jira/browse/MNG-8595