### PR TITLE
[MNG-8572] Support DI beans in build extensions

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultTypeRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultTypeRegistry.java
@@ -54,7 +54,7 @@ public class DefaultTypeRegistry extends AbstractEventSpy implements TypeRegistr
 
     @Inject
     public DefaultTypeRegistry(Lookup lookup, LanguageRegistry languageRegistry, LegacyArtifactHandlerManager manager) {
-        this.lookup = lookup;
+        this.lookup = requireNonNull(lookup, "lookup cannot be null");
         this.languageRegistry = requireNonNull(languageRegistry, "languageRegistry cannot be null");
         this.usedTypes = new ConcurrentHashMap<>();
         this.manager = requireNonNull(manager, "artifactHandlerManager cannot be null");

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -63,6 +63,7 @@ import org.apache.maven.execution.scope.internal.MojoExecutionScopeModule;
 import org.apache.maven.internal.impl.DefaultLog;
 import org.apache.maven.internal.impl.DefaultMojoExecution;
 import org.apache.maven.internal.impl.InternalMavenSession;
+import org.apache.maven.internal.impl.SisuDiBridgeModule;
 import org.apache.maven.internal.xml.XmlPlexusConfiguration;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.ContextEnabled;
@@ -430,6 +431,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
     private void discoverPluginComponents(
             final ClassRealm pluginRealm, Plugin plugin, PluginDescriptor pluginDescriptor)
             throws PluginContainerException {
+        ClassLoader prevTccl = Thread.currentThread().getContextClassLoader();
         try {
             if (pluginDescriptor != null) {
                 for (MojoDescriptor mojo : pluginDescriptor.getMojos()) {
@@ -440,18 +442,22 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                 }
             }
 
+            Thread.currentThread().setContextClassLoader(pluginRealm);
             ((DefaultPlexusContainer) container)
                     .discoverComponents(
                             pluginRealm,
                             new SessionScopeModule(container.lookup(SessionScope.class)),
                             new MojoExecutionScopeModule(container.lookup(MojoExecutionScope.class)),
-                            new PluginConfigurationModule(plugin.getDelegate()));
+                            new PluginConfigurationModule(plugin.getDelegate()),
+                            new SisuDiBridgeModule(true));
         } catch (ComponentLookupException | CycleDetectedInComponentGraphException e) {
             throw new PluginContainerException(
                     plugin,
                     pluginRealm,
                     "Error in component graph of plugin " + plugin.getId() + ": " + e.getMessage(),
                     e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(prevTccl);
         }
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8525MavenDIPlugin.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8525MavenDIPlugin.java
@@ -48,7 +48,7 @@ public class MavenITmng8525MavenDIPlugin extends AbstractMavenIntegrationTestCas
         Verifier v0 = newVerifier(testDir.getAbsolutePath());
         v0.setAutoclean(false);
         v0.deleteDirectory("target");
-        v0.deleteArtifacts("org.apache.maven.its");
+        v0.deleteArtifacts("org.apache.maven.its.mng8525");
         v0.addCliArgument("install");
         v0.execute();
         v0.verifyErrorFreeLog();
@@ -58,7 +58,7 @@ public class MavenITmng8525MavenDIPlugin extends AbstractMavenIntegrationTestCas
         //
         Verifier v1 = newVerifier(testDir.getAbsolutePath());
         v1.setAutoclean(false);
-        v1.addCliArgument("org.apache.maven.its:mavendi-maven-plugin:0.0.1-SNAPSHOT:hello");
+        v1.addCliArgument("org.apache.maven.its.mng8525:mavendi-maven-plugin:0.0.1-SNAPSHOT:hello");
         v1.addCliArgument("-Dname=World");
         v1.execute();
         v1.verifyErrorFreeLog();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8572DITypeHandlerTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8572DITypeHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8572">MNG-8572</a>.
+ *
+ * It verifies that Maven plugins with extensions=true can provide custom artifact type handlers using the Maven API DI system.
+ */
+public class MavenITmng8572DITypeHandlerTest extends AbstractMavenIntegrationTestCase {
+
+    public MavenITmng8572DITypeHandlerTest() {
+        super("[4.0.0-rc-4,)");
+    }
+
+    @Test
+    public void testCustomTypeHandler() throws Exception {
+        // Build the extension first
+        File testDir = extractResources("/mng-8572-di-type-handler");
+        Verifier verifier = newVerifier(new File(testDir, "extension").getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.mng8572");
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Now use the extension in a test project
+        verifier = newVerifier(new File(testDir, "test").getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Verify that our custom type handler was used
+        verifier.verifyTextInLog("[INFO] Using custom type handler for type: custom-type");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8572DITypeHandlerTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8572DITypeHandlerTest.java
@@ -49,11 +49,22 @@ public class MavenITmng8572DITypeHandlerTest extends AbstractMavenIntegrationTes
         verifier = newVerifier(new File(testDir, "test").getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
+        verifier.addCliArguments(
+                "install:install-file",
+                "-Dfile=src/main/java/org/apache/maven/its/mng8572/test/DummyClass.java",
+                "-DpomFile=dummy-artifact-pom.xml",
+                "-Dpackaging=custom",
+                "-DcreateChecksum=true");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        verifier = newVerifier(new File(testDir, "test").getAbsolutePath());
+        verifier.setAutoclean(false);
         verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
         // Verify that our custom type handler was used
-        verifier.verifyTextInLog("[INFO] Using custom type handler for type: custom-type");
+        verifier.verifyTextInLog("[INFO] [MNG-8572] Registering custom type handler for type: custom-type");
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -101,6 +101,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8572DITypeHandlerTest.class);
         suite.addTestSuite(MavenITmng3558PropertyEscapingTest.class);
         suite.addTestSuite(MavenITmng4559MultipleJvmArgsTest.class);
         suite.addTestSuite(MavenITmng4559SpacesInJvmOptsTest.class);

--- a/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/pom.xml
@@ -20,7 +20,7 @@ under the License.
 <project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
   <modelVersion>4.1.0</modelVersion>
 
-  <groupId>org.apache.maven.its</groupId>
+  <groupId>org.apache.maven.its.mng8525</groupId>
   <artifactId>mavendi-maven-plugin</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/README.md
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/README.md
@@ -1,0 +1,57 @@
+# MNG-8572 Custom Type Handler with Maven API DI
+
+This integration test demonstrates how to create a Maven plugin with `extensions=true` that provides a custom artifact type handler using the Maven API DI system.
+
+## Structure
+
+- `extension/`: The Maven plugin with extensions=true that provides a custom artifact type handler
+  - Uses `org.apache.maven.api.di.Named` annotation
+  - Implements `org.apache.maven.api.spi.TypeProvider` interface
+  - Provides a custom type with ID "custom-type"
+  - Uses the Maven API DI system for component discovery
+  - The annotation processor automatically generates the DI index
+
+- `test/`: A test project that uses the custom type handler
+  - References the plugin in the build section with `<extensions>true</extensions>`
+  - Has a dependency with `type="custom-type"`
+  - Verifies that the custom type handler is used
+
+## Key Points
+
+1. **Maven Plugin with extensions=true**:
+   - The plugin is configured with `<extensions>true</extensions>`
+   - This allows it to participate in the build process and provide custom components
+
+2. **TypeProvider Implementation**:
+   - Implements the `org.apache.maven.api.spi.TypeProvider` interface
+   - Annotated with `@Named` from `org.apache.maven.api.di`
+   - Returns a custom implementation of the `Type` interface
+
+3. **Annotation Processing**:
+   - The Maven API DI annotation processor automatically generates the index file
+   - No need to manually create the `META-INF/maven/org.apache.maven.api.di.Inject` file
+
+## Running the Test
+
+1. Build and install the plugin:
+   ```
+   cd extension
+   mvn install
+   ```
+
+2. Install the dummy artifact:
+   ```
+   cd test
+   ./install-dummy.sh
+   ```
+
+3. Run the test project:
+   ```
+   cd test
+   mvn validate
+   ```
+
+4. Verify that the custom type handler is used:
+   ```
+   [INFO] Using custom type handler for type: custom-type
+   ```

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/README.md
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/README.md
@@ -53,5 +53,5 @@ This integration test demonstrates how to create a Maven plugin with `extensions
 
 4. Verify that the custom type handler is used:
    ```
-   [INFO] Using custom type handler for type: custom-type
+   [INFO] [MNG-8572] Registering custom type handler for type: custom-type
    ```

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng8572</groupId>
+  <artifactId>custom-type-maven-plugin</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>MNG-8572 Custom Type Handler Maven Plugin</name>
+  <description>Maven plugin with extensions=true that provides a custom artifact type handler using Maven API DI</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <!-- Maven API for DI and SPI -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-core</artifactId>
+      <version>4.0.0-rc-3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-di</artifactId>
+      <version>4.0.0-rc-3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-spi</artifactId>
+      <version>4.0.0-rc-3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Configure as extension -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>4.0.0-beta-1</version>
+        <extensions>true</extensions>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          <extractors>
+            <extractor>java-annotations</extractor>
+          </extractors>
+        </configuration>
+      </plugin>
+
+      <!-- Compiler with annotation processing for DI index generation -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.0</version>
+        <configuration>
+          <release>17</release>
+          <proc>full</proc>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/pom.xml
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.1.0">
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
   <modelVersion>4.1.0</modelVersion>
 
   <groupId>org.apache.maven.its.mng8572</groupId>

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/CustomType.java
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/CustomType.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.mng8572.extension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.maven.api.Language;
+import org.apache.maven.api.PathType;
+import org.apache.maven.api.Type;
+
+/**
+ * Implementation of a custom artifact type.
+ */
+public class CustomType implements Type {
+
+    private final String id;
+    private final Language language;
+    private final String extension;
+    private final String classifier;
+    private final boolean includesDependencies;
+    private final Set<PathType> pathTypes;
+
+    public CustomType(
+            String id,
+            Language language,
+            String extension,
+            String classifier,
+            boolean includesDependencies,
+            PathType... pathTypes) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.language = Objects.requireNonNull(language, "language cannot be null");
+        this.extension = Objects.requireNonNull(extension, "extension cannot be null");
+        this.classifier = classifier;
+        this.includesDependencies = includesDependencies;
+        this.pathTypes = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(pathTypes)));
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public Language getLanguage() {
+        return language;
+    }
+
+    @Override
+    public String getExtension() {
+        return extension;
+    }
+
+    @Override
+    public String getClassifier() {
+        return classifier;
+    }
+
+    @Override
+    public boolean isIncludesDependencies() {
+        return includesDependencies;
+    }
+
+    @Override
+    public Set<PathType> getPathTypes() {
+        return pathTypes;
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/CustomTypeProvider.java
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/CustomTypeProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.mng8572.extension;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.maven.api.JavaPathType;
+import org.apache.maven.api.Language;
+import org.apache.maven.api.Type;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.spi.TypeProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides a custom artifact type handler using the Maven API DI system.
+ */
+@Named
+public class CustomTypeProvider implements TypeProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomTypeProvider.class);
+
+    @Override
+    public Collection<Type> provides() {
+        System.out.println("[MNG-8572] Registering custom type handler for type: custom-type");
+        LOGGER.info("[MNG-8572] Registering custom type handler for type: custom-type");
+
+        // Create a custom type that will be used for dependencies with type="custom-type"
+        CustomType customType = new CustomType(
+                "custom-type", // type id
+                Language.JAVA_FAMILY, // language
+                "custom", // extension
+                null, // classifier
+                false, // includesDependencies
+                JavaPathType.CLASSES // pathTypes - add to classpath
+                );
+
+        return Collections.singleton(customType);
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/CustomTypeProvider.java
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/CustomTypeProvider.java
@@ -39,7 +39,6 @@ public class CustomTypeProvider implements TypeProvider {
 
     @Override
     public Collection<Type> provides() {
-        System.out.println("[MNG-8572] Registering custom type handler for type: custom-type");
         LOGGER.info("[MNG-8572] Registering custom type handler for type: custom-type");
 
         // Create a custom type that will be used for dependencies with type="custom-type"

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/NoOpMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/NoOpMojo.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.mng8572.extension;
+
+import org.apache.maven.api.di.Inject;
+import org.apache.maven.api.plugin.Log;
+import org.apache.maven.api.plugin.Mojo;
+import org.apache.maven.api.plugin.annotations.Parameter;
+
+/**
+ * A no-operation Mojo that does nothing. This is just to make the plugin valid.
+ * The real functionality is in the TypeProvider.
+ *
+ * @goal noop
+ */
+@org.apache.maven.api.plugin.annotations.Mojo(name = "noop")
+public class NoOpMojo implements Mojo {
+
+    @Inject
+    private Log log;
+
+    @Parameter(defaultValue = "${project.name}", readonly = true)
+    private String projectName;
+
+    @Override
+    public void execute() {
+        log.info("NoOpMojo executed for project: " + projectName);
+        log.info("This Mojo does nothing. The real functionality is in the TypeProvider.");
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/dummy-artifact-pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/dummy-artifact-pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng8572</groupId>
+  <artifactId>dummy-artifact</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>custom-type</packaging>
+
+  <name>MNG-8572 Dummy Artifact</name>
+  <description>Dummy artifact with custom type</description>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/install-dummy.sh
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/install-dummy.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Install the dummy artifact with our custom type
+mvn install:install-file \
+  -Dfile=src/main/java/org/apache/maven/its/mng8572/test/DummyClass.java \
+  -DpomFile=dummy-artifact-pom.xml \
+  -Dpackaging=custom-type \
+  -DcreateChecksum=true

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/install-dummy.sh
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/install-dummy.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-# Install the dummy artifact with our custom type
-mvn install:install-file \
-  -Dfile=src/main/java/org/apache/maven/its/mng8572/test/DummyClass.java \
-  -DpomFile=dummy-artifact-pom.xml \
-  -Dpackaging=custom-type \
-  -DcreateChecksum=true

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng8572</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>MNG-8572 Custom Type Handler Test</name>
+  <description>Test project that uses a custom artifact type handler</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <!-- This dependency uses our custom type -->
+    <dependency>
+      <groupId>org.apache.maven.its.mng8572</groupId>
+      <artifactId>dummy-artifact</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>custom-type</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>17</release>
+        </configuration>
+      </plugin>
+      <!-- Our plugin with extensions=true that provides the custom type handler -->
+      <plugin>
+        <groupId>org.apache.maven.its.mng8572</groupId>
+        <artifactId>custom-type-maven-plugin</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <extensions>true</extensions>
+      </plugin>
+      <!-- Plugin to verify the custom type handler is working -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <id>list</id>
+            <goals>
+              <goal>list</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/pom.xml
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.1.0">
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
   <modelVersion>4.1.0</modelVersion>
 
   <groupId>org.apache.maven.its.mng8572</groupId>

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/settings.xml
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+  <localRepository>${basedir}/target/local-repo</localRepository>
+  <offline>false</offline>
+</settings>

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/src/main/java/org/apache/maven/its/mng8572/test/DummyClass.java
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/test/src/main/java/org/apache/maven/its/mng8572/test/DummyClass.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.mng8572.test;
+
+/**
+ * Dummy class for testing.
+ */
+public class DummyClass {
+    public static void main(String[] args) {
+        System.out.println("Hello from DummyClass");
+    }
+}


### PR DESCRIPTION
This PR adds support for using the Maven API DI system in build extensions (plugins with extensions=true). It enables build extensions to provide custom artifact type handlers using the new DI mechanism.

## Key changes
- Added an integration test that demonstrates a custom artifact type handler using the Maven API DI system in a build extension
- The test shows how to implement a TypeProvider using `@Named` annotation
- The annotation processor automatically generates the DI index file
- The custom type handler is properly discovered and used during the build

This enhancement allows build extensions to leverage the new Maven API DI system, making it easier to create and maintain extensions that provide custom artifact type handlers.

Fixes: https://issues.apache.org/jira/browse/MNG-8572