### PR TITLE
Make maven-cli module tests use Mimir as well

### DIFF
--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
@@ -98,6 +98,8 @@ public abstract class MavenInvokerTestSupport {
         Files.createDirectories(appJava.getParent());
         Files.writeString(appJava, APP_JAVA_STRING);
 
+        MimirInfuser.infuse(userHome);
+
         HashMap<String, String> logs = new HashMap<>();
         Parser parser = createParser();
         try (ClassWorld classWorld = createClassWorld();

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MimirInfuser.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MimirInfuser.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvn;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class that sets up Mimir for maven-cli tests IF outer build uses Mimir as well (CI setup).
+ */
+public final class MimirInfuser {
+    public static void infuse(Path userHome) throws IOException {
+        requireNonNull(userHome);
+        // GH CI copies this to place, or user may have it already
+        Path realUserWideExtensions =
+                Path.of(System.getProperty("user.home")).resolve(".m2").resolve("extensions.xml");
+        if (Files.isRegularFile(realUserWideExtensions)) {
+            String realUserWideExtensionsString = Files.readString(realUserWideExtensions);
+            if (realUserWideExtensionsString.contains("<groupId>eu.maveniverse.maven.mimir</groupId>")
+                    && realUserWideExtensionsString.contains("<artifactId>extension</artifactId>")) {
+                Path userWideExtensions = userHome.resolve(".m2").resolve("extensions.xml");
+                // some tests do prepare project and user wide extensions; skip those for now
+                if (!Files.isRegularFile(userWideExtensions)) {
+                    Files.createDirectories(userWideExtensions.getParent());
+                    Files.copy(realUserWideExtensions, userWideExtensions, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+    }
+}

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
@@ -311,6 +311,7 @@ public abstract class MavenExecutorTestSupport {
     protected void execute(@Nullable Path logFile, Collection<ExecutorRequest> requests) throws Exception {
         Executor invoker = createAndMemoizeExecutor();
         for (ExecutorRequest request : requests) {
+            MimirInfuser.infuse(request.userHomeDirectory());
             int exitCode = invoker.execute(request);
             if (exitCode != 0) {
                 throw new FailedExecution(request, exitCode, logFile == null ? "" : Files.readString(logFile));

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MimirInfuser.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MimirInfuser.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.executor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class that sets up Mimir for maven-cli tests IF outer build uses Mimir as well (CI setup).
+ */
+public final class MimirInfuser {
+    public static void infuse(Path userHome) throws IOException {
+        requireNonNull(userHome);
+        // GH CI copies this to place, or user may have it already
+        Path realUserWideExtensions =
+                Path.of(System.getProperty("user.home")).resolve(".m2").resolve("extensions.xml");
+        if (Files.isRegularFile(realUserWideExtensions)) {
+            String realUserWideExtensionsString = Files.readString(realUserWideExtensions);
+            if (realUserWideExtensionsString.contains("<groupId>eu.maveniverse.maven.mimir</groupId>")
+                    && realUserWideExtensionsString.contains("<artifactId>extension</artifactId>")) {
+                Path userWideExtensions = userHome.resolve(".m2").resolve("extensions.xml");
+                // some tests do prepare project and user wide extensions; skip those for now
+                if (!Files.isRegularFile(userWideExtensions)) {
+                    Files.createDirectories(userWideExtensions.getParent());
+                    Files.copy(realUserWideExtensions, userWideExtensions, StandardCopyOption.REPLACE_EXISTING);
+
+                    Path mimirProperties = userHome.resolve(".mimir").resolve("mimir.properties");
+                    Files.createDirectories(mimirProperties.getParent());
+                    Files.copy(Path.of("target/test-classes/ut-mimir.properties"), mimirProperties);
+                }
+            }
+        }
+    }
+}

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -26,8 +26,10 @@ import java.util.Map;
 
 import org.apache.maven.cling.executor.ExecutorHelper;
 import org.apache.maven.cling.executor.MavenExecutorTestSupport;
+import org.apache.maven.cling.executor.MimirInfuser;
 import org.apache.maven.cling.executor.internal.HelperImpl;
 import org.apache.maven.cling.executor.internal.ToolboxTool;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -42,6 +44,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ToolboxToolTest {
     @TempDir
     private static Path userHome;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        MimirInfuser.infuse(userHome);
+    }
 
     @Timeout(15)
     @ParameterizedTest

--- a/impl/maven-executor/src/test/resources-filtered/ut-mimir.properties
+++ b/impl/maven-executor/src/test/resources-filtered/ut-mimir.properties
@@ -1,0 +1,8 @@
+# Used IF outer build uses Mimir (CI setup)
+
+# we change user.home in IT, so we want this interpolated
+mimir.daemon.socketPath=${user.home}/.mimir/mimir-socket
+# outer build already did this
+mimir.daemon.autoupdate=false
+# outer build already did this
+mimir.daemon.autostart=false


### PR DESCRIPTION
Make subproject maven-cli use "outer" Mimir (if used): This locally cuts UT runtime from 10+ sec to 2+ sec.
Same thing for maven-executor.

