### PR TITLE
[MNG-8646] Make IT tests use "outer" Mimir caching as well

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilderRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilderRequest.java
@@ -59,7 +59,7 @@ public interface ModelBuilderRequest extends Request<Session> {
         BUILD_EFFECTIVE,
         /**
          * The request is used specifically to parse the POM used as a basis for creating the consumer POM.
-         * This POM will not ungergo any profile activation.
+         * This POM will not undergo any profile activation.
          */
         BUILD_CONSUMER,
         /**

--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -98,7 +98,7 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     public File findArtifact(Artifact artifact) {
-        MavenProject project = getProject(artifact, true);
+        MavenProject project = getProject(artifact);
 
         if (project != null) {
             File file = findArtifact(project, artifact, true);
@@ -140,7 +140,7 @@ class ReactorReader implements MavenWorkspaceReader {
 
     @Override
     public Model findModel(Artifact artifact) {
-        MavenProject project = getProject(artifact, false);
+        MavenProject project = getProject(artifact);
         return project == null ? null : project.getModel().getDelegate();
     }
 
@@ -470,8 +470,8 @@ class ReactorReader implements MavenWorkspaceReader {
         return projectLocalRepository;
     }
 
-    private MavenProject getProject(Artifact artifact, boolean includeAllProjects) {
-        return (includeAllProjects ? getAllProjects() : getProjects())
+    private MavenProject getProject(Artifact artifact) {
+        return getProjects()
                 .getOrDefault(artifact.getGroupId(), Collections.emptyMap())
                 .getOrDefault(artifact.getArtifactId(), Collections.emptyMap())
                 .getOrDefault(artifact.getBaseVersion(), null);

--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -111,6 +111,11 @@ class ReactorReader implements MavenWorkspaceReader {
         // No project, but most certainly a dependency which has been built previously
         File packagedArtifactFile = findInProjectLocalRepository(artifact);
         if (packagedArtifactFile != null && packagedArtifactFile.exists()) {
+            // Check if artifact is up-to-date
+            project = getProject(artifact, getAllProjects());
+            if (project != null) {
+                isPackagedArtifactUpToDate(project, packagedArtifactFile);
+            }
             return packagedArtifactFile;
         }
 
@@ -471,8 +476,11 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     private MavenProject getProject(Artifact artifact) {
-        return getProjects()
-                .getOrDefault(artifact.getGroupId(), Collections.emptyMap())
+        return getProject(artifact, getProjects());
+    }
+
+    private MavenProject getProject(Artifact artifact, Map<String, Map<String, Map<String, MavenProject>>> projects) {
+        return projects.getOrDefault(artifact.getGroupId(), Collections.emptyMap())
                 .getOrDefault(artifact.getArtifactId(), Collections.emptyMap())
                 .getOrDefault(artifact.getBaseVersion(), null);
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -98,7 +98,7 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     public File findArtifact(Artifact artifact) {
-        MavenProject project = getProject(artifact);
+        MavenProject project = getProject(artifact, true);
 
         if (project != null) {
             File file = findArtifact(project, artifact, true);
@@ -140,7 +140,7 @@ class ReactorReader implements MavenWorkspaceReader {
 
     @Override
     public Model findModel(Artifact artifact) {
-        MavenProject project = getProject(artifact);
+        MavenProject project = getProject(artifact, false);
         return project == null ? null : project.getModel().getDelegate();
     }
 
@@ -470,8 +470,8 @@ class ReactorReader implements MavenWorkspaceReader {
         return projectLocalRepository;
     }
 
-    private MavenProject getProject(Artifact artifact) {
-        return getProjects()
+    private MavenProject getProject(Artifact artifact, boolean includeAllProjects) {
+        return (includeAllProjects ? getAllProjects() : getProjects())
                 .getOrDefault(artifact.getGroupId(), Collections.emptyMap())
                 .getOrDefault(artifact.getArtifactId(), Collections.emptyMap())
                 .getOrDefault(artifact.getBaseVersion(), null);

--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -471,7 +471,7 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     private MavenProject getProject(Artifact artifact) {
-        return getAllProjects()
+        return getProjects()
                 .getOrDefault(artifact.getGroupId(), Collections.emptyMap())
                 .getOrDefault(artifact.getArtifactId(), Collections.emptyMap())
                 .getOrDefault(artifact.getBaseVersion(), null);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -361,9 +361,14 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                             && session.getProjects().stream()
                                     .anyMatch(
                                             p -> p.getPomPath().toAbsolutePath().equals(pomFile.toAbsolutePath()));
+                    boolean isStandalone = pomFile == null
+                            && modelSource != null
+                            && modelSource.getLocation().startsWith("jar:")
+                            && modelSource.getLocation().endsWith("/org/apache/maven/project/standalone.xml");
 
                     ModelBuilderRequest.ModelBuilderRequestBuilder builder = getModelBuildingRequest();
                     ModelBuilderRequest.RequestType type = reactorMember
+                                    || isStandalone
                                     || (pomFile != null
                                             && this.request.isProcessPlugins()
                                             && this.request.getValidationLevel()

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -357,8 +357,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
 
                     ModelBuilderRequest.ModelBuilderRequestBuilder builder = getModelBuildingRequest();
                     ModelBuilderRequest.RequestType type = pomFile != null
-                                    && this.request.isProcessPlugins()
-                                    && this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
+                                    //&& this.request.isProcessPlugins()
+                                    //&& this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
                             ? ModelBuilderRequest.RequestType.BUILD_EFFECTIVE
                             : ModelBuilderRequest.RequestType.CONSUMER_PARENT;
                     MavenProject theProject = project;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -91,6 +91,7 @@ import org.apache.maven.impl.resolver.ArtifactDescriptorUtils;
 import org.apache.maven.internal.impl.InternalMavenSession;
 import org.apache.maven.model.building.DefaultModelProblem;
 import org.apache.maven.model.building.FileModelSource;
+import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelSource2;
 import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.plugin.PluginManagerException;
@@ -356,8 +357,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
 
                     ModelBuilderRequest.ModelBuilderRequestBuilder builder = getModelBuildingRequest();
                     ModelBuilderRequest.RequestType type = pomFile != null
-                            // && this.request.isProcessPlugins()
-                            // && this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
+                                    //&& this.request.isProcessPlugins()
+                                    //&& this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
                             ? ModelBuilderRequest.RequestType.BUILD_EFFECTIVE
                             : ModelBuilderRequest.RequestType.CONSUMER_PARENT;
                     MavenProject theProject = project;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -91,7 +91,6 @@ import org.apache.maven.impl.resolver.ArtifactDescriptorUtils;
 import org.apache.maven.internal.impl.InternalMavenSession;
 import org.apache.maven.model.building.DefaultModelProblem;
 import org.apache.maven.model.building.FileModelSource;
-import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelSource2;
 import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.plugin.PluginManagerException;
@@ -357,8 +356,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
 
                     ModelBuilderRequest.ModelBuilderRequestBuilder builder = getModelBuildingRequest();
                     ModelBuilderRequest.RequestType type = pomFile != null
-                                    //&& this.request.isProcessPlugins()
-                                    //&& this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
+                            // && this.request.isProcessPlugins()
+                            // && this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
                             ? ModelBuilderRequest.RequestType.BUILD_EFFECTIVE
                             : ModelBuilderRequest.RequestType.CONSUMER_PARENT;
                     MavenProject theProject = project;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -809,6 +809,24 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                             "Failed to create snapshot distribution repository for " + project.getId(), e);
                 }
             }
+
+            // remote repositories
+            List<ArtifactRepository> remoteRepositories = request.getRemoteRepositories();
+            try {
+                remoteRepositories = projectBuildingHelper.createArtifactRepositories(
+                        project.getModel().getRepositories(), remoteRepositories, request);
+            } catch (Exception e) {
+                result.getProblemCollector()
+                        .reportProblem(new org.apache.maven.impl.model.DefaultModelProblem(
+                                "",
+                                Severity.ERROR,
+                                Version.BASE,
+                                project.getModel().getDelegate(),
+                                -1,
+                                -1,
+                                e));
+            }
+            project.setRemoteArtifactRepositories(remoteRepositories);
         }
 
         private void initParent(MavenProject project, ModelBuilderResult result) {
@@ -828,7 +846,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     // remote repositories with those found in the pom.xml, along with the existing externally
                     // defined repositories.
                     //
-                    request.setRemoteRepositories(project.getRemoteArtifactRepositories());
+                    request.getRemoteRepositories().addAll(project.getRemoteArtifactRepositories());
                     Path parentPomFile = parentModel.getPomFile();
                     if (parentPomFile != null) {
                         project.setParentFile(parentPomFile.toFile());
@@ -1019,7 +1037,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             projectBuildingHelper.selectProjectRealm(project);
         }
 
-        // build the regular repos after extensions are loaded to allow for custom layouts
+        // (re)build the regular repos after extensions are loaded to allow for custom layouts
         try {
             remoteRepositories = projectBuildingHelper.createArtifactRepositories(
                     model3.getRepositories(), remoteRepositories, projectBuildingRequest);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -357,8 +357,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
 
                     ModelBuilderRequest.ModelBuilderRequestBuilder builder = getModelBuildingRequest();
                     ModelBuilderRequest.RequestType type = pomFile != null
-                                    //&& this.request.isProcessPlugins()
-                                    //&& this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
+                                    && this.request.isProcessPlugins()
+                                    && this.request.getValidationLevel() == ModelBuildingRequest.VALIDATION_LEVEL_STRICT
                             ? ModelBuilderRequest.RequestType.BUILD_EFFECTIVE
                             : ModelBuilderRequest.RequestType.CONSUMER_PARENT;
                     MavenProject theProject = project;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -968,10 +968,16 @@ public class MavenProject implements Cloneable {
     }
 
     public List<RemoteRepository> getRemoteProjectRepositories() {
+        if (remoteProjectRepositories == null) {
+            remoteProjectRepositories = new ArrayList<>();
+        }
         return remoteProjectRepositories;
     }
 
     public List<RemoteRepository> getRemotePluginRepositories() {
+        if (remotePluginRepositories == null) {
+            remotePluginRepositories = new ArrayList<>();
+        }
         return remotePluginRepositories;
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/MappedList.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/MappedList.java
@@ -22,13 +22,15 @@ import java.util.AbstractList;
 import java.util.List;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNull;
+
 public class MappedList<U, V> extends AbstractList<U> {
     private final List<V> list;
     private final Function<V, U> mapper;
 
     public MappedList(List<V> list, Function<V, U> mapper) {
-        this.list = list;
-        this.mapper = mapper;
+        this.list = requireNonNull(list, "list");
+        this.mapper = requireNonNull(mapper, "mapper");
     }
 
     @Override

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3477DependencyResolutionErrorMessageTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3477DependencyResolutionErrorMessageTest.java
@@ -96,7 +96,7 @@ class MavenITmng3477DependencyResolutionErrorMessageTest extends AbstractMavenIn
                 new String[] {
                     ".*The following artifacts could not be resolved: org.apache.maven.its.plugins:maven-it-plugin-not-exists:pom:1.2.3 \\(absent\\): "
                             + "Could not transfer artifact org.apache.maven.its.plugins:maven-it-plugin-not-exists:pom:1.2.3 from/to "
-                            + "maven-core-it \\(http://localhost:.*/repo\\): Connection to http://localhost:.*2/repo/ refused.*"
+                            + "central \\(http://localhost:.*/repo\\): Connection to http://localhost:.*2/repo/ refused.*"
                 },
                 "pom-plugin.xml");
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660ResumeFromTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660ResumeFromTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.File;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,7 +41,21 @@ public class MavenITmng4660ResumeFromTest extends AbstractMavenIntegrationTestCa
      * module-a has not been packaged.
      *
      * @throws Exception in case of failure
