### PR TITLE
Avoid exposing non-public type outside its scope

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -67,7 +67,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
 
     private static final String PLUGIN_EXCLUDES_KEY = DefaultPluginValidationManager.class.getName() + ".excludes";
 
-    public static final ValidationReportLevel DEFAULT_VALIDATION_LEVEL = ValidationReportLevel.INLINE;
+    private static final ValidationReportLevel DEFAULT_VALIDATION_LEVEL = ValidationReportLevel.INLINE;
 
     private static final Collection<ValidationReportLevel> INLINE_VALIDATION_LEVEL = Collections.unmodifiableCollection(
             Arrays.asList(ValidationReportLevel.INLINE, ValidationReportLevel.BRIEF));


### PR DESCRIPTION
ValidationReportLevel isn't public so there shouldn't be a public constant with this type