### PR TITLE
[MNG-8653] Fix 'all' phase and  add 'each' phase

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
@@ -102,6 +102,7 @@ public interface Lifecycle extends ExtensibleEnum {
         // Maven defined phases
         // ======================
         String ALL = "all";
+        String EACH = "each";
         String BUILD = "build";
         String INITIALIZE = "initialize";
         String VALIDATE = "validate";

--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -338,14 +338,18 @@ class ReactorReader implements MavenWorkspaceReader {
                     if (!Objects.equals(phase, phases.peekLast())) {
                         phases.addLast(phase);
                         if ("clean".equals(phase)) {
-                            cleanProjectLocalRepository(project);
+                            synchronized (project) {
+                                cleanProjectLocalRepository(project);
+                            }
                         }
                     }
                 }
                 break;
             case ProjectSucceeded:
             case ForkedProjectSucceeded:
-                installIntoProjectLocalRepository(project);
+                synchronized (project) {
+                    installIntoProjectLocalRepository(project);
+                }
                 break;
             default:
                 break;

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
@@ -89,7 +89,7 @@ public class Lifecycles {
     }
 
     /** Indicates the phase is after the phases given in arguments */
-    static Lifecycle.Link after(String b) {
+    static Lifecycle.Link after(String phase) {
         return new Lifecycle.Link() {
             @Override
             public Kind kind() {
@@ -101,9 +101,19 @@ public class Lifecycles {
                 return new Lifecycle.PhasePointer() {
                     @Override
                     public String phase() {
-                        return b;
+                        return phase;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "phase(" + phase + ")";
                     }
                 };
+            }
+
+            @Override
+            public String toString() {
+                return "after(" + pointer() + ")";
             }
         };
     }
@@ -128,7 +138,46 @@ public class Lifecycles {
                     public String scope() {
                         return scope;
                     }
+
+                    @Override
+                    public String toString() {
+                        return "dependencies(" + scope + ", " + phase + ")";
+                    }
                 };
+            }
+
+            @Override
+            public String toString() {
+                return "after(" + pointer() + ")";
+            }
+        };
+    }
+
+    static Lifecycle.Link children(String phase) {
+        return new Lifecycle.Link() {
+            @Override
+            public Kind kind() {
+                return Kind.AFTER;
+            }
+
+            @Override
+            public Lifecycle.Pointer pointer() {
+                return new Lifecycle.ChildrenPointer() {
+                    @Override
+                    public String phase() {
+                        return phase;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "children(" + phase + ")";
+                    }
+                };
+            }
+
+            @Override
+            public String toString() {
+                return "after(" + pointer() + ")";
             }
         };
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -254,6 +254,7 @@ public class BuildPlanExecutor {
                 pplan.status.set(PLANNING); // the plan step always need planning
                 BuildStep setup = new BuildStep(SETUP, project, null);
                 BuildStep teardown = new BuildStep(TEARDOWN, project, null);
+                teardown.executeAfter(setup);
                 setup.executeAfter(pplan);
                 plan.steps(project).forEach(step -> {
                     if (step.predecessors.isEmpty()) {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildStep.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildStep.java
@@ -103,6 +103,10 @@ public class BuildStep {
         }
     }
 
+    public void executeBefore(BuildStep stepToExecuteAfter) {
+        stepToExecuteAfter.executeAfter(this);
+    }
+
     public Stream<MojoExecution> executions() {
         return mojos.values().stream().flatMap(m -> m.values().stream());
     }

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
@@ -38,6 +38,7 @@ class BuildPlanCreatorTest {
     @Test
     void testMulti() {
         MavenProject project = new MavenProject();
+        project.setCollectedProjects(List.of());
         Map<MavenProject, List<MavenProject>> projects = Collections.singletonMap(project, Collections.emptyList());
 
         BuildPlan plan = calculateLifecycleMappings(projects, "package");
@@ -48,8 +49,10 @@ class BuildPlanCreatorTest {
     @Test
     void testCondense() {
         MavenProject p1 = new MavenProject();
+        p1.setCollectedProjects(List.of());
         p1.setArtifactId("p1");
         MavenProject p2 = new MavenProject();
+        p2.setCollectedProjects(List.of());
         p2.setArtifactId("p2");
         Map<MavenProject, List<MavenProject>> projects = new HashMap<>();
         projects.put(p1, Collections.emptyList());
@@ -83,10 +86,39 @@ class BuildPlanCreatorTest {
     void testAlias() {
         MavenProject p1 = new MavenProject();
         p1.setArtifactId("p1");
+        p1.setCollectedProjects(List.of());
         Map<MavenProject, List<MavenProject>> projects = Collections.singletonMap(p1, Collections.emptyList());
 
         BuildPlan plan = calculateLifecycleMappings(projects, "generate-resources");
         assertNotNull(plan);
+    }
+
+    @Test
+    void testAllPhase() {
+        MavenProject c1 = new MavenProject();
+        c1.setArtifactId("c1");
+        c1.setCollectedProjects(List.of());
+        MavenProject c2 = new MavenProject();
+        c2.setArtifactId("c2");
+        c2.setCollectedProjects(List.of());
+        MavenProject p = new MavenProject();
+        p.setArtifactId("p");
+        p.setCollectedProjects(List.of(c1, c2));
+        Map<MavenProject, List<MavenProject>> projects = Map.of(p, List.of(), c1, List.of(), c2, List.of());
+
+        BuildPlan plan = calculateLifecycleMappings(projects, "all");
+        assertNotNull(plan);
+        assertIsSuccessor(plan.requiredStep(p, "before:all"), plan.requiredStep(p, "before:each"));
+        assertIsSuccessor(plan.requiredStep(p, "before:all"), plan.requiredStep(c1, "before:all"));
+        assertIsSuccessor(plan.requiredStep(p, "before:all"), plan.requiredStep(c2, "before:all"));
+        assertIsSuccessor(plan.requiredStep(c1, "after:all"), plan.requiredStep(p, "after:all"));
+        assertIsSuccessor(plan.requiredStep(c2, "after:all"), plan.requiredStep(p, "after:all"));
+    }
+
+    private void assertIsSuccessor(BuildStep predecessor, BuildStep successor) {
+        assertTrue(
+                successor.isSuccessorOf(predecessor),
+                String.format("Expected '%s' to be a successor of '%s'", successor.toString(), predecessor.toString()));
     }
 
     @SuppressWarnings("checkstyle:UnusedLocalVariable")

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8653AfterAndEachPhasesWithConcurrentBuilderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8653AfterAndEachPhasesWithConcurrentBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8653">MNG-8653</a>.
+ */
+class MavenITmng8653AfterAndEachPhasesWithConcurrentBuilderTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8653AfterAndEachPhasesWithConcurrentBuilderTest() {
+        super("(4.0.0-rc-3,)");
+    }
+
+    /**
+     *  Verify the dependency management of the consumer POM is computed correctly
+     */
+    @Test
+    void testIt() throws Exception {
+        Path basedir = extractResources("/mng-8653").getAbsoluteFile().toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArguments("compile", "-b", "concurrent", "-T8");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        List<String> lines = verifier.loadLogLines();
+        List<String> hallo = lines.stream().filter(l -> l.contains("Hallo")).toList();
+
+        // Verify parent's before:all is first
+        assertTrue(
+                hallo.get(0).contains("'before:all' phase from 'parent'"),
+                "First line should be parent's before:all but was: " + hallo.get(0));
+
+        // Verify parent's after:all is last
+        assertTrue(
+                hallo.get(hallo.size() - 1).contains("'after:all' phase from 'parent'"),
+                "Last line should be parent's after:all but was: " + hallo.get(hallo.size() - 1));
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -101,6 +101,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8653AfterAndEachPhasesWithConcurrentBuilderTest.class);
         suite.addTestSuite(MavenITmng5668AfterPhaseExecutionTest.class);
         suite.addTestSuite(MavenITmng8648ProjectStartedEventsTest.class);
         suite.addTestSuite(MavenITmng8645ConsumerPomDependencyManagementTest.class);

--- a/its/core-it-suite/src/test/resources/mng-8653/child-1/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8653/child-1/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <parent />
+  <artifactId>child-1</artifactId>
+  <packaging>pom</packaging>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8653/child-2/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8653/child-2/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <parent />
+  <artifactId>child-2</artifactId>
+  <packaging>pom</packaging>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8653/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8653/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+
+  <groupId>org.apache.maven.it.mng8653</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.soebes.maven.plugins</groupId>
+        <artifactId>echo-maven-plugin</artifactId>
+        <version>0.5.0</version>
+        <executions>
+          <execution>
+            <id>before-ready</id>
+            <goals>
+              <goal>echo</goal>
+            </goals>
+            <phase>before:ready</phase>
+            <configuration>
+              <echos>
+                <echo>Hallo 'before:ready' phase from '${project.artifactId}'.</echo>
+              </echos>
+            </configuration>
+          </execution>
+          <execution>
+            <id>before-each</id>
+            <goals>
+              <goal>echo</goal>
+            </goals>
+            <phase>before:each</phase>
+            <configuration>
+              <echos>
+                <echo>Hallo 'before:each' phase from '${project.artifactId}'.</echo>
+              </echos>
+            </configuration>
+          </execution>
+          <execution>
+            <id>after-each</id>
+            <goals>
+              <goal>echo</goal>
+            </goals>
+            <phase>after:each</phase>
+            <configuration>
+              <echos>
+                <echo>Hallo 'after:each' phase from '${project.artifactId}'.</echo>
+              </echos>
+            </configuration>
+          </execution>
+          <execution>
+            <id>before-all</id>
+            <goals>
+              <goal>echo</goal>
+            </goals>
+            <phase>before:all</phase>
+            <configuration>
+              <echos>
+                <echo>Hallo 'before:all' phase from '${project.artifactId}'.</echo>
+              </echos>
+            </configuration>
+          </execution>
+          <execution>
+            <id>all</id>
+            <goals>
+              <goal>echo</goal>
+            </goals>
+            <phase>all</phase>
+            <configuration>
+              <echos>
+                <echo>Hallo 'all' phase from '${project.artifactId}'.</echo>
+              </echos>
+            </configuration>
+          </execution>
+          <execution>
+            <id>after-all</id>
+            <goals>
+              <goal>echo</goal>
+            </goals>
+            <phase>after:all</phase>
+            <configuration>
+              <echos>
+                <echo>Hallo 'after:all' phase from '${project.artifactId}'.</echo>
+              </echos>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
JIRA issue: [MNG-8653](https://issues.apache.org/jira/browse/MNG-8653)

Fixes the existing 'all' phase and introduces a new 'each' phase to better support 
hierarchical builds and concurrent execution:

- 'all': Properly coordinates execution across parent-child project hierarchies
- 'each': A new phase that executes for each individual project in isolation

Key changes:
- Enhanced BuildPlanExecutor to properly handle parent-child relationships in phases
- Added new children() pointer type for explicit phase dependencies
- Improved phase dependency management to ensure:
  - Parent's before:all executes before children's phases
  - Children's after:all executes before parent's after:all
  - Each project's phases execute in isolation within the 'each' phase
- Added comprehensive documentation to BuildPlanExecutor
- Added integration test to verify hierarchical phase execution

This commit also fixes thread-safety issues in concurrent builds:
- Added synchronization to ReactorReader for project operations
- Improved thread-safety for project-level clean and install operations
- Enhanced build step state management in concurrent scenarios

Fixes: MNG-8653