### PR TITLE
[MNG-8599] Fix configuration for maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,9 +767,6 @@ under the License.</licenseText>
             <!-- Include generated sources in the sources JAR -->
             <excludeResources>false</excludeResources>
             <includePom>true</includePom>
-            <sources>
-              <source>${project.build.directory}/generated-sources/modello</source>
-            </sources>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
There is no sources parameter for maven-source-plugin

added in #2133

sources.jar still contains generated code 😄 