### PR TITLE
[experiment] Mimir

### DIFF
--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -21,6 +21,6 @@ under the License.
   <extension>
     <groupId>eu.maveniverse.maven.mimir</groupId>
     <artifactId>extension3</artifactId>
-    <version>0.3.5</version>
+    <version>0.3.6</version>
   </extension>
 </extensions>

--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>eu.maveniverse.maven.mimir</groupId>
+    <artifactId>extension3</artifactId>
+    <version>0.3.4</version>
+  </extension>
+</extensions>

--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -20,7 +20,7 @@ under the License.
 <extensions>
   <extension>
     <groupId>eu.maveniverse.maven.mimir</groupId>
-    <artifactId>extension3</artifactId>
-    <version>0.3.6</version>
+    <artifactId>extension</artifactId>
+    <version>0.4.0</version>
   </extension>
 </extensions>

--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -21,6 +21,6 @@ under the License.
   <extension>
     <groupId>eu.maveniverse.maven.mimir</groupId>
     <artifactId>extension3</artifactId>
-    <version>0.3.4</version>
+    <version>0.3.5</version>
   </extension>
 </extensions>

--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <extensions>
   <extension>
     <groupId>eu.maveniverse.maven.mimir</groupId>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,10 +41,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Put extension.xml in place
+      - name: Put extensions.xml in place
         shell: bash
         run: |
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          mkdir ~/.mimir
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -107,10 +108,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Put extension.xml in place
+      - name: Put extensions.xml in place
         shell: bash
         run: |
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          mkdir ~/.mimir
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4
@@ -187,10 +189,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Put extension.xml in place
+      - name: Put extensions.xml in place
         shell: bash
         run: |
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          mkdir ~/.mimir
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,6 +41,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Put extension.xml in place
+        uses: canastro/copy-file-action@master
+        with:
+          source: .github/ci-extensions.xml
+          target: ~/.m2/extensions.xml
+
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
@@ -101,6 +107,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Put extension.xml in place
+        uses: canastro/copy-file-action@master
+        with:
+          source: .github/ci-extensions.xml
+          target: ~/.m2/extensions.xml
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4
@@ -176,6 +188,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Put extension.xml in place
+        uses: canastro/copy-file-action@master
+        with:
+          source: .github/ci-extensions.xml
+          target: ~/.m2/extensions.xml
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Build Maven and ITs and run them
         shell: bash
-        run: mvn install -DskipTests -e -B -V -Prun-its
+        run: mvn install -e -B -V -Prun-its
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Build Maven and ITs and run them
         shell: bash
-        run: mvn install -e -B -V -Prun-its
+        run: mvn install -e -B -V -Prun-its,mimir
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set up Maven
         shell: bash
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=4.0.0-rc-2"
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=4.0.0-rc-3"
 
       - name: Build Maven distributions
         shell: bash

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,10 +42,9 @@ jobs:
           persist-credentials: false
 
       - name: Put extension.xml in place
-        uses: canastro/copy-file-action@master
-        with:
-          source: .github/ci-extensions.xml
-          target: ~/.m2/extensions.xml
+        shell: bash
+        run: |
+          cp .github/ci-extensions.xml ~/.m2/extensions.xml
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -109,10 +108,9 @@ jobs:
           persist-credentials: false
 
       - name: Put extension.xml in place
-        uses: canastro/copy-file-action@master
-        with:
-          source: .github/ci-extensions.xml
-          target: ~/.m2/extensions.xml
+        shell: bash
+        run: |
+          cp .github/ci-extensions.xml ~/.m2/extensions.xml
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4
@@ -190,10 +188,9 @@ jobs:
           persist-credentials: false
 
       - name: Put extension.xml in place
-        uses: canastro/copy-file-action@master
-        with:
-          source: .github/ci-extensions.xml
-          target: ~/.m2/extensions.xml
+        shell: bash
+        run: |
+          cp .github/ci-extensions.xml ~/.m2/extensions.xml
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,21 +41,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Put extensions.xml in place
+      - name: Prepare Mimir
         shell: bash
         run: |
           mkdir -p ~/.m2
