### PR TITLE
[MNG-8594] Add atFile option

### DIFF
--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
@@ -208,7 +208,9 @@ public interface MavenOptions extends Options {
     Optional<Boolean> ignoreTransitiveRepositories();
 
     /**
-     * Allows {@code @filename} to read options from file.
+     * Specifies "@file"-like file, to load up command line from. It may contain goals as well. Format is one parameter
+     * per line (similar to {@code maven.conf}) and {@code '#'} (hash) marked comment lines are allowed. Goals, if
+     * present, are appended, to those specified on CLI input, if any.
      */
     Optional<String> atFile();
 

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
@@ -208,6 +208,11 @@ public interface MavenOptions extends Options {
     Optional<Boolean> ignoreTransitiveRepositories();
 
     /**
+     * Allows {@code @filename} to read options from file.
+     */
+    Optional<String> atFile();
+
+    /**
      * Returns the list of goals and phases to execute.
      *
      * @return an {@link Optional} containing the list of goals and phases to execute, or empty if not specified

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LayeredOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LayeredOptions.java
@@ -181,7 +181,9 @@ public abstract class LayeredOptions<O extends Options> implements Options {
             Optional<Map<String, String>> up = getter.apply(option);
             if (up.isPresent()) {
                 had++;
-                items.putAll(up.get());
+                for (Map.Entry<String, String> entry : up.get().entrySet()) {
+                    items.putIfAbsent(entry.getKey(), entry.getValue());
+                }
             }
         }
         return had == 0 ? Optional.empty() : Optional.of(Map.copyOf(items));

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
@@ -387,7 +387,8 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
             options.addOption(Option.builder(AT_FILE)
                     .longOpt("at-file")
                     .hasArg()
-                    .desc("If set, Maven will load command line options from the specified file and merge with CLI specified ones.")
+                    .desc(
+                            "If set, Maven will load command line options from the specified file and merge with CLI specified ones.")
                     .build());
         }
     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
@@ -239,6 +239,14 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
     }
 
     @Override
+    public Optional<String> atFile() {
+        if (commandLine.hasOption(CLIManager.AT_FILE)) {
+            return Optional.of(commandLine.getOptionValue(CLIManager.AT_FILE));
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<List<String>> goals() {
         if (!commandLine.getArgList().isEmpty()) {
             return Optional.of(commandLine.getArgList());
@@ -273,6 +281,7 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
         public static final String CACHE_ARTIFACT_NOT_FOUND = "canf";
         public static final String STRICT_ARTIFACT_DESCRIPTOR_POLICY = "sadp";
         public static final String IGNORE_TRANSITIVE_REPOSITORIES = "itr";
+        public static final String AT_FILE = "af";
 
         @Override
         protected void prepareOptions(org.apache.commons.cli.Options options) {
@@ -374,6 +383,11 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
             options.addOption(Option.builder(IGNORE_TRANSITIVE_REPOSITORIES)
                     .longOpt("ignore-transitive-repositories")
                     .desc("If set, Maven will ignore remote repositories introduced by transitive dependencies.")
+                    .build());
+            options.addOption(Option.builder(AT_FILE)
+                    .longOpt("at-file")
+                    .hasArg()
+                    .desc("If set, Maven load and merge command line options from the file as well.")
                     .build());
         }
     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
@@ -387,7 +387,7 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
             options.addOption(Option.builder(AT_FILE)
                     .longOpt("at-file")
                     .hasArg()
-                    .desc("If set, Maven load and merge command line options from the file as well.")
+                    .desc("If set, Maven will load command line options from the specified file and merge with CLI specified ones.")
                     .build());
         }
     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/LayeredMavenOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/LayeredMavenOptions.java
@@ -155,6 +155,11 @@ public class LayeredMavenOptions<O extends MavenOptions> extends LayeredOptions<
     }
 
     @Override
+    public Optional<String> atFile() {
+        return returnFirstPresentOrEmpty(MavenOptions::atFile);
+    }
+
+    @Override
     public Optional<List<String>> goals() {
         return collectListIfPresentOrEmpty(MavenOptions::goals);
     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
@@ -45,7 +45,7 @@ public class MavenParser extends BaseParser {
             if (Files.isRegularFile(file)) {
                 result.add(parseMavenAtFileOptions(file));
             } else {
-                throw new IllegalArgumentException("Specified atFile does not exists (" + file + ")");
+                throw new IllegalArgumentException("Specified file does not exists (" + file + ")");
             }
         }
         // maven.config; if exists

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8594AtFileTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8594AtFileTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8594">MNG-8594</a>.
+ */
+class MavenITmng8594AtFileTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8594AtFileTest() {
+        super("[4.0.0-rc-3-SNAPSHOT,)");
+    }
+
+    /**
+     *  Verify Maven picks up params/goals from atFile.
+     */
+    @Test
+    void testIt() throws Exception {
+        Path basedir = extractResources("/mng-8594").getAbsoluteFile().toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("-af");
+        verifier.addCliArgument("cmd.txt");
+        verifier.addCliArgument("-Dcolor1=green");
+        verifier.addCliArgument("-Dcolor2=blue");
+        verifier.addCliArgument("clean");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // clean did run
+        verifier.verifyTextInLog("(default-clean) @ root");
+        // validate bound plugin did run
+        verifier.verifyTextInLog("(eval) @ root");
+
+        // validate properties
+        List<String> properties = verifier.loadLines("target/pom.properties");
+        assertTrue(properties.contains("session.executionProperties.color1=green")); // CLI only
+        assertTrue(properties.contains("session.executionProperties.color2=blue")); // both
+        assertTrue(properties.contains("session.executionProperties.color3=yellow")); // cmd.txt only
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -100,6 +100,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8594AtFileTest.class);
         suite.addTestSuite(MavenITmng8561SourceRootTest.class);
         suite.addTestSuite(MavenITmng8523ModelPropertiesTest.class);
         suite.addTestSuite(MavenITmng8527ConsumerPomTest.class);

--- a/its/core-it-suite/src/test/resources/mng-8594/cmd.txt
+++ b/its/core-it-suite/src/test/resources/mng-8594/cmd.txt
@@ -1,0 +1,3 @@
+validate
+-Dcolor2=gray
+-Dcolor3=yellow

--- a/its/core-it-suite/src/test/resources/mng-8594/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8594/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.it.mng8594</groupId>
+  <artifactId>root</artifactId>
+  <version>1.0.0</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <configuration>
+          <outputFile>target/pom.properties</outputFile>
+          <expressions>
+            <expression>session/executionProperties</expression>
+          </expressions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>eval</id>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Where user can create ad-hoc command line parms. The difference between .mvn/maven.conf and this file is that this file allows goals as well. The CLI and atFile are merged, in this order, hence, goals in atFile will come AFTER goals specified on CLI, if CLI has them.

Source order (first wins for options, while goals are collected/aggregated from sources):
* CLI
* atFile (if specified, may have goals that are appended)
* maven.config (if present, may not have goals)

Note: option is called `af` or long `at-file` for similarity with `javac @file`, but commons CLI does not support options without leading hyphen.

---

https://issues.apache.org/jira/browse/MNG-8594