### PR TITLE
[MNG-8669] Add missing context

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
@@ -99,6 +99,7 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                 ArtifactRequest req = new ArtifactRequest();
                 req.setRepositories(repositories);
                 req.setArtifact(session.toArtifact(coords));
+                req.setRequestContext(trace.context());
                 req.setTrace(trace.trace());
                 requests.add(new ResolverRequest(session, trace.mvnTrace(), req));
             }


### PR DESCRIPTION
The only spot where trace was set but not context, all the rest of the spots were checked and are ok.

---

https://issues.apache.org/jira/browse/MNG-8669