### PR TITLE
[MNG-8632] Update Full Build pipeline to also build with JDK 24

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: ['17', '21']
+        java: ['17', '21', '24']
     steps:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4


### PR DESCRIPTION
This PR adds JDK 24 into the Full Build matrix.

The simply adds '24' to the build section.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
