### PR TITLE
[MNG-8687] Restore ability to run on JIMFS

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
@@ -20,6 +20,8 @@ package org.apache.maven.model.building;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.maven.building.FileSource;
 
@@ -40,6 +42,10 @@ public class FileModelSource extends FileSource implements ModelSource2 {
         super(pomFile);
     }
 
+    public FileModelSource(Path pomFile) {
+        super(pomFile);
+    }
+
     /**
      *
      * @return the file of this source
@@ -55,15 +61,15 @@ public class FileModelSource extends FileSource implements ModelSource2 {
     public ModelSource2 getRelatedSource(String relPath) {
         relPath = relPath.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 
-        File relatedPom = new File(getFile().getParentFile(), relPath);
+        Path relatedPom = getPath().getParent().resolve(relPath);
 
-        if (relatedPom.isDirectory()) {
+        if (Files.isDirectory(relatedPom)) {
             // TODO figure out how to reuse ModelLocator.locatePom(File) here
-            relatedPom = new File(relatedPom, "pom.xml");
+            relatedPom = relatedPom.resolve("pom.xml");
         }
 
-        if (relatedPom.isFile() && relatedPom.canRead()) {
-            return new FileModelSource(new File(relatedPom.toURI().normalize()));
+        if (Files.isRegularFile(relatedPom) && Files.isReadable(relatedPom)) {
+            return new FileModelSource(relatedPom.normalize());
         }
 
         return null;

--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.repository.internal;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -161,7 +161,7 @@ class DefaultModelResolver implements ModelResolver {
             throw new UnresolvableModelException(e.getMessage(), groupId, artifactId, version, e);
         }
 
-        File pomFile = pomArtifact.getFile();
+        Path pomFile = pomArtifact.getPath();
 
         return new FileModelSource(pomFile);
     }


### PR DESCRIPTION
When worked on https://github.com/apache/maven-resolver/commit/35c2d7579d0c1c1e577c4d847171102ca91be2c7 turned out that Resolver "demos" cannot run anymore on JIMFS. Restore that _minimally_ to make sure lowest possible binary compatibility disruption.

---

https://issues.apache.org/jira/browse/MNG-8687