+     *
+     * THIS TEST IS DISABLED
+     * this test (and expectation) goes against Maven nature: here it is expected that
+     * - you "cut" your reactor w/ -rf
+     * - but make Maven pick up "artifact" from some 4th place: not from Project Local Repository, not from
+     *   Local Repository, and not from any Remote Repository, but from target/classes of left out subproject.
+     *
+     * Questions to tinker for those that are missing this use case:
+     * - if you want access to un-packaged subproject, why are you leaving it out from reactor?
+     * - if you do must leave it out, why are you not packaging it?
+     * - (maven3) why the hell are you not installing it?
+     *
+     * Recommended read: https://maveniverse.eu/blog/2025/03/17/never-say-never/
      */
+    @Disabled("This test goes against Maven (see javadoc above)")
     @Test
     public void testShouldResolveOutputDirectoryFromEarlierBuild() throws Exception {
         final File testDir = extractResources("/mng-4660-resume-from");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6090CIFriendlyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6090CIFriendlyTest.java
@@ -56,7 +56,7 @@ public class MavenITmng6090CIFriendlyTest extends AbstractMavenIntegrationTestCa
         verifier.addCliArgument("-Drevision=1.2");
         verifier.addCliArgument("-Dmaven.consumer.pom=false");
         verifier.setLogFileName("install-log.txt");
-        verifier.addCliArguments("clean", "install");
+        verifier.addCliArguments("clean", "package");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
@@ -82,7 +82,7 @@ public class MavenITmng6090CIFriendlyTest extends AbstractMavenIntegrationTestCa
         verifier.addCliArgument("-Drevision=1.2");
         verifier.addCliArgument("-Dmaven.consumer.pom=true");
         verifier.setLogFileName("install-log.txt");
-        verifier.addCliArguments("clean", "install");
+        verifier.addCliArguments("clean", "package");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-suite/src/test/resources-filtered/settings-remote.xml
+++ b/its/core-it-suite/src/test/resources-filtered/settings-remote.xml
@@ -49,7 +49,7 @@ plugins/artifacts from test repos so use of these settings should be the excepti
             <enabled>true</enabled>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
           </snapshots>
         </repository>
       </repositories>
@@ -62,7 +62,7 @@ plugins/artifacts from test repos so use of these settings should be the excepti
             <enabled>true</enabled>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
           </snapshots>
         </pluginRepository>
       </pluginRepositories>

--- a/its/core-it-suite/src/test/resources-filtered/settings.xml
+++ b/its/core-it-suite/src/test/resources-filtered/settings.xml
@@ -51,7 +51,7 @@ own test repos or can employ the local repository (after bootstrapping). This co
             <enabled>true</enabled>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
           </snapshots>
         </pluginRepository>
       </pluginRepositories>

--- a/its/core-it-suite/src/test/resources/mng-5175/settings-template.xml
+++ b/its/core-it-suite/src/test/resources/mng-5175/settings-template.xml
@@ -20,5 +20,46 @@
       <url>http://localhost:@port@/archiva/repository/internal/</url>
     </mirror>
   </mirrors>
+  <!--
+  This IT got Central only from env, then set it mirrorOf* and expected to get snapshot;
+  This is wrong: As IT had no new repo in context, only default ones (from env, Central) and none of them
+  serve snapshots; despite mirrorOf*. Fixing it by adding a fluke snapshot enabled repo below
+  -->
+  <profiles>
+    <profile>
+      <id>maven-core-it-repo</id>
+      <repositories>
+        <repository>
+          <id>maven-core-it</id>
+          <url>http://unimportant</url>
+          <releases>
+            <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>maven-core-it</id>
+          <url>http://localhost:@port@/repo</url>
+          <releases>
+            <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>maven-core-it-repo</activeProfile>
+  </activeProfiles>
 </settings>
 


### PR DESCRIPTION
As it turned out, ITs were not using Mimir as they redefined Maven Central to allow snapshots, and that made Mimir not handle the IT used Maven Central (while those did not contain snapshots, it was still pointing at canonical Maven Central URL).

Fixing this revealed several other (related or unrelated) issues:
* MavenProject was NPE prone regarding remote repositories handling
* MappedList was NPE prone regarding null values (emitted by MavenProject remote repositories)
several ProjectModelBuilder (detailed below) had no remote repositories set anymore (as central is not in super POM anymore)
* some ITs revaled ReactorReader issues as well

The `org.apache.maven.project.DefaultProjectBuilder issues` fixed:
* model request type CONSUMER_PARENT is used for non-locally built projects (ie. plugins invoked with direct mojo invocation), this seems strange. This skips CI friendly replacement for example as shows in Maven ITs
* remote repositories are injected ONLY when injecting lifecycle plugins (processPlugins=true). This was ok when root pom was defining default repository, but that's not the case anymore, and this results in projects built that has 0 remote reposes.

At the end of the day, all issues were fixed but one IT that we declared "invalid" was disabled (w/ remark about why's).

---

https://issues.apache.org/jira/browse/MNG-8646