-          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
 
-      - name: Cache Maven packages
+      - name: Handle Mimir caches
         uses: actions/cache@v4
         with:
-          path: ~/.m2/repository/cached
-          key: maven-${{ runner.os }}-initial-${{ hashFiles('**/pom.xml') }}
+          path: ~/.mimir/local
+          key: mimir-${{ runner.os }}-initial-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-${{ runner.os }}-initial-
-            maven-${{ runner.os }}-
+            mimir-${{ runner.os }}-initial-
+            mimir-${{ runner.os }}-
 
       - name: Set up Maven
         shell: bash
@@ -63,7 +62,7 @@ jobs:
 
       - name: Build Maven distributions
         shell: bash
-        run: ./mvnw verify -e -B -V -Dmaven.repo.local=$HOME/.m2/repository/cached
+        run: ./mvnw verify -e -B -V
 
       - name: List contents of target directory
         shell: bash
@@ -109,12 +108,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Put extensions.xml in place
+      - name: Prepare Mimir
         shell: bash
         run: |
           mkdir -p ~/.m2
-          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+
+      - name: Handle Mimir caches
+        uses: actions/cache@v4
+        with:
+          path: ~/.mimir/local
+          key: mimir-${{ runner.os }}-full-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mimir-${{ runner.os }}-full-
+            mimir-${{ runner.os }}-
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4
@@ -143,26 +150,17 @@ jobs:
           echo "MAVEN_HOME=$PWD/maven-local" >> $GITHUB_ENV
           echo "$PWD/maven-local/bin" >> $GITHUB_PATH
 
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository/cached
-          key: maven-${{ runner.os }}-full-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-${{ runner.os }}-full-
-            maven-${{ runner.os }}-
-
       - name: Show IP
         shell: bash
         run: curl --silent https://api.ipify.org
 
       - name: Build with downloaded Maven
         shell: bash
-        run: mvn verify -e -B -V -Dmaven.repo.local=$HOME/.m2/repository/cached
+        run: mvn verify -e -B -V
 
       - name: Build site with downloaded Maven
         shell: bash
-        run: mvn site -e -B -V -Preporting -Dmaven.repo.local=$HOME/.m2/repository/cached
+        run: mvn site -e -B -V -Preporting
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
@@ -191,12 +189,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Put extensions.xml in place
+      - name: Prepare Mimir
         shell: bash
         run: |
           mkdir -p ~/.m2
-          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+
+      - name: Handle Mimir caches
+        uses: actions/cache@v4
+        with:
+          path: ~/.mimir/local
+          key: mimir-${{ runner.os }}-its-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mimir-${{ runner.os }}-its-
+            mimir-${{ runner.os }}-
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4
@@ -225,29 +231,13 @@ jobs:
           echo "MAVEN_HOME=$PWD/maven-local" >> $GITHUB_ENV
           echo "$PWD/maven-local/bin" >> $GITHUB_PATH
 
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository/cached
-          key: maven-${{ runner.os }}-its-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-${{ runner.os }}-its
-            maven-${{ runner.os }}-
-
       - name: Show IP
         shell: bash
         run: curl --silent https://api.ipify.org
 
-      # we use two steps so that we can cache artifacts downloaded from Maven Central repository
-      # without installing any local artifacts to not pollute the cache
-      - name: Build maven and ITs
+      - name: Build Maven and ITs and run them
         shell: bash
-        run: mvn package -DskipTests -e -B -V -Prun-its -Dmaven.repo.local=$HOME/.m2/repository/cached
-
-      # Now run tests and ITs using a separate local repo (using the previous filled repo as tail)
-      - name: Run integration tests
-        shell: bash
-        run: mvn install -e -B -V -Prun-its -Dmaven.repo.local=$HOME/.m2/repository/local -Dmaven.repo.local.tail=$HOME/.m2/repository/cached
+        run: mvn install -DskipTests -e -B -V -Prun-its
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,8 +44,9 @@ jobs:
       - name: Put extensions.xml in place
         shell: bash
         run: |
