### PR TITLE
Drop unused assembly exclude

### DIFF
--- a/apache-maven/src/assembly/component.xml
+++ b/apache-maven/src/assembly/component.xml
@@ -31,7 +31,6 @@ under the License.
       <outputDirectory>lib</outputDirectory>
       <excludes>
         <exclude>org.codehaus.plexus:plexus-classworlds</exclude>
-        <exclude>org.apache.maven:maven-xml-impl</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
This just emits warning by assembly plugin, as is unused, since this module is gone.
