### PR TITLE
[MNG-8598] Add support for MAVEN_PROJECTBASEDIR substitution in jvm.config

### DIFF
--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -168,13 +168,12 @@ find_file_argument_basedir() {
 # concatenates all lines of a file and replaces variables
 concat_lines() {
   if [ -f "$1" ]; then
-    # First replace variables in the content
-    while IFS= read -r line || [ -n "$line" ]; do
-      # Replace both ${MAVEN_PROJECTBASEDIR} and $MAVEN_PROJECTBASEDIR with actual value
-      line=${line//\$\{MAVEN_PROJECTBASEDIR\}/$MAVEN_PROJECTBASEDIR}
-      line=${line//\$MAVEN_PROJECTBASEDIR/$MAVEN_PROJECTBASEDIR}
-      echo "$line"
-    done < "$1" | tr -s '\r\n' '  '
+    # First transform line endings to spaces
+    content=`tr -s '\r\n' '  ' < "$1"`
+    # Then do variable substitution on the single line
+    content=${content//\$\{MAVEN_PROJECTBASEDIR\}/$MAVEN_PROJECTBASEDIR}
+    content=${content//\$MAVEN_PROJECTBASEDIR/$MAVEN_PROJECTBASEDIR}
+    echo "$content"
   fi
 }
 

--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -169,11 +169,10 @@ find_file_argument_basedir() {
 concat_lines() {
   if [ -f "$1" ]; then
     # First transform line endings to spaces
-    content=`tr -s '\r\n' '  ' < "$1"`
-    # Then do variable substitution on the single line
-    content=${content//\$\{MAVEN_PROJECTBASEDIR\}/$MAVEN_PROJECTBASEDIR}
-    content=${content//\$MAVEN_PROJECTBASEDIR/$MAVEN_PROJECTBASEDIR}
-    echo "$content"
+    content=$(tr -s '\r\n' ' ' < "$1")
+    # Handle both ${var} and $var formats, only substitute MAVEN_PROJECTBASEDIR
+    echo "$content" | sed -e "s|\${MAVEN_PROJECTBASEDIR}|$MAVEN_PROJECTBASEDIR|g" \
+                         -e "s|\$MAVEN_PROJECTBASEDIR|$MAVEN_PROJECTBASEDIR|g"
   fi
 }
 

--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -165,10 +165,16 @@ find_file_argument_basedir() {
 )
 }
 
-# concatenates all lines of a file
+# concatenates all lines of a file and replaces variables
 concat_lines() {
   if [ -f "$1" ]; then
-    echo "`tr -s '\r\n' '  ' < "$1"`"
+    # First replace variables in the content
+    while IFS= read -r line || [ -n "$line" ]; do
+      # Replace both ${MAVEN_PROJECTBASEDIR} and $MAVEN_PROJECTBASEDIR with actual value
+      line=${line//\$\{MAVEN_PROJECTBASEDIR\}/$MAVEN_PROJECTBASEDIR}
+      line=${line//\$MAVEN_PROJECTBASEDIR/$MAVEN_PROJECTBASEDIR}
+      echo "$line"
+    done < "$1" | tr -s '\r\n' '  '
   fi
 }
 

--- a/apache-maven/src/assembly/maven/bin/mvn.cmd
+++ b/apache-maven/src/assembly/maven/bin/mvn.cmd
@@ -176,7 +176,13 @@ cd /d "%EXEC_DIR%"
 if not exist "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadJvmConfig
 
 @setlocal EnableExtensions EnableDelayedExpansion
-for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_OPTS=!JVM_CONFIG_MAVEN_OPTS! %%a
+set JVM_CONFIG_MAVEN_OPTS=
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do (
+    set "line=%%a"
+    set "line=!line:$MAVEN_PROJECTBASEDIR=%MAVEN_PROJECTBASEDIR%!"
+    set "line=!line:${MAVEN_PROJECTBASEDIR}=%MAVEN_PROJECTBASEDIR%!"
+    set JVM_CONFIG_MAVEN_OPTS=!JVM_CONFIG_MAVEN_OPTS! !line!
+)
 @endlocal & set MAVEN_OPTS=%MAVEN_OPTS% %JVM_CONFIG_MAVEN_OPTS%
 
 :endReadJvmConfig

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8598JvmConfigSubstitutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8598JvmConfigSubstitutionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8598">MNG-8598</a>:
+ * Verify that ${MAVEN_PROJECTBASEDIR} and $MAVEN_PROJECTBASEDIR in .mvn/jvm.config are properly
+ * substituted with the actual project base directory.
+ */
+public class MavenITmng8598JvmConfigSubstitutionTest extends AbstractMavenIntegrationTestCase {
+    public MavenITmng8598JvmConfigSubstitutionTest() {
+        super("[4.0.0-rc-4,)");
+    }
+
+    @Test
+    public void testProjectBasedirSubstitution() throws Exception {
+        File testDir = extractResources("/mng-8598");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.addCliArgument(
+                "-Dexpression.outputFile=" + new File(testDir, "target/pom.properties").getAbsolutePath());
+        verifier.setForkJvm(true); // custom .mvn/jvm.config
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/pom.properties");
+        String expectedPath = testDir.getAbsolutePath().replace('\\', '/');
+        assertEquals(
+                expectedPath + "/curated",
+                props.getProperty("project.properties.curatedPathProp").replace('\\', '/'));
+        assertEquals(
+                expectedPath + "/simple",
+                props.getProperty("project.properties.simplePathProp").replace('\\', '/'));
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -101,6 +101,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8598JvmConfigSubstitutionTest.class);
         suite.addTestSuite(MavenITmng5668AfterPhaseExecutionTest.class);
         suite.addTestSuite(MavenITmng8648ProjectStartedEventsTest.class);
         suite.addTestSuite(MavenITmng8645ConsumerPomDependencyManagementTest.class);

--- a/its/core-it-suite/src/test/resources/mng-8598/.mvn/jvm.config
+++ b/its/core-it-suite/src/test/resources/mng-8598/.mvn/jvm.config
@@ -1,0 +1,2 @@
+-DcuratedPath=${MAVEN_PROJECTBASEDIR}/curated
+-DsimplePath=$MAVEN_PROJECTBASEDIR/simple

--- a/its/core-it-suite/src/test/resources/mng-8598/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8598/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng8598</groupId>
+  <artifactId>jvm-config-substitution</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <curatedPathProp>${curatedPath}</curatedPathProp>
+    <simplePathProp>${simplePath}</simplePathProp>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputFile>${expression.outputFile}</outputFile>
+              <expressions>
+                <expression>project/properties/curatedPathProp</expression>
+                <expression>project/properties/simplePathProp</expression>
+              </expressions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
JIRA issue: [MNG-8598](https://issues.apache.org/jira/browse/MNG-8598)

Added support for substituting  `${MAVEN_PROJECTBASEDIR}` and `$MAVEN_PROJECTBASEDIR`
in `.mvn/jvm.config` with the actual project base directory.

Changes:
- Modified `mvn` and `mvn.cmd` scripts to handle the substitution
- Added integration test to verify the functionality

The test verifies:
- Both curly brace and simple syntax variants work
- Substitution happens correctly in forked JVM
- Feature is available in Maven 4.0+
