### PR TITLE
[CI] Disable Mimir JGroups node

### DIFF
--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -1,0 +1,4 @@
+# Mimir Daemon properties
+
+# Disable JGroups; we don't want/use LAN cache sharing
+mimir.jgroups.enabled=false

--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -1,3 +1,20 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 # Mimir Daemon properties
 
 # Disable JGroups; we don't want/use LAN cache sharing

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           mkdir -p ~/.m2
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
       - name: Handle Mimir caches
         uses: actions/cache@v4
@@ -113,6 +114,7 @@ jobs:
         run: |
           mkdir -p ~/.m2
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
       - name: Handle Mimir caches
         uses: actions/cache@v4
@@ -194,6 +196,7 @@ jobs:
         run: |
           mkdir -p ~/.m2
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
       - name: Handle Mimir caches
         uses: actions/cache@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,6 +45,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
           cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
@@ -113,6 +114,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
           cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
@@ -195,6 +197,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
           cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 


### PR DESCRIPTION
We do not utilize LAN sharing on CI, caches are "local" only. 
Also, as can be seen, Jgroups may fail to start on Windoze.