+          mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
-          mkdir ~/.mimir
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -111,8 +112,9 @@ jobs:
       - name: Put extensions.xml in place
         shell: bash
         run: |
+          mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
-          mkdir ~/.mimir
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4
@@ -192,8 +194,9 @@ jobs:
       - name: Put extensions.xml in place
         shell: bash
         run: |
+          mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
-          mkdir ~/.mimir
 
       - name: Download Maven distribution
         uses: actions/download-artifact@v4

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -67,6 +67,7 @@ under the License.
     <!-- The (possibly instrumented copy of the) Maven distribution we actually
       use for the tests. -->
     <preparedMavenHome>${mavenHome}</preparedMavenHome>
+    <preparedUserHome>${project.build.directory}/user-home</preparedUserHome>
     <!-- default properties used to filter the global settings -->
     <maven.it.central>https://repo.maven.apache.org/maven2</maven.it.central>
     <proxy.active>false</proxy.active>
@@ -518,7 +519,7 @@ under the License.
           <useSystemClassLoader>false</useSystemClassLoader>
           <promoteUserPropertiesToSystemProperties>false</promoteUserPropertiesToSystemProperties>
           <systemPropertyVariables>
-            <maven.test.user.home>${project.build.directory}/user-home</maven.test.user.home>
+            <maven.test.user.home>${preparedUserHome}</maven.test.user.home>
             <maven.test.repo.local>${settings.localRepository}</maven.test.repo.local>
             <maven.test.tmpdir>${project.build.testOutputDirectory}</maven.test.tmpdir>
             <maven.version>${maven.version}</maven.version>
@@ -540,8 +541,34 @@ under the License.
       </plugin>
     </plugins>
   </build>
-
   <profiles>
+    <profile>
+      <id>mimir</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>setup-mimir</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>process-test-resources</phase>
+                <configuration>
+                  <target>
+                    <delete dir="${preparedUserHome}" />
+                    <copy file="${session.rootDirectory}/.github/ci-extensions.xml" toFile="${preparedUserHome}/.m2/extensions.xml" />
+                    <copy file="${project.build.testOutputDirectory}/it-mimir.properties" toFile="${preparedUserHome}/.mimir/mimir.properties" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>parallel</id>
       <build>

--- a/its/core-it-suite/src/test/resources-filtered/it-mimir.properties
+++ b/its/core-it-suite/src/test/resources-filtered/it-mimir.properties
@@ -1,3 +1,5 @@
+# Used when profile "mimir" is activated
+
 # we change user.home in IT, so we want this interpolated
 mimir.daemon.socketPath=${user.home}/.mimir/mimir-socket
 # outer build already did this

--- a/its/core-it-suite/src/test/resources-filtered/it-mimir.properties
+++ b/its/core-it-suite/src/test/resources-filtered/it-mimir.properties
@@ -1,0 +1,6 @@
+# we change user.home in IT, so we want this interpolated
+mimir.daemon.socketPath=${user.home}/.mimir/mimir-socket
+# outer build already did this
+mimir.daemon.autoupdate=false
+# outer build already did this
+mimir.daemon.autostart=false

--- a/pom.xml
+++ b/pom.xml
@@ -767,9 +767,6 @@ under the License.</licenseText>
             <!-- Include generated sources in the sources JAR -->
             <excludeResources>false</excludeResources>
             <includePom>true</includePom>
-            <sources>
-              <source>${project.build.directory}/generated-sources/modello</source>
-            </sources>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
Use Maveniverse Mimir to cache central artifacts. This makes caching way simpler as well. Update Maven used to build to Maven 4.0.0-rc-3 as well.