### PR TITLE
[MNG-8707] Add methods to remove compile and test source roots

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -320,7 +320,7 @@ public class MavenProject implements Cloneable {
      * @param path the source root to add
      */
     public void addCompileSourceRoot(String path) {
-        addPath(getCompileSourceRoots(), path);
+        addPath(compileSourceRoots, path);
     }
 
     /**
@@ -330,7 +330,7 @@ public class MavenProject implements Cloneable {
      * @since 3.9.10
      */
     public void removeCompileSourceRoot(String path) {
-        removePath(getCompileSourceRoots(), path);
+        removePath(compileSourceRoots, path);
     }
 
     /**
@@ -339,7 +339,7 @@ public class MavenProject implements Cloneable {
      * @param path the test source root to add
      */
     public void addTestCompileSourceRoot(String path) {
-        addPath(getTestCompileSourceRoots(), path);
+        addPath(testCompileSourceRoots, path);
     }
 
     /**
@@ -349,7 +349,7 @@ public class MavenProject implements Cloneable {
      * @since 3.9.10
      */
     public void removeTestCompileSourceRoot(String path) {
-        removePath(getTestCompileSourceRoots(), path);
+        removePath(testCompileSourceRoots, path);
     }
 
     /**

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -279,7 +279,7 @@ public class MavenProject implements Cloneable {
     private void addPath(List<String> paths, String path) {
         if (path != null) {
             path = path.trim();
-            if (path.length() > 0) {
+            if (!path.isEmpty()) {
                 File file = new File(path);
                 if (file.isAbsolute()) {
                     path = file.getAbsolutePath();
@@ -296,12 +296,38 @@ public class MavenProject implements Cloneable {
         }
     }
 
+    private void removePath(List<String> paths, String path) {
+        if (path != null) {
+            path = path.trim();
+            if (!path.isEmpty()) {
+                File file = new File(path);
+                if (file.isAbsolute()) {
+                    path = file.getAbsolutePath();
+                } else if (".".equals(path)) {
+                    path = getBasedir().getAbsolutePath();
+                } else {
+                    path = new File(getBasedir(), path).getAbsolutePath();
+                }
+
+                paths.remove(path);
+            }
+        }
+    }
+
     public void addCompileSourceRoot(String path) {
         addPath(getCompileSourceRoots(), path);
     }
 
+    public void removeCompileSourceRoot(String path) {
+        removePath(getCompileSourceRoots(), path);
+    }
+
     public void addTestCompileSourceRoot(String path) {
         addPath(getTestCompileSourceRoots(), path);
+    }
+
+    public void removeTestCompileSourceRoot(String path) {
+        removePath(getTestCompileSourceRoots(), path);
     }
 
     public List<String> getCompileSourceRoots() {

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -21,6 +21,7 @@ package org.apache.maven.project;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1211,7 +1212,8 @@ public class MavenProject implements Cloneable {
                 return;
             }
 
-            LOGGER.warn("Direct modification of " + collectionName + " through " + method + "() is deprecated and will not work in Maven 4.0.0. "
+            LOGGER.warn("Direct modification of " + collectionName + " through " + method
+                    + "() is deprecated and will not work in Maven 4.0.0. "
                     + "Please use the add/remove methods instead. If you're using a plugin that causes this warning, "
                     + "please upgrade to the latest version and report an issue if the warning persists. "
                     + "To disable these warnings, set -D" + DISABLE_WARNINGS_PROPERTY + "=true");

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -314,6 +314,11 @@ public class MavenProject implements Cloneable {
         }
     }
 
+    /**
+     * Adds the specified path to the list of compile source roots for this project.
+     *
+     * @param path the source root to add
+     */
     public void addCompileSourceRoot(String path) {
         addPath(getCompileSourceRoots(), path);
     }
@@ -328,6 +333,11 @@ public class MavenProject implements Cloneable {
         removePath(getCompileSourceRoots(), path);
     }
 
+    /**
+     * Adds the specified path to the list of test compile source roots for this project.
+     *
+     * @param path the test source root to add
+     */
     public void addTestCompileSourceRoot(String path) {
         addPath(getTestCompileSourceRoots(), path);
     }
@@ -342,12 +352,28 @@ public class MavenProject implements Cloneable {
         removePath(getTestCompileSourceRoots(), path);
     }
 
+    /**
+     * Gets the list of compile source roots for this project.
+     * <p>
+     * <strong>Note:</strong> The collection returned by this method should not be modified directly.
+     * Use {@link #addCompileSourceRoot(String)} and {@link #removeCompileSourceRoot(String)} methods instead.
+     *
+     * @return a list of compile source roots
+     */
     public List<String> getCompileSourceRoots() {
-        return compileSourceRoots;
+        return new LoggingList<>(compileSourceRoots, "compileSourceRoots");
     }
 
+    /**
+     * Gets the list of test compile source roots for this project.
+     * <p>
+     * <strong>Note:</strong> The collection returned by this method should not be modified directly.
+     * Use {@link #addTestCompileSourceRoot(String)} and {@link #removeTestCompileSourceRoot(String)} methods instead.
+     *
+     * @return a list of test compile source roots
+     */
     public List<String> getTestCompileSourceRoots() {
-        return testCompileSourceRoots;
+        return new LoggingList<>(testCompileSourceRoots, "testCompileSourceRoots");
     }
 
     public List<String> getCompileClasspathElements() throws DependencyResolutionRequiredException {
@@ -1156,6 +1182,91 @@ public class MavenProject implements Cloneable {
         StringBuilder buffer = new StringBuilder(128);
         buffer.append(groupId).append(':').append(artifactId).append(':').append(version);
         return buffer.toString();
+    }
+
+    /**
+     * A List implementation that logs warnings when modified directly instead of using the proper add/remove methods.
+     *
+     * @param <E> the type of elements in the list
+     * @since 3.9.10
+     */
+    private static class LoggingList<E> extends ArrayList<E> {
+        private static final long serialVersionUID = 1L;
+        private final String collectionName;
+
+        LoggingList(List<E> delegate, String collectionName) {
+            super(delegate);
+            this.collectionName = collectionName;
+        }
+
+        private void logWarning(String method) {
+            LOGGER.warn("Direct modification of " + collectionName + " through " + method + "() is deprecated. "
+                    + "Please use the add/remove methods instead.");
+            // Log a stack trace to help identify the caller
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Stack trace", new Exception("Stack trace"));
+            }
+        }
+
+        @Override
+        public boolean add(E e) {
+            logWarning("add");
+            return super.add(e);
+        }
+
+        @Override
+        public void add(int index, E element) {
+            logWarning("add");
+            super.add(index, element);
+        }
+
+        @Override
+        public boolean addAll(java.util.Collection<? extends E> c) {
+            logWarning("addAll");
+            return super.addAll(c);
+        }
+
+        @Override
+        public boolean addAll(int index, java.util.Collection<? extends E> c) {
+            logWarning("addAll");
+            return super.addAll(index, c);
+        }
+
+        @Override
+        public void clear() {
+            logWarning("clear");
+            super.clear();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            logWarning("remove");
+            return super.remove(o);
+        }
+
+        @Override
+        public E remove(int index) {
+            logWarning("remove");
+            return super.remove(index);
+        }
+
+        @Override
+        public boolean removeAll(java.util.Collection<?> c) {
+            logWarning("removeAll");
+            return super.removeAll(c);
+        }
+
+        @Override
+        public boolean retainAll(java.util.Collection<?> c) {
+            logWarning("retainAll");
+            return super.retainAll(c);
+        }
+
+        @Override
+        public E set(int index, E element) {
+            logWarning("set");
+            return super.set(index, element);
+        }
     }
 
     /**

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -22,11 +22,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -1192,7 +1195,7 @@ public class MavenProject implements Cloneable {
      * @param <E> the type of elements in the list
      * @since 3.9.10
      */
-    private static class LoggingList<E> implements List<E> {
+    private static class LoggingList<E> extends AbstractList<E> {
         private static final String DISABLE_WARNINGS_PROPERTY = "maven.project.sourceRoots.warningsDisabled";
         private final List<E> delegate;
         private final String collectionName;
@@ -1219,18 +1222,43 @@ public class MavenProject implements Cloneable {
         }
 
         @Override
+        public E get(int index) {
+            return delegate.get(index);
+        }
+
+        @Override
         public int size() {
             return delegate.size();
         }
 
         @Override
-        public boolean isEmpty() {
-            return delegate.isEmpty();
+        public E set(int index, E element) {
+            logWarning("set");
+            return delegate.set(index, element);
         }
 
         @Override
-        public boolean contains(Object o) {
-            return delegate.contains(o);
+        public void add(int index, E element) {
+            logWarning("add");
+            delegate.add(index, element);
+        }
+
+        @Override
+        public E remove(int index) {
+            logWarning("remove");
+            return delegate.remove(index);
+        }
+
+        @Override
+        public void clear() {
+            logWarning("clear");
+            delegate.clear();
+        }
+
+        @Override
+        public boolean addAll(int index, Collection<? extends E> c) {
+            logWarning("addAll");
+            return delegate.addAll(index, c);
         }
 
         @Override
@@ -1257,103 +1285,63 @@ public class MavenProject implements Cloneable {
         }
 
         @Override
-        public Object[] toArray() {
-            return delegate.toArray();
-        }
-
-        @Override
-        public <T> T[] toArray(T[] a) {
-            return delegate.toArray(a);
-        }
-
-        @Override
-        public boolean add(E e) {
-            logWarning("add");
-            return delegate.add(e);
-        }
-
-        @Override
-        public boolean remove(Object o) {
-            logWarning("remove");
-            return delegate.remove(o);
-        }
-
-        @Override
-        public boolean containsAll(Collection<?> c) {
-            return delegate.containsAll(c);
-        }
-
-        @Override
-        public boolean addAll(Collection<? extends E> c) {
-            logWarning("addAll");
-            return delegate.addAll(c);
-        }
-
-        @Override
-        public boolean addAll(int index, Collection<? extends E> c) {
-            logWarning("addAll");
-            return delegate.addAll(index, c);
-        }
-
-        @Override
-        public boolean removeAll(Collection<?> c) {
-            logWarning("removeAll");
-            return delegate.removeAll(c);
-        }
-
-        @Override
-        public boolean retainAll(Collection<?> c) {
-            logWarning("retainAll");
-            return delegate.retainAll(c);
-        }
-
-        @Override
-        public void clear() {
-            logWarning("clear");
-            delegate.clear();
-        }
-
-        @Override
-        public E get(int index) {
-            return delegate.get(index);
-        }
-
-        @Override
-        public E set(int index, E element) {
-            logWarning("set");
-            return delegate.set(index, element);
-        }
-
-        @Override
-        public void add(int index, E element) {
-            logWarning("add");
-            delegate.add(index, element);
-        }
-
-        @Override
-        public E remove(int index) {
-            logWarning("remove");
-            return delegate.remove(index);
-        }
-
-        @Override
-        public int indexOf(Object o) {
-            return delegate.indexOf(o);
-        }
-
-        @Override
-        public int lastIndexOf(Object o) {
-            return delegate.lastIndexOf(o);
-        }
-
-        @Override
         public ListIterator<E> listIterator() {
-            return new LoggingListIterator(delegate.listIterator());
+            return listIterator(0);
         }
 
         @Override
         public ListIterator<E> listIterator(int index) {
-            return new LoggingListIterator(delegate.listIterator(index));
+            return new ListIterator<E>() {
+                private final ListIterator<E> it = delegate.listIterator(index);
+
+                @Override
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                @Override
+                public E next() {
+                    return it.next();
+                }
+
+                @Override
+                public boolean hasPrevious() {
+                    return it.hasPrevious();
+                }
+
+                @Override
+                public E previous() {
+                    return it.previous();
+                }
+
+                @Override
+                public int nextIndex() {
+                    return it.nextIndex();
+                }
+
+                @Override
+                public int previousIndex() {
+                    return it.previousIndex();
+                }
+
+                @Override
+                public void remove() {
+                    logWarning("listIterator.remove");
+                    it.remove();
+                }
+
+                @Override
+                public void set(E e) {
+                    logWarning("listIterator.set");
+                    it.set(e);
+                }
+
+                @Override
+                public void add(E e) {
+                    logWarning("listIterator.add");
+                    it.add(e);
+                }
+            };
         }
 
         @Override
@@ -1374,62 +1362,6 @@ public class MavenProject implements Cloneable {
         @Override
         public String toString() {
             return delegate.toString();
-        }
-
-        private class LoggingListIterator implements ListIterator<E> {
-            private final ListIterator<E> it;
-
-            LoggingListIterator(ListIterator<E> it) {
-                this.it = it;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return it.hasNext();
-            }
-
-            @Override
-            public E next() {
-                return it.next();
-            }
-
-            @Override
-            public boolean hasPrevious() {
-                return it.hasPrevious();
-            }
-
-            @Override
-            public E previous() {
-                return it.previous();
-            }
-
-            @Override
-            public int nextIndex() {
-                return it.nextIndex();
-            }
-
-            @Override
-            public int previousIndex() {
-                return it.previousIndex();
-            }
-
-            @Override
-            public void remove() {
-                logWarning("listIterator.remove");
-                it.remove();
-            }
-
-            @Override
-            public void set(E e) {
-                logWarning("listIterator.set");
-                it.set(e);
-            }
-
-            @Override
-            public void add(E e) {
-                logWarning("listIterator.add");
-                it.add(e);
-            }
         }
     }
 

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -279,41 +279,41 @@ public class MavenProject implements Cloneable {
     // Test and compile sourceroots.
     // ----------------------------------------------------------------------
 
-    private void addPath(List<String> paths, String path) {
-        if (path != null) {
-            path = path.trim();
-            if (!path.isEmpty()) {
-                File file = new File(path);
-                if (file.isAbsolute()) {
-                    path = file.getAbsolutePath();
-                } else if (".".equals(path)) {
-                    path = getBasedir().getAbsolutePath();
-                } else {
-                    path = new File(getBasedir(), path).getAbsolutePath();
-                }
+    /**
+     * Sanitizes a path by trimming it and converting it to an absolute path.
+     *
+     * @param path the path to sanitize
+     * @return the sanitized path, or null if the input path is null, empty, or consists only of whitespace
+     */
+    private String sanitizePath(String path) {
+        if (path == null) {
+            return null;
+        }
+        path = path.trim();
+        if (path.isEmpty()) {
+            return null;
+        }
+        File file = new File(path);
+        if (file.isAbsolute()) {
+            return file.getAbsolutePath();
+        } else if (".".equals(path)) {
+            return getBasedir().getAbsolutePath();
+        } else {
+            return new File(getBasedir(), path).getAbsolutePath();
+        }
+    }
 
-                if (!paths.contains(path)) {
-                    paths.add(path);
-                }
-            }
+    private void addPath(List<String> paths, String path) {
+        String sanitizedPath = sanitizePath(path);
+        if (sanitizedPath != null && !paths.contains(sanitizedPath)) {
+            paths.add(sanitizedPath);
         }
     }
 
     private void removePath(List<String> paths, String path) {
-        if (path != null) {
-            path = path.trim();
-            if (!path.isEmpty()) {
-                File file = new File(path);
-                if (file.isAbsolute()) {
-                    path = file.getAbsolutePath();
-                } else if (".".equals(path)) {
-                    path = getBasedir().getAbsolutePath();
-                } else {
-                    path = new File(getBasedir(), path).getAbsolutePath();
-                }
-
-                paths.remove(path);
-            }
+        String sanitizedPath = sanitizePath(path);
+        if (sanitizedPath != null) {
+            paths.remove(sanitizedPath);
         }
     }
 

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1196,7 +1196,7 @@ public class MavenProject implements Cloneable {
      * @param <E> the type of elements in the list
      * @since 3.9.10
      */
-    private static class LoggingList<E> extends AbstractList<E> {
+    private class LoggingList<E> extends AbstractList<E> {
         private static final String DISABLE_WARNINGS_PROPERTY = "maven.project.sourceRoots.warningsDisabled";
         private final List<E> delegate;
         private final String collectionName;
@@ -1208,7 +1208,11 @@ public class MavenProject implements Cloneable {
 
         private void logWarning(String method) {
             // Check if warnings are disabled
-            if (Boolean.getBoolean(DISABLE_WARNINGS_PROPERTY)) {
+            String property = getProperties().getProperty(DISABLE_WARNINGS_PROPERTY);
+            if (property == null) {
+                property = System.getProperty(DISABLE_WARNINGS_PROPERTY);
+            }
+            if (Boolean.parseBoolean(property)) {
                 return;
             }
 
@@ -1216,7 +1220,8 @@ public class MavenProject implements Cloneable {
                     + "() is deprecated and will not work in Maven 4.0.0. "
                     + "Please use the add/remove methods instead. If you're using a plugin that causes this warning, "
                     + "please upgrade to the latest version and report an issue if the warning persists. "
-                    + "To disable these warnings, set -D" + DISABLE_WARNINGS_PROPERTY + "=true");
+                    + "To disable these warnings, set -D" + DISABLE_WARNINGS_PROPERTY + "=true on the command line, "
+                    + "in the .mvn/maven.config file, or in project POM properties.");
             // Log a stack trace to help identify the caller
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Stack trace", new Exception("Stack trace"));

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1192,6 +1192,7 @@ public class MavenProject implements Cloneable {
      */
     private static class LoggingList<E> extends ArrayList<E> {
         private static final long serialVersionUID = 1L;
+        private static final String DISABLE_WARNINGS_PROPERTY = "maven.project.sourceRoots.warningsDisabled";
         private final String collectionName;
 
         LoggingList(List<E> delegate, String collectionName) {
@@ -1200,8 +1201,15 @@ public class MavenProject implements Cloneable {
         }
 
         private void logWarning(String method) {
-            LOGGER.warn("Direct modification of " + collectionName + " through " + method + "() is deprecated. "
-                    + "Please use the add/remove methods instead.");
+            // Check if warnings are disabled
+            if (Boolean.getBoolean(DISABLE_WARNINGS_PROPERTY)) {
+                return;
+            }
+
+            LOGGER.warn("Direct modification of " + collectionName + " through " + method + "() is deprecated and will not work in Maven 4.0.0. "
+                    + "Please use the add/remove methods instead. If you're using a plugin that causes this warning, "
+                    + "please upgrade to the latest version and report an issue if the warning persists. "
+                    + "To disable these warnings, set -D" + DISABLE_WARNINGS_PROPERTY + "=true");
             // Log a stack trace to help identify the caller
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Stack trace", new Exception("Stack trace"));

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -318,6 +318,12 @@ public class MavenProject implements Cloneable {
         addPath(getCompileSourceRoots(), path);
     }
 
+    /**
+     * Removes the specified path from the list of compile source roots.
+     *
+     * @param path the source root to remove
+     * @since 3.9.10
+     */
     public void removeCompileSourceRoot(String path) {
         removePath(getCompileSourceRoots(), path);
     }
@@ -326,6 +332,12 @@ public class MavenProject implements Cloneable {
         addPath(getTestCompileSourceRoots(), path);
     }
 
+    /**
+     * Removes the specified path from the list of test compile source roots.
+     *
+     * @param path the test source root to remove
+     * @since 3.9.10
+     */
     public void removeTestCompileSourceRoot(String path) {
         removePath(getTestCompileSourceRoots(), path);
     }

--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1186,17 +1186,19 @@ public class MavenProject implements Cloneable {
 
     /**
      * A List implementation that logs warnings when modified directly instead of using the proper add/remove methods.
+     * This is a wrapper that delegates all operations to the underlying list, so modifications to this list
+     * will affect the original list.
      *
      * @param <E> the type of elements in the list
      * @since 3.9.10
      */
-    private static class LoggingList<E> extends ArrayList<E> {
-        private static final long serialVersionUID = 1L;
+    private static class LoggingList<E> implements List<E> {
         private static final String DISABLE_WARNINGS_PROPERTY = "maven.project.sourceRoots.warningsDisabled";
+        private final List<E> delegate;
         private final String collectionName;
 
         LoggingList(List<E> delegate, String collectionName) {
-            super(delegate);
+            this.delegate = delegate;
             this.collectionName = collectionName;
         }
 
@@ -1217,63 +1219,217 @@ public class MavenProject implements Cloneable {
         }
 
         @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return delegate.isEmpty();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return delegate.contains(o);
+        }
+
+        @Override
+        public Iterator<E> iterator() {
+            return new Iterator<E>() {
+                private final Iterator<E> it = delegate.iterator();
+
+                @Override
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                @Override
+                public E next() {
+                    return it.next();
+                }
+
+                @Override
+                public void remove() {
+                    logWarning("iterator.remove");
+                    it.remove();
+                }
+            };
+        }
+
+        @Override
+        public Object[] toArray() {
+            return delegate.toArray();
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            return delegate.toArray(a);
+        }
+
+        @Override
         public boolean add(E e) {
             logWarning("add");
-            return super.add(e);
-        }
-
-        @Override
-        public void add(int index, E element) {
-            logWarning("add");
-            super.add(index, element);
-        }
-
-        @Override
-        public boolean addAll(java.util.Collection<? extends E> c) {
-            logWarning("addAll");
-            return super.addAll(c);
-        }
-
-        @Override
-        public boolean addAll(int index, java.util.Collection<? extends E> c) {
-            logWarning("addAll");
-            return super.addAll(index, c);
-        }
-
-        @Override
-        public void clear() {
-            logWarning("clear");
-            super.clear();
+            return delegate.add(e);
         }
 
         @Override
         public boolean remove(Object o) {
             logWarning("remove");
-            return super.remove(o);
+            return delegate.remove(o);
         }
 
         @Override
-        public E remove(int index) {
-            logWarning("remove");
-            return super.remove(index);
+        public boolean containsAll(Collection<?> c) {
+            return delegate.containsAll(c);
         }
 
         @Override
-        public boolean removeAll(java.util.Collection<?> c) {
+        public boolean addAll(Collection<? extends E> c) {
+            logWarning("addAll");
+            return delegate.addAll(c);
+        }
+
+        @Override
+        public boolean addAll(int index, Collection<? extends E> c) {
+            logWarning("addAll");
+            return delegate.addAll(index, c);
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
             logWarning("removeAll");
-            return super.removeAll(c);
+            return delegate.removeAll(c);
         }
 
         @Override
-        public boolean retainAll(java.util.Collection<?> c) {
+        public boolean retainAll(Collection<?> c) {
             logWarning("retainAll");
-            return super.retainAll(c);
+            return delegate.retainAll(c);
+        }
+
+        @Override
+        public void clear() {
+            logWarning("clear");
+            delegate.clear();
+        }
+
+        @Override
+        public E get(int index) {
+            return delegate.get(index);
         }
 
         @Override
         public E set(int index, E element) {
             logWarning("set");
-            return super.set(index, element);
+            return delegate.set(index, element);
+        }
+
+        @Override
+        public void add(int index, E element) {
+            logWarning("add");
+            delegate.add(index, element);
+        }
+
+        @Override
+        public E remove(int index) {
+            logWarning("remove");
+            return delegate.remove(index);
+        }
+
+        @Override
+        public int indexOf(Object o) {
+            return delegate.indexOf(o);
+        }
+
+        @Override
+        public int lastIndexOf(Object o) {
+            return delegate.lastIndexOf(o);
+        }
+
+        @Override
+        public ListIterator<E> listIterator() {
+            return new LoggingListIterator(delegate.listIterator());
+        }
+
+        @Override
+        public ListIterator<E> listIterator(int index) {
+            return new LoggingListIterator(delegate.listIterator(index));
+        }
+
+        @Override
+        public List<E> subList(int fromIndex, int toIndex) {
+            return new LoggingList<>(delegate.subList(fromIndex, toIndex), collectionName);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return delegate.equals(o);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        private class LoggingListIterator implements ListIterator<E> {
+            private final ListIterator<E> it;
+
+            LoggingListIterator(ListIterator<E> it) {
+                this.it = it;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public E next() {
+                return it.next();
+            }
+
+            @Override
+            public boolean hasPrevious() {
+                return it.hasPrevious();
+            }
+
+            @Override
+            public E previous() {
+                return it.previous();
+            }
+
+            @Override
+            public int nextIndex() {
+                return it.nextIndex();
+            }
+
+            @Override
+            public int previousIndex() {
+                return it.previousIndex();
+            }
+
+            @Override
+            public void remove() {
+                logWarning("listIterator.remove");
+                it.remove();
+            }
+
+            @Override
+            public void set(E e) {
+                logWarning("listIterator.set");
+                it.set(e);
+            }
+
+            @Override
+            public void add(E e) {
+                logWarning("listIterator.add");
+                it.add(e);
+            }
         }
     }
 


### PR DESCRIPTION
JIRA issue: [MNG-8707](https://issues.apache.org/jira/browse/MNG-8707)

# Add methods to remove compile and test source roots

## Overview
This PR adds new methods to the `MavenProject` class to allow removing source roots, complementing the existing methods for adding them. This provides a more complete API for managing source roots in Maven projects.

## Changes
- Added `removeCompileSourceRoot(String)` method to remove a compile source root
- Added `removeTestCompileSourceRoot(String)` method to remove a test compile source root
- Added `removePath(List<String>, String)` utility method to handle path removal
- Extracted common path handling logic into a new `sanitizePath(String)` method
- Added proper Javadoc with `@since 3.9.10` tags to new methods
- Added warning mechanism when source root collections are modified directly
- Improved code readability by replacing `path.length() > 0` with `!path.isEmpty()`

## Implementation Details
- The new methods mirror the behavior of the existing add methods
- Path sanitization is consistent between add and remove operations
- Added a `LoggingList` wrapper that logs warnings when collections are modified directly
- Warnings can be disabled via the system property `maven.project.sourceRoots.warningsDisabled`
- Warning messages indicate that direct modification will not work in Maven 4.0.0

## Motivation
These changes provide a more complete API for managing source roots, which is particularly useful for plugins that need to manipulate the source roots of a project during the build process.

## Compatibility
This change is fully backward compatible. The new methods are marked with `@since 3.9.10` to indicate when they were added.