### PR TITLE
[MNG-8467] Add links to configuration pages in index.xml

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -39,6 +39,8 @@ under the License.
     number of other development tools for reporting or the build
     process.</p>
 
+      <p>Learn more about <a href="configuring.html">configuring Maven</a> and <a href="maven-configuration.html">Maven's configuration</a>.</p>
+
       <p>
         <object data="images/maven-deps.svg" width="968" height="605"></object>
       </p>


### PR DESCRIPTION
JIRA issue: [MNG-8467](https://issues.apache.org/jira/browse/MNG-8467)

Add links to configuring.html and maven-configuration.html in the main index page to improve documentation navigation and discoverability of configuration options.
