### PR TITLE
[MNG-8548] - Add cycle detection to dependency injection

### DIFF
--- a/impl/maven-di/pom.xml
+++ b/impl/maven-di/pom.xml
@@ -45,6 +45,11 @@ under the License.
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
JIRA issue: [MNG-8548](https://issues.apache.org/jira/browse/MNG-8548)

Adds cycle detection during instance creation in the DI container to prevent StackOverflowError when circular dependencies are present. The error message now clearly shows the dependency chain that caused the cycle.
