### PR TITLE
Use dedicated local repo for ITs on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,7 @@ for (String os in runITsOses) {
                             withEnv(["JAVA_HOME=${ tool "$jdkName" }",
                                         "PATH+MAVEN=${ tool "$jdkName" }/bin:${tool "$mvnName"}/bin",
                                         "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {                                               
-                                String cmd = "${runITscommand} -DmavenDistro=$WORK_DIR/dists/apache-maven-bin.zip -Dmaven.test.failure.ignore"
+                                String cmd = "${runITscommand} -DmavenDistro=$WORK_DIR/dists/apache-maven-bin.zip -Dmaven.test.failure.ignore -Dmaven.repo.local=$WORK_DIR/it-local-repo"
                                 if (isUnix()) {
                                     sh 'df -hT'
                                     sh "${cmd}"


### PR DESCRIPTION
ITs can not use system default local repository as tests can install own artifacts.
It is a cause of unstable tests on 3.9.x branch on Jenkins