### PR TITLE
[MNG-8647] Set the default source directory to `src/${scope}/${lang}` as per documentation

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
@@ -28,8 +28,9 @@ import java.util.Optional;
  * The sources may be Java main classes, test classes, resources or anything else identified by the scope.
  *
  * <h2>Default values</h2>
- * The default implementation of all methods in this interface match the default values
- * documented in {@code maven.mdo} (the <abbr>POM</abbr> model).
+ * The properties in this interface are defined in the {@code <Source>} element of the
+ * {@linkplain org.apache.maven.api.model.Model Maven project descriptor}.
+ * For each property, the default value is either empty or documented in the project descriptor.
  */
 public interface SourceRoot {
     /**
@@ -64,7 +65,10 @@ public interface SourceRoot {
 
     /**
      * {@return in which context the source files will be used}.
-     * The default value is {@link ProjectScope#MAIN}.
+     * Not to be confused with dependency scope.
+     * The default value is {@code "main"}.
+     *
+     * @see ProjectScope#MAIN
      */
     default ProjectScope scope() {
         return ProjectScope.MAIN;
@@ -72,7 +76,9 @@ public interface SourceRoot {
 
     /**
      * {@return the language of the source files}.
-     * The default value is {@link Language#JAVA_FAMILY}.
+     * The default value is {@code "java"}.
+     *
+     * @see Language#JAVA_FAMILY
      */
     default Language language() {
         return Language.JAVA_FAMILY;

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
@@ -26,13 +26,23 @@ import java.util.Optional;
 /**
  * A root directory of source files.
  * The sources may be Java main classes, test classes, resources or anything else identified by the scope.
+ *
+ * <h2>Default values</h2>
+ * The default implementation of all methods in this interface match the default values
+ * documented in {@code maven.mdo} (the <abbr>POM</abbr> model).
  */
 public interface SourceRoot {
     /**
      * {@return the root directory where the sources are stored}.
      * The path is relative to the <abbr>POM</abbr> file.
+     *
+     * <h4>Default implementation</h4>
+     * The default value is <code>src/{@linkplain #scope() scope}/{@linkplain #language() language}</code>
+     * as a relative path. Implementation classes may override this default with an absolute path instead.
      */
-    Path directory();
+    default Path directory() {
+        return Path.of("src", scope().id(), language().id());
+    }
 
     /**
      * {@return the list of pattern matchers for the files to include}.
@@ -62,8 +72,11 @@ public interface SourceRoot {
 
     /**
      * {@return the language of the source files}.
+     * The default value is {@link Language#JAVA_FAMILY}.
      */
-    Language language();
+    default Language language() {
+        return Language.JAVA_FAMILY;
+    }
 
     /**
      * {@return the name of the Java module (or other language-specific module) which is built by the sources}.

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -875,7 +875,7 @@
           <description>
             All the sources to compile and resources files to copy for a project or it's unit tests.
             The sources can be Java source files, generated source files, scripts or resources for examples.
-            Each source is specified by a mandatory {@code directory} element, which is relative to the POM.
+            Each source is specified by a {@code directory} element, which is relative to the POM.
             The kind of sources (codes to compile or resources to copy) and their usage (for the main code
             or for the tests) is specified by the {@code scope} element together with each source directory.
           </description>
@@ -2005,7 +2005,7 @@
         <![CDATA[
         Description of the sources associated with a project main code or unit tests.
         The sources can be Java source files, generated source files, scripts or resources for examples.
-        A source is specified by a mandatory {@code directory} element, which is relative to the POM.
+        A source is specified by a {@code directory} element, which is relative to the POM.
         The directory content can optionally by reduced to a subset with the {@code includes} and
         {@code excludes} elements. The kind of sources (codes, resources, <i>etc.</i>) and their
         usage (main code, tests, <i>etc.</i>) is specified by the {@code scope} element.

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -874,9 +874,9 @@
           <version>4.1.0+</version>
           <description>
             All the sources to compile and resources files to copy for a project or it's unit tests.
-            The sources can be Java source files, generated source files, scripts or resources for examples.
+            The sources can be Java source files, generated source files, scripts, or resources for examples.
             Each source is specified by a {@code directory} element, which is relative to the POM.
-            The kind of sources (codes to compile or resources to copy) and their usage (for the main code
+            The kind of sources (source files to compile or resources to copy) and their usage (for the main code
             or for the tests) is specified by the {@code scope} element together with each source directory.
           </description>
           <association>
@@ -2004,9 +2004,9 @@
       <description>
         <![CDATA[
         Description of the sources associated with a project main code or unit tests.
-        The sources can be Java source files, generated source files, scripts or resources for examples.
+        The sources can be Java source files, generated source files, scripts, or resources for examples.
         A source is specified by a {@code directory} element, which is relative to the POM.
-        The directory content can optionally by reduced to a subset with the {@code includes} and
+        The directory content can optionally be reduced to a subset with the {@code includes} and
         {@code excludes} elements. The kind of sources (codes, resources, <i>etc.</i>) and their
         usage (main code, tests, <i>etc.</i>) is specified by the {@code scope} element.
 
@@ -2084,7 +2084,7 @@
             resource file will be copied as {@code foo.biz/foo/bar.properties}.</p>
 
             <p>This element can be combined with the {@code targetVersion} element for specifying sources,
-            scripts or resources that are specific to both a particular module and a target version.</p>
+            scripts, or resources that are specific to both a particular module and a target version.</p>
             ]]>
           </description>
           <type>String</type>
@@ -2108,7 +2108,7 @@
             resource file will be copied as {@code META-INF/versions/17/foo/bar.properties}.</p>
 
             <p>This element can be combined with the {@code module} element for specifying sources,
-            scripts or resources that are specific to both a particular module and a target version.</p>
+            scripts, or resources that are specific to both a particular module and a target version.</p>
             ]]>
           </description>
           <type>String</type>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -65,23 +65,25 @@ public final class DefaultSourceRoot implements SourceRoot {
      * @param source a source element from the model
      */
     public DefaultSourceRoot(final Session session, final Path baseDir, final Source source) {
-        String value = nonBlank(source.getDirectory());
-        if (value == null) {
-            throw new IllegalArgumentException("Source declaration without directory value.");
-        }
-        directory = baseDir.resolve(value);
-        FileSystem fs = directory.getFileSystem();
+        FileSystem fs = baseDir.getFileSystem();
         includes = matchers(fs, source.getIncludes());
         excludes = matchers(fs, source.getExcludes());
         stringFiltering = source.isStringFiltering();
         enabled = source.isEnabled();
         moduleName = nonBlank(source.getModule());
 
-        value = nonBlank(source.getScope());
+        String value = nonBlank(source.getScope());
         scope = (value != null) ? session.requireProjectScope(value) : ProjectScope.MAIN;
 
         value = nonBlank(source.getLang());
         language = (value != null) ? session.requireLanguage(value) : Language.JAVA_FAMILY;
+
+        value = nonBlank(source.getDirectory());
+        if (value != null) {
+            directory = baseDir.resolve(value);
+        } else {
+            directory = baseDir.resolve("src").resolve(scope.id()).resolve(language.id());
+        }
 
         value = nonBlank(source.getTargetVersion());
         targetVersion = (value != null) ? session.parseVersion(value) : null;


### PR DESCRIPTION
JIRA issue: [MNG-8647](https://issues.apache.org/jira/browse/MNG-8647)

The `maven.mdo` file for the `<Source>` element said that the default directories are `src/${scope}/${lang}`. but this is effective only if no source is specified at all. It would be helpful to have this default value when some `<Source>` are specified. The intend is to allow users to write:

```xml
  <build>
    <sources>
      <source>
        <targetVersion>21</targetVersion>
      </source>
      <source>
        <scope>test</scope>
      </source>
    </sources>
</build>
```

instead of:

```xml
  <build>
    <sources>
      <source>
        <directory>src/main/java</directory>
        <targetVersion>21</targetVersion>
      </source>
      <source>
        <scope>test</scope>
        <directory>src/test/java</directory>
      </source>
    </sources>
</build>
```