### PR TITLE
[MNG-8075] Deprecate project.baseUri in favor of project.basedir.uri

### DIFF
--- a/compat/maven-model-builder/src/site/apt/index.apt
+++ b/compat/maven-model-builder/src/site/apt/index.apt
@@ -180,8 +180,8 @@ Maven Model Builder
 <<<pom.basedir>>> (<deprecated>)\
 <<<basedir>>> (<deprecated>) | the directory containing the <<<pom.xml>>> file | <<<$\{project.basedir\}>>> |
 *----+------+------+
-| <<<project.baseUri>>>\
-<<<pom.baseUri>>> (<deprecated>) | the directory containing the <<<pom.xml>>> file as URI | <<<$\{project.baseUri\}>>> |
+| <<<project.baseUri>>> (<deprecated>)\
+<<<pom.baseUri>>> (<deprecated>) | the directory containing the <<<pom.xml>>> file as URI. Those properties are deprecated, use <<<$\{project.basedir.uri\}>>> instead. | <<<$\{project.basedir.uri\}>>> |
 *----+------+------+
 | <<<project.rootDirectory>>> | the project's root directory (containing a <<<.mvn>>> directory or with the <<<root="true">>> xml attribute) | <<<$\{project.rootDirectory\}>>> |
 *----+------+------+

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1534,7 +1534,16 @@ public class DefaultModelValidator implements ModelValidator {
                 Matcher matcher = EXPRESSION_NAME_PATTERN.matcher(repository.getUrl());
                 while (matcher.find()) {
                     String expr = matcher.group(1);
-                    if (!("basedir".equals(expr)
+                    if ("project.baseUri".equals(expr)) {
+                        addViolation(
+                                problems,
+                                Severity.WARNING,
+                                Version.V40,
+                                prefix + prefix2 + "[" + repository.getId() + "].url",
+                                null,
+                                "contains a deprecated 'project.baseUri' expression,  use 'project.basedir.uri' instead.",
+                                repository);
+                    } else if (!("basedir".equals(expr)
                             || "project.basedir".equals(expr)
                             || expr.startsWith("project.basedir.")
                             || "project.rootDirectory".equals(expr)

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -896,8 +896,8 @@ class DefaultModelValidatorTest {
 
     @Test
     void repositoryWithBasedirExpression() throws Exception {
-        SimpleProblemCollector result = validateRaw("raw-model/repository-with-basedir-expression.xml");
-        assertViolations(result, 0, 0, 0);
+        SimpleProblemCollector result = validateFile("raw-model/repository-with-basedir-expression.xml");
+        assertViolations(result, 0, 0, 1);
     }
 
     @Test

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/repository-with-expression.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/repository-with-expression.xml
@@ -41,6 +41,10 @@ under the License.
       <id>repo</id>
       <url>file://${x}/sdk/maven/repo</url>
     </repository>
+    <repository>
+      <id>repo2</id>
+      <url>${project.basedir.uri}/sdk/maven/repo</url>
+    </repository>
   </repositories>
 
 </project>


### PR DESCRIPTION
JIRA issue: [MNG-8075](https://issues.apache.org/jira/browse/MNG-8075)

The original issue was adding support for `${project.baseUri}`, however, it has been inadvertently dropped when refactoring the Maven 4 model builder.  Overall, instead of providing a new property, I think using the newly supported syntax of `${project.basedir.uri}` is a better idea.

This PR isn't really complete as it only deprecates the expression in repository URIs for now.