### PR TITLE
Remove old symbolic link in ITmng8400 test

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -50,6 +50,7 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
         Path linkedMavenHome = tempDir.resolve("linked-maven-home");
 
         Path oldMavenHome = Paths.get(System.getProperty("maven.home"));
+        Files.deleteIfExists(linkedMavenHome);
         Files.createSymbolicLink(linkedMavenHome, oldMavenHome);
         System.setProperty("maven.home", linkedMavenHome.toString());
 


### PR DESCRIPTION
when we execute ITs without cleaning a project test will fail
