### PR TITLE
[MNG-8615] [MNG-8616] Maven core extensions handling improvements

### DIFF
--- a/api/maven-api-cli/pom.xml
+++ b/api/maven-api-cli/pom.xml
@@ -59,6 +59,8 @@
             <template>model.vm</template>
           </templates>
           <params>
+            <param>locationTracking=true</param>
+            <param>generateLocationClasses=true</param>
             <param>packageModelV4=org.apache.maven.api.cli.extensions</param>
             <param>packageToolV4=org.apache.maven.cli.internal.extension.io</param>
           </params>

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/CoreExtensions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/CoreExtensions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.api.cli;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.maven.api.Constants;
@@ -31,30 +32,16 @@ import static java.util.Objects.requireNonNull;
  * other logic than that is applied.
  *
  * @since 4.0.0
- * @param source The source of core extensions, is never {@code null}.
+ * @param source The source file of core extensions, is never {@code null}.
  * @param coreExtensions The configured core extensions, is never {@code null}. Contents of list is guaranteed to be unique by GA.
+ *
+ * @see Constants#MAVEN_PROJECT_EXTENSIONS
+ * @see Constants#MAVEN_USER_EXTENSIONS
+ * @see Constants#MAVEN_INSTALLATION_EXTENSIONS
  */
 @Experimental
-public record CoreExtensions(Source source, List<CoreExtension> coreExtensions) {
-    /**
-     * Represents the source of configured core extensions and their precedence.
-     */
-    public enum Source {
-        /**
-         * Value indicating that the source is project {@link Constants#MAVEN_PROJECT_EXTENSIONS}
-         */
-        PROJECT,
-        /**
-         * Value indicating that the source is user env {@link Constants#MAVEN_USER_EXTENSIONS}
-         */
-        USER,
-        /**
-         * Value indicating that the source is user env {@link Constants#MAVEN_INSTALLATION_EXTENSIONS}
-         */
-        INSTALLATION;
-    }
-
-    public CoreExtensions(Source source, List<CoreExtension> coreExtensions) {
+public record CoreExtensions(Path source, List<CoreExtension> coreExtensions) {
+    public CoreExtensions(Path source, List<CoreExtension> coreExtensions) {
         this.source = requireNonNull(source, "source");
         this.coreExtensions = requireNonNull(coreExtensions, "coreExtensions");
     }

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/CoreExtensions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/CoreExtensions.java
@@ -27,7 +27,8 @@ import org.apache.maven.api.cli.extensions.CoreExtension;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents the list of core extensions, that may be configured in various places.
+ * Represents the list of core extensions configured at one source. The list is validated (are GA unique), but no
+ * other logic than that is applied.
  *
  * @since 4.0.0
  * @param source The source of core extensions, is never {@code null}.

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/CoreExtensions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/CoreExtensions.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api.cli;
+
+import java.util.List;
+
+import org.apache.maven.api.Constants;
+import org.apache.maven.api.annotations.Experimental;
+import org.apache.maven.api.cli.extensions.CoreExtension;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents the list of core extensions, that may be configured in various places.
+ *
+ * @since 4.0.0
+ * @param source The source of core extensions, is never {@code null}.
+ * @param coreExtensions The configured core extensions, is never {@code null}. Contents of list is guaranteed to be unique by GA.
+ */
+@Experimental
+public record CoreExtensions(Source source, List<CoreExtension> coreExtensions) {
+    /**
+     * Represents the source of configured core extensions and their precedence.
+     */
+    public enum Source {
+        /**
+         * Value indicating that the source is project {@link Constants#MAVEN_PROJECT_EXTENSIONS}
+         */
+        PROJECT,
+        /**
+         * Value indicating that the source is user env {@link Constants#MAVEN_USER_EXTENSIONS}
+         */
+        USER,
+        /**
+         * Value indicating that the source is user env {@link Constants#MAVEN_INSTALLATION_EXTENSIONS}
+         */
+        INSTALLATION;
+    }
+
+    public CoreExtensions(Source source, List<CoreExtension> coreExtensions) {
+        this.source = requireNonNull(source, "source");
+        this.coreExtensions = requireNonNull(coreExtensions, "coreExtensions");
+    }
+}

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Immutable;
 import org.apache.maven.api.annotations.Nonnull;
-import org.apache.maven.api.cli.extensions.CoreExtension;
 import org.apache.maven.api.services.Lookup;
 import org.apache.maven.api.services.MessageBuilderFactory;
 
@@ -172,12 +171,12 @@ public interface InvokerRequest {
     }
 
     /**
-     * Returns a list of core extensions, if configured in the .mvn/extensions.xml file.
+     * Returns a list of core extensions.
      *
-     * @return an {@link Optional} containing the list of core extensions, or empty if not configured
+     * @return an {@link Optional} containing the {@link CoreExtensions}, or empty if not configured
      */
     @Nonnull
-    Optional<List<CoreExtension>> coreExtensions();
+    Optional<List<CoreExtensions>> coreExtensions();
 
     /**
      * Returns the options associated with this invocation request.

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
@@ -174,6 +174,8 @@ public interface InvokerRequest {
      * Returns a list of core extensions from all sources, that were discovered and loaded. Each instance of
      * {@link CoreExtensions} is validated, but the list elements may have overlapping elements, that requires
      * some logic to sort out (like precedence).
+     * <p>
+     * The list of {@link CoreExtensions} if present, is in precedence order.
      *
      * @return an {@link Optional} containing the {@link CoreExtensions}, or empty if not configured
      */

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/InvokerRequest.java
@@ -171,7 +171,9 @@ public interface InvokerRequest {
     }
 
     /**
-     * Returns a list of core extensions.
+     * Returns a list of core extensions from all sources, that were discovered and loaded. Each instance of
+     * {@link CoreExtensions} is validated, but the list elements may have overlapping elements, that requires
+     * some logic to sort out (like precedence).
      *
      * @return an {@link Optional} containing the {@link CoreExtensions}, or empty if not configured
      */

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/ParserRequest.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/ParserRequest.java
@@ -317,7 +317,7 @@ public interface ParserRequest {
                     command,
                     commandName,
                     List.copyOf(args),
-                    logger,
+                    lookup.lookupOptional(Logger.class).orElse(logger),
                     messageBuilderFactory,
                     lookup,
                     cwd,

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -60,6 +60,7 @@ import org.apache.maven.InternalErrorException;
 import org.apache.maven.Maven;
 import org.apache.maven.api.Constants;
 import org.apache.maven.api.cli.extensions.CoreExtension;
+import org.apache.maven.api.cli.extensions.InputSource;
 import org.apache.maven.api.services.MessageBuilder;
 import org.apache.maven.api.services.MessageBuilderFactory;
 import org.apache.maven.building.FileSource;
@@ -858,7 +859,9 @@ public class MavenCli {
             Path extensionsPath = Path.of(extensionsFile);
             if (Files.exists(extensionsPath)) {
                 try (InputStream is = Files.newInputStream(extensionsPath)) {
-                    return new CoreExtensionsStaxReader().read(is, true).getExtensions();
+                    return new CoreExtensionsStaxReader()
+                            .read(is, true, new InputSource(extensionsFile))
+                            .getExtensions();
                 }
             }
         }

--- a/impl/maven-cli/pom.xml
+++ b/impl/maven-cli/pom.xml
@@ -261,6 +261,7 @@ under the License.
           <params>
             <param>packageModelV4=org.apache.maven.api.cli.extensions</param>
             <param>packageToolV4=org.apache.maven.cling.internal.extension.io</param>
+            <param>locationTracking=true</param>
           </params>
           <velocityBasedir>${project.basedir}/../../src/mdo</velocityBasedir>
         </configuration>

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
@@ -132,7 +132,7 @@ public class BootstrapCoreExtensionManager {
         this.interpolator = interpolator;
     }
 
-    public List<CoreExtensionEntry> loadCoreExtensions(
+    public List<LoadedCoreExtension> loadCoreExtensions(
             MavenExecutionRequest request, Set<String> providedArtifacts, List<CoreExtension> extensions)
             throws Exception {
         try (CloseableSession repoSession = repositorySystemSessionFactory
@@ -150,14 +150,14 @@ public class BootstrapCoreExtensionManager {
         }
     }
 
-    private List<CoreExtensionEntry> resolveCoreExtensions(
+    private List<LoadedCoreExtension> resolveCoreExtensions(
             RepositorySystemSession repoSession,
             List<RemoteRepository> repositories,
             Set<String> providedArtifacts,
             List<CoreExtension> configuration,
             UnaryOperator<String> interpolator)
             throws Exception {
-        List<CoreExtensionEntry> extensions = new ArrayList<>();
+        List<LoadedCoreExtension> extensions = new ArrayList<>();
 
         DependencyFilter dependencyFilter = new ExclusionsDependencyFilter(providedArtifacts);
 
@@ -165,7 +165,7 @@ public class BootstrapCoreExtensionManager {
             List<Artifact> artifacts =
                     resolveExtension(extension, repoSession, repositories, dependencyFilter, interpolator);
             if (!artifacts.isEmpty()) {
-                extensions.add(createExtension(extension, artifacts));
+                extensions.add(new LoadedCoreExtension(extension, createExtension(extension, artifacts)));
             }
         }
 

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/LoadedCoreExtension.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/LoadedCoreExtension.java
@@ -16,17 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.maven.cling.extensions;
+
+import org.apache.maven.api.cli.extensions.CoreExtension;
+import org.apache.maven.extension.internal.CoreExtensionEntry;
 
 /**
- * Provides support for Maven core extensions configuration and management.
- *
- * <p>This package contains classes for:</p>
- * <ul>
- *   <li>Extension configuration model</li>
- *   <li>Extension loading and validation</li>
- *   <li>Extension lifecycle management</li>
- * </ul>
- *
- * @since 4.0.0
+ * Represents a core extension that has been selected to be loaded.
+ * @param coreExtension The extension configuration entry with location tracking.
+ * @param entry The loaded entry with descriptor.
  */
-package org.apache.maven.api.cli.extensions;
+public record LoadedCoreExtension(CoreExtension coreExtension, CoreExtensionEntry entry) {}

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseInvokerRequest.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseInvokerRequest.java
@@ -25,9 +25,9 @@ import java.util.Optional;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.annotations.Nullable;
+import org.apache.maven.api.cli.CoreExtensions;
 import org.apache.maven.api.cli.InvokerRequest;
 import org.apache.maven.api.cli.ParserRequest;
-import org.apache.maven.api.cli.extensions.CoreExtension;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,7 +41,7 @@ public abstract class BaseInvokerRequest implements InvokerRequest {
     private final Map<String, String> systemProperties;
     private final Path topDirectory;
     private final Path rootDirectory;
-    private final List<CoreExtension> coreExtensions;
+    private final List<CoreExtensions> coreExtensions;
 
     @SuppressWarnings("ParameterNumber")
     public BaseInvokerRequest(
@@ -54,7 +54,7 @@ public abstract class BaseInvokerRequest implements InvokerRequest {
             @Nonnull Map<String, String> systemProperties,
             @Nonnull Path topDirectory,
             @Nullable Path rootDirectory,
-            @Nullable List<CoreExtension> coreExtensions) {
+            @Nullable List<CoreExtensions> coreExtensions) {
         this.parserRequest = requireNonNull(parserRequest);
         this.parsingFailed = parsingFailed;
         this.cwd = requireNonNull(cwd);
@@ -114,7 +114,7 @@ public abstract class BaseInvokerRequest implements InvokerRequest {
     }
 
     @Override
-    public Optional<List<CoreExtension>> coreExtensions() {
+    public Optional<List<CoreExtensions>> coreExtensions() {
         return Optional.ofNullable(coreExtensions);
     }
 }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -431,27 +431,36 @@ public abstract class BaseParser implements Parser {
 
     protected abstract Options assembleOptions(List<Options> parsedOptions);
 
+    /**
+     * Important: This method must return list of {@link CoreExtensions} in precedence order.
+     */
     protected List<CoreExtensions> readCoreExtensionsDescriptor(LocalContext context) {
         ArrayList<CoreExtensions> result = new ArrayList<>();
+        Path file;
         List<CoreExtension> loaded;
 
-        loaded = readCoreExtensionsDescriptorFromFile(context.installationDirectory.resolve(
-                context.userProperties.get(Constants.MAVEN_INSTALLATION_EXTENSIONS)));
+        // project
+        file = context.cwd.resolve(context.userProperties.get(Constants.MAVEN_PROJECT_EXTENSIONS));
+        loaded = readCoreExtensionsDescriptorFromFile(file);
         if (!loaded.isEmpty()) {
-            result.add(new CoreExtensions(CoreExtensions.Source.INSTALLATION, loaded));
+            result.add(new CoreExtensions(file, loaded));
         }
 
-        loaded = readCoreExtensionsDescriptorFromFile(
-                context.userHomeDirectory.resolve(context.userProperties.get(Constants.MAVEN_USER_EXTENSIONS)));
+        // user
+        file = context.userHomeDirectory.resolve(context.userProperties.get(Constants.MAVEN_USER_EXTENSIONS));
+        loaded = readCoreExtensionsDescriptorFromFile(file);
         if (!loaded.isEmpty()) {
-            result.add(new CoreExtensions(CoreExtensions.Source.USER, loaded));
+            result.add(new CoreExtensions(file, loaded));
         }
 
-        loaded = readCoreExtensionsDescriptorFromFile(
-                context.cwd.resolve(context.userProperties.get(Constants.MAVEN_PROJECT_EXTENSIONS)));
+        // installation
+        file = context.installationDirectory.resolve(
+                context.userProperties.get(Constants.MAVEN_INSTALLATION_EXTENSIONS));
+        loaded = readCoreExtensionsDescriptorFromFile(file);
         if (!loaded.isEmpty()) {
-            result.add(new CoreExtensions(CoreExtensions.Source.PROJECT, loaded));
+            result.add(new CoreExtensions(file, loaded));
         }
+
         return result.isEmpty() ? null : result;
     }
 

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -461,7 +461,7 @@ public abstract class BaseParser implements Parser {
             result.add(new CoreExtensions(file, loaded));
         }
 
-        return result.isEmpty() ? null : result;
+        return result.isEmpty() ? null : List.copyOf(result);
     }
 
     protected List<CoreExtension> readCoreExtensionsDescriptorFromFile(Path extensionsFile) {
@@ -470,9 +470,9 @@ public abstract class BaseParser implements Parser {
                 try (InputStream is = Files.newInputStream(extensionsFile)) {
                     return validateCoreExtensionsDescriptorFromFile(
                             extensionsFile,
-                            new CoreExtensionsStaxReader()
+                            List.copyOf(new CoreExtensionsStaxReader()
                                     .read(is, true, new InputSource(extensionsFile.toString()))
-                                    .getExtensions());
+                                    .getExtensions()));
                 }
             }
             return List.of();

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -34,14 +34,18 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import org.apache.maven.api.Constants;
 import org.apache.maven.api.annotations.Nullable;
+import org.apache.maven.api.cli.CoreExtensions;
 import org.apache.maven.api.cli.InvokerRequest;
 import org.apache.maven.api.cli.Options;
 import org.apache.maven.api.cli.Parser;
 import org.apache.maven.api.cli.ParserRequest;
 import org.apache.maven.api.cli.extensions.CoreExtension;
+import org.apache.maven.api.cli.extensions.InputLocation;
+import org.apache.maven.api.cli.extensions.InputSource;
 import org.apache.maven.api.services.Interpolator;
 import org.apache.maven.cling.internal.extension.io.CoreExtensionsStaxReader;
 import org.apache.maven.cling.props.MavenPropertiesLoader;
@@ -79,7 +83,9 @@ public abstract class BaseParser implements Parser {
         @Nullable
         public Path rootDirectory;
 
-        public List<CoreExtension> extensions;
+        @Nullable
+        public List<CoreExtensions> extensions;
+
         public Options options;
 
         public Map<String, String> extraInterpolationSource() {
@@ -425,59 +431,64 @@ public abstract class BaseParser implements Parser {
 
     protected abstract Options assembleOptions(List<Options> parsedOptions);
 
-    protected List<CoreExtension> readCoreExtensionsDescriptor(LocalContext context) {
-        String installationExtensionsFile = context.userProperties.get(Constants.MAVEN_INSTALLATION_EXTENSIONS);
-        ArrayList<CoreExtension> installationExtensions = new ArrayList<>(readCoreExtensionsDescriptorFromFile(
-                context.installationDirectory.resolve(installationExtensionsFile)));
+    protected List<CoreExtensions> readCoreExtensionsDescriptor(LocalContext context) {
+        ArrayList<CoreExtensions> result = new ArrayList<>();
+        List<CoreExtension> loaded;
 
-        String userExtensionsFile = context.userProperties.get(Constants.MAVEN_USER_EXTENSIONS);
-        ArrayList<CoreExtension> userExtensions = new ArrayList<>(
-                readCoreExtensionsDescriptorFromFile(context.userHomeDirectory.resolve(userExtensionsFile)));
-
-        String projectExtensionsFile = context.userProperties.get(Constants.MAVEN_PROJECT_EXTENSIONS);
-        ArrayList<CoreExtension> projectExtensions =
-                new ArrayList<>(readCoreExtensionsDescriptorFromFile(context.cwd.resolve(projectExtensionsFile)));
-
-        // merge these 3 but check for GA uniqueness; we don't want to load up same extension w/ different Vs
-        HashMap<String, String> gas = new HashMap<>();
-        ArrayList<String> conflicts = new ArrayList<>();
-
-        ArrayList<CoreExtension> coreExtensions =
-                new ArrayList<>(installationExtensions.size() + userExtensions.size() + projectExtensions.size());
-        coreExtensions.addAll(mergeExtensions(installationExtensions, installationExtensionsFile, gas, conflicts));
-        coreExtensions.addAll(mergeExtensions(userExtensions, userExtensionsFile, gas, conflicts));
-        coreExtensions.addAll(mergeExtensions(projectExtensions, projectExtensionsFile, gas, conflicts));
-
-        if (!conflicts.isEmpty()) {
-            throw new IllegalStateException("Extension conflicts: " + String.join("; ", conflicts));
+        loaded = readCoreExtensionsDescriptorFromFile(context.installationDirectory.resolve(
+                context.userProperties.get(Constants.MAVEN_INSTALLATION_EXTENSIONS)));
+        if (!loaded.isEmpty()) {
+            result.add(new CoreExtensions(CoreExtensions.Source.INSTALLATION, loaded));
         }
 
-        return coreExtensions;
-    }
-
-    private List<CoreExtension> mergeExtensions(
-            List<CoreExtension> extensions, String extensionsSource, Map<String, String> gas, List<String> conflicts) {
-        for (CoreExtension extension : extensions) {
-            String ga = extension.getGroupId() + ":" + extension.getArtifactId();
-            if (gas.containsKey(ga)) {
-                conflicts.add(ga + " from " + extensionsSource + " already specified in " + gas.get(ga));
-            } else {
-                gas.put(ga, extensionsSource);
-            }
+        loaded = readCoreExtensionsDescriptorFromFile(
+                context.userHomeDirectory.resolve(context.userProperties.get(Constants.MAVEN_USER_EXTENSIONS)));
+        if (!loaded.isEmpty()) {
+            result.add(new CoreExtensions(CoreExtensions.Source.USER, loaded));
         }
-        return extensions;
+
+        loaded = readCoreExtensionsDescriptorFromFile(
+                context.cwd.resolve(context.userProperties.get(Constants.MAVEN_PROJECT_EXTENSIONS)));
+        if (!loaded.isEmpty()) {
+            result.add(new CoreExtensions(CoreExtensions.Source.PROJECT, loaded));
+        }
+        return result.isEmpty() ? null : result;
     }
 
     protected List<CoreExtension> readCoreExtensionsDescriptorFromFile(Path extensionsFile) {
         try {
             if (extensionsFile != null && Files.exists(extensionsFile)) {
                 try (InputStream is = Files.newInputStream(extensionsFile)) {
-                    return new CoreExtensionsStaxReader().read(is, true).getExtensions();
+                    return validateCoreExtensionsDescriptorFromFile(
+                            extensionsFile,
+                            new CoreExtensionsStaxReader()
+                                    .read(is, true, new InputSource(extensionsFile.toString()))
+                                    .getExtensions());
                 }
             }
             return List.of();
         } catch (XMLStreamException | IOException e) {
             throw new IllegalArgumentException("Failed to parse extensions file: " + extensionsFile, e);
         }
+    }
+
+    protected List<CoreExtension> validateCoreExtensionsDescriptorFromFile(
+            Path extensionFile, List<CoreExtension> coreExtensions) {
+        Map<String, List<InputLocation>> gasLocations = new HashMap<>();
+        for (CoreExtension coreExtension : coreExtensions) {
+            String ga = coreExtension.getGroupId() + ":" + coreExtension.getArtifactId();
+            InputLocation location = coreExtension.getLocation("");
+            gasLocations.computeIfAbsent(ga, k -> new ArrayList<>()).add(location);
+        }
+        if (gasLocations.values().stream().noneMatch(l -> l.size() > 1)) {
+            return coreExtensions;
+        }
+        throw new IllegalStateException("Extension conflicts in file " + extensionFile + ": "
+                + gasLocations.entrySet().stream()
+                        .map(e -> e.getKey() + " defined on lines "
+                                + e.getValue().stream()
+                                        .map(l -> String.valueOf(l.getLineNumber()))
+                                        .collect(Collectors.joining(", ")))
+                        .collect(Collectors.joining("; ")));
     }
 }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CoreExtensionSelector.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CoreExtensionSelector.java
@@ -18,18 +18,21 @@
  */
 package org.apache.maven.cling.invoker;
 
+import java.util.List;
+
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.cli.InvokerRequest;
+import org.apache.maven.api.cli.extensions.CoreExtension;
 
 /**
- * Container capsule factory.
+ * Core extension selector: selects which entries to load from {@link InvokerRequest#coreExtensions()}.
  *
  * @param <C> The context type.
  */
-public interface ContainerCapsuleFactory<C extends LookupContext> {
+public interface CoreExtensionSelector<C extends LookupContext> {
     /**
-     * Creates container capsule.
+     * Selects core extensions to be loaded from list of all sources detected.
      */
     @Nonnull
-    ContainerCapsule createContainerCapsule(
-            LookupInvoker<C> invoker, C context, CoreExtensionSelector<C> coreExtensionSelector) throws Exception;
+    List<CoreExtension> selectCoreExtensions(LookupInvoker<C> invoker, C context);
 }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -503,12 +503,17 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
 
     protected void container(C context) throws Exception {
         if (context.lookup == null) {
-            context.containerCapsule = createContainerCapsuleFactory().createContainerCapsule(this, context);
+            context.containerCapsule = createContainerCapsuleFactory()
+                    .createContainerCapsule(this, context, createCoreExtensionSelector());
             context.closeables.add(context::closeContainer);
             context.lookup = context.containerCapsule.getLookup();
         } else {
             context.containerCapsule.updateLogging(context);
         }
+    }
+
+    protected CoreExtensionSelector<C> createCoreExtensionSelector() {
+        return new PrecedenceCoreExtensionSelector<>();
     }
 
     protected ContainerCapsuleFactory<C> createContainerCapsuleFactory() {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
@@ -132,7 +132,8 @@ public class PlexusContainerCapsuleFactory<C extends LookupContext> implements C
                     new ExtensionConfigurationModule(extension, extensionSource));
         }
         if (!throwables.isEmpty()) {
-            IllegalStateException mavenDiFailed = new IllegalStateException("Maven dependency injection failed for at least one of the registered core extension");
+            IllegalStateException mavenDiFailed = new IllegalStateException(
+                    "Maven dependency injection failed for at least one of the registered core extension");
             throwables.forEach(mavenDiFailed::addSuppressed);
             throw mavenDiFailed;
         }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
@@ -273,6 +273,9 @@ public class PlexusContainerCapsuleFactory<C extends LookupContext> implements C
             Set<String> providedArtifacts,
             List<CoreExtension> extensions)
             throws Exception {
+        if (extensions.isEmpty()) {
+            return List.of();
+        }
         ContainerConfiguration cc = new DefaultContainerConfiguration()
                 .setClassWorld(containerRealm.getWorld())
                 .setRealm(containerRealm)

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
@@ -132,7 +132,7 @@ public class PlexusContainerCapsuleFactory<C extends LookupContext> implements C
                     new ExtensionConfigurationModule(extension, extensionSource));
         }
         if (!throwables.isEmpty()) {
-            IllegalStateException mavenDiFailed = new IllegalStateException("Maven DI failed");
+            IllegalStateException mavenDiFailed = new IllegalStateException("Maven dependency injection failed for at least one of the registered core extension");
             throwables.forEach(mavenDiFailed::addSuppressed);
             throw mavenDiFailed;
         }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
@@ -67,6 +67,7 @@ import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.slf4j.ILoggerFactory;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.maven.cling.invoker.Utils.toPlexusLoggingLevel;
 
 /**
@@ -77,12 +78,14 @@ import static org.apache.maven.cling.invoker.Utils.toPlexusLoggingLevel;
 public class PlexusContainerCapsuleFactory<C extends LookupContext> implements ContainerCapsuleFactory<C> {
     @Override
     public ContainerCapsule createContainerCapsule(LookupInvoker<C> invoker, C context) throws Exception {
+        requireNonNull(invoker, "invoker");
+        requireNonNull(context, "context");
         return new PlexusContainerCapsule(
                 context, Thread.currentThread().getContextClassLoader(), container(invoker, context));
     }
 
     protected DefaultPlexusContainer container(LookupInvoker<C> invoker, C context) throws Exception {
-        ClassWorld classWorld = invoker.protoLookup.lookup(ClassWorld.class);
+        ClassWorld classWorld = requireNonNull(invoker.protoLookup.lookup(ClassWorld.class), "classWorld");
         ClassRealm coreRealm = classWorld.getClassRealm("plexus.core");
         List<Path> extClassPath = parseExtClasspath(context);
         CoreExtensionEntry coreEntry = CoreExtensionEntry.discoverFrom(coreRealm);

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PrecedenceCoreExtensionSelector.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PrecedenceCoreExtensionSelector.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.maven.api.cli.CoreExtensions;
+import org.apache.maven.api.cli.InvokerRequest;
+import org.apache.maven.api.cli.extensions.CoreExtension;
+import org.apache.maven.api.cli.extensions.InputLocation;
+
+public class PrecedenceCoreExtensionSelector<C extends LookupContext> implements CoreExtensionSelector<C> {
+    @Override
+    public List<CoreExtension> selectCoreExtensions(LookupInvoker<C> invoker, C context) {
+        InvokerRequest invokerRequest = context.invokerRequest;
+        if (invokerRequest.coreExtensions().isEmpty()
+                || invokerRequest.coreExtensions().get().isEmpty()) {
+            return List.of();
+        }
+
+        return selectCoreExtensions(
+                context, context.invokerRequest.coreExtensions().orElseThrow());
+    }
+
+    /**
+     * Selects extensions to load discovered from various sources. Also reports conflicts.
+     */
+    protected List<CoreExtension> selectCoreExtensions(C context, List<CoreExtensions> configuredCoreExtensions) {
+        context.logger.debug("Configured core extensions:");
+        for (CoreExtensions source : configuredCoreExtensions) {
+            context.logger.debug("* " + source.source() + ":");
+            for (CoreExtension extension : source.coreExtensions()) {
+                context.logger.debug("  - " + extension.getId() + " -> " + formatLocation(extension.getLocation("")));
+            }
+        }
+
+        Map<CoreExtensions.Source, CoreExtensions> coreExtensionsBySource = configuredCoreExtensions.stream()
+                .collect(Collectors.toMap(CoreExtensions::source, Function.identity()));
+        LinkedHashMap<String, CoreExtension> selectedExtensions = new LinkedHashMap<>();
+        List<String> conflicts = new ArrayList<>();
+        for (CoreExtensions.Source source : CoreExtensions.Source.values()) {
+            CoreExtensions coreExtensions = coreExtensionsBySource.get(source);
+            if (coreExtensions != null) {
+                for (CoreExtension coreExtension : coreExtensions.coreExtensions()) {
+                    String key = coreExtension.getGroupId() + ":" + coreExtension.getArtifactId();
+                    CoreExtension conflict = selectedExtensions.putIfAbsent(key, coreExtension);
+                    if (conflict != null) {
+                        conflicts.add(String.format(
+                                "Conflicting extension %s: %s vs %s",
+                                key,
+                                formatLocation(conflict.getLocation("")),
+                                formatLocation(coreExtension.getLocation(""))));
+                    }
+                }
+            }
+        }
+        if (!conflicts.isEmpty()) {
+            context.logger.warn("Found " + conflicts.size() + " extension conflict(s):");
+            for (String conflict : conflicts) {
+                context.logger.warn("* " + conflict);
+            }
+            context.logger.warn("");
+            context.logger.warn(
+                    "Order of core extensions precedence is project > user > installation. Selected extensions are:");
+            for (CoreExtension extension : selectedExtensions.values()) {
+                context.logger.warn(
+                        "* " + extension.getId() + " configured in " + formatLocation(extension.getLocation("")));
+            }
+        }
+
+        context.logger.debug("Selected core extensions:");
+        for (CoreExtension source : selectedExtensions.values()) {
+            context.logger.debug("* " + source.getId() + ": " + formatLocation(source.getLocation("")));
+        }
+        return List.copyOf(selectedExtensions.values());
+    }
+
+    protected String formatLocation(InputLocation location) {
+        return location.getSource().getLocation() + ":" + location.getLineNumber();
+    }
+}

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvokerRequest.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvokerRequest.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.cli.CoreExtensions;
 import org.apache.maven.api.cli.ParserRequest;
-import org.apache.maven.api.cli.extensions.CoreExtension;
 import org.apache.maven.api.cli.mvn.MavenOptions;
 import org.apache.maven.cling.invoker.BaseInvokerRequest;
 
@@ -47,7 +47,7 @@ public class MavenInvokerRequest extends BaseInvokerRequest {
             Map<String, String> systemProperties,
             Path topDirectory,
             Path rootDirectory,
-            List<CoreExtension> coreExtensions,
+            List<CoreExtensions> coreExtensions,
             MavenOptions options) {
         super(
                 parserRequest,

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/EncryptInvokerRequest.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/EncryptInvokerRequest.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.cli.CoreExtensions;
 import org.apache.maven.api.cli.ParserRequest;
-import org.apache.maven.api.cli.extensions.CoreExtension;
 import org.apache.maven.api.cli.mvnenc.EncryptOptions;
 import org.apache.maven.cling.invoker.BaseInvokerRequest;
 
@@ -44,7 +44,7 @@ public class EncryptInvokerRequest extends BaseInvokerRequest {
             Map<String, String> systemProperties,
             Path topDirectory,
             Path rootDirectory,
-            List<CoreExtension> coreExtensions,
+            List<CoreExtensions> coreExtensions,
             EncryptOptions options) {
         super(
                 parserRequest,

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/ShellInvokerRequest.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/ShellInvokerRequest.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.cli.CoreExtensions;
 import org.apache.maven.api.cli.ParserRequest;
-import org.apache.maven.api.cli.extensions.CoreExtension;
 import org.apache.maven.api.cli.mvnsh.ShellOptions;
 import org.apache.maven.cling.invoker.BaseInvokerRequest;
 
@@ -44,7 +44,7 @@ public class ShellInvokerRequest extends BaseInvokerRequest {
             Map<String, String> systemProperties,
             Path topDirectory,
             Path rootDirectory,
-            List<CoreExtension> coreExtensions,
+            List<CoreExtensions> coreExtensions,
             ShellOptions options) {
         super(
                 parserRequest,

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -144,8 +144,10 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
         Path userExtensions = userConf.resolve("extensions.xml");
         Files.writeString(userExtensions, extensionsXml);
 
+        // this should not throw
         assertDoesNotThrow(() -> invoke(cwd, userHome, List.of("validate"), List.of()));
-        // TODO: but warns
+        // but warn
+
         // [main] WARNING org.apache.maven.cling.invoker.PlexusContainerCapsuleFactory - Found 1 extension conflict(s):
         // [main] WARNING org.apache.maven.cling.invoker.PlexusContainerCapsuleFactory - * Conflicting extension
         // eu.maveniverse.maven.mimir:extension3: /tmp/junit-191051426131307150/.mvn/extensions.xml:3 vs

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -112,9 +112,7 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
         Path userExtensions = userConf.resolve("extensions.xml");
         Files.writeString(userExtensions, userExtensionsXml);
 
-        InvokerException e =
-                assertThrows(InvokerException.class, () -> invoke(cwd, userHome, List.of("validate"), List.of()));
-        System.out.println(e.getMessage());
+        assertThrows(InvokerException.class, () -> invoke(cwd, userHome, List.of("validate"), List.of()));
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -48,10 +48,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Order(200)
 public class MavenInvokerTest extends MavenInvokerTestSupport {
     @Override
-    protected Invoker createInvoker() {
-        return new MavenInvoker(ProtoLookup.builder()
-                .addMapping(ClassWorld.class, new ClassWorld("plexus.core", ClassLoader.getSystemClassLoader()))
-                .build());
+    protected Invoker createInvoker(ClassWorld classWorld) {
+        return new MavenInvoker(
+                ProtoLookup.builder().addMapping(ClassWorld.class, classWorld).build());
     }
 
     @Override

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -80,14 +80,14 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <extensions>
                     <extension>
-                        <groupId>eu.maveniverse.maven.mimir</groupId>
-                        <artifactId>extension3</artifactId>
-                        <version>0.3.4</version>
+                        <groupId>io.takari.maven</groupId>
+                        <artifactId>takari-smart-builder</artifactId>
+                        <version>1.0.2</version>
                     </extension>
                     <extension>
-                        <groupId>eu.maveniverse.maven.mimir</groupId>
-                        <artifactId>extension3</artifactId>
-                        <version>0.3.3</version>
+                        <groupId>io.takari.maven</groupId>
+                        <artifactId>takari-smart-builder</artifactId>
+                        <version>1.0.1</version>
                     </extension>
                 </extensions>
                 """;
@@ -101,9 +101,9 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <extensions>
                     <extension>
-                        <groupId>eu.maveniverse.maven.mimir</groupId>
-                        <artifactId>extension3</artifactId>
-                        <version>0.3.4</version>
+                        <groupId>io.takari.maven</groupId>
+                        <artifactId>takari-smart-builder</artifactId>
+                        <version>1.0.2</version>
                     </extension>
                 </extensions>
                 """;
@@ -128,9 +128,9 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <extensions>
                     <extension>
-                        <groupId>eu.maveniverse.maven.mimir</groupId>
-                        <artifactId>extension3</artifactId>
-                        <version>0.3.4</version>
+                        <groupId>io.takari.maven</groupId>
+                        <artifactId>takari-smart-builder</artifactId>
+                        <version>1.0.2</version>
                     </extension>
                 </extensions>
                 """;

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
@@ -32,6 +32,7 @@ import org.apache.maven.api.cli.Invoker;
 import org.apache.maven.api.cli.Parser;
 import org.apache.maven.api.cli.ParserRequest;
 import org.apache.maven.jline.JLineMessageBuilderFactory;
+import org.codehaus.plexus.classworlds.ClassWorld;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -99,7 +100,8 @@ public abstract class MavenInvokerTestSupport {
 
         HashMap<String, String> logs = new HashMap<>();
         Parser parser = createParser();
-        try (Invoker invoker = createInvoker()) {
+        try (ClassWorld classWorld = createClassWorld();
+                Invoker invoker = createInvoker(classWorld)) {
             for (String goal : goals) {
                 ByteArrayOutputStream stdout = new ByteArrayOutputStream();
                 ByteArrayOutputStream stderr = new ByteArrayOutputStream();
@@ -134,7 +136,11 @@ public abstract class MavenInvokerTestSupport {
         return logs;
     }
 
-    protected abstract Invoker createInvoker();
+    protected ClassWorld createClassWorld() {
+        return new ClassWorld("plexus.core", ClassLoader.getSystemClassLoader());
+    }
+
+    protected abstract Invoker createInvoker(ClassWorld classWorld);
 
     protected abstract Parser createParser();
 }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvokerTest.java
@@ -43,10 +43,9 @@ import org.junit.jupiter.api.io.TempDir;
 public class ResidentMavenInvokerTest extends MavenInvokerTestSupport {
 
     @Override
-    protected Invoker createInvoker() {
-        return new ResidentMavenInvoker(ProtoLookup.builder()
-                .addMapping(ClassWorld.class, new ClassWorld("plexus.core", ClassLoader.getSystemClassLoader()))
-                .build());
+    protected Invoker createInvoker(ClassWorld classWorld) {
+        return new ResidentMavenInvoker(
+                ProtoLookup.builder().addMapping(ClassWorld.class, classWorld).build());
     }
 
     @Override


### PR DESCRIPTION
It all started with MNG-8615 to not swallow DI problems while loading core extensions. Then tried to add origin as well, but it turns out there is lack of context. Then turned out models are not location tracking. Then came MNG-8616 as Maven was too rigid and did not apply precedence for extensions making project hopping problematic, if not impossible...

Changes:
* do not swallow DI issues happened during core extension loading; belly up instead.
* report which extension caused DI issue
* make core extension models and IO location tracking
* alter CLI api to carry all extensions "by origin" (project, user, installation)
* parser should be plain dumb, all it does is load extensions in precedence order and validates them (validity: they must be GA unique)
* DI capsule performs now "selection" of extensions (based on precedence) and loads them as before
* finally: we have now DEBUG logs which all extensions were considered and which were effectively loaded, something I missed a lot
* new UTs revealed MavenInvokerUT problem: ClassWorlds were not cleaned up properly

Behavioural change since 4.0.0-rc-3:
* conflict within same source (same file) makes Maven fail - as before
* conflict spanning across sources is warning only; precedence is applied to select extension to be loaded

---

https://issues.apache.org/jira/browse/MNG-8615
https://issues.apache.org/jira/browse/MNG-8616