### PR TITLE
Replace a `NullPointerException` by a more explicit error message

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
@@ -99,6 +99,13 @@ public enum DependencyScope {
     private static final Map<String, DependencyScope> IDS = Collections.unmodifiableMap(
             Stream.of(DependencyScope.values()).collect(Collectors.toMap(s -> s.id, s -> s)));
 
+    /**
+     * {@return the dependency scope for the given identifier, or {@code null} if none}.
+     * The identifiers are usually in lower cases with {@code '-'} instead of {@code '_'}
+     * as word separator.
+     *
+     * @param id the identifier of the scope (case-sensitive)
+     */
     public static DependencyScope forId(String id) {
         return IDS.get(id);
     }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
@@ -833,7 +833,11 @@ public interface Session extends ProtoSession {
     /**
      * Obtain the {@link DependencyScope} from the specified {@code id}.
      * <p>
-     * Shortcut for {@code DependencyScope.forId(...)}.
+     * Shortcut for {@code DependencyScope.forId(...)} with a verification that the given identifier exists.
+     *
+     * @param id the identifier of the scope (case-sensitive)
+     * @return the scope for the given identifier (never null)
+     * @throws IllegalArgumentException if the given identifier is not a known scope
      *
      * @see org.apache.maven.api.DependencyScope#forId(String)
      */

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
@@ -243,7 +243,10 @@ public class DefaultProject implements Project {
             @Nonnull
             @Override
             public DependencyScope getScope() {
-                String scope = dependency.getScope() != null ? dependency.getScope() : "";
+                String scope = dependency.getScope();
+                if (scope == null) {
+                    scope = "";
+                }
                 return session.requireDependencyScope(scope);
             }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
@@ -967,7 +967,11 @@ public abstract class AbstractSession implements InternalSession {
 
     @Override
     public DependencyScope requireDependencyScope(String id) {
-        return DependencyScope.forId(nonNull(id, "id"));
+        DependencyScope scope = DependencyScope.forId(nonNull(id, "id"));
+        if (scope == null) {
+            throw new IllegalArgumentException("Invalid dependency scope: " + id);
+        }
+        return scope;
     }
 
     @Override


### PR DESCRIPTION
`Session.requireDependencyScope(…)` is annotated as `@Nonnull` but its implementation can still return null, causing `NullPointerException` later. This pull request replace the null value by an `IllegalArgumentException` that describes the problem.