### PR TITLE
[MNG-8645] Fix dependency management section of consumer POM

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -176,8 +176,8 @@ class DefaultConsumerPomBuilder implements ConsumerPomBuilder {
     }
 
     private static String getDependencyKey(org.apache.maven.api.Dependency dependency) {
-        return dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getType() + ":"
-                + dependency.getClassifier();
+        return dependency.getGroupId() + ":" + dependency.getArtifactId() + ":"
+                + dependency.getType().id() + ":" + dependency.getClassifier();
     }
 
     private static String getDependencyKey(Dependency dependency) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/type/DefaultType.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/type/DefaultType.java
@@ -111,4 +111,16 @@ public class DefaultType implements Type, ArtifactType {
     public Map<String, String> getProperties() {
         return properties;
     }
+
+    @Override
+    public String toString() {
+        return "DefaultType[" + "id='"
+                + id + '\'' + ", language="
+                + language + ", extension='"
+                + extension + '\'' + ", classifier='"
+                + classifier + '\'' + ", includesDependencies="
+                + includesDependencies + ", pathTypes="
+                + pathTypes + ", properties="
+                + properties + ']';
+    }
 }


### PR DESCRIPTION
JIRA issue: [MNG-8645](https://issues.apache.org/jira/browse/MNG-8645)

The implicit call to Type#toString() instead of Type#id() causes the wrong string id to generated, thus causing the code to not find matches nodes and discarding all managed dependencies.

I'll try to add an IT later.

