### PR TITLE
[MNG-8679] Align superpom with mvn3

### DIFF
--- a/compat/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/compat/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -42,18 +42,10 @@ under the License.
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>
       </resource>
-      <resource>
-        <directory>${project.basedir}/src/main/resources-filtered</directory>
-        <filtering>true</filtering>
-      </resource>
     </resources>
     <testResources>
       <testResource>
         <directory>${project.basedir}/src/test/resources</directory>
-      </testResource>
-      <testResource>
-        <directory>${project.basedir}/src/test/resources-filtered</directory>
-        <filtering>true</filtering>
       </testResource>
     </testResources>
   </build>

--- a/impl/maven-impl/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/impl/maven-impl/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -42,18 +42,10 @@ under the License.
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>
       </resource>
-      <resource>
-        <directory>${project.basedir}/src/main/resources-filtered</directory>
-        <filtering>true</filtering>
-      </resource>
     </resources>
     <testResources>
       <testResource>
         <directory>${project.basedir}/src/test/resources</directory>
-      </testResource>
-      <testResource>
-        <directory>${project.basedir}/src/test/resources-filtered</directory>
-        <filtering>true</filtering>
       </testResource>
     </testResources>
   </build>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3843PomInheritanceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3843PomInheritanceTest.java
@@ -114,14 +114,6 @@ class MavenITmng3843PomInheritanceTest extends AbstractMavenIntegrationTestCase 
         assertEquals("1", props.getProperty("project.build.testResources"));
         assertPathEquals(basedir, "src/main/resources", props.getProperty("project.build.resources.0.directory"));
         assertPathEquals(basedir, "src/test/resources", props.getProperty("project.build.testResources.0.directory"));
-        if (matchesVersionRange("[4.0.0-alpha-1,)")) {
-            assertPathEquals(
-                    basedir, "src/main/resources-filtered", props.getProperty("project.build.resources.1.directory"));
-            assertPathEquals(
-                    basedir,
-                    "src/test/resources-filtered",
-                    props.getProperty("project.build.testResources.1.directory"));
-        }
         assertPathEquals(basedir, "target", props.getProperty("project.build.directory"));
         assertPathEquals(basedir, "target/classes", props.getProperty("project.build.outputDirectory"));
         assertPathEquals(basedir, "target/test-classes", props.getProperty("project.build.testOutputDirectory"));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3843PomInheritanceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3843PomInheritanceTest.java
@@ -109,13 +109,9 @@ class MavenITmng3843PomInheritanceTest extends AbstractMavenIntegrationTestCase 
         assertPathEquals(basedir, "src/main/java", props.getProperty("project.build.sourceDirectory"));
         assertPathEquals(basedir, "src/test/java", props.getProperty("project.build.testSourceDirectory"));
         assertPathEquals(basedir, "src/main/scripts", props.getProperty("project.build.scriptSourceDirectory"));
-        if (matchesVersionRange("[4.0.0-alpha-1,)")) {
-            assertEquals("2", props.getProperty("project.build.resources"));
-            assertEquals("2", props.getProperty("project.build.testResources"));
-        } else {
-            assertEquals("1", props.getProperty("project.build.resources"));
-            assertEquals("1", props.getProperty("project.build.testResources"));
-        }
+        // model is 4.0.0: SuperPOM does not auto-add filtered-resources
+        assertEquals("1", props.getProperty("project.build.resources"));
+        assertEquals("1", props.getProperty("project.build.testResources"));
         assertPathEquals(basedir, "src/main/resources", props.getProperty("project.build.resources.0.directory"));
         assertPathEquals(basedir, "src/test/resources", props.getProperty("project.build.testResources.0.directory"));
         if (matchesVersionRange("[4.0.0-alpha-1,)")) {


### PR DESCRIPTION
The filtered resources were not added in mvn3, causing slight diffs when a model 4.0.0 project is built with mvn3 and mvn4.

---

https://issues.apache.org/jira/browse/MNG-8679
