### PR TITLE
Modernize codebase with Java improvements

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaToolchain.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaToolchain.java
@@ -19,6 +19,7 @@
 package org.apache.maven.api;
 
 import org.apache.maven.api.annotations.Experimental;
+import org.apache.maven.api.annotations.Nonnull;
 
 /**
  * Represents a Java toolchain in the Maven build system.
@@ -41,5 +42,6 @@ import org.apache.maven.api.annotations.Experimental;
 @Experimental
 public interface JavaToolchain extends Toolchain {
 
+    @Nonnull
     String getJavaHome();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
@@ -62,6 +62,7 @@ public interface Lifecycle extends ExtensibleEnum {
      * @return the unique identifier for this lifecycle
      */
     @Override
+    @Nonnull
     String id();
 
     /**
@@ -69,6 +70,7 @@ public interface Lifecycle extends ExtensibleEnum {
      *
      * @return the collection of top-level phases in this lifecycle
      */
+    @Nonnull
     Collection<Phase> phases();
 
     /**
@@ -78,6 +80,7 @@ public interface Lifecycle extends ExtensibleEnum {
      *
      * @return the collection of phases in Maven 3 compatible ordering
      */
+    @Nonnull
     default Collection<Phase> v3phases() {
         return phases();
     }
@@ -87,6 +90,7 @@ public interface Lifecycle extends ExtensibleEnum {
      *
      * @return a stream of all phases in this lifecycle, including nested phases
      */
+    @Nonnull
     default Stream<Phase> allPhases() {
         return phases().stream().flatMap(Phase::allPhases);
     }
@@ -97,6 +101,7 @@ public interface Lifecycle extends ExtensibleEnum {
      *
      * @return the collection of phase aliases
      */
+    @Nonnull
     Collection<Alias> aliases();
 
     /**
@@ -180,6 +185,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the Maven 3 phase name
          */
+        @Nonnull
         String v3Phase();
 
         /**
@@ -187,6 +193,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the Maven 4 phase name
          */
+        @Nonnull
         String v4Phase();
     }
 
@@ -206,6 +213,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the link kind
          */
+        @Nonnull
         Kind kind();
 
         /**
@@ -213,6 +221,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the phase pointer
          */
+        @Nonnull
         Pointer pointer();
     }
 
@@ -228,6 +237,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the phase name
          */
+        @Nonnull
         String phase();
 
         /**
@@ -235,6 +245,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the pointer type
          */
+        @Nonnull
         Type type();
     }
 
@@ -244,6 +255,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the PROJECT pointer type
          */
+        @Nonnull
         default Type type() {
             return Type.PROJECT;
         }
@@ -255,6 +267,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the dependency scope, or "all" if not specified
          */
+        @Nonnull
         String scope(); // default: all
 
         /**
@@ -262,6 +275,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the DEPENDENCIES pointer type
          */
+        @Nonnull
         default Type type() {
             return Type.DEPENDENCIES;
         }
@@ -273,6 +287,7 @@ public interface Lifecycle extends ExtensibleEnum {
          *
          * @return the CHILDREN pointer type
          */
+        @Nonnull
         default Type type() {
             return Type.CHILDREN;
         }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
@@ -106,7 +106,7 @@ public interface Lifecycle extends ExtensibleEnum {
 
     /**
      * A phase in the lifecycle.
-     *
+     * <p>
      * A phase is identified by its name. It also contains a list of plugins bound to that phase,
      * a list of {@link Link links}, and a list of sub-phases.  This forms a tree of phases.
      */

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Lifecycle.java
@@ -172,7 +172,9 @@ public interface Lifecycle extends ExtensibleEnum {
          * @return a stream of all phases
          */
         @Nonnull
-        Stream<Phase> allPhases();
+        default Stream<Phase> allPhases() {
+            return Stream.concat(Stream.of(this), phases().stream().flatMap(Lifecycle.Phase::allPhases));
+        }
     }
 
     /**

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Toolchain.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Toolchain.java
@@ -21,6 +21,8 @@ package org.apache.maven.api;
 import java.util.Map;
 
 import org.apache.maven.api.annotations.Experimental;
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
 import org.apache.maven.api.toolchain.ToolchainModel;
 
 /**
@@ -69,6 +71,7 @@ public interface Toolchain {
      *
      * @return the toolchain type
      */
+    @Nonnull
     String getType();
 
     /**
@@ -76,6 +79,7 @@ public interface Toolchain {
      *
      * @return the toolchain model
      */
+    @Nonnull
     ToolchainModel getModel();
 
     /**
@@ -84,7 +88,8 @@ public interface Toolchain {
      * @param toolName the tool platform independent tool name
      * @return file representing the tool executable, or null if the tool cannot be found
      */
-    String findTool(String toolName);
+    @Nullable
+    String findTool(@Nonnull String toolName);
 
     /**
      * Let the toolchain decide if it matches requirements defined
@@ -93,5 +98,5 @@ public interface Toolchain {
      * @param requirements key value pair, may not be {@code null}
      * @return {@code true} if the requirements match, otherwise {@code false}
      */
-    boolean matchesRequirements(Map<String, String> requirements);
+    boolean matchesRequirements(@Nonnull Map<String, String> requirements);
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/LifecycleProvider.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/LifecycleProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.maven.api.annotations.Consumer;
 import org.apache.maven.api.annotations.Experimental;
+import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.plugin.descriptor.lifecycle.Lifecycle;
 
 /**
@@ -37,5 +38,6 @@ import org.apache.maven.api.plugin.descriptor.lifecycle.Lifecycle;
 @Consumer
 public interface LifecycleProvider {
 
+    @Nonnull
     List<Lifecycle> getLifecycles();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
@@ -21,6 +21,8 @@ package org.apache.maven.api.plugin;
 import java.util.function.Supplier;
 
 import org.apache.maven.api.annotations.Experimental;
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
 import org.apache.maven.api.annotations.Provider;
 
 /**
@@ -46,7 +48,7 @@ public interface Log {
      *
      * @param content the message to log
      */
-    void debug(CharSequence content);
+    void debug(@Nullable CharSequence content);
 
     /**
      * Sends a message (and accompanying exception) to the user in the <b>debug</b> error level.
@@ -55,7 +57,7 @@ public interface Log {
      * @param content the message to log
      * @param error the error that caused this log
      */
-    void debug(CharSequence content, Throwable error);
+    void debug(@Nullable CharSequence content, @Nullable Throwable error);
 
     /**
      * Sends an exception to the user in the <b>debug</b> error level.
@@ -63,11 +65,11 @@ public interface Log {
      *
      * @param error the error that caused this log
      */
-    void debug(Throwable error);
+    void debug(@Nullable Throwable error);
 
-    void debug(Supplier<String> content);
+    void debug(@Nonnull Supplier<String> content);
 
-    void debug(Supplier<String> content, Throwable error);
+    void debug(@Nonnull Supplier<String> content, @Nullable Throwable error);
 
     /**
      * {@return true if the <b>info</b> error level is enabled}
@@ -79,7 +81,7 @@ public interface Log {
      *
      * @param content the message to log
      */
-    void info(CharSequence content);
+    void info(@Nullable CharSequence content);
 
     /**
      * Sends a message (and accompanying exception) to the user in the <b>info</b> error level.
@@ -88,7 +90,7 @@ public interface Log {
      * @param content the message to log
      * @param error the error that caused this log
      */
-    void info(CharSequence content, Throwable error);
+    void info(@Nullable CharSequence content, @Nullable Throwable error);
 
     /**
      * Sends an exception to the user in the <b>info</b> error level.
@@ -96,11 +98,11 @@ public interface Log {
      *
      * @param error the error that caused this log
      */
-    void info(Throwable error);
+    void info(@Nullable Throwable error);
 
-    void info(Supplier<String> content);
+    void info(@Nonnull Supplier<String> content);
 
-    void info(Supplier<String> content, Throwable error);
+    void info(@Nonnull Supplier<String> content, @Nullable Throwable error);
 
     /**
      * {@return true if the <b>warn</b> error level is enabled}
@@ -112,7 +114,7 @@ public interface Log {
      *
      * @param content the message to log
      */
-    void warn(CharSequence content);
+    void warn(@Nullable CharSequence content);
 
     /**
      * Sends a message (and accompanying exception) to the user in the <b>warn</b> error level.
@@ -121,7 +123,7 @@ public interface Log {
      * @param content the message to log
      * @param error the error that caused this log
      */
-    void warn(CharSequence content, Throwable error);
+    void warn(@Nullable CharSequence content, @Nullable Throwable error);
 
     /**
      * Sends an exception to the user in the <b>warn</b> error level.
@@ -129,11 +131,11 @@ public interface Log {
      *
      * @param error the error that caused this log
      */
-    void warn(Throwable error);
+    void warn(@Nullable Throwable error);
 
-    void warn(Supplier<String> content);
+    void warn(@Nonnull Supplier<String> content);
 
-    void warn(Supplier<String> content, Throwable error);
+    void warn(@Nonnull Supplier<String> content, @Nullable Throwable error);
 
     /**
      * {@return true if the <b>error</b> error level is enabled}
@@ -145,7 +147,7 @@ public interface Log {
      *
      * @param content the message to log
      */
-    void error(CharSequence content);
+    void error(@Nullable CharSequence content);
 
     /**
      * Sends a message (and accompanying exception) to the user in the <b>error</b> error level.
@@ -154,7 +156,7 @@ public interface Log {
      * @param content the message to log
      * @param error the error that caused this log
      */
-    void error(CharSequence content, Throwable error);
+    void error(@Nullable CharSequence content, @Nullable Throwable error);
 
     /**
      * Sends an exception to the user in the <b>error</b> error level.
@@ -162,9 +164,9 @@ public interface Log {
      *
      * @param error the error that caused this log
      */
-    void error(Throwable error);
+    void error(@Nullable Throwable error);
 
-    void error(Supplier<String> content);
+    void error(@Nonnull Supplier<String> content);
 
-    void error(Supplier<String> content, Throwable error);
+    void error(@Nonnull Supplier<String> content, @Nullable Throwable error);
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstaller.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstaller.java
@@ -19,7 +19,7 @@
 package org.apache.maven.api.services;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Service;
@@ -51,7 +51,7 @@ public interface ArtifactInstaller extends Service {
      *          {@code artifact} is {@code null}
      */
     default void install(Session session, ProducedArtifact artifact) {
-        install(session, Collections.singletonList(artifact));
+        install(session, List.of(artifact));
     }
 
     /**

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactInstallerRequest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.api.services;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -62,7 +61,7 @@ public interface ArtifactInstallerRequest extends Request<Session> {
     class ArtifactInstallerRequestBuilder {
         Session session;
         RequestTrace trace;
-        Collection<ProducedArtifact> artifacts = Collections.emptyList();
+        Collection<ProducedArtifact> artifacts = List.of();
 
         ArtifactInstallerRequestBuilder() {}
 
@@ -80,7 +79,7 @@ public interface ArtifactInstallerRequest extends Request<Session> {
 
         @Nonnull
         public ArtifactInstallerRequestBuilder artifacts(@Nullable Collection<ProducedArtifact> artifacts) {
-            this.artifacts = artifacts != null ? artifacts : Collections.emptyList();
+            this.artifacts = artifacts != null ? artifacts : List.of();
             return this;
         }
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolver.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolver.java
@@ -26,6 +26,8 @@ import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Service;
 import org.apache.maven.api.Session;
 import org.apache.maven.api.annotations.Experimental;
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
 
 /**
  * Resolves the artifact, i.e. download the file when required and attach it to the artifact
@@ -42,7 +44,8 @@ public interface ArtifactResolver extends Service {
      * @throws IllegalArgumentException in case of parameter {@code buildingRequest} is {@code null} or
      *             parameter {@code mavenArtifact} is {@code null} or invalid
      */
-    ArtifactResolverResult resolve(ArtifactResolverRequest request);
+    @Nonnull
+    ArtifactResolverResult resolve(@Nonnull ArtifactResolverRequest request);
 
     /**
      * Resolves several artifacts from their coordinates.
@@ -54,7 +57,9 @@ public interface ArtifactResolver extends Service {
      * @throws IllegalArgumentException in case of parameter {@code buildingRequest} is {@code null} or
      *             parameter {@code coordinates} is {@code null} or invalid
      */
-    default ArtifactResolverResult resolve(Session session, Collection<? extends ArtifactCoordinates> coordinates) {
+    @Nonnull
+    default ArtifactResolverResult resolve(
+            @Nonnull Session session, @Nonnull Collection<? extends ArtifactCoordinates> coordinates) {
         return resolve(ArtifactResolverRequest.build(session, coordinates));
     }
 
@@ -69,10 +74,11 @@ public interface ArtifactResolver extends Service {
      * @throws IllegalArgumentException in case of parameter {@code buildingRequest} is {@code null} or
      *             parameter {@code coordinates} is {@code null} or invalid
      */
+    @Nonnull
     default ArtifactResolverResult resolve(
-            Session session,
-            Collection<? extends ArtifactCoordinates> coordinates,
-            List<RemoteRepository> repositories) {
+            @Nonnull Session session,
+            @Nonnull Collection<? extends ArtifactCoordinates> coordinates,
+            @Nullable List<RemoteRepository> repositories) {
         return resolve(ArtifactResolverRequest.build(session, coordinates, repositories));
     }
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ArtifactResolverResult.java
@@ -88,6 +88,7 @@ public interface ArtifactResolverResult extends Result<ArtifactResolverRequest> 
          *
          * @return The {@link ArtifactCoordinates} of the artifact.
          */
+        @Nonnull
         ArtifactCoordinates getCoordinates();
 
         /**
@@ -95,6 +96,7 @@ public interface ArtifactResolverResult extends Result<ArtifactResolverRequest> 
          *
          * @return The {@link DownloadedArtifact} instance.
          */
+        @Nonnull
         DownloadedArtifact getArtifact();
 
         /**
@@ -102,6 +104,7 @@ public interface ArtifactResolverResult extends Result<ArtifactResolverRequest> 
          *
          * @return A {@link Map} where keys are {@link Repository} instances and values are {@link Exception} instances.
          */
+        @Nonnull
         Map<Repository, List<Exception>> getExceptions();
 
         /**
@@ -109,6 +112,7 @@ public interface ArtifactResolverResult extends Result<ArtifactResolverRequest> 
          *
          * @return The {@link Repository} instance.
          */
+        @Nullable
         Repository getRepository();
 
         /**
@@ -116,6 +120,7 @@ public interface ArtifactResolverResult extends Result<ArtifactResolverRequest> 
          *
          * @return The {@link Path} to the artifact.
          */
+        @Nonnull
         Path getPath();
 
         /**

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinatesFactoryRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyCoordinatesFactoryRequest.java
@@ -20,7 +20,7 @@ package org.apache.maven.api.services;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.maven.api.ArtifactCoordinates;
@@ -117,7 +117,7 @@ public interface DependencyCoordinatesFactoryRequest extends ArtifactCoordinates
         private String coordinateString;
         private String scope;
         private boolean optional;
-        private Collection<Exclusion> exclusions = Collections.emptyList();
+        private Collection<Exclusion> exclusions = List.of();
 
         DependencyCoordinatesFactoryRequestBuilder() {}
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolver.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolver.java
@@ -200,6 +200,7 @@ public interface DependencyResolver extends Service {
      * @see #flatten(Session, Node, PathScope)
      * @see ArtifactResolver#resolve(ArtifactResolverRequest)
      */
-    DependencyResolverResult resolve(DependencyResolverRequest request)
+    @Nonnull
+    DependencyResolverResult resolve(@Nonnull DependencyResolverRequest request)
             throws DependencyResolverException, ArtifactResolverException;
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/DependencyResolverRequest.java
@@ -20,7 +20,6 @@ package org.apache.maven.api.services;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -176,8 +175,8 @@ public interface DependencyResolverRequest extends Request<Session> {
         Project project;
         Artifact rootArtifact;
         DependencyCoordinates root;
-        List<DependencyCoordinates> dependencies = Collections.emptyList();
-        List<DependencyCoordinates> managedDependencies = Collections.emptyList();
+        List<DependencyCoordinates> dependencies = List.of();
+        List<DependencyCoordinates> managedDependencies = List.of();
         boolean verbose;
         PathScope pathScope;
         Predicate<PathType> pathTypeFilter;
@@ -246,7 +245,7 @@ public interface DependencyResolverRequest extends Request<Session> {
          */
         @Nonnull
         public DependencyResolverRequestBuilder dependencies(@Nullable List<DependencyCoordinates> dependencies) {
-            this.dependencies = (dependencies != null) ? dependencies : Collections.emptyList();
+            this.dependencies = (dependencies != null) ? dependencies : List.of();
             return this;
         }
 
@@ -278,7 +277,7 @@ public interface DependencyResolverRequest extends Request<Session> {
         @Nonnull
         public DependencyResolverRequestBuilder managedDependencies(
                 @Nullable List<DependencyCoordinates> managedDependencies) {
-            this.managedDependencies = (managedDependencies != null) ? managedDependencies : Collections.emptyList();
+            this.managedDependencies = (managedDependencies != null) ? managedDependencies : List.of();
             return this;
         }
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/LifecycleRegistry.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/LifecycleRegistry.java
@@ -23,12 +23,15 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.apache.maven.api.Lifecycle;
+import org.apache.maven.api.annotations.Nonnull;
 
 public interface LifecycleRegistry extends ExtensibleEnumRegistry<Lifecycle>, Iterable<Lifecycle> {
 
+    @Nonnull
     default Stream<Lifecycle> stream() {
         return StreamSupport.stream(spliterator(), false);
     }
 
-    List<String> computePhases(Lifecycle lifecycle);
+    @Nonnull
+    List<String> computePhases(@Nonnull Lifecycle lifecycle);
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilder.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/MessageBuilder.java
@@ -154,8 +154,10 @@ public interface MessageBuilder extends Appendable {
         return style(style).a(message).resetStyle();
     }
 
-    MessageBuilder style(String style);
+    @Nonnull
+    MessageBuilder style(@Nonnull String style);
 
+    @Nonnull
     MessageBuilder resetStyle();
 
     //
@@ -262,6 +264,7 @@ public interface MessageBuilder extends Appendable {
      * @param length the new length
      * @return the current builder
      */
+    @Nonnull
     MessageBuilder setLength(int length);
 
     /**

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilder.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilder.java
@@ -21,6 +21,7 @@ package org.apache.maven.api.services;
 import java.util.List;
 
 import org.apache.maven.api.Service;
+import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.model.Model;
 
 public interface ModelBuilder extends Service {
@@ -31,12 +32,15 @@ public interface ModelBuilder extends Service {
 
     List<String> VALID_MODEL_VERSIONS = List.of(MODEL_VERSION_4_0_0, MODEL_VERSION_4_1_0);
 
+    @Nonnull
     ModelBuilderSession newSession();
 
     interface ModelBuilderSession {
 
-        ModelBuilderResult build(ModelBuilderRequest request) throws ModelBuilderException;
+        @Nonnull
+        ModelBuilderResult build(@Nonnull ModelBuilderRequest request) throws ModelBuilderException;
     }
 
-    Model buildRawModel(ModelBuilderRequest request) throws ModelBuilderException;
+    @Nonnull
+    Model buildRawModel(@Nonnull ModelBuilderRequest request) throws ModelBuilderException;
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelProblemCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelProblemCollector.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.api.services;
 
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.Model;
 
@@ -31,6 +33,7 @@ import org.apache.maven.api.model.Model;
  */
 public interface ModelProblemCollector {
 
+    @Nonnull
     ProblemCollector<ModelProblem> getProblemCollector();
 
     default boolean hasErrors() {
@@ -66,15 +69,18 @@ public interface ModelProblemCollector {
         getProblemCollector().reportProblem(problem);
     }
 
+    @Nonnull
     ModelBuilderException newModelBuilderException();
 
-    void setSource(String location);
+    void setSource(@Nullable String location);
 
-    void setSource(Model model);
+    void setSource(@Nullable Model model);
 
+    @Nullable
     String getSource();
 
-    void setRootModel(Model model);
+    void setRootModel(@Nullable Model model);
 
+    @Nullable
     Model getRootModel();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
@@ -73,7 +73,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
      * Returns {@code true} if there is at least one problem collected with severity equal or more severe than
      * passed in severity.
      */
-    default boolean hasProblemsFor(BuilderProblem.Severity severity) {
+    default boolean hasProblemsFor(@Nonnull BuilderProblem.Severity severity) {
         requireNonNull(severity, "severity");
         for (BuilderProblem.Severity s : BuilderProblem.Severity.values()) {
             if (s.ordinal() <= severity.ordinal() && problemsReportedFor(s) > 0) {
@@ -96,7 +96,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
      * @param severities the severity levels to count problems for
      * @return the total count of problems for the specified severities
      */
-    int problemsReportedFor(BuilderProblem.Severity... severities);
+    int problemsReportedFor(@Nonnull BuilderProblem.Severity... severities);
 
     /**
      * Returns {@code true} if reported problem count exceeded allowed count, and issues were lost. When this
@@ -114,7 +114,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
      * @param problem the problem to report
      * @return {@code true} if passed problem is preserved by this call.
      */
-    boolean reportProblem(P problem);
+    boolean reportProblem(@Nonnull P problem);
 
     /**
      * Returns all reported and preserved problems ordered by severity in decreasing order. Note: counters and

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainsBuilder.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ToolchainsBuilder.java
@@ -38,7 +38,8 @@ public interface ToolchainsBuilder extends Service {
      * @return the result of the toolchains building, never {@code null}
      * @throws ToolchainsBuilderException if the effective toolchains could not be built
      */
-    ToolchainsBuilderResult build(ToolchainsBuilderRequest request);
+    @Nonnull
+    ToolchainsBuilderResult build(@Nonnull ToolchainsBuilderRequest request);
 
     /**
      * Builds the effective toolchains for the specified toolchains sources.

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/Location.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/xml/Location.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.api.services.xml;
 
+import org.apache.maven.api.annotations.Nullable;
+
 public interface Location {
 
     /**
@@ -48,11 +50,13 @@ public interface Location {
      * Returns the public ID of the XML
      * @return the public ID, or null if not available
      */
+    @Nullable
     String getPublicId();
 
     /**
      * Returns the system ID of the XML
      * @return the system ID, or null if not available
      */
+    @Nullable
     String getSystemId();
 }

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,7 +43,7 @@ class SourcesTest {
 
     @Test
     void testFromPath() {
-        Path path = Paths.get("/tmp");
+        Path path = Path.of("/tmp");
         Source source = Sources.fromPath(path);
 
         assertNotNull(source);
@@ -54,7 +53,7 @@ class SourcesTest {
 
     @Test
     void testBuildSource() {
-        Path path = Paths.get("/tmp");
+        Path path = Path.of("/tmp");
         ModelSource source = Sources.buildSource(path);
 
         assertNotNull(source);
@@ -64,7 +63,7 @@ class SourcesTest {
 
     @Test
     void testResolvedSource() {
-        Path path = Paths.get("/tmp");
+        Path path = Path.of("/tmp");
         String location = "custom-location";
         ModelSource source = Sources.resolvedSource(path, location);
 
@@ -77,7 +76,7 @@ class SourcesTest {
     @Test
     void testPathSourceFunctionality() {
         // Test basic source functionality
-        Path path = Paths.get("/tmp");
+        Path path = Path.of("/tmp");
         Sources.PathSource source = (Sources.PathSource) Sources.fromPath(path);
 
         assertEquals(path.normalize(), source.getPath());
@@ -91,9 +90,9 @@ class SourcesTest {
     @Test
     void testBuildPathSourceFunctionality() {
         // Test build source functionality
-        Path basePath = Paths.get("/tmp");
+        Path basePath = Path.of("/tmp");
         ModelSource.ModelLocator locator = mock(ModelSource.ModelLocator.class);
-        Path resolvedPath = Paths.get("/tmp/subproject/pom.xml");
+        Path resolvedPath = Path.of("/tmp/subproject/pom.xml");
         when(locator.locateExistingPom(any(Path.class))).thenReturn(resolvedPath);
 
         Sources.BuildPathSource source = (Sources.BuildPathSource) Sources.buildSource(basePath);
@@ -109,7 +108,7 @@ class SourcesTest {
     @Test
     void testResolvedPathSourceFunctionality() {
         // Test resolved source functionality
-        Path path = Paths.get("/tmp");
+        Path path = Path.of("/tmp");
         String location = "custom-location";
         Sources.ResolvedPathSource source = (Sources.ResolvedPathSource) Sources.resolvedSource(path, location);
 

--- a/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocation.java
+++ b/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocation.java
@@ -20,7 +20,6 @@ package org.apache.maven.api.model;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -44,7 +43,7 @@ public class InputLocation implements Serializable, InputLocationTracker {
         this.lineNumber = -1;
         this.columnNumber = -1;
         this.source = source;
-        this.locations = Collections.singletonMap(0, this);
+        this.locations = Map.of(0, this);
         this.importedFrom = null;
     }
 
@@ -60,8 +59,7 @@ public class InputLocation implements Serializable, InputLocationTracker {
         this.lineNumber = lineNumber;
         this.columnNumber = columnNumber;
         this.source = source;
-        this.locations =
-                selfLocationKey != null ? Collections.singletonMap(selfLocationKey, this) : Collections.emptyMap();
+        this.locations = selfLocationKey != null ? Map.of(selfLocationKey, this) : Map.of();
         this.importedFrom = null;
     }
 

--- a/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/LanguageProvider.java
+++ b/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/LanguageProvider.java
@@ -35,7 +35,7 @@ import org.apache.maven.api.di.Named;
  * <pre>
  * public class CustomLanguageProvider implements LanguageProvider {
  *     public Collection&lt;Language&gt; provides() {
- *         return Collections.singleton(language("kotlin"));
+ *         return Set.of(language("kotlin"));
  *     }
  * }
  * </pre>

--- a/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/LifecycleProvider.java
+++ b/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/LifecycleProvider.java
@@ -37,7 +37,7 @@ import org.apache.maven.api.di.Named;
  * <pre>
  * public class CustomLifecycleProvider implements LifecycleProvider {
  *     public Collection&lt;Lifecycle&gt; provides() {
- *         return Collections.singleton(
+ *         return Set.of(
  *             lifecycle("deploy-docker", Arrays.asList(
  *                 "build-image",
  *                 "tag-image",

--- a/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/PathScopeProvider.java
+++ b/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/PathScopeProvider.java
@@ -37,7 +37,7 @@ import org.apache.maven.api.di.Named;
  * <pre>
  * public class CustomPathScopeProvider implements PathScopeProvider {
  *     public Collection&lt;PathScope&gt; provides() {
- *         return Collections.singleton(pathScope("integration-test",
+ *         return Set.of(pathScope("integration-test",
  *                 ProjectScope.TEST, DependencyScope.TEST));
  *     }
  * }

--- a/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/ProjectScopeProvider.java
+++ b/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/ProjectScopeProvider.java
@@ -35,7 +35,7 @@ import org.apache.maven.api.di.Named;
  * <pre>
  * public class CustomProjectScopeProvider implements ProjectScopeProvider {
  *     public Collection&lt;ProjectScope&gt; provides() {
- *         return Collections.singleton(projectScope("integration-test"));
+ *         return Set.of(projectScope("integration-test"));
  *     }
  * }
  * </pre>

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.maven.api.Lifecycle;
@@ -54,26 +55,32 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
     private static final LifecycleRegistry EMPTY_LIFECYCLE_REGISTRY = new LifecycleRegistry() {
 
         @Override
+        @Nonnull
         public Iterator<Lifecycle> iterator() {
             return Collections.emptyIterator();
         }
 
         @Override
-        public Optional<Lifecycle> lookup(String id) {
+        @Nonnull
+        public Optional<Lifecycle> lookup(@Nonnull String id) {
             return Optional.empty();
         }
 
         @Override
-        public List<String> computePhases(Lifecycle lifecycle) {
+        @Nonnull
+        public List<String> computePhases(@Nonnull Lifecycle lifecycle) {
             return List.of();
         }
     };
 
     private static final PackagingRegistry EMPTY_PACKAGING_REGISTRY = new PackagingRegistry() {
         @Override
-        public Optional<Packaging> lookup(String id) {
+        @Nonnull
+        public Optional<Packaging> lookup(@Nonnull String id) {
+            Objects.requireNonNull(id, "id cannot be null");
             return Optional.of(new Packaging() {
                 @Override
+                @Nonnull
                 public String id() {
                     return id;
                 }
@@ -84,6 +91,7 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
                 }
 
                 @Override
+                @Nonnull
                 public Map<String, PluginContainer> plugins() {
                     if ("JAR".equals(id)) {
                         return Map.of(
@@ -133,11 +141,12 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
     static class WrapperLifecycleRegistry implements LifecycleRegistry {
         @Override
         @Nonnull
-        public Optional<Lifecycle> lookup(String id) {
+        public Optional<Lifecycle> lookup(@Nonnull String id) {
             return getDelegate().lookup(id);
         }
 
         @Override
+        @Nonnull
         public Iterator<Lifecycle> iterator() {
             return getDelegate().iterator();
         }
@@ -147,7 +156,8 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
         }
 
         @Override
-        public List<String> computePhases(Lifecycle lifecycle) {
+        @Nonnull
+        public List<String> computePhases(@Nonnull Lifecycle lifecycle) {
             return List.of();
         }
     }

--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/ArtifactDescriptorReaderDelegate.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/ArtifactDescriptorReaderDelegate.java
@@ -19,7 +19,6 @@
 package org.apache.maven.repository.internal;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -104,7 +103,7 @@ public class ArtifactDescriptorReaderDelegate {
 
         Map<String, String> props = null;
         if (system) {
-            props = Collections.singletonMap(MavenArtifactProperties.LOCAL_PATH, dependency.getSystemPath());
+            props = Map.of(MavenArtifactProperties.LOCAL_PATH, dependency.getSystemPath());
         }
 
         Artifact artifact = new DefaultArtifact(

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.Service;
@@ -231,7 +230,7 @@ public class BootstrapCoreExtensionManager {
             return result.getArtifactResults().stream()
                     .filter(ArtifactResult::isResolved)
                     .map(ArtifactResult::getArtifact)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (PluginResolutionException | InterpolatorException e) {
             throw new ExtensionResolutionException(extension, e);
         }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
@@ -202,7 +202,7 @@ public class BootstrapCoreExtensionManager {
         }
         return CoreExtensionEntry.discoverFrom(
                 realm,
-                Collections.singleton(artifacts.get(0).getPath().toFile()),
+                Set.of(artifacts.get(0).getPath().toFile()),
                 extension.getGroupId() + ":" + extension.getArtifactId(),
                 extension.getConfiguration());
     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/EncryptParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/EncryptParser.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.cling.invoker.mvnenc;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.cli.ParseException;
@@ -56,7 +55,7 @@ public class EncryptParser extends BaseParser {
 
     @Override
     protected List<Options> parseCliOptions(LocalContext context) {
-        return Collections.singletonList(parseEncryptCliOptions(context.parserRequest.args()));
+        return List.of(parseEncryptCliOptions(context.parserRequest.args()));
     }
 
     protected CommonsCliEncryptOptions parseEncryptCliOptions(List<String> args) {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/ShellParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/ShellParser.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.cling.invoker.mvnsh;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.cli.ParseException;
@@ -55,7 +54,7 @@ public class ShellParser extends BaseParser {
 
     @Override
     protected List<Options> parseCliOptions(LocalContext context) {
-        return Collections.singletonList(parseShellCliOptions(context.parserRequest.args()));
+        return List.of(parseShellCliOptions(context.parserRequest.args()));
     }
 
     protected CommonsCliShellOptions parseShellCliOptions(List<String> args) {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/props/MavenProperties.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/props/MavenProperties.java
@@ -311,7 +311,7 @@ public class MavenProperties extends AbstractMap<String, String> {
     }
 
     public String put(String key, String comment, String value) {
-        return put(key, Collections.singletonList(comment), value);
+        return put(key, List.of(comment), value);
     }
 
     public boolean update(Map<String, String> props) {

--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -439,7 +438,7 @@ public class DefaultMaven implements Maven {
 
     protected <T> Collection<T> getProjectScopedExtensionComponents(Collection<MavenProject> projects, Class<T> role) {
         if (projects == null) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         Collection<T> foundComponents = new LinkedHashSet<>();

--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -124,8 +124,8 @@ class ReactorReader implements MavenWorkspaceReader {
 
     public List<String> findVersions(Artifact artifact) {
         List<String> versions = getProjects()
-                .getOrDefault(artifact.getGroupId(), Collections.emptyMap())
-                .getOrDefault(artifact.getArtifactId(), Collections.emptyMap())
+                .getOrDefault(artifact.getGroupId(), Map.of())
+                .getOrDefault(artifact.getArtifactId(), Map.of())
                 .values()
                 .stream()
                 .map(MavenProject::getVersion)
@@ -134,8 +134,8 @@ class ReactorReader implements MavenWorkspaceReader {
             return versions;
         }
         return getAllProjects()
-                .getOrDefault(artifact.getGroupId(), Collections.emptyMap())
-                .getOrDefault(artifact.getArtifactId(), Collections.emptyMap())
+                .getOrDefault(artifact.getGroupId(), Map.of())
+                .getOrDefault(artifact.getArtifactId(), Map.of())
                 .values()
                 .stream()
                 .filter(p -> Objects.nonNull(findArtifact(p, artifact, false)))
@@ -484,8 +484,8 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     private MavenProject getProject(Artifact artifact, Map<String, Map<String, Map<String, MavenProject>>> projects) {
-        return projects.getOrDefault(artifact.getGroupId(), Collections.emptyMap())
-                .getOrDefault(artifact.getArtifactId(), Collections.emptyMap())
+        return projects.getOrDefault(artifact.getGroupId(), Map.of())
+                .getOrDefault(artifact.getArtifactId(), Map.of())
                 .getOrDefault(artifact.getBaseVersion(), null);
     }
 
@@ -501,7 +501,7 @@ class ReactorReader implements MavenWorkspaceReader {
                         .put(project.getVersion(), project));
                 this.allProjects = map;
             } else {
-                return Collections.emptyMap();
+                return Map.of();
             }
         }
         return allProjects;
@@ -518,7 +518,7 @@ class ReactorReader implements MavenWorkspaceReader {
                         .put(project.getVersion(), project));
                 this.projects = map;
             } else {
-                return Collections.emptyMap();
+                return Map.of();
             }
         }
         return projects;

--- a/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
@@ -21,7 +21,6 @@ package org.apache.maven;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +121,7 @@ public class RepositoryUtils {
             nodeTrail.addAll(trail);
             nodeTrail.add(artifact.getId());
 
-            if (filter == null || filter.accept(node, Collections.emptyList())) {
+            if (filter == null || filter.accept(node, List.of())) {
                 artifact.setDependencyTrail(nodeTrail);
                 artifacts.add(artifact);
             }
@@ -144,7 +143,7 @@ public class RepositoryUtils {
         Map<String, String> props = null;
         if (org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(artifact.getScope())) {
             String localPath = (artifact.getFile() != null) ? artifact.getFile().getPath() : "";
-            props = Collections.singletonMap(MavenArtifactProperties.LOCAL_PATH, localPath);
+            props = Map.of(MavenArtifactProperties.LOCAL_PATH, localPath);
         }
 
         Artifact result = new DefaultArtifact(
@@ -168,14 +167,14 @@ public class RepositoryUtils {
 
         Artifact result = toArtifact(artifact);
 
-        List<Exclusion> excl = Optional.ofNullable(exclusions).orElse(Collections.emptyList()).stream()
+        List<Exclusion> excl = Optional.ofNullable(exclusions).orElse(List.of()).stream()
                 .map(RepositoryUtils::toExclusion)
                 .toList();
         return new Dependency(result, artifact.getScope(), artifact.isOptional(), excl);
     }
 
     public static List<RemoteRepository> toRepos(List<ArtifactRepository> repos) {
-        return Optional.ofNullable(repos).orElse(Collections.emptyList()).stream()
+        return Optional.ofNullable(repos).orElse(List.of()).stream()
                 .map(RepositoryUtils::toRepo)
                 .toList();
     }
@@ -279,7 +278,7 @@ public class RepositoryUtils {
 
         Map<String, String> props = null;
         if (system) {
-            props = Collections.singletonMap(MavenArtifactProperties.LOCAL_PATH, dependency.getSystemPath());
+            props = Map.of(MavenArtifactProperties.LOCAL_PATH, dependency.getSystemPath());
         }
 
         Artifact artifact = new DefaultArtifact(

--- a/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
@@ -171,14 +170,14 @@ public class RepositoryUtils {
 
         List<Exclusion> excl = Optional.ofNullable(exclusions).orElse(Collections.emptyList()).stream()
                 .map(RepositoryUtils::toExclusion)
-                .collect(Collectors.toList());
+                .toList();
         return new Dependency(result, artifact.getScope(), artifact.isOptional(), excl);
     }
 
     public static List<RemoteRepository> toRepos(List<ArtifactRepository> repos) {
         return Optional.ofNullable(repos).orElse(Collections.emptyList()).stream()
                 .map(RepositoryUtils::toRepo)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public static RemoteRepository toRepo(ArtifactRepository repo) {
@@ -294,7 +293,7 @@ public class RepositoryUtils {
 
         List<Exclusion> exclusions = dependency.getExclusions().stream()
                 .map(RepositoryUtils::toExclusion)
-                .collect(Collectors.toList());
+                .toList();
 
         return new Dependency(
                 artifact,
@@ -326,7 +325,7 @@ public class RepositoryUtils {
     }
 
     public static Collection<Artifact> toArtifacts(Collection<org.apache.maven.artifact.Artifact> artifactsToConvert) {
-        return artifactsToConvert.stream().map(RepositoryUtils::toArtifact).collect(Collectors.toList());
+        return artifactsToConvert.stream().map(RepositoryUtils::toArtifact).toList();
     }
 
     public static WorkspaceRepository getWorkspace(RepositorySystemSession session) {

--- a/impl/maven-core/src/main/java/org/apache/maven/artifact/repository/MavenArtifactRepository.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/artifact/repository/MavenArtifactRepository.java
@@ -57,7 +57,7 @@ public class MavenArtifactRepository implements ArtifactRepository {
 
     private Proxy proxy;
 
-    private List<ArtifactRepository> mirroredRepositories = Collections.emptyList();
+    private List<ArtifactRepository> mirroredRepositories = List.of();
 
     private boolean blocked;
 
@@ -190,7 +190,7 @@ public class MavenArtifactRepository implements ArtifactRepository {
     }
 
     public List<String> findVersions(Artifact artifact) {
-        return Collections.emptyList();
+        return List.of();
     }
 
     public String getId() {
@@ -386,7 +386,7 @@ public class MavenArtifactRepository implements ArtifactRepository {
         if (mirroredRepositories != null) {
             this.mirroredRepositories = Collections.unmodifiableList(mirroredRepositories);
         } else {
-            this.mirroredRepositories = Collections.emptyList();
+            this.mirroredRepositories = List.of();
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Exclusion;
@@ -40,7 +39,7 @@ public class ExclusionArtifactFilter implements ArtifactFilter {
     public ExclusionArtifactFilter(List<Exclusion> exclusions) {
         this.exclusions = exclusions;
         this.predicates =
-                exclusions.stream().map(ExclusionArtifactFilter::toPredicate).collect(Collectors.toList());
+                exclusions.stream().map(ExclusionArtifactFilter::toPredicate).toList();
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
@@ -28,7 +28,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -207,7 +206,7 @@ public class MavenRepositorySystem {
                     repository.getSnapshots(),
                     repository.getReleases());
 
-            repository.setMirroredRepositories(Collections.singletonList(original));
+            repository.setMirroredRepositories(List.of(original));
 
             repository.setId(mirror.getId());
             repository.setUrl(mirror.getUrl());

--- a/impl/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -228,7 +227,7 @@ public class DefaultClassRealmManager implements ClassRealmManager {
     public ClassRealm createExtensionRealm(Plugin plugin, List<Artifact> artifacts) {
         Objects.requireNonNull(plugin, "plugin cannot be null");
 
-        Map<String, ClassLoader> foreignImports = Collections.singletonMap("", getMavenApiRealm());
+        Map<String, ClassLoader> foreignImports = Map.of("", getMavenApiRealm());
 
         return createRealm(
                 getKey(plugin, true), RealmType.Extension, PARENT_CLASSLOADER, null, foreignImports, artifacts);

--- a/impl/maven-core/src/main/java/org/apache/maven/exception/ExceptionSummary.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/exception/ExceptionSummary.java
@@ -49,7 +49,7 @@ public class ExceptionSummary {
         this.exception = exception;
         this.message = (message != null) ? message : "";
         this.reference = (reference != null) ? reference : "";
-        this.children = (children != null) ? Collections.unmodifiableList(children) : Collections.emptyList();
+        this.children = (children != null) ? Collections.unmodifiableList(children) : List.of();
     }
 
     public Throwable getException() {

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzer.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzer.java
@@ -23,7 +23,6 @@ import javax.inject.Singleton;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ public class DefaultBuildResumptionAnalyzer implements BuildResumptionAnalyzer {
                 .filter(project -> result.getBuildSummary(project) == null
                         || result.getBuildSummary(project) instanceof BuildFailure)
                 .map(project -> project.getGroupId() + ":" + project.getArtifactId())
-                .collect(Collectors.toList());
+                .toList();
 
         if (remainingProjects.isEmpty()) {
             LOGGER.info("No remaining projects found, resuming the build would not make sense.");

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionResult.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/DefaultMavenExecutionResult.java
@@ -30,7 +30,7 @@ import org.apache.maven.project.MavenProject;
 public class DefaultMavenExecutionResult implements MavenExecutionResult {
     private MavenProject project;
 
-    private List<MavenProject> topologicallySortedProjects = Collections.emptyList();
+    private List<MavenProject> topologicallySortedProjects = List.of();
 
     private DependencyResolutionResult dependencyResolutionResult;
 
@@ -58,7 +58,7 @@ public class DefaultMavenExecutionResult implements MavenExecutionResult {
 
     public List<MavenProject> getTopologicallySortedProjects() {
         return null == topologicallySortedProjects
-                ? Collections.emptyList()
+                ? List.of()
                 : Collections.unmodifiableList(topologicallySortedProjects);
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Session;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -423,13 +422,13 @@ public class MavenSession implements Cloneable {
                 .localRepository(localRepo != null ? localRepo.getAbsolutePath() : null)
                 .interactiveMode(request.isInteractiveMode())
                 .offline(request.isOffline())
-                .proxies(request.getProxies().stream().map(Proxy::getDelegate).collect(Collectors.toList()))
-                .servers(request.getServers().stream().map(Server::getDelegate).collect(Collectors.toList()))
-                .mirrors(request.getMirrors().stream().map(Mirror::getDelegate).collect(Collectors.toList()))
+                .proxies(request.getProxies().stream().map(Proxy::getDelegate).toList())
+                .servers(request.getServers().stream().map(Server::getDelegate).toList())
+                .mirrors(request.getMirrors().stream().map(Mirror::getDelegate).toList())
                 .profiles(request.getProfiles().stream()
                         .map(Profile::getDelegate)
                         .map(SettingsUtilsV4::convertToSettingsProfile)
-                        .collect(Collectors.toList()))
+                        .toList())
                 .activeProfiles(request.getActiveProfiles())
                 .pluginGroups(request.getPluginGroups())
                 .build());

--- a/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -106,12 +105,11 @@ public class DefaultGraphBuilder implements GraphBuilder {
 
             return result;
         } catch (final ProjectBuildingException | DuplicateProjectException | MavenExecutionException e) {
-            return Result.error(Collections.singletonList(new DefaultModelProblem(null, null, null, null, 0, 0, e)));
+            return Result.error(List.of(new DefaultModelProblem(null, null, null, null, 0, 0, e)));
         } catch (final CycleDetectedException e) {
             String message = "The projects in the reactor contain a cyclic reference: " + e.getMessage();
             ProjectCycleException error = new ProjectCycleException(message, e);
-            return Result.error(
-                    Collections.singletonList(new DefaultModelProblem(null, null, null, null, 0, 0, error)));
+            return Result.error(List.of(new DefaultModelProblem(null, null, null, null, 0, 0, error)));
         }
     }
 
@@ -318,9 +316,8 @@ public class DefaultGraphBuilder implements GraphBuilder {
                 .orElseThrow(() -> new MavenExecutionException(
                         "Could not find a project in reactor matching the request POM", request.getPom()));
 
-        List<MavenProject> modules = requestPomProject.getCollectedProjects() != null
-                ? requestPomProject.getCollectedProjects()
-                : Collections.emptyList();
+        List<MavenProject> modules =
+                requestPomProject.getCollectedProjects() != null ? requestPomProject.getCollectedProjects() : List.of();
 
         List<MavenProject> result = new ArrayList<>(modules);
         result.add(requestPomProject);

--- a/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultProjectDependencyGraph.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultProjectDependencyGraph.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.project.CycleDetectedException;
@@ -153,7 +152,7 @@ public class DefaultProjectDependencyGraph implements ProjectDependencyGraph {
         return projectIds.stream()
                 .map(projects::get)
                 .sorted(Comparator.comparingInt(order::get))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -231,7 +231,7 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
                 XmlNode dom = server.getDelegate().getConfiguration();
                 List<XmlNode> children = dom.children().stream()
                         .filter(c -> !"wagonProvider".equals(c.name()))
-                        .collect(Collectors.toList());
+                        .toList();
                 dom = XmlNode.newInstance(dom.name(), children);
                 PlexusConfiguration config = XmlPlexusConfiguration.toPlexusConfiguration(dom);
                 configProps.put("aether.transport.wagon.config." + server.getId(), config);

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/aether/LegacyRepositorySystemSessionExtender.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/aether/LegacyRepositorySystemSessionExtender.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.internal.aether;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +77,7 @@ public class LegacyRepositorySystemSessionExtender implements RepositorySystemSe
                     repository.getSnapshots(),
                     repository.getReleases());
 
-            repository.setMirroredRepositories(Collections.singletonList(original));
+            repository.setMirroredRepositories(List.of(original));
 
             repository.setId(mirror.getId());
             repository.setUrl(mirror.getUrl());

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
@@ -29,13 +29,24 @@ import org.apache.maven.api.annotations.Nullable;
 
 class CoreUtils {
 
+    /**
+     * Casts an object to the specified type, with validation and error handling.
+     *
+     * @param <T> the target type
+     * @param clazz the class representing the target type
+     * @param o the object to cast
+     * @param name the name of the parameter for error messages
+     * @return the cast object
+     * @throws NullPointerException if the object is null
+     * @throws ClassCastException if the object is not an instance of the target type
+     */
     @Nonnull
     public static <T> T cast(@Nonnull Class<T> clazz, @Nullable Object o, @Nonnull String name) {
         if (!clazz.isInstance(o)) {
             if (o == null) {
-                throw new IllegalArgumentException(name + " is null");
+                throw new NullPointerException(name + " is null");
             }
-            throw new IllegalArgumentException(name + " is not an instance of " + clazz.getName());
+            throw new ClassCastException(name + " is not an instance of " + clazz.getName());
         }
         return clazz.cast(o);
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
@@ -24,9 +24,13 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
+
 class CoreUtils {
 
-    public static <T> T cast(Class<T> clazz, Object o, String name) {
+    @Nonnull
+    public static <T> T cast(@Nonnull Class<T> clazz, @Nullable Object o, @Nonnull String name) {
         if (!clazz.isInstance(o)) {
             if (o == null) {
                 throw new IllegalArgumentException(name + " is null");
@@ -36,7 +40,8 @@ class CoreUtils {
         return clazz.cast(o);
     }
 
-    public static <U, V> List<V> map(Collection<U> list, Function<U, V> mapper) {
+    @Nonnull
+    public static <U, V> List<V> map(@Nonnull Collection<U> list, @Nonnull Function<U, V> mapper) {
         return list.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.annotations.Nullable;
@@ -53,6 +52,6 @@ class CoreUtils {
 
     @Nonnull
     public static <U, V> List<V> map(@Nonnull Collection<U> list, @Nonnull Function<U, V> mapper) {
-        return list.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
+        return list.stream().map(mapper).filter(Objects::nonNull).toList();
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -101,7 +101,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
     private final List<LifecycleProvider> providers;
 
     public DefaultLifecycleRegistry() {
-        this(Collections.emptyList());
+        this(List.of());
     }
 
     @Inject

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.DependencyScope;
@@ -147,9 +146,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         addPhases(graph, null, null, lifecycle.v3phases());
         List<String> allPhases = graph.visitAll();
         Collections.reverse(allPhases);
-        List<String> computed =
-                allPhases.stream().filter(s -> !s.startsWith("$")).collect(Collectors.toList());
-        return computed;
+        return allPhases.stream().filter(s -> !s.startsWith("$")).toList();
     }
 
     private static void addPhase(
@@ -217,7 +214,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
                                 && !Lifecycle.DEFAULT.equals(id)
                                 && !Lifecycle.SITE.equals(id))
                         .map(id -> wrap(all.get(id)))
-                        .collect(Collectors.toList());
+                        .toList();
             } catch (ComponentLookupException e) {
                 throw new LookupException(e);
             }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 
 import org.apache.maven.api.DependencyScope;
 import org.apache.maven.api.Lifecycle;
+import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.model.Plugin;
@@ -123,21 +124,25 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
     }
 
     @Override
+    @Nonnull
     public Iterator<Lifecycle> iterator() {
         return stream().toList().iterator();
     }
 
     @Override
+    @Nonnull
     public Stream<Lifecycle> stream() {
         return providers.stream().map(ExtensibleEnumProvider::provides).flatMap(Collection::stream);
     }
 
     @Override
-    public Optional<Lifecycle> lookup(String id) {
+    @Nonnull
+    public Optional<Lifecycle> lookup(@Nonnull String id) {
         return stream().filter(lf -> Objects.equals(id, lf.id())).findAny();
     }
 
-    public List<String> computePhases(Lifecycle lifecycle) {
+    @Nonnull
+    public List<String> computePhases(@Nonnull Lifecycle lifecycle) {
         Graph graph = new Graph();
         addPhases(graph, null, null, lifecycle.v3phases());
         List<String> allPhases = graph.visitAll();
@@ -202,6 +207,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         }
 
         @Override
+        @Nonnull
         public Collection<Lifecycle> provides() {
             try {
                 Map<String, org.apache.maven.lifecycle.Lifecycle> all =
@@ -360,11 +366,13 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         private static final String MAVEN_CLEAN_PLUGIN_VERSION = "3.4.0";
 
         @Override
+        @Nonnull
         public String id() {
             return Lifecycle.CLEAN;
         }
 
         @Override
+        @Nonnull
         public Collection<Phase> phases() {
             // START SNIPPET: clean
             return List.of(phase(
@@ -376,6 +384,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         }
 
         @Override
+        @Nonnull
         public Collection<Alias> aliases() {
             return List.of(alias("pre-clean", BEFORE + Phase.CLEAN), alias("post-clean", AFTER + Phase.CLEAN));
         }
@@ -383,11 +392,13 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
 
     static class DefaultLifecycle implements Lifecycle {
         @Override
+        @Nonnull
         public String id() {
             return Lifecycle.DEFAULT;
         }
 
         @Override
+        @Nonnull
         public Collection<Phase> phases() {
             // START SNIPPET: default
             return List.of(phase(
@@ -428,6 +439,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         }
 
         @Override
+        @Nonnull
         public Collection<Phase> v3phases() {
             return List.of(phase(
                     ALL,
@@ -450,6 +462,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         }
 
         @Override
+        @Nonnull
         public Collection<Alias> aliases() {
             return List.of(
                     alias("generate-sources", SOURCES),
@@ -477,11 +490,13 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         private static final String PHASE_SITE_DEPLOY = "site-deploy";
 
         @Override
+        @Nonnull
         public String id() {
             return Lifecycle.SITE;
         }
 
         @Override
+        @Nonnull
         public Collection<Phase> phases() {
             // START SNIPPET: site
             return List.of(
@@ -494,6 +509,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         }
 
         @Override
+        @Nonnull
         public Collection<Alias> aliases() {
             return List.of(alias("pre-site", BEFORE + PHASE_SITE), alias("post-site", AFTER + PHASE_SITE));
         }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLog.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLog.java
@@ -152,14 +152,14 @@ public class DefaultLog implements Log {
     @Override
     public void error(Supplier<String> content) {
         if (isErrorEnabled()) {
-            logger.error(content.get());
+            logger.error(toString(content.get()));
         }
     }
 
     @Override
     public void error(Supplier<String> content, Throwable error) {
         if (isErrorEnabled()) {
-            logger.error(content.get(), error);
+            logger.error(toString(content.get()), error);
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultPackagingRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultPackagingRegistry.java
@@ -23,7 +23,8 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -73,41 +74,34 @@ public class DefaultPackagingRegistry
 
     @Override
     public Optional<Packaging> lookup(String id) {
-        id = id.toLowerCase(Locale.ROOT);
+        String lid = id.toLowerCase(Locale.ROOT);
         // TODO: we should be able to inject a Map<String, LifecycleMapping> directly,
         // however, SISU visibility filtering can only happen when an explicit
         // lookup is performed. The whole problem here is caused by "project extensions"
         // which are bound to a project's classloader, without any clear definition
         // of a "project scope"
-        LifecycleMapping lifecycleMapping =
-                lookup.lookupOptional(LifecycleMapping.class, id).orElse(null);
-        if (lifecycleMapping == null) {
-            return Optional.empty();
-        }
-        Type type = typeRegistry.lookup(id).orElse(null);
-        if (type == null) {
-            return Optional.empty();
-        }
-        return Optional.of(new DefaultPackaging(id, type, getPlugins(lifecycleMapping)));
+        return lookup.lookupOptional(LifecycleMapping.class, lid).flatMap(lifecycleMapping -> typeRegistry
+                .lookup(lid)
+                .map(type -> new DefaultPackaging(lid, type, getPlugins(lifecycleMapping))));
     }
 
     private Map<String, PluginContainer> getPlugins(LifecycleMapping lifecycleMapping) {
-        Map<String, PluginContainer> lfs = new HashMap<>();
-        lifecycleMapping.getLifecycles().forEach((id, lifecycle) -> {
-            Map<String, Plugin> plugins = new HashMap<>();
-            lifecycle
-                    .getLifecyclePhases()
-                    .forEach((phase, lifecyclePhase) -> parseLifecyclePhaseDefinitions(plugins, phase, lifecyclePhase));
-            lfs.put(id, PluginContainer.newBuilder().plugins(plugins.values()).build());
-        });
-        return lfs;
+        return lifecycleMapping.getLifecycles().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> PluginContainer.newBuilder()
+                        .plugins(parseLifecyclePhaseDefinitions(e.getValue().getLifecyclePhases()))
+                        .build()));
     }
 
-    static void parseLifecyclePhaseDefinitions(Map<String, Plugin> plugins, String phase, LifecyclePhase goals) {
+    static Collection<Plugin> parseLifecyclePhaseDefinitions(Map<String, LifecyclePhase> phases) {
         InputLocation location = DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION;
+        Map<String, Plugin> plugins = new LinkedHashMap<>();
 
-        List<LifecycleMojo> mojos = goals.getMojos();
-        if (mojos != null) {
+        phases.forEach((phase, goals) -> {
+            List<LifecycleMojo> mojos = goals.getMojos();
+            if (mojos == null) {
+                return;
+            }
+
             for (int i = 0; i < mojos.size(); i++) {
                 LifecycleMojo mojo = mojos.get(i);
 
@@ -181,7 +175,9 @@ public class DefaultPackagingRegistry
 
                 plugins.put(key, plugin);
             }
-        }
+        });
+
+        return plugins.values();
     }
 
     private static String getExecutionId(Plugin plugin, String goal) {

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
@@ -144,7 +144,7 @@ public class DefaultProject implements Project {
         if (dependencyManagement != null) {
             return new MappedList<>(dependencyManagement.getDependencies(), this::toDependency);
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProject.java
@@ -158,11 +158,13 @@ public class DefaultProject implements Project {
     }
 
     @Override
+    @Nonnull
     public Path getRootDirectory() {
         return project.getRootDirectory();
     }
 
     @Override
+    @Nonnull
     public Optional<Project> getParent() {
         MavenProject parent = project.getParent();
         return Optional.ofNullable(session.getProject(parent));

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Graph.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Graph.java
@@ -20,12 +20,12 @@ package org.apache.maven.internal.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 class Graph {
     private enum DfsState {
@@ -69,7 +69,7 @@ class Graph {
     }
 
     List<String> findCycle(Vertex vertex) {
-        return visitCycle(Collections.singleton(vertex), new HashMap<>(), new LinkedList<>());
+        return visitCycle(Set.of(vertex), new HashMap<>(), new LinkedList<>());
     }
 
     private static List<String> visitAll(

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
@@ -19,51 +19,47 @@
 package org.apache.maven.internal.impl;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.Objects;
 
 import org.apache.maven.api.Lifecycle;
+import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.model.Plugin;
 import org.apache.maven.api.model.PluginExecution;
-
-import static java.util.Arrays.asList;
 
 public class Lifecycles {
 
     static Lifecycle.Phase phase(String name) {
-        return new DefaultPhase(name, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        return new DefaultPhase(name, List.of(), List.of(), List.of());
     }
 
     static Lifecycle.Phase phase(String name, Lifecycle.Phase... phases) {
-        return new DefaultPhase(name, Collections.emptyList(), Collections.emptyList(), asList(phases));
+        return new DefaultPhase(name, List.of(), List.of(), List.of(phases));
     }
 
     static Lifecycle.Phase phase(String name, Lifecycle.Link link, Lifecycle.Phase... phases) {
-        return new DefaultPhase(name, Collections.emptyList(), Collections.singletonList(link), asList(phases));
+        return new DefaultPhase(name, List.of(), List.of(link), List.of(phases));
     }
 
     static Lifecycle.Phase phase(String name, Plugin plugin) {
-        return new DefaultPhase(
-                name, Collections.singletonList(plugin), Collections.emptyList(), Collections.emptyList());
+        return new DefaultPhase(name, List.of(plugin), List.of(), List.of());
     }
 
     static Lifecycle.Phase phase(String name, Lifecycle.Link link, Plugin plugin) {
-        return new DefaultPhase(
-                name, Collections.singletonList(plugin), Collections.singletonList(link), Collections.emptyList());
+        return new DefaultPhase(name, List.of(plugin), List.of(link), List.of());
     }
 
     static Lifecycle.Phase phase(String name, Lifecycle.Link link1, Lifecycle.Link link2, Lifecycle.Phase... phases) {
-        return new DefaultPhase(name, Collections.emptyList(), asList(link1, link2), asList(phases));
+        return new DefaultPhase(name, List.of(), List.of(link1, link2), List.of(phases));
     }
 
     static Lifecycle.Phase phase(
             String name, Lifecycle.Link link1, Lifecycle.Link link2, Lifecycle.Link link3, Lifecycle.Phase... phases) {
-        return new DefaultPhase(name, Collections.emptyList(), asList(link1, link2, link3), asList(phases));
+        return new DefaultPhase(name, List.of(), List.of(link1, link2, link3), List.of(phases));
     }
 
     static Lifecycle.Phase phase(String name, Collection<Lifecycle.Link> links, Lifecycle.Phase... phases) {
-        return new DefaultPhase(name, Collections.emptyList(), links, asList(phases));
+        return new DefaultPhase(name, List.of(), links, List.of(phases));
     }
 
     static Plugin plugin(String coords, String phase) {
@@ -72,10 +68,10 @@ public class Lifecycles {
                 .groupId(c[0])
                 .artifactId(c[1])
                 .version(c[2])
-                .executions(Collections.singletonList(PluginExecution.newBuilder()
+                .executions(List.of(PluginExecution.newBuilder()
                         .id("default-" + c[3])
                         .phase(phase)
-                        .goals(Collections.singletonList(c[3]))
+                        .goals(List.of(c[3]))
                         .location("", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
                         .location("id", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
                         .location("phase", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)
@@ -90,159 +86,148 @@ public class Lifecycles {
 
     /** Indicates the phase is after the phases given in arguments */
     static Lifecycle.Link after(String phase) {
-        return new Lifecycle.Link() {
-            @Override
-            public Kind kind() {
-                return Kind.AFTER;
-            }
-
-            @Override
-            public Lifecycle.Pointer pointer() {
-                return new Lifecycle.PhasePointer() {
-                    @Override
-                    public String phase() {
-                        return phase;
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "phase(" + phase + ")";
-                    }
-                };
-            }
-
-            @Override
-            public String toString() {
-                return "after(" + pointer() + ")";
-            }
-        };
+        return new DefaultLink(Lifecycle.Link.Kind.AFTER, new DefaultPhasePointer(phase));
     }
 
     /** Indicates the phase is after the phases for the dependencies in the given scope */
     static Lifecycle.Link dependencies(String scope, String phase) {
-        return new Lifecycle.Link() {
-            @Override
-            public Kind kind() {
-                return Kind.AFTER;
-            }
-
-            @Override
-            public Lifecycle.Pointer pointer() {
-                return new Lifecycle.DependenciesPointer() {
-                    @Override
-                    public String phase() {
-                        return phase;
-                    }
-
-                    @Override
-                    public String scope() {
-                        return scope;
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "dependencies(" + scope + ", " + phase + ")";
-                    }
-                };
-            }
-
-            @Override
-            public String toString() {
-                return "after(" + pointer() + ")";
-            }
-        };
+        return new DefaultLink(Lifecycle.Link.Kind.AFTER, new DefaultDependenciesPointer(phase, scope));
     }
 
     static Lifecycle.Link children(String phase) {
-        return new Lifecycle.Link() {
-            @Override
-            public Kind kind() {
-                return Kind.AFTER;
-            }
-
-            @Override
-            public Lifecycle.Pointer pointer() {
-                return new Lifecycle.ChildrenPointer() {
-                    @Override
-                    public String phase() {
-                        return phase;
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "children(" + phase + ")";
-                    }
-                };
-            }
-
-            @Override
-            public String toString() {
-                return "after(" + pointer() + ")";
-            }
-        };
+        return new DefaultLink(Lifecycle.Link.Kind.AFTER, new DefaultChildrenPointer(phase));
     }
 
     static Lifecycle.Alias alias(String v3Phase, String v4Phase) {
         return new DefaultAlias(v3Phase, v4Phase);
     }
 
-    static class DefaultPhase implements Lifecycle.Phase {
-        private final String name;
-        private final List<Plugin> plugins;
-        private final Collection<Lifecycle.Link> links;
-        private final List<Lifecycle.Phase> phases;
-
-        DefaultPhase(
-                String name, List<Plugin> plugins, Collection<Lifecycle.Link> links, List<Lifecycle.Phase> phases) {
-            this.name = name;
-            this.plugins = plugins;
-            this.links = links;
-            this.phases = phases;
+    /**
+     * Record implementation of Link.
+     *
+     * @param kind The kind of link (BEFORE or AFTER)
+     * @param pointer The pointer to the target phase
+     */
+    record DefaultLink(Lifecycle.Link.Kind kind, Lifecycle.Pointer pointer) implements Lifecycle.Link {
+        /**
+         * Compact constructor with null validation.
+         */
+        DefaultLink {
+            Objects.requireNonNull(kind, "kind cannot be null");
+            Objects.requireNonNull(pointer, "pointer cannot be null");
         }
 
         @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public List<Plugin> plugins() {
-            return plugins;
-        }
-
-        @Override
-        public Collection<Lifecycle.Link> links() {
-            return links;
-        }
-
-        @Override
-        public List<Lifecycle.Phase> phases() {
-            return phases;
-        }
-
-        @Override
-        public Stream<Lifecycle.Phase> allPhases() {
-            return Stream.concat(Stream.of(this), phases().stream().flatMap(Lifecycle.Phase::allPhases));
+        @Nonnull
+        public String toString() {
+            return kind.name().toLowerCase() + "(" + pointer + ")";
         }
     }
 
-    static class DefaultAlias implements Lifecycle.Alias {
-        private final String v3Phase;
-        private final String v4Phase;
-
-        DefaultAlias(String v3Phase, String v4Phase) {
-            this.v3Phase = v3Phase;
-            this.v4Phase = v4Phase;
+    /**
+     * Record implementation of PhasePointer.
+     *
+     * @param phase The name of the target phase
+     */
+    record DefaultPhasePointer(String phase) implements Lifecycle.PhasePointer {
+        /**
+         * Compact constructor with null validation.
+         */
+        DefaultPhasePointer {
+            Objects.requireNonNull(phase, "phase cannot be null");
         }
 
         @Override
-        public String v3Phase() {
-            return v3Phase;
+        @Nonnull
+        public String toString() {
+            return "phase(" + phase + ")";
+        }
+    }
+
+    /**
+     * Record implementation of DependenciesPointer.
+     *
+     * @param phase The name of the target phase
+     * @param scope The dependency scope
+     */
+    record DefaultDependenciesPointer(String phase, String scope) implements Lifecycle.DependenciesPointer {
+        /**
+         * Compact constructor with null validation.
+         */
+        DefaultDependenciesPointer {
+            Objects.requireNonNull(phase, "phase cannot be null");
+            Objects.requireNonNull(scope, "scope cannot be null");
         }
 
         @Override
-        public String v4Phase() {
-            return v4Phase;
+        @Nonnull
+        public String toString() {
+            return "dependencies(" + scope + ", " + phase + ")";
+        }
+    }
+
+    /**
+     * Record implementation of ChildrenPointer.
+     *
+     * @param phase The name of the target phase
+     */
+    record DefaultChildrenPointer(String phase) implements Lifecycle.ChildrenPointer {
+        /**
+         * Compact constructor with null validation.
+         */
+        DefaultChildrenPointer {
+            Objects.requireNonNull(phase, "phase cannot be null");
+        }
+
+        @Override
+        @Nonnull
+        public String toString() {
+            return "children(" + phase + ")";
+        }
+    }
+
+    /**
+     * Record implementation of Lifecycle.Phase.
+     *
+     * @param name The name of the phase
+     * @param plugins The list of plugins bound to this phase
+     * @param links The collection of links from this phase to other phases
+     * @param phases The list of sub-phases
+     */
+    record DefaultPhase(
+            String name, List<Plugin> plugins, Collection<Lifecycle.Link> links, List<Lifecycle.Phase> phases)
+            implements Lifecycle.Phase {
+
+        /**
+         * Canonical constructor with null validation and defensive copying.
+         *
+         * @param name The name of the phase
+         * @param plugins The list of plugins bound to this phase
+         * @param links The collection of links from this phase to other phases
+         * @param phases The list of sub-phases
+         */
+        DefaultPhase(
+                String name, List<Plugin> plugins, Collection<Lifecycle.Link> links, List<Lifecycle.Phase> phases) {
+            this.name = Objects.requireNonNull(name, "name cannot be null");
+            this.plugins = List.copyOf(Objects.requireNonNull(plugins, "plugins cannot be null"));
+            this.links = List.copyOf(Objects.requireNonNull(links, "links cannot be null"));
+            this.phases = List.copyOf(Objects.requireNonNull(phases, "phases cannot be null"));
+        }
+    }
+
+    /**
+     * Record implementation of Lifecycle.Alias.
+     *
+     * @param v3Phase The Maven 3 phase name
+     * @param v4Phase The Maven 4 phase name
+     */
+    record DefaultAlias(String v3Phase, String v4Phase) implements Lifecycle.Alias {
+        /**
+         * Compact constructor with null validation.
+         */
+        DefaultAlias {
+            Objects.requireNonNull(v3Phase, "v3Phase cannot be null");
+            Objects.requireNonNull(v4Phase, "v4Phase cannot be null");
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -288,7 +288,7 @@ class DefaultConsumerPomBuilder implements ConsumerPomBuilder {
                     return builder.build(null).build();
                 })
                 .filter(p -> !isEmpty(p))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static boolean isEmpty(Profile profile) {
@@ -324,6 +324,6 @@ class DefaultConsumerPomBuilder implements ConsumerPomBuilder {
     private static List<Repository> pruneRepositories(List<Repository> repositories) {
         return repositories.stream()
                 .filter(r -> !org.apache.maven.api.Repository.CENTRAL_ID.equals(r.getId()))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
@@ -161,7 +161,7 @@ public class DefaultLifecycles {
         return lifecyclesMap.values().stream()
                 .peek(l -> Objects.requireNonNull(l.getId(), "A lifecycle must have an id."))
                 .sorted(Comparator.comparing(Lifecycle::getId, comparator))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Map<String, Lifecycle> lookupLifecycles() {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildListCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/BuildListCalculator.java
@@ -22,7 +22,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.execution.MavenSession;
@@ -46,7 +45,7 @@ public class BuildListCalculator {
             List<MavenProject> projects;
 
             if (taskSegment.isAggregating()) {
-                projects = Collections.singletonList(rootProject);
+                projects = List.of(rootProject);
             } else {
                 projects = session.getProjects();
             }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -26,7 +26,6 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -113,7 +112,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         this.lifecyclePluginResolver = lifecyclePluginResolver;
         this.standardDelegate = null;
         this.delegates = null;
-        this.mojoExecutionConfigurators = Collections.singletonMap("default", new DefaultMojoExecutionConfigurator());
+        this.mojoExecutionConfigurators = Map.of("default", new DefaultMojoExecutionConfigurator());
     }
 
     @Override
@@ -551,7 +550,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         }
 
         if (alreadyPlannedExecutions.contains(forkedMojoDescriptor)) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         MojoExecution forkedExecution = new MojoExecution(forkedMojoDescriptor, forkedGoal);
@@ -562,7 +561,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
 
         calculateForkedExecutions(forkedExecution, session, project, alreadyPlannedExecutions);
 
-        return Collections.singletonList(forkedExecution);
+        return List.of(forkedExecution);
     }
 
     private MojoExecutionConfigurator mojoExecutionConfigurator(MojoExecution mojoExecution) {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
@@ -84,7 +83,7 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
                         && !rootProject.getDefaultGoal().isEmpty())) {
             tasks = Stream.of(rootProject.getDefaultGoal().split("\\s+"))
                     .filter(g -> !g.isEmpty())
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         return calculateTaskSegments(session, tasks);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DependencyContext.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DependencyContext.java
@@ -20,6 +20,7 @@ package org.apache.maven.lifecycle.internal;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.TreeSet;
 
 import org.apache.maven.project.MavenProject;
@@ -45,7 +46,7 @@ public class DependencyContext {
 
     private final Collection<String> scopesToResolveForAggregatedProjects;
 
-    private volatile Collection<?> lastDependencyArtifacts = Collections.emptyList();
+    private volatile Collection<?> lastDependencyArtifacts = List.of();
 
     private volatile int lastDependencyArtifactCount = -1;
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -97,7 +97,7 @@ public class LifecycleDependencyResolver {
                     .filter(projectAndSubmodules::contains)
                     .toList(); // sorted and filtered to what we need
         } else {
-            return Collections.singletonList(project);
+            return List.of(project);
         }
     }
 
@@ -287,7 +287,7 @@ public class LifecycleDependencyResolver {
             RepositoryUtils.toArtifacts(
                     artifacts,
                     result.getDependencyGraph().getChildren(),
-                    Collections.singletonList(project.getArtifact().getId()),
+                    List.of(project.getArtifact().getId()),
                     collectionFilter);
         }
         return new SetWithResolutionResult(result, artifacts);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -30,7 +30,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.services.MessageBuilderFactory;
@@ -96,7 +95,7 @@ public class LifecycleDependencyResolver {
             projectAndSubmodules.add(project);
             return session.getProjects().stream() // sorted all
                     .filter(projectAndSubmodules::contains)
-                    .collect(Collectors.toList()); // sorted and filtered to what we need
+                    .toList(); // sorted and filtered to what we need
         } else {
             return Collections.singletonList(project);
         }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.execution.MavenSession;
@@ -102,7 +101,7 @@ public class MojoDescriptorCreator {
                                 : null,
                         null,
                         null))
-                .collect(Collectors.toList());
+                .toList();
         return XmlNode.newInstance("configuration", children);
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
@@ -24,8 +24,8 @@ import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.execution.MavenSession;
@@ -96,9 +96,7 @@ public class MojoDescriptorCreator {
                 .map(p -> XmlNode.newInstance(
                         p.getName(),
                         p.getExpression(),
-                        p.getDefaultValue() != null
-                                ? Collections.singletonMap("default-value", p.getDefaultValue())
-                                : null,
+                        p.getDefaultValue() != null ? Map.of("default-value", p.getDefaultValue()) : null,
                         null,
                         null))
                 .toList();
@@ -118,7 +116,7 @@ public class MojoDescriptorCreator {
                     XmlNode e = XmlNode.newInstance(
                             ce.getName(),
                             value,
-                            defaultValue != null ? Collections.singletonMap("default-value", defaultValue) : null,
+                            defaultValue != null ? Map.of("default-value", defaultValue) : null,
                             null,
                             null);
                     children.add(e);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -131,7 +131,7 @@ public class MojoExecutor {
     }
 
     private Collection<String> toScopes(String classpath) {
-        Collection<String> scopes = Collections.emptyList();
+        Collection<String> scopes = List.of();
 
         if (classpath != null && !classpath.isEmpty()) {
             if (Artifact.SCOPE_COMPILE.equals(classpath)) {
@@ -419,7 +419,7 @@ public class MojoExecutor {
 
     public List<MavenProject> executeForkedExecutions(MojoExecution mojoExecution, MavenSession session)
             throws LifecycleExecutionException {
-        List<MavenProject> forkedProjects = Collections.emptyList();
+        List<MavenProject> forkedProjects = List.of();
 
         Map<String, List<MojoExecution>> forkedExecutions = mojoExecution.getForkedExecutions();
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectBuildList.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectBuildList.java
@@ -55,7 +55,7 @@ public class ProjectBuildList implements Iterable<ProjectSegment> {
      */
     public ProjectBuildList getByTaskSegment(TaskSegment taskSegment) {
         return new ProjectBuildList(
-                items.stream().filter(pb -> taskSegment == pb.getTaskSegment()).collect(Collectors.toList()));
+                items.stream().filter(pb -> taskSegment == pb.getTaskSegment()).toList());
     }
 
     public Map<MavenProject, ProjectSegment> selectSegment(TaskSegment taskSegment) {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/Task.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/Task.java
@@ -32,7 +32,7 @@ public abstract class Task {
     private final String value;
 
     public Task(String value) {
-        this.value = Objects.requireNonNull(value, "value");
+        this.value = Objects.requireNonNull(value, "value cannot be null");
     }
 
     public String getValue() {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlan.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlan.java
@@ -76,9 +76,7 @@ public class BuildPlan {
     }
 
     public Stream<BuildStep> steps(MavenProject project) {
-        return Optional.ofNullable(plan.get(project))
-                .map(m -> m.values().stream())
-                .orElse(Stream.empty());
+        return Optional.ofNullable(plan.get(project)).stream().flatMap(m -> m.values().stream());
     }
 
     public Optional<BuildStep> step(MavenProject project, String name) {
@@ -103,7 +101,7 @@ public class BuildPlan {
                 add.values().stream().filter(b -> b.predecessors.isEmpty()).toList();
         firsts.stream()
                 .filter(addNode -> !org.containsKey(addNode.name))
-                .forEach(addNode -> lasts.forEach(orgNode -> addNode.executeAfter(orgNode)));
+                .forEach(addNode -> lasts.forEach(addNode::executeAfter));
         add.forEach((name, node) -> org.merge(name, node, this::merge));
         return org;
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -242,9 +241,8 @@ public class BuildPlanExecutor {
 
             BuildPlan plan = new BuildPlan(allProjects);
             for (TaskSegment taskSegment : taskSegments) {
-                Map<MavenProject, List<MavenProject>> projects = taskSegment.isAggregating()
-                        ? Collections.singletonMap(rootProject, allProjects.get(rootProject))
-                        : allProjects;
+                Map<MavenProject, List<MavenProject>> projects =
+                        taskSegment.isAggregating() ? Map.of(rootProject, allProjects.get(rootProject)) : allProjects;
 
                 BuildPlan segment = calculateMojoExecutions(projects, taskSegment.getTasks());
                 plan.then(segment);
@@ -535,7 +533,7 @@ public class BuildPlanExecutor {
                     } else if (allStepsExecuted) {
                         // If there were no failures, report success
                         projectExecutionListener.afterProjectExecutionSuccess(
-                                new ProjectExecutionEvent(session, step.project, Collections.emptyList()));
+                                new ProjectExecutionEvent(session, step.project, List.of()));
                         reactorContext
                                 .getResult()
                                 .addBuildSummary(new BuildSuccess(step.project, clock.wallTime(), clock.execTime()));
@@ -713,8 +711,8 @@ public class BuildPlanExecutor {
 
                 String resolvedPhase = getResolvedPhase(lifecycle, phase);
 
-                Map<MavenProject, List<MavenProject>> map = Collections.singletonMap(
-                        step.project, plan.getAllProjects().get(step.project));
+                Map<MavenProject, List<MavenProject>> map =
+                        Map.of(step.project, plan.getAllProjects().get(step.project));
                 BuildPlan forkedPlan = calculateLifecycleMappings(map, lifecycle, resolvedPhase);
                 forkedPlan.then(buildPlan);
                 return forkedPlan;

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -253,7 +253,7 @@ public class BuildPlanExecutor {
             // Create plan, setup and teardown
             for (MavenProject project : plan.getAllProjects().keySet()) {
                 BuildStep pplan = new BuildStep(PLAN, project, null);
-                pplan.status.set(PLANNING); // the plan step always need planning
+                pplan.status.set(PLANNING); // the plan step always needs planning
                 BuildStep setup = new BuildStep(SETUP, project, null);
                 BuildStep teardown = new BuildStep(TEARDOWN, project, null);
                 teardown.executeAfter(setup);
@@ -787,7 +787,7 @@ public class BuildPlanExecutor {
             } else if (MavenExecutionRequest.REACTOR_FAIL_FAST.equals(session.getReactorFailureBehavior())) {
                 buildContext.getReactorBuildStatus().halt();
             } else {
-                logger.error("invalid reactor failure behavior " + session.getReactorFailureBehavior());
+                logger.error("invalid reactor failure behavior {}", session.getReactorFailureBehavior());
                 buildContext.getReactorBuildStatus().halt();
             }
         }
@@ -941,11 +941,11 @@ public class BuildPlanExecutor {
                 plan.addProject(project, steps);
             }
 
-            // Create inter project dependencies
+            // Create inter-project dependencies
             plan.allSteps().filter(step -> step.phase != null).forEach(step -> {
                 Lifecycle.Phase phase = step.phase;
                 MavenProject project = step.project;
-                phase.links().stream().forEach(link -> {
+                phase.links().forEach(link -> {
                     BuildStep before = plan.requiredStep(project, BEFORE + phase.name());
                     BuildStep after = plan.requiredStep(project, AFTER + phase.name());
                     Lifecycle.Pointer pointer = link.pointer();

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/ConcurrentLifecycleStarter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/ConcurrentLifecycleStarter.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
@@ -128,7 +127,7 @@ public class ConcurrentLifecycleStarter implements LifecycleStarter {
                         && !rootProject.getDefaultGoal().isEmpty())) {
             tasks = Stream.of(rootProject.getDefaultGoal().split("\\s+"))
                     .filter(g -> !g.isEmpty())
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         return calculateTaskSegments(session, tasks);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
@@ -19,7 +19,6 @@
 package org.apache.maven.lifecycle.internal.concurrent;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.api.Lifecycle;
@@ -58,7 +57,7 @@ class PluginLifecycle implements Lifecycle {
                     @Override
                     @Nonnull
                     public List<Plugin> plugins() {
-                        return Collections.singletonList(Plugin.newBuilder()
+                        return List.of(Plugin.newBuilder()
                                 .groupId(pluginDescriptor.getGroupId())
                                 .artifactId(pluginDescriptor.getArtifactId())
                                 .version(pluginDescriptor.getVersion())

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
+import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.model.Plugin;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 
@@ -40,20 +41,24 @@ class PluginLifecycle implements Lifecycle {
     }
 
     @Override
+    @Nonnull
     public String id() {
         return lifecycleOverlay.getId();
     }
 
     @Override
+    @Nonnull
     public Collection<Phase> phases() {
         return lifecycleOverlay.getPhases().stream()
                 .map(phase -> new Phase() {
                     @Override
+                    @Nonnull
                     public String name() {
                         return phase.getId();
                     }
 
                     @Override
+                    @Nonnull
                     public List<Plugin> plugins() {
                         return Collections.singletonList(Plugin.newBuilder()
                                 .groupId(pluginDescriptor.getGroupId())
@@ -70,16 +75,19 @@ class PluginLifecycle implements Lifecycle {
                     }
 
                     @Override
+                    @Nonnull
                     public Collection<Link> links() {
                         return Collections.emptyList();
                     }
 
                     @Override
+                    @Nonnull
                     public List<Phase> phases() {
                         return Collections.emptyList();
                     }
 
                     @Override
+                    @Nonnull
                     public Stream<Phase> allPhases() {
                         return Stream.concat(Stream.of(this), phases().stream().flatMap(Phase::allPhases));
                     }
@@ -88,6 +96,7 @@ class PluginLifecycle implements Lifecycle {
     }
 
     @Override
+    @Nonnull
     public Collection<Alias> aliases() {
         return Collections.emptyList();
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
@@ -21,7 +21,6 @@ package org.apache.maven.lifecycle.internal.concurrent;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
 import org.apache.maven.api.annotations.Nonnull;
@@ -83,12 +82,6 @@ class PluginLifecycle implements Lifecycle {
                     @Nonnull
                     public List<Phase> phases() {
                         return List.of();
-                    }
-
-                    @Override
-                    @Nonnull
-                    public Stream<Phase> allPhases() {
-                        return Stream.concat(Stream.of(this), phases().stream().flatMap(Phase::allPhases));
                     }
                 })
                 .toList();

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
@@ -21,7 +21,6 @@ package org.apache.maven.lifecycle.internal.concurrent;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
@@ -50,7 +49,7 @@ class PluginLifecycle implements Lifecycle {
     @Nonnull
     public Collection<Phase> phases() {
         return lifecycleOverlay.getPhases().stream()
-                .map(phase -> new Phase() {
+                .map(phase -> (Phase) new Phase() {
                     @Override
                     @Nonnull
                     public String name() {
@@ -70,20 +69,20 @@ class PluginLifecycle implements Lifecycle {
                                                 .goals(exec.getGoals())
                                                 .configuration(exec.getConfiguration())
                                                 .build())
-                                        .collect(Collectors.toList()))
+                                        .toList())
                                 .build());
                     }
 
                     @Override
                     @Nonnull
                     public Collection<Link> links() {
-                        return Collections.emptyList();
+                        return List.of();
                     }
 
                     @Override
                     @Nonnull
                     public List<Phase> phases() {
-                        return Collections.emptyList();
+                        return List.of();
                     }
 
                     @Override
@@ -92,12 +91,12 @@ class PluginLifecycle implements Lifecycle {
                         return Stream.concat(Stream.of(this), phases().stream().flatMap(Phase::allPhases));
                     }
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
     @Nonnull
     public Collection<Alias> aliases() {
-        return Collections.emptyList();
+        return List.of();
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/Lifecycle.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/Lifecycle.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.lifecycle.mapping;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -76,7 +75,7 @@ public class Lifecycle {
         }
 
         if (lphases.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
 
         Map<String, String> phases = new LinkedHashMap<>();

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
@@ -20,7 +20,6 @@ package org.apache.maven.lifecycle.mapping;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +67,7 @@ public class LifecyclePhase {
 
     @Override
     public String toString() {
-        return Optional.ofNullable(getMojos()).orElse(Collections.emptyList()).stream()
+        return Optional.ofNullable(getMojos()).orElse(List.of()).stream()
                 .map(LifecycleMojo::getGoal)
                 .collect(Collectors.joining(","));
     }
@@ -80,7 +79,7 @@ public class LifecyclePhase {
         }
 
         if (lifecyclePhases.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
 
         Map<String, String> phases = new LinkedHashMap<>();

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
@@ -56,7 +56,7 @@ public class LifecyclePhase {
 
         if (goals != null && !goals.isEmpty()) {
             String[] mojoGoals = goals.split(",");
-            mojos = Arrays.stream(mojoGoals).map(fromGoalIntoLifecycleMojo).collect(Collectors.toList());
+            mojos = Arrays.stream(mojoGoals).map(fromGoalIntoLifecycleMojo).toList();
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
@@ -22,6 +22,7 @@ import javax.inject.Provider;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping;
 import org.apache.maven.lifecycle.mapping.Lifecycle;
@@ -78,7 +79,7 @@ public abstract class AbstractLifecycleMappingProvider implements Provider<Lifec
         lifecycle.setId("default");
         lifecycle.setLifecyclePhases(Collections.unmodifiableMap(lifecyclePhaseBindings));
 
-        this.lifecycleMapping = new DefaultLifecycleMapping(Collections.singletonList(lifecycle));
+        this.lifecycleMapping = new DefaultLifecycleMapping(List.of(lifecycle));
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,8 +89,8 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                 target.setBuild(new Build());
             }
 
-            Map<Object, Object> context = Collections.singletonMap(
-                    PLUGIN_MANAGEMENT, target.getBuild().getPluginManagement());
+            Map<Object, Object> context =
+                    Map.of(PLUGIN_MANAGEMENT, target.getBuild().getPluginManagement());
 
             mergePluginContainer_Plugins(target.getBuild(), source.getBuild(), false, context);
         }
@@ -132,7 +131,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                             Plugin addedPlugin = added.get(key);
                             if (addedPlugin != null) {
                                 Plugin plugin = managedPlugin.clone();
-                                mergePlugin(plugin, addedPlugin, sourceDominant, Collections.emptyMap());
+                                mergePlugin(plugin, addedPlugin, sourceDominant, Map.of());
                                 merged.put(key, plugin);
                             }
                         }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
@@ -22,7 +22,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -87,7 +86,7 @@ public class DefaultPluginRealmCache implements PluginRealmCache, Disposable {
                 }
             }
             this.parentRealm = parentRealm;
-            this.foreignImports = (foreignImports != null) ? foreignImports : Collections.emptyMap();
+            this.foreignImports = (foreignImports != null) ? foreignImports : Map.of();
             this.filter = dependencyFilter;
 
             int hash = 17;

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.RepositoryUtils;
@@ -240,7 +239,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                             e.getResult().getArtifactResults().stream()
                                     .filter(r -> !r.isResolved())
                                     .flatMap(r -> r.getExceptions().stream()))
-                    .collect(Collectors.toList());
+                    .toList();
             throw new PluginResolutionException(plugin, exceptions, e);
         } finally {
             RequestTraceHelper.exit(trace);

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -103,7 +103,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
     private List<String> parsePluginExcludes(RepositorySystemSession session) {
         String excludes = ConfigUtils.getString(session, null, Constants.MAVEN_PLUGIN_VALIDATION_EXCLUDES);
         if (excludes == null || excludes.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Arrays.stream(excludes.split(","))
                 .map(String::trim)

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -36,7 +36,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Constants;
 import org.apache.maven.eventspy.AbstractEventSpy;
@@ -109,7 +108,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
         return Arrays.stream(excludes.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private ValidationReportLevel validationReportLevel(RepositorySystemSession session) {

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/DefaultPluginPrefixRequest.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/DefaultPluginPrefixRequest.java
@@ -36,11 +36,11 @@ public class DefaultPluginPrefixRequest implements PluginPrefixRequest {
 
     private String prefix;
 
-    private List<String> pluginGroups = Collections.emptyList();
+    private List<String> pluginGroups = List.of();
 
     private Model pom;
 
-    private List<RemoteRepository> repositories = Collections.emptyList();
+    private List<RemoteRepository> repositories = List.of();
 
     private RepositorySystemSession session;
 
@@ -89,7 +89,7 @@ public class DefaultPluginPrefixRequest implements PluginPrefixRequest {
         if (pluginGroups != null) {
             this.pluginGroups = Collections.unmodifiableList(pluginGroups);
         } else {
-            this.pluginGroups = Collections.emptyList();
+            this.pluginGroups = List.of();
         }
 
         return this;
@@ -113,7 +113,7 @@ public class DefaultPluginPrefixRequest implements PluginPrefixRequest {
         if (repositories != null) {
             this.repositories = Collections.unmodifiableList(repositories);
         } else {
-            this.repositories = Collections.emptyList();
+            this.repositories = List.of();
         }
 
         return this;

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -227,7 +226,7 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
             ArtifactRepository repository) {
         if (metadata != null && metadata.getFile() != null && metadata.getFile().isFile()) {
             try {
-                Map<String, ?> options = Collections.singletonMap(MetadataReader.IS_STRICT, Boolean.FALSE);
+                Map<String, ?> options = Map.of(MetadataReader.IS_STRICT, Boolean.FALSE);
 
                 Metadata pluginGroupMetadata = metadataReader.read(metadata.getFile(), options);
 

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/version/DefaultPluginVersionRequest.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/version/DefaultPluginVersionRequest.java
@@ -41,7 +41,7 @@ public class DefaultPluginVersionRequest implements PluginVersionRequest {
 
     private Model pom;
 
-    private List<RemoteRepository> repositories = Collections.emptyList();
+    private List<RemoteRepository> repositories = List.of();
 
     private RepositorySystemSession session;
 
@@ -124,7 +124,7 @@ public class DefaultPluginVersionRequest implements PluginVersionRequest {
         if (repositories != null) {
             this.repositories = Collections.unmodifiableList(repositories);
         } else {
-            this.repositories = Collections.emptyList();
+            this.repositories = List.of();
         }
 
         return this;

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
@@ -311,7 +311,7 @@ public class DefaultPluginVersionResolver implements PluginVersionResolver {
             ArtifactRepository repository) {
         if (metadata != null && metadata.getFile() != null && metadata.getFile().isFile()) {
             try {
-                Map<String, ?> options = Collections.singletonMap(MetadataReader.IS_STRICT, Boolean.FALSE);
+                Map<String, ?> options = Map.of(MetadataReader.IS_STRICT, Boolean.FALSE);
 
                 Metadata repoMetadata = metadataReader.read(metadata.getFile(), options);
 

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultDependencyResolutionResult.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultDependencyResolutionResult.java
@@ -82,7 +82,7 @@ class DefaultDependencyResolutionResult implements DependencyResolutionResult {
 
     public List<Exception> getResolutionErrors(Dependency dependency) {
         List<Exception> errors = resolutionErrors.get(dependency);
-        return (errors != null) ? Collections.unmodifiableList(errors) : Collections.emptyList();
+        return (errors != null) ? Collections.unmodifiableList(errors) : List.of();
     }
 
     public void setResolutionErrors(Dependency dependency, List<Exception> errors) {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -740,7 +740,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             project.setExtensionArtifacts(extensionArtifacts);
 
             // managedVersionMap
-            Map<String, Artifact> map = Collections.emptyMap();
+            Map<String, Artifact> map = Map.of();
             final DependencyManagement dependencyManagement =
                     project.getModel().getDelegate().getDependencyManagement();
             if (dependencyManagement != null
@@ -924,7 +924,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 RepositoryUtils.toArtifacts(
                         artifacts,
                         resolutionResult.getDependencyGraph().getChildren(),
-                        Collections.singletonList(project.getArtifact().getId()),
+                        List.of(project.getArtifact().getId()),
                         null);
 
                 // Maven 2.x quirk: an artifact always points at the local repo, regardless whether resolved or not

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -505,7 +505,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 return pomFiles.stream()
                         .map(pomFile -> build(pomFile, recursive))
                         .flatMap(List::stream)
-                        .collect(Collectors.toList());
+                        .toList();
             } finally {
                 Thread.currentThread().setContextClassLoader(oldContextClassLoader);
             }
@@ -551,7 +551,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     project.setCollectedProjects(results(r)
                             .filter(cr -> cr != r && cr.getEffectiveModel() != null)
                             .map(cr -> projectIndex.get(cr.getEffectiveModel().getId()))
-                            .collect(Collectors.toList()));
+                            .toList());
 
                     DependencyResolutionResult resolutionResult = null;
                     if (request.isResolveDependencies()) {
@@ -944,7 +944,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
     }
 
     private List<String> getProfileIds(List<Profile> profiles) {
-        return profiles.stream().map(Profile::getId).collect(Collectors.toList());
+        return profiles.stream().map(Profile::getId).toList();
     }
 
     private static ModelSource createStubModelSource(Artifact artifact) {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingResult.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingResult.java
@@ -19,7 +19,6 @@
 package org.apache.maven.project;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.model.building.ModelProblem;
@@ -54,7 +53,7 @@ class DefaultProjectBuildingResult implements ProjectBuildingResult {
                 : "";
         this.pomFile = (project != null) ? project.getFile() : null;
         this.project = project;
-        this.problems = problems != null ? problems : Collections.emptyList();
+        this.problems = problems != null ? problems : List.of();
         this.dependencyResolutionResult = dependencyResolutionResult;
     }
 
@@ -69,7 +68,7 @@ class DefaultProjectBuildingResult implements ProjectBuildingResult {
         this.projectId = (projectId != null) ? projectId : "";
         this.pomFile = pomFile;
         this.project = null;
-        this.problems = problems != null ? problems : Collections.emptyList();
+        this.problems = problems != null ? problems : List.of();
         this.dependencyResolutionResult = null;
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectRealmCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectRealmCache.java
@@ -49,7 +49,7 @@ public class DefaultProjectRealmCache implements ProjectRealmCache, Disposable {
 
         public CacheKey(List<? extends ClassRealm> extensionRealms) {
             this.extensionRealms =
-                    (extensionRealms != null) ? Collections.unmodifiableList(extensionRealms) : Collections.emptyList();
+                    (extensionRealms != null) ? Collections.unmodifiableList(extensionRealms) : List.of();
 
             this.hashCode = this.extensionRealms.hashCode();
         }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/Graph.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/Graph.java
@@ -20,12 +20,12 @@ package org.apache.maven.project;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 class Graph {
     private enum DfsState {
@@ -69,7 +69,7 @@ class Graph {
     }
 
     List<String> findCycle(Vertex vertex) {
-        return visitCycle(Collections.singleton(vertex), new HashMap<>(), new LinkedList<>());
+        return visitCycle(Set.of(vertex), new HashMap<>(), new LinkedList<>());
     }
 
     private static List<String> visitAll(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -934,7 +934,7 @@ public class MavenProject implements Cloneable {
 
     public List<Plugin> getBuildPlugins() {
         if (getModel().getBuild() == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Collections.unmodifiableList(getModel().getBuild().getPlugins());
     }
@@ -1204,7 +1204,7 @@ public class MavenProject implements Cloneable {
     public List<Extension> getBuildExtensions() {
         Build build = getBuild();
         if ((build == null) || (build.getExtensions() == null)) {
-            return Collections.emptyList();
+            return List.of();
         } else {
             return Collections.unmodifiableList(build.getExtensions());
         }
@@ -1637,7 +1637,7 @@ public class MavenProject implements Cloneable {
         Set<Artifact> artifacts = getArtifacts();
 
         if ((artifacts == null) || artifacts.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         List<Dependency> list = new ArrayList<>(artifacts.size());
@@ -1678,7 +1678,7 @@ public class MavenProject implements Cloneable {
         Set<Artifact> artifacts = getArtifacts();
 
         if ((artifacts == null) || artifacts.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         List<Dependency> list = new ArrayList<>(artifacts.size());
@@ -1703,7 +1703,7 @@ public class MavenProject implements Cloneable {
         Set<Artifact> artifacts = getArtifacts();
 
         if ((artifacts == null) || artifacts.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         List<Dependency> list = new ArrayList<>(artifacts.size());
@@ -1783,7 +1783,7 @@ public class MavenProject implements Cloneable {
         Set<Artifact> artifacts = getArtifacts();
 
         if ((artifacts == null) || artifacts.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         List<Dependency> list = new ArrayList<>(artifacts.size());
@@ -1860,7 +1860,7 @@ public class MavenProject implements Cloneable {
     @Deprecated
     public List<ReportPlugin> getReportPlugins() {
         if (getModel().getReporting() == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Collections.unmodifiableList(getModel().getReporting().getPlugins());
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1962,6 +1962,7 @@ public class MavenProject implements Cloneable {
      * @return the rootDirectory for this project
      * @throws IllegalStateException if the rootDirectory cannot be found
      */
+    @Nonnull
     public Path getRootDirectory() {
         if (rootDirectory == null) {
             throw new IllegalStateException(RootLocator.UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
@@ -127,7 +127,7 @@ public class ProjectModelResolver implements ModelResolver {
         }
 
         List<RemoteRepository> newRepositories =
-                Collections.singletonList(ArtifactDescriptorUtils.toRemoteRepository(repository.getDelegate()));
+                List.of(ArtifactDescriptorUtils.toRemoteRepository(repository.getDelegate()));
 
         if (ProjectBuildingRequest.RepositoryMerging.REQUEST_DOMINANT.equals(repositoryMerging)) {
             repositories = remoteRepositoryManager.aggregateRepositories(session, repositories, newRepositories, true);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
@@ -262,11 +262,11 @@ public class ProjectSorter {
     }
 
     public List<String> getDependents(String id) {
-        return graph.getVertex(id).getParents().stream().map(Vertex::getLabel).collect(Collectors.toList());
+        return graph.getVertex(id).getParents().stream().map(Vertex::getLabel).toList();
     }
 
     public List<String> getDependencies(String id) {
-        return graph.getVertex(id).getChildren().stream().map(Vertex::getLabel).collect(Collectors.toList());
+        return graph.getVertex(id).getChildren().stream().map(Vertex::getLabel).toList();
     }
 
     public static String getId(MavenProject project) {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/artifact/AttachedArtifact.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/artifact/AttachedArtifact.java
@@ -19,7 +19,6 @@
 package org.apache.maven.project.artifact;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
@@ -52,7 +51,7 @@ public class AttachedArtifact extends DefaultArtifact {
                 artifactHandler,
                 parent.isOptional());
 
-        setDependencyTrail(Collections.singletonList(parent.getId()));
+        setDependencyTrail(List.of(parent.getId()));
 
         this.parent = parent;
 
@@ -162,6 +161,6 @@ public class AttachedArtifact extends DefaultArtifact {
     }
 
     public Collection<ArtifactMetadata> getMetadataList() {
-        return Collections.emptyList();
+        return List.of();
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/artifact/PluginArtifact.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/artifact/PluginArtifact.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.project.artifact;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
@@ -52,7 +51,7 @@ public class PluginArtifact extends DefaultArtifact implements ArtifactWithDepen
     }
 
     public List<Dependency> getManagedDependencies() {
-        return Collections.emptyList();
+        return List.of();
     }
 
     // TODO: this is duplicate of MavenPluginArtifactHandlerProvider provided one

--- a/impl/maven-core/src/main/java/org/apache/maven/project/artifact/ProjectArtifact.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/artifact/ProjectArtifact.java
@@ -57,7 +57,7 @@ public class ProjectArtifact extends DefaultArtifact implements ArtifactWithDepe
 
     public List<Dependency> getManagedDependencies() {
         DependencyManagement depMngt = project.getModel().getDependencyManagement();
-        return (depMngt != null) ? Collections.unmodifiableList(depMngt.getDependencies()) : Collections.emptyList();
+        return (depMngt != null) ? Collections.unmodifiableList(depMngt.getDependencies()) : List.of();
     }
 
     // TODO: this is duplicate of PomArtifactHandlerProvider provided one

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -63,7 +62,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy 
     @Override
     public List<MavenProject> collectProjects(MavenExecutionRequest request) throws ProjectBuildingException {
         File moduleProjectPomFile = getRootProject(request);
-        List<File> files = Collections.singletonList(moduleProjectPomFile.getAbsoluteFile());
+        List<File> files = List.of(moduleProjectPomFile.getAbsoluteFile());
         try {
             List<MavenProject> projects = projectsSelector.selectProjects(files, request);
             boolean isRequestedProjectCollected = isRequestedProjectCollected(request, projects);
@@ -78,7 +77,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy 
                         System.lineSeparator(),
                         moduleProjectPomFile.getAbsolutePath(),
                         request.getPom().getAbsolutePath());
-                return Collections.emptyList();
+                return List.of();
             }
         } catch (ProjectBuildingException e) {
             boolean fallThrough = isModuleOutsideRequestScopeDependingOnPluginModule(request, e);
@@ -90,7 +89,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy 
                                 + "plugin extension which still needed to be built. This is not possible within the same "
                                 + "reactor build. Another project collection strategy will be executed as result.",
                         System.lineSeparator());
-                return Collections.emptyList();
+                return List.of();
             }
 
             throw e;
@@ -153,7 +152,7 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy 
                 .map(requestPomProject -> {
                     List<MavenProject> modules = requestPomProject.getCollectedProjects() != null
                             ? requestPomProject.getCollectedProjects()
-                            : Collections.emptyList();
+                            : List.of();
                     List<MavenProject> projectsInRequestScope = new ArrayList<>(modules);
                     projectsInRequestScope.add(requestPomProject);
 

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/RequestPomCollectionStrategy.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/RequestPomCollectionStrategy.java
@@ -23,7 +23,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -45,7 +44,7 @@ public class RequestPomCollectionStrategy implements ProjectCollectionStrategy {
 
     @Override
     public List<MavenProject> collectProjects(MavenExecutionRequest request) throws ProjectBuildingException {
-        List<File> files = Collections.singletonList(request.getPom().getAbsoluteFile());
+        List<File> files = List.of(request.getPom().getAbsoluteFile());
         return projectsSelector.selectProjects(files, request);
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/resolver/MavenChainedWorkspaceReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/resolver/MavenChainedWorkspaceReader.java
@@ -109,7 +109,7 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
         requireNonNull(readers, "readers");
         // skip possible null entries
         this.readers = Collections.unmodifiableList(
-                new ArrayList<>(readers.stream().filter(Objects::nonNull).collect(Collectors.toList())));
+                new ArrayList<>(readers.stream().filter(Objects::nonNull).toList()));
         Key key = new Key(this.readers);
         this.repository = new WorkspaceRepository(key.getContentType(), key);
     }
@@ -130,7 +130,7 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
         private final String type;
 
         Key(Collection<WorkspaceReader> readers) {
-            keys = readers.stream().map(r -> r.getRepository().getKey()).collect(Collectors.toList());
+            keys = readers.stream().map(r -> r.getRepository().getKey()).toList();
             type = readers.stream().map(r -> r.getRepository().getContentType()).collect(Collectors.joining("+"));
         }
 

--- a/impl/maven-core/src/test/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilterTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilterTest.java
@@ -19,7 +19,7 @@
 package org.apache.maven.artifact.resolver.filter;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Exclusion;
@@ -51,7 +51,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.maven");
         exclusion.setArtifactId("maven-core");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(false));
     }
@@ -61,7 +61,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.maven");
         exclusion.setArtifactId("maven-model");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(true));
     }
@@ -71,7 +71,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("maven-core");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(false));
     }
@@ -81,7 +81,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("maven-compat");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(true));
     }
@@ -91,7 +91,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.maven");
         exclusion.setArtifactId("*");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(false));
     }
@@ -101,7 +101,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.groovy");
         exclusion.setArtifactId("*");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(true));
     }
@@ -111,7 +111,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("*");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(false));
     }
@@ -151,7 +151,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("maven-*");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(false));
         assertThat(filter.include(artifact2), is(true));
@@ -162,7 +162,7 @@ class ExclusionArtifactFilterTest {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("**");
         exclusion.setArtifactId("maven-**");
-        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(Collections.singletonList(exclusion));
+        ExclusionArtifactFilter filter = new ExclusionArtifactFilter(List.of(exclusion));
 
         assertThat(filter.include(artifact), is(false));
         assertThat(filter.include(artifact2), is(true));

--- a/impl/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.execution;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.maven.lifecycle.LifecycleExecutionException;
@@ -27,7 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -82,7 +82,7 @@ class DefaultBuildResumptionAnalyzerTest {
         MavenProject projectA = createSucceededMavenProject("A");
         MavenProject projectB = createFailedMavenProject("B");
         MavenProject projectC = createSkippedMavenProject("C");
-        projectC.setDependencies(singletonList(toDependency(projectB)));
+        projectC.setDependencies(List.of(toDependency(projectB)));
         executionResult.setTopologicallySortedProjects(asList(projectA, projectB, projectC));
 
         Optional<BuildResumptionData> result = analyzer.determineBuildResumptionData(executionResult);

--- a/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static org.apache.maven.execution.MavenExecutionRequest.REACTOR_MAKE_DOWNSTREAM;
@@ -348,7 +347,7 @@ class DefaultGraphBuilderTest {
         MavenProject projectParent = getMavenProject(PARENT_MODULE);
         MavenProject projectModuleD = getMavenProject(MODULE_D, projectParent, "bom");
 
-        projectParent.setCollectedProjects(singletonList(projectModuleD));
+        projectParent.setCollectedProjects(List.of(projectModuleD));
 
         // Set up needed mocks
         when(session.getRequest()).thenReturn(mavenExecutionRequest);
@@ -404,8 +403,8 @@ class DefaultGraphBuilderTest {
                 .collect(Collectors.toMap(MavenProject::getArtifactId, identity()));
 
         // Set dependencies and modules
-        projectModuleB.setDependencies(singletonList(toDependency(projectModuleA)));
-        projectModuleC2.setDependencies(singletonList(toDependency(projectModuleB)));
+        projectModuleB.setDependencies(List.of(toDependency(projectModuleA)));
+        projectModuleC2.setDependencies(List.of(toDependency(projectModuleB)));
         projectParent.setCollectedProjects(asList(
                 projectIndependentModule,
                 projectModuleA,

--- a/impl/maven-core/src/test/java/org/apache/maven/graph/ProjectSelectorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/graph/ProjectSelectorTest.java
@@ -21,7 +21,6 @@ package org.apache.maven.graph;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -117,7 +116,7 @@ class ProjectSelectorTest {
         selectors.add(":optional");
 
         final MavenProject mavenProject = createMavenProject("maven-core");
-        final List<MavenProject> listOfProjects = Collections.singletonList(mavenProject);
+        final List<MavenProject> listOfProjects = List.of(mavenProject);
 
         final Set<MavenProject> optionalProjectsBySelectors =
                 sut.getOptionalProjectsBySelectors(mavenExecutionRequest, listOfProjects, selectors);
@@ -133,7 +132,7 @@ class ProjectSelectorTest {
         selectors.add(":required");
 
         final MavenProject mavenProject = createMavenProject("maven-core");
-        final List<MavenProject> listOfProjects = Collections.singletonList(mavenProject);
+        final List<MavenProject> listOfProjects = List.of(mavenProject);
 
         final MavenExecutionException exception = assertThrows(
                 MavenExecutionException.class,
@@ -148,7 +147,7 @@ class ProjectSelectorTest {
         selectors.add(":maven-core");
 
         final MavenProject mavenProject = createMavenProject("maven-core");
-        final List<MavenProject> listOfProjects = Collections.singletonList(mavenProject);
+        final List<MavenProject> listOfProjects = List.of(mavenProject);
 
         final Set<MavenProject> requiredProjectsBySelectors =
                 sut.getRequiredProjectsBySelectors(mavenExecutionRequest, listOfProjects, selectors);
@@ -166,8 +165,8 @@ class ProjectSelectorTest {
 
         final MavenProject mavenProject = createMavenProject("maven-core");
         final MavenProject child = createMavenProject("maven-core-child");
-        mavenProject.setCollectedProjects(Collections.singletonList(child));
-        final List<MavenProject> listOfProjects = Collections.singletonList(mavenProject);
+        mavenProject.setCollectedProjects(List.of(child));
+        final List<MavenProject> listOfProjects = List.of(mavenProject);
 
         final Set<MavenProject> requiredProjectsBySelectors =
                 sut.getRequiredProjectsBySelectors(mavenExecutionRequest, listOfProjects, selectors);
@@ -185,8 +184,8 @@ class ProjectSelectorTest {
 
         final MavenProject mavenProject = createMavenProject("maven-core");
         final MavenProject child = createMavenProject("maven-core-child");
-        mavenProject.setCollectedProjects(Collections.singletonList(child));
-        final List<MavenProject> listOfProjects = Collections.singletonList(mavenProject);
+        mavenProject.setCollectedProjects(List.of(child));
+        final List<MavenProject> listOfProjects = List.of(mavenProject);
 
         final Set<MavenProject> optionalProjectsBySelectors =
                 sut.getOptionalProjectsBySelectors(mavenExecutionRequest, listOfProjects, selectors);

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -83,12 +82,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
     @Test
     void isNoSnapshotUpdatesTest() throws InvalidRepositoryException {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepository(getLocalRepository());
@@ -105,12 +99,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
     @Test
     void isSnapshotUpdatesTest() throws InvalidRepositoryException {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepository(getLocalRepository());
@@ -139,12 +128,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
         request.setServers(servers);
 
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         PlexusConfiguration plexusConfiguration = (PlexusConfiguration) systemSessionFactory
                 .newRepositorySession(request)
@@ -181,12 +165,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
         request.setServers(servers);
 
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         Map<String, String> headers = (Map<String, String>) systemSessionFactory
                 .newRepositorySession(request)
@@ -217,12 +196,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
         request.setServers(servers);
 
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         int connectionTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -257,12 +231,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
         request.setServers(servers);
 
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         int connectionTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -291,12 +260,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
         request.setServers(servers);
 
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         int requestTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -331,12 +295,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
         request.setServers(servers);
 
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         int requestTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -348,12 +307,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
     @Test
     void transportConfigurationTest() throws InvalidRepositoryException {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepository(getLocalRepository());
@@ -393,12 +347,7 @@ public class DefaultRepositorySystemSessionFactoryTest {
     @Test
     void versionFilteringTest() throws InvalidRepositoryException {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
+                aetherRepositorySystem, eventSpyDispatcher, information, defaultTypeRegistry, versionScheme, Map.of());
 
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepository(getLocalRepository());

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
@@ -19,7 +19,7 @@
 package org.apache.maven.internal.impl;
 
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
@@ -40,8 +40,7 @@ public class DefaultSessionTest {
         RepositorySystemSession rss = new DefaultRepositorySystemSession(h -> false);
         DefaultMavenExecutionRequest mer = new DefaultMavenExecutionRequest();
         MavenSession ms = new MavenSession(null, rss, mer, null);
-        DefaultSession session =
-                new DefaultSession(ms, mock(RepositorySystem.class), Collections.emptyList(), null, null, null);
+        DefaultSession session = new DefaultSession(ms, mock(RepositorySystem.class), List.of(), null, null, null);
 
         assertEquals(
                 RootLocator.UNABLE_TO_FIND_ROOT_PROJECT_MESSAGE,
@@ -55,8 +54,7 @@ public class DefaultSessionTest {
         DefaultMavenExecutionRequest mer = new DefaultMavenExecutionRequest();
         MavenSession ms = new MavenSession(null, rss, mer, null);
         ms.getRequest().setRootDirectory(Paths.get("myRootDirectory"));
-        DefaultSession session =
-                new DefaultSession(ms, mock(RepositorySystem.class), Collections.emptyList(), null, null, null);
+        DefaultSession session = new DefaultSession(ms, mock(RepositorySystem.class), List.of(), null, null, null);
 
         assertEquals(Paths.get("myRootDirectory"), session.getRootDirectory());
     }

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.ArtifactCoordinates;
@@ -243,7 +242,7 @@ class TestApi {
         List<Dependency> deps2 = result.getNodes().stream()
                 .map(Node::getDependency)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
         assertEquals(deps, deps2);
         for (Dependency dep : deps2) {
             dep.getVersion();

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -124,13 +123,13 @@ class TestApi {
         DefaultSession session = new DefaultSession(
                 ms,
                 repositorySystem,
-                Collections.emptyList(),
+                List.of(),
                 mavenRepositorySystem,
                 new DefaultLookup(plexusContainer),
                 runtimeInformation);
         org.apache.maven.api.RemoteRepository remoteRepository = session.getRemoteRepository(
                 new RemoteRepository.Builder("mirror", "default", "file:target/test-classes/repo").build());
-        this.session = session.withRemoteRepositories(Collections.singletonList(remoteRepository));
+        this.session = session.withRemoteRepositories(List.of(remoteRepository));
         InternalSession.associate(rss, this.session);
         sessionScope.enter();
         sessionScope.seed(InternalMavenSession.class, InternalMavenSession.from(this.session));

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -79,8 +78,7 @@ class DefaultLifecyclesTest {
     @Test
     void testCustomLifecycle() throws ComponentLookupException {
         List<Lifecycle> myLifecycles = new ArrayList<>();
-        Lifecycle myLifecycle =
-                new Lifecycle("etl", Arrays.asList("extract", "transform", "load"), Collections.emptyMap());
+        Lifecycle myLifecycle = new Lifecycle("etl", Arrays.asList("extract", "transform", "load"), Map.of());
         myLifecycles.add(myLifecycle);
         myLifecycles.addAll(defaultLifeCycles.getLifeCycles());
 

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -381,7 +380,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
         session.setProjectDependencyGraph(new ProjectDependencyGraph() {
             @Override
             public List<MavenProject> getUpstreamProjects(MavenProject project, boolean transitive) {
-                return Collections.emptyList();
+                return List.of();
             }
 
             @Override
@@ -391,12 +390,12 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
 
             @Override
             public List<MavenProject> getSortedProjects() {
-                return Collections.singletonList(session.getCurrentProject());
+                return List.of(session.getCurrentProject());
             }
 
             @Override
             public List<MavenProject> getDownstreamProjects(MavenProject project, boolean transitive) {
-                return Collections.emptyList();
+                return List.of();
             }
         });
 

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolverTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolverTest.java
@@ -22,8 +22,8 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -50,7 +50,7 @@ class LifecycleDependencyResolverTest extends AbstractCoreMavenComponentTestCase
         MavenSession session = createMavenSession(
                 new File("src/test/projects/lifecycle-dependency-resolver/pom.xml"), new Properties(), true);
         Collection<String> scopesToCollect = null;
-        Collection<String> scopesToResolve = Collections.singletonList("compile");
+        Collection<String> scopesToResolve = List.of("compile");
         boolean aggregating = false;
 
         Set<Artifact> reactorArtifacts = new HashSet<>(3);

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.lifecycle.internal.concurrent;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,7 @@ class BuildPlanCreatorTest {
     void testMulti() {
         MavenProject project = new MavenProject();
         project.setCollectedProjects(List.of());
-        Map<MavenProject, List<MavenProject>> projects = Collections.singletonMap(project, Collections.emptyList());
+        Map<MavenProject, List<MavenProject>> projects = Map.of(project, List.of());
 
         BuildPlan plan = calculateLifecycleMappings(projects, "package");
 
@@ -55,8 +54,8 @@ class BuildPlanCreatorTest {
         p2.setCollectedProjects(List.of());
         p2.setArtifactId("p2");
         Map<MavenProject, List<MavenProject>> projects = new HashMap<>();
-        projects.put(p1, Collections.emptyList());
-        projects.put(p2, Collections.singletonList(p1));
+        projects.put(p1, List.of());
+        projects.put(p2, List.of(p1));
 
         BuildPlan plan = calculateLifecycleMappings(projects, "verify");
         plan.then(calculateLifecycleMappings(projects, "install"));
@@ -87,7 +86,7 @@ class BuildPlanCreatorTest {
         MavenProject p1 = new MavenProject();
         p1.setArtifactId("p1");
         p1.setCollectedProjects(List.of());
-        Map<MavenProject, List<MavenProject>> projects = Collections.singletonMap(p1, Collections.emptyList());
+        Map<MavenProject, List<MavenProject>> projects = Map.of(p1, List.of());
 
         BuildPlan plan = calculateLifecycleMappings(projects, "generate-resources");
         assertNotNull(plan);
@@ -123,7 +122,7 @@ class BuildPlanCreatorTest {
 
     @SuppressWarnings("checkstyle:UnusedLocalVariable")
     private BuildPlan calculateLifecycleMappings(Map<MavenProject, List<MavenProject>> projects, String phase) {
-        DefaultLifecycleRegistry lifecycles = new DefaultLifecycleRegistry(Collections.emptyList());
+        DefaultLifecycleRegistry lifecycles = new DefaultLifecycleRegistry(List.of());
         BuildPlanExecutor builder = new BuildPlanExecutor(null, null, null, null, null, null, null, null, lifecycles);
         BuildPlanExecutor.BuildContext context = builder.new BuildContext();
         return context.calculateLifecycleMappings(projects, phase);
@@ -133,7 +132,7 @@ class BuildPlanCreatorTest {
     @Test
     void testPlugins() {
         DefaultLifecycleRegistry lifecycles =
-                new DefaultLifecycleRegistry(Collections.emptyList(), Collections.emptyMap());
+                new DefaultLifecycleRegistry(List.of(), Map.of());
         BuildPlanCreator builder = new BuildPlanCreator(null, null, null, null, null, lifecycles);
         MavenProject p1 = new MavenProject();
         p1.setGroupId("g");
@@ -147,8 +146,8 @@ class BuildPlanCreatorTest {
         p2.setArtifactId("p2");
 
         Map<MavenProject, List<MavenProject>> projects = new HashMap<>();
-        projects.put(p1, Collections.emptyList());
-        projects.put(p2, Collections.singletonList(p1));
+        projects.put(p1, List.of());
+        projects.put(p2, List.of(p1));
         Lifecycle lifecycle = lifecycles.require("default");
         BuildPlan plan = builder.calculateLifecycleMappings(null, projects, lifecycle, "verify");
         plan.then(builder.calculateLifecycleMappings(null, projects, lifecycle, "install"));

--- a/impl/maven-core/src/test/java/org/apache/maven/model/ModelBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/model/ModelBuilderTest.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.SimpleLookup;
@@ -88,8 +87,8 @@ public class ModelBuilderTest {
                 null);
         InternalSession.associate(rsession, session);
 
-        List<ProjectBuildingResult> results = projectBuilder.build(
-                Collections.singletonList(new File("src/test/resources/projects/tree/pom.xml")), true, request);
+        List<ProjectBuildingResult> results =
+                projectBuilder.build(List.of(new File("src/test/resources/projects/tree/pom.xml")), true, request);
 
         assertEquals(3, results.size());
     }

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExceptionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExceptionTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.plugin;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
@@ -51,8 +51,7 @@ class PluginParameterExceptionTest {
 
         parameter.setRequired(true);
 
-        PluginParameterException exception =
-                new PluginParameterException(mojoDescriptor, Collections.singletonList(parameter));
+        PluginParameterException exception = new PluginParameterException(mojoDescriptor, List.of(parameter));
 
         assertEquals(
                 "One or more required plugin parameters are invalid/missing for 'goalPrefix:goal'" + LS
@@ -83,8 +82,7 @@ class PluginParameterExceptionTest {
 
         parameter.setRequired(true);
 
-        PluginParameterException exception =
-                new PluginParameterException(mojoDescriptor, Collections.singletonList(parameter));
+        PluginParameterException exception = new PluginParameterException(mojoDescriptor, List.of(parameter));
 
         assertEquals(
                 "One or more required plugin parameters are invalid/missing for 'goalPrefix:goal'" + LS
@@ -115,8 +113,7 @@ class PluginParameterExceptionTest {
 
         parameter.setRequired(true);
 
-        PluginParameterException exception =
-                new PluginParameterException(mojoDescriptor, Collections.singletonList(parameter));
+        PluginParameterException exception = new PluginParameterException(mojoDescriptor, List.of(parameter));
 
         assertEquals(
                 "One or more required plugin parameters are invalid/missing for 'goalPrefix:goal'" + LS
@@ -147,8 +144,7 @@ class PluginParameterExceptionTest {
 
         parameter.setRequired(true);
 
-        PluginParameterException exception =
-                new PluginParameterException(mojoDescriptor, Collections.singletonList(parameter));
+        PluginParameterException exception = new PluginParameterException(mojoDescriptor, List.of(parameter));
 
         assertEquals(
                 "One or more required plugin parameters are invalid/missing for 'goalPrefix:goal'" + LS

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorTest.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -341,11 +340,11 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
             throws CycleDetectedException, DuplicateProjectException {
         MavenExecutionRequest request = new DefaultMavenExecutionRequest()
                 .setSystemProperties(properties)
-                .setGoals(Collections.emptyList())
+                .setGoals(List.of())
                 .setBaseDirectory(new File(""))
                 .setLocalRepository(repo);
 
-        return new MavenSession(container, request, new DefaultMavenExecutionResult(), Collections.emptyList());
+        return new MavenSession(container, request, new DefaultMavenExecutionResult(), List.of());
     }
 
     @Test
@@ -380,7 +379,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
 
         Artifact artifact = createArtifact("testGroup", "testArtifact", "1.0");
 
-        pd.setArtifacts(Collections.singletonList(artifact));
+        pd.setArtifacts(List.of(artifact));
 
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), pd, new Properties());
 

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
@@ -25,7 +25,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -296,7 +296,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
             throws CycleDetectedException, DuplicateProjectException, NoLocalRepositoryManagerException {
         MavenExecutionRequest request = new DefaultMavenExecutionRequest()
                 .setSystemProperties(properties)
-                .setGoals(Collections.emptyList())
+                .setGoals(List.of())
                 .setBaseDirectory(new File(""))
                 .setLocalRepository(repo);
 
@@ -306,7 +306,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
                 .newInstance(repositorySession, new LocalRepository(repo.getUrl())));
         MavenSession session =
                 new MavenSession(container, repositorySession, request, new DefaultMavenExecutionResult());
-        session.setProjects(Collections.emptyList());
+        session.setProjects(List.of());
         return session;
     }
 
@@ -405,7 +405,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
                 new DefaultArtifactHandler("maven-plugin"));
         pd.setPluginArtifact(artifact);
 
-        pd.setArtifacts(Collections.singletonList(artifact));
+        pd.setArtifacts(List.of(artifact));
         DefaultDependencyNode node = new DefaultDependencyNode(
                 new org.eclipse.aether.graph.Dependency(RepositoryUtils.toArtifact(artifact), "compile"));
         pd.setDependencyNode(node);

--- a/impl/maven-core/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/EmptyLifecycleBindingsInjector.java
@@ -53,26 +53,31 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
     private static final LifecycleRegistry EMPTY_LIFECYCLE_REGISTRY = new LifecycleRegistry() {
 
         @Override
+        @Nonnull
         public Iterator<Lifecycle> iterator() {
             return Collections.emptyIterator();
         }
 
         @Override
-        public Optional<Lifecycle> lookup(String id) {
+        @Nonnull
+        public Optional<Lifecycle> lookup(@Nonnull String id) {
             return Optional.empty();
         }
 
         @Override
-        public List<String> computePhases(Lifecycle lifecycle) {
+        @Nonnull
+        public List<String> computePhases(@Nonnull Lifecycle lifecycle) {
             return List.of();
         }
     };
 
     private static final PackagingRegistry EMPTY_PACKAGING_REGISTRY = new PackagingRegistry() {
         @Override
-        public Optional<Packaging> lookup(String id) {
+        @Nonnull
+        public Optional<Packaging> lookup(@Nonnull String id) {
             return Optional.of(new Packaging() {
                 @Override
+                @Nonnull
                 public String id() {
                     return id;
                 }
@@ -83,6 +88,7 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
                 }
 
                 @Override
+                @Nonnull
                 public Map<String, PluginContainer> plugins() {
                     if ("JAR".equals(id)) {
                         return Map.of(
@@ -137,6 +143,7 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
         }
 
         @Override
+        @Nonnull
         public Iterator<Lifecycle> iterator() {
             return getDelegate().iterator();
         }
@@ -146,14 +153,16 @@ public class EmptyLifecycleBindingsInjector extends DefaultLifecycleBindingsInje
         }
 
         @Override
-        public List<String> computePhases(Lifecycle lifecycle) {
+        @Nonnull
+        public List<String> computePhases(@Nonnull Lifecycle lifecycle) {
             return List.of();
         }
     }
 
     static class WrapperPackagingRegistry implements PackagingRegistry {
         @Override
-        public Optional<Packaging> lookup(String id) {
+        @Nonnull
+        public Optional<Packaging> lookup(@Nonnull String id) {
             return getDelegate().lookup(id);
         }
 

--- a/impl/maven-core/src/test/java/org/apache/maven/project/EmptyLifecycleExecutor.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/EmptyLifecycleExecutor.java
@@ -76,7 +76,7 @@ public class EmptyLifecycleExecutor implements LifecycleExecutor {
         for (String goal : goals) {
             PluginExecution pluginExecution = new PluginExecution();
             pluginExecution.setId("default-" + goal);
-            pluginExecution.setGoals(Collections.singletonList(goal));
+            pluginExecution.setGoals(List.of(goal));
             plugin.addExecution(pluginExecution);
         }
 
@@ -86,6 +86,6 @@ public class EmptyLifecycleExecutor implements LifecycleExecutor {
     public void calculateForkedExecutions(MojoExecution mojoExecution, MavenSession session) {}
 
     public List<MavenProject> executeForkedExecutions(MojoExecution mojoExecution, MavenSession session) {
-        return Collections.emptyList();
+        return List.of();
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -122,7 +122,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
         // multi projects build entry point
         List<ProjectBuildingResult> results = getContainer()
                 .lookup(org.apache.maven.project.ProjectBuilder.class)
-                .build(Collections.singletonList(pomFile), false, configuration);
+                .build(List.of(pomFile), false, configuration);
         assertEquals(1, results.size());
         MavenProject mavenProject = results.get(0).getProject();
         assertEquals(1, mavenProject.getArtifacts().size());
@@ -156,7 +156,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
         // multi projects build entry point
         List<ProjectBuildingResult> results = getContainer()
                 .lookup(org.apache.maven.project.ProjectBuilder.class)
-                .build(Collections.singletonList(pomFile), false, configuration);
+                .build(List.of(pomFile), false, configuration);
         assertEquals(1, results.size());
         MavenProject mavenProject = results.get(0).getProject();
         assertEquals(0, mavenProject.getArtifacts().size());
@@ -213,8 +213,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
 
         // multi projects build entry point
         ProjectBuildingException ex2 = assertThrows(
-                ProjectBuildingException.class,
-                () -> projectBuilder.build(Collections.singletonList(pomFile), true, configuration));
+                ProjectBuildingException.class, () -> projectBuilder.build(List.of(pomFile), true, configuration));
 
         assertEquals(1, ex2.getResults().size());
         MavenProject project2 = ex2.getResults().get(0).getProject();
@@ -239,8 +238,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
 
         // multi projects build entry point
         ProjectBuildingException pex = assertThrows(
-                ProjectBuildingException.class,
-                () -> projectBuilder.build(Collections.singletonList(pomFile), false, configuration));
+                ProjectBuildingException.class, () -> projectBuilder.build(List.of(pomFile), false, configuration));
         assertEquals(1, pex.getResults().size());
         assertNotNull(pex.getResults().get(0).getPomFile());
         assertThat(pex.getResults().get(0).getProblems().size(), greaterThan(0));
@@ -266,8 +264,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
         // read poms separately
         boolean parentFileWasFoundOnChild = false;
         for (File file : toRead) {
-            List<ProjectBuildingResult> results =
-                    projectBuilder.build(Collections.singletonList(file), false, configuration);
+            List<ProjectBuildingResult> results = projectBuilder.build(List.of(file), false, configuration);
             assertResultShowNoError(results);
             MavenProject project = findChildProject(results);
             if (project != null) {
@@ -310,8 +307,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
         configuration.setRepositorySession(mavenSession.getRepositorySession());
         configuration.setResolveDependencies(true);
-        List<ProjectBuildingResult> result =
-                projectBuilder.build(Collections.singletonList(file), false, configuration);
+        List<ProjectBuildingResult> result = projectBuilder.build(List.of(file), false, configuration);
         MavenProject project = result.get(0).getProject();
         // verify a few typical parameters are not duplicated
         assertEquals(1, project.getTestCompileSourceRoots().size());

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.project;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.artifact.InvalidRepositoryException;
@@ -208,6 +207,6 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
                         repoDir.toURI().toASCIIString())
                 .build();
 
-        return Collections.singletonList(remoteRepository);
+        return List.of(remoteRepository);
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectSorterTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectSorterTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.project;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.model.Build;
@@ -108,7 +107,7 @@ class ProjectSorterTest {
 
         build.addPlugin(plugin);
 
-        new ProjectSorter(Collections.singletonList(project));
+        new ProjectSorter(List.of(project));
     }
 
     @Test
@@ -129,7 +128,7 @@ class ProjectSorterTest {
 
         build.setPluginManagement(pMgmt);
 
-        new ProjectSorter(Collections.singletonList(project));
+        new ProjectSorter(List.of(project));
     }
 
     @Test
@@ -142,7 +141,7 @@ class ProjectSorterTest {
 
         build.addExtension(extension);
 
-        new ProjectSorter(Collections.singletonList(project));
+        new ProjectSorter(List.of(project));
     }
 
     @Test

--- a/impl/maven-core/src/test/java/org/apache/maven/project/harness/Xpp3DomAttributeIterator.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/harness/Xpp3DomAttributeIterator.java
@@ -20,7 +20,6 @@ package org.apache.maven.project.harness;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.commons.jxpath.ri.QName;
 import org.apache.commons.jxpath.ri.model.NodeIterator;
@@ -49,7 +48,7 @@ class Xpp3DomAttributeIterator implements NodeIterator {
 
         this.attributes = this.node.attributes().entrySet().stream()
                 .filter(a -> a.getKey().equals(qname.getName()) || "*".equals(qname.getName()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public NodePointer getNodePointer() {

--- a/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
+++ b/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
@@ -220,7 +220,7 @@ public class InjectorImpl implements Injector {
         if (key.getRawType() == List.class) {
             Set<Binding<Object>> res2 = getBindings(key.getTypeParameter(0));
             if (res2 != null) {
-                List<Supplier<Object>> list = res2.stream().map(this::compile).collect(Collectors.toList());
+                List<Supplier<Object>> list = res2.stream().map(this::compile).toList();
                 //noinspection unchecked
                 return () -> (Q) list(list, Supplier::get);
             }

--- a/impl/maven-di/src/main/java/org/apache/maven/di/impl/ReflectionUtils.java
+++ b/impl/maven-di/src/main/java/org/apache/maven/di/impl/ReflectionUtils.java
@@ -31,9 +31,9 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -227,7 +227,7 @@ public final class ReflectionUtils {
         Key<Object> key = keyOf(container.getType(), field.getGenericType(), field);
         boolean optional = field.isAnnotationPresent(Nullable.class);
         Dependency<Object> dep = new Dependency<>(key, optional);
-        return new BindingInitializer<T>(Collections.singleton(dep)) {
+        return new BindingInitializer<T>(Set.of(dep)) {
             @Override
             public Consumer<T> compile(Function<Dependency<?>, Supplier<?>> compiler) {
                 Supplier<?> binding = compiler.apply(dep);

--- a/impl/maven-di/src/main/java/org/apache/maven/di/impl/Types.java
+++ b/impl/maven-di/src/main/java/org/apache/maven/di/impl/Types.java
@@ -25,7 +25,6 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -116,7 +115,7 @@ public class Types {
     public static Map<TypeVariable<?>, Type> getTypeBindings(Type type) {
         Type[] typeArguments = getActualTypeArguments(type);
         if (typeArguments.length == 0) {
-            return Collections.emptyMap();
+            return Map.of();
         }
         TypeVariable<?>[] typeVariables = getRawType(type).getTypeParameters();
         Map<TypeVariable<?>, Type> map = new HashMap<>();

--- a/impl/maven-di/src/test/java/org/apache/maven/di/impl/TypeUtilsTest.java
+++ b/impl/maven-di/src/test/java/org/apache/maven/di/impl/TypeUtilsTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import org.apache.maven.di.Key;
 import org.junit.jupiter.api.Test;
@@ -41,9 +40,12 @@ public class TypeUtilsTest {
         Type type = new Key<TreeSet<String>>() {}.getType();
         Set<Type> types = Types.getAllSuperTypes(type);
         assertNotNull(types);
-        List<String> typesStr = types.stream().map(Type::toString).sorted().collect(Collectors.toList());
-        typesStr.remove("java.util.SequencedSet<java.lang.String>");
-        typesStr.remove("java.util.SequencedCollection<java.lang.String>");
+        List<String> typesStr = types.stream()
+                .map(Type::toString)
+                .sorted()
+                .filter(s -> !"java.util.SequencedSet<java.lang.String>".equals(s)
+                        && !"java.util.SequencedCollection<java.lang.String>".equals(s))
+                .toList();
         assertEquals(
                 Arrays.asList(
                         "class java.lang.Object",

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -233,7 +232,7 @@ public class EmbeddedMavenExecutor implements Executor {
         properties.setProperty(
                 "maven.mainClass", requireNonNull(MVN4_MAIN_CLASSES.get(ExecutorRequest.MVN), "mainClass"));
         System.setProperties(properties);
-        URLClassLoader bootClassLoader = createMavenBootClassLoader(boot, Collections.emptyList());
+        URLClassLoader bootClassLoader = createMavenBootClassLoader(boot, List.of());
         Thread.currentThread().setContextClassLoader(bootClassLoader);
         try {
             Class<?> launcherClass = bootClassLoader.loadClass("org.codehaus.plexus.classworlds.launcher.Launcher");

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
@@ -19,8 +19,9 @@
 package org.apache.maven.cling.executor.internal;
 
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.api.annotations.Nullable;
@@ -94,8 +95,8 @@ public class HelperImpl implements ExecutorHelper {
     }
 
     private Executor getExecutorByRequest(ExecutorRequest request) {
-        if (request.environmentVariables().orElse(Collections.emptyMap()).isEmpty()
-                && request.jvmArguments().orElse(Collections.emptyList()).isEmpty()) {
+        if (request.environmentVariables().orElse(Map.of()).isEmpty()
+                && request.jvmArguments().orElse(List.of()).isEmpty()) {
             return getExecutor(Mode.EMBEDDED, request);
         } else {
             return getExecutor(Mode.FORKED, request);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractNode.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractNode.java
@@ -18,10 +18,8 @@
  */
 package org.apache.maven.impl;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Node;
 import org.apache.maven.api.NodeVisitor;
@@ -45,8 +43,8 @@ public abstract class AbstractNode implements Node {
     @Override
     public Node filter(Predicate<Node> filter) {
         List<Node> children =
-                getChildren().stream().filter(filter).map(n -> n.filter(filter)).collect(Collectors.toList());
-        return new WrapperNode(this, Collections.unmodifiableList(children));
+                getChildren().stream().filter(filter).map(n -> n.filter(filter)).toList();
+        return new WrapperNode(this, children);
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
@@ -614,7 +614,7 @@ public abstract class AbstractSession implements InternalSession {
     @Override
     public DownloadedArtifact resolveArtifact(ArtifactCoordinates coordinates) {
         return getService(ArtifactResolver.class)
-                .resolve(this, Collections.singletonList(coordinates))
+                .resolve(this, List.of(coordinates))
                 .getResults()
                 .values()
                 .iterator()
@@ -631,7 +631,7 @@ public abstract class AbstractSession implements InternalSession {
     @Override
     public DownloadedArtifact resolveArtifact(ArtifactCoordinates coordinates, List<RemoteRepository> repositories) {
         return getService(ArtifactResolver.class)
-                .resolve(this, Collections.singletonList(coordinates), repositories)
+                .resolve(this, List.of(coordinates), repositories)
                 .getResults()
                 .values()
                 .iterator()

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.ArtifactCoordinates;
@@ -706,7 +705,7 @@ public abstract class AbstractSession implements InternalSession {
     public Collection<DownloadedArtifact> resolveArtifacts(Artifact... artifacts) {
         ArtifactCoordinatesFactory acf = getService(ArtifactCoordinatesFactory.class);
         List<ArtifactCoordinates> coords =
-                Arrays.stream(artifacts).map(a -> acf.create(this, a)).collect(Collectors.toList());
+                Arrays.stream(artifacts).map(a -> acf.create(this, a)).toList();
         return resolveArtifacts(coords);
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
@@ -104,7 +104,6 @@ import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.transfer.TransferResource;
 
 import static org.apache.maven.impl.ImplUtils.map;
-import static org.apache.maven.impl.ImplUtils.nonNull;
 
 public abstract class AbstractSession implements InternalSession {
 
@@ -134,7 +133,7 @@ public abstract class AbstractSession implements InternalSession {
             List<RemoteRepository> repositories,
             List<org.eclipse.aether.repository.RemoteRepository> resolverRepositories,
             Lookup lookup) {
-        this.session = nonNull(session, "session");
+        this.session = Objects.requireNonNull(session, "session cannot be null");
         this.repositorySystem = repositorySystem;
         this.repositories = getRepositories(repositories, resolverRepositories);
         this.lookup = lookup;
@@ -337,7 +336,7 @@ public abstract class AbstractSession implements InternalSession {
     @Nonnull
     @Override
     public Session withLocalRepository(@Nonnull LocalRepository localRepository) {
-        nonNull(localRepository, "localRepository");
+        Objects.requireNonNull(localRepository, "localRepository cannot be null");
         if (session.getLocalRepository() != null
                 && Objects.equals(session.getLocalRepository().getBasePath(), localRepository.getPath())) {
             return this;
@@ -461,12 +460,12 @@ public abstract class AbstractSession implements InternalSession {
 
     @Override
     public void registerListener(@Nonnull Listener listener) {
-        listeners.add(nonNull(listener));
+        listeners.add(Objects.requireNonNull(listener));
     }
 
     @Override
     public void unregisterListener(@Nonnull Listener listener) {
-        listeners.remove(nonNull(listener));
+        listeners.remove(Objects.requireNonNull(listener));
     }
 
     @Nonnull
@@ -967,7 +966,7 @@ public abstract class AbstractSession implements InternalSession {
 
     @Override
     public DependencyScope requireDependencyScope(String id) {
-        DependencyScope scope = DependencyScope.forId(nonNull(id, "id"));
+        DependencyScope scope = DependencyScope.forId(Objects.requireNonNull(id, "id cannot be null"));
         if (scope == null) {
             throw new IllegalArgumentException("Invalid dependency scope: " + id);
         }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AetherDependencyWrapper.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AetherDependencyWrapper.java
@@ -55,8 +55,8 @@ abstract class AetherDependencyWrapper {
      * @param dependency the Eclipse Aether dependency to wrap
      */
     AetherDependencyWrapper(@Nonnull InternalSession session, @Nonnull Dependency dependency) {
-        this.session = Objects.requireNonNull(session, "session");
-        this.dependency = Objects.requireNonNull(dependency, "dependency");
+        this.session = Objects.requireNonNull(session, "session cannot be null");
+        this.dependency = Objects.requireNonNull(dependency, "dependency cannot be null");
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AetherDependencyWrapper.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AetherDependencyWrapper.java
@@ -40,11 +40,13 @@ abstract class AetherDependencyWrapper {
     /**
      * The session to install / deploy / resolve artifacts and dependencies.
      */
+    @Nonnull
     final InternalSession session;
 
     /**
      * The wrapped Eclipse Aether dependency.
      */
+    @Nonnull
     final Dependency dependency;
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifact.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifact.java
@@ -26,7 +26,8 @@ import org.apache.maven.api.Version;
 import org.apache.maven.api.annotations.Nonnull;
 
 /**
- * A wrapper class around a maven resolver artifact.
+ * Default implementation of the Artifact interface.
+ * Wraps an Aether artifact and provides access to its properties.
  */
 public class DefaultArtifact implements Artifact {
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifact.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifact.java
@@ -25,8 +25,6 @@ import org.apache.maven.api.ArtifactCoordinates;
 import org.apache.maven.api.Version;
 import org.apache.maven.api.annotations.Nonnull;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 /**
  * A wrapper class around a maven resolver artifact.
  */
@@ -50,8 +48,8 @@ public class DefaultArtifact implements Artifact {
     protected final String key;
 
     public DefaultArtifact(@Nonnull InternalSession session, @Nonnull org.eclipse.aether.artifact.Artifact artifact) {
-        this.session = nonNull(session, "session");
-        this.artifact = nonNull(artifact, "artifact");
+        this.session = Objects.requireNonNull(session, "session cannot be null");
+        this.artifact = Objects.requireNonNull(artifact, "artifact cannot be null");
         this.key = getGroupId()
                 + ':'
                 + getArtifactId()

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifact.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifact.java
@@ -31,8 +31,22 @@ import static org.apache.maven.impl.ImplUtils.nonNull;
  * A wrapper class around a maven resolver artifact.
  */
 public class DefaultArtifact implements Artifact {
-    protected final @Nonnull InternalSession session;
-    protected final @Nonnull org.eclipse.aether.artifact.Artifact artifact;
+    /**
+     * The session used for artifact operations.
+     */
+    @Nonnull
+    protected final InternalSession session;
+
+    /**
+     * The wrapped Aether artifact.
+     */
+    @Nonnull
+    protected final org.eclipse.aether.artifact.Artifact artifact;
+
+    /**
+     * The unique key for this artifact.
+     */
+    @Nonnull
     protected final String key;
 
     public DefaultArtifact(@Nonnull InternalSession session, @Nonnull org.eclipse.aether.artifact.Artifact artifact) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactCoordinates.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactCoordinates.java
@@ -24,8 +24,6 @@ import org.apache.maven.api.ArtifactCoordinates;
 import org.apache.maven.api.VersionConstraint;
 import org.apache.maven.api.annotations.Nonnull;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 /**
  * A wrapper class around a maven resolver artifact.
  */
@@ -35,8 +33,8 @@ public class DefaultArtifactCoordinates implements ArtifactCoordinates {
 
     public DefaultArtifactCoordinates(
             @Nonnull InternalSession session, @Nonnull org.eclipse.aether.artifact.Artifact coordinates) {
-        this.session = nonNull(session, "session");
-        this.coordinates = nonNull(coordinates, "coordinates");
+        this.session = Objects.requireNonNull(session, "session cannot be null");
+        this.coordinates = Objects.requireNonNull(coordinates, "coordinates cannot be null");
     }
 
     public org.eclipse.aether.artifact.Artifact getCoordinates() {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactCoordinatesFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactCoordinatesFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.impl;
 
+import java.util.Objects;
+
 import org.apache.maven.api.ArtifactCoordinates;
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.di.Named;
@@ -26,14 +28,12 @@ import org.apache.maven.api.services.ArtifactCoordinatesFactory;
 import org.apache.maven.api.services.ArtifactCoordinatesFactoryRequest;
 import org.eclipse.aether.artifact.ArtifactType;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 @Named
 @Singleton
 public class DefaultArtifactCoordinatesFactory implements ArtifactCoordinatesFactory {
     @Override
     public ArtifactCoordinates create(@Nonnull ArtifactCoordinatesFactoryRequest request) {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         if (request.getCoordinatesString() != null) {
             return new DefaultArtifactCoordinates(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactDeployer.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactDeployer.java
@@ -32,8 +32,6 @@ import org.apache.maven.api.services.ArtifactDeployerRequest;
 import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.deployment.DeploymentException;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 /**
  * Implementation of {@link ArtifactDeployer} service.
  */
@@ -43,7 +41,7 @@ public class DefaultArtifactDeployer implements ArtifactDeployer {
 
     @Override
     public void deploy(@Nonnull ArtifactDeployerRequest request) {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         Collection<ProducedArtifact> artifacts =
                 Objects.requireNonNull(request.getArtifacts(), "request.artifacts cannot be null");

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactDeployer.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactDeployer.java
@@ -19,6 +19,7 @@
 package org.apache.maven.impl;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.RemoteRepository;
@@ -44,8 +45,10 @@ public class DefaultArtifactDeployer implements ArtifactDeployer {
     public void deploy(@Nonnull ArtifactDeployerRequest request) {
         nonNull(request, "request");
         InternalSession session = InternalSession.from(request.getSession());
-        Collection<ProducedArtifact> artifacts = nonNull(request.getArtifacts(), "request.artifacts");
-        RemoteRepository repository = nonNull(request.getRepository(), "request.repository");
+        Collection<ProducedArtifact> artifacts =
+                Objects.requireNonNull(request.getArtifacts(), "request.artifacts cannot be null");
+        RemoteRepository repository =
+                Objects.requireNonNull(request.getRepository(), "request.repository cannot be null");
         try {
             DeployRequest deployRequest = new DeployRequest()
                     .setRepository(session.toRepository(repository))

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.impl;
 
+import java.util.Objects;
+
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.annotations.Nonnull;
@@ -27,14 +29,12 @@ import org.apache.maven.api.services.ArtifactFactory;
 import org.apache.maven.api.services.ArtifactFactoryRequest;
 import org.eclipse.aether.artifact.ArtifactType;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 @Named
 @Singleton
 public class DefaultArtifactFactory implements ArtifactFactory {
     @Override
     public Artifact create(@Nonnull ArtifactFactoryRequest request) {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         ArtifactType type = null;
         if (request.getType() != null) {
@@ -59,7 +59,7 @@ public class DefaultArtifactFactory implements ArtifactFactory {
 
     @Override
     public ProducedArtifact createProduced(@Nonnull ArtifactFactoryRequest request) {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         ArtifactType type = null;
         if (request.getType() != null) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactInstaller.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactInstaller.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.impl;
 
+import java.util.Objects;
+
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Named;
@@ -29,8 +31,6 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.installation.InstallationException;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 @Named
 @Singleton
 public class DefaultArtifactInstaller implements ArtifactInstaller {
@@ -39,12 +39,12 @@ public class DefaultArtifactInstaller implements ArtifactInstaller {
 
     @Inject
     DefaultArtifactInstaller(@Nonnull RepositorySystem repositorySystem) {
-        this.repositorySystem = nonNull(repositorySystem);
+        this.repositorySystem = Objects.requireNonNull(repositorySystem);
     }
 
     @Override
     public void install(ArtifactInstallerRequest request) throws ArtifactInstallerException, IllegalArgumentException {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         try {
             InstallRequest installRequest =

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,8 +52,6 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 @Named
 @Singleton
 public class DefaultArtifactResolver implements ArtifactResolver {
@@ -60,7 +59,7 @@ public class DefaultArtifactResolver implements ArtifactResolver {
     @Override
     public ArtifactResolverResult resolve(ArtifactResolverRequest request)
             throws ArtifactResolverException, IllegalArgumentException {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         return session.request(request, this::doResolve);
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
@@ -239,7 +239,7 @@ public class DefaultArtifactResolver implements ArtifactResolver {
         @Nonnull
         @Override
         public Collection<DownloadedArtifact> getArtifacts() {
-            return results.values().stream().map(ResultItem::getArtifact).collect(Collectors.toList());
+            return results.values().stream().map(ResultItem::getArtifact).toList();
         }
 
         @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
@@ -50,8 +50,8 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
 
     @Inject
     public DefaultChecksumAlgorithmService(ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector) {
-        this.checksumAlgorithmFactorySelector =
-                nonNull(checksumAlgorithmFactorySelector, "checksumAlgorithmFactorySelector");
+        this.checksumAlgorithmFactorySelector = Objects.requireNonNull(
+                checksumAlgorithmFactorySelector, "checksumAlgorithmFactorySelector cannot be null");
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
@@ -41,8 +41,6 @@ import org.apache.maven.api.services.ChecksumAlgorithmServiceException;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 @Named
 @Singleton
 public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService {
@@ -63,7 +61,7 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
 
     @Override
     public ChecksumAlgorithm select(String algorithmName) {
-        nonNull(algorithmName, "algorithmName");
+        Objects.requireNonNull(algorithmName, "algorithmName cannot be null");
         try {
             return new DefaultChecksumAlgorithm(checksumAlgorithmFactorySelector.select(algorithmName));
         } catch (IllegalArgumentException e) {
@@ -73,7 +71,7 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
 
     @Override
     public Collection<ChecksumAlgorithm> select(Collection<String> algorithmNames) {
-        nonNull(algorithmNames, "algorithmNames");
+        Objects.requireNonNull(algorithmNames, "algorithmNames cannot be null");
         try {
             return checksumAlgorithmFactorySelector.selectList(new ArrayList<>(algorithmNames)).stream()
                     .map(DefaultChecksumAlgorithm::new)
@@ -85,8 +83,8 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
 
     @Override
     public Map<ChecksumAlgorithm, String> calculate(byte[] data, Collection<ChecksumAlgorithm> algorithms) {
-        nonNull(data, "data");
-        nonNull(algorithms, "algorithms");
+        Objects.requireNonNull(data, "data cannot be null");
+        Objects.requireNonNull(algorithms, "algorithms cannot be null");
         try {
             return calculate(new ByteArrayInputStream(data), algorithms);
         } catch (IOException e) {
@@ -96,8 +94,8 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
 
     @Override
     public Map<ChecksumAlgorithm, String> calculate(ByteBuffer data, Collection<ChecksumAlgorithm> algorithms) {
-        nonNull(data, "data");
-        nonNull(algorithms, "algorithms");
+        Objects.requireNonNull(data, "data cannot be null");
+        Objects.requireNonNull(algorithms, "algorithms cannot be null");
         LinkedHashMap<ChecksumAlgorithm, ChecksumCalculator> algMap = new LinkedHashMap<>();
         algorithms.forEach(f -> algMap.put(f, f.getCalculator()));
         data.mark();
@@ -113,8 +111,8 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
     @Override
     public Map<ChecksumAlgorithm, String> calculate(Path file, Collection<ChecksumAlgorithm> algorithms)
             throws IOException {
-        nonNull(file, "file");
-        nonNull(algorithms, "algorithms");
+        Objects.requireNonNull(file, "file cannot be null");
+        Objects.requireNonNull(algorithms, "algorithms cannot be null");
         try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(file))) {
             return calculate(inputStream, algorithms);
         }
@@ -123,8 +121,8 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
     @Override
     public Map<ChecksumAlgorithm, String> calculate(InputStream stream, Collection<ChecksumAlgorithm> algorithms)
             throws IOException {
-        nonNull(stream, "stream");
-        nonNull(algorithms, "algorithms");
+        Objects.requireNonNull(stream, "stream cannot be null");
+        Objects.requireNonNull(algorithms, "algorithms cannot be null");
         LinkedHashMap<ChecksumAlgorithm, ChecksumCalculator> algMap = new LinkedHashMap<>();
         algorithms.forEach(f -> algMap.put(f, f.getCalculator()));
         final byte[] buffer = new byte[1024 * 32];

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Named;
@@ -56,7 +55,7 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
     public Collection<String> getChecksumAlgorithmNames() {
         return checksumAlgorithmFactorySelector.getChecksumAlgorithmFactories().stream()
                 .map(ChecksumAlgorithmFactory::getName)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -74,8 +73,8 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
         Objects.requireNonNull(algorithmNames, "algorithmNames cannot be null");
         try {
             return checksumAlgorithmFactorySelector.selectList(new ArrayList<>(algorithmNames)).stream()
-                    .map(DefaultChecksumAlgorithm::new)
-                    .collect(Collectors.toList());
+                    .map(a -> (ChecksumAlgorithm) new DefaultChecksumAlgorithm(a))
+                    .toList();
         } catch (IllegalArgumentException e) {
             throw new ChecksumAlgorithmServiceException("unsupported algorithm", e);
         }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependency.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependency.java
@@ -26,8 +26,16 @@ import org.apache.maven.api.DependencyCoordinates;
 import org.apache.maven.api.Version;
 import org.apache.maven.api.annotations.Nonnull;
 
+/**
+ * Default implementation of the Dependency interface.
+ * Extends AetherDependencyWrapper to provide dependency-specific functionality.
+ */
 public class DefaultDependency extends AetherDependencyWrapper implements Dependency {
 
+    /**
+     * The unique key for this dependency.
+     */
+    @Nonnull
     private final String key;
 
     public DefaultDependency(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyCoordinatesFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyCoordinatesFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.impl;
 
+import java.util.Objects;
+
 import org.apache.maven.api.DependencyCoordinates;
 import org.apache.maven.api.Exclusion;
 import org.apache.maven.api.annotations.Nonnull;
@@ -28,7 +30,6 @@ import org.apache.maven.api.services.DependencyCoordinatesFactoryRequest;
 import org.eclipse.aether.artifact.ArtifactType;
 
 import static org.apache.maven.impl.ImplUtils.map;
-import static org.apache.maven.impl.ImplUtils.nonNull;
 
 @Named
 @Singleton
@@ -37,7 +38,7 @@ public class DefaultDependencyCoordinatesFactory implements DependencyCoordinate
     @Nonnull
     @Override
     public DependencyCoordinates create(@Nonnull DependencyCoordinatesFactoryRequest request) {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
 
         ArtifactType type = null;

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
@@ -188,7 +188,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
                         .map(Node::getDependency)
                         .filter(Objects::nonNull)
                         .map(Artifact::toCoordinates)
-                        .collect(Collectors.toList());
+                        .toList();
                 Predicate<PathType> filter = request.getPathTypeFilter();
                 if (request.getRequestType() == DependencyResolverRequest.RequestType.FLATTEN) {
                     DefaultDependencyResolverResult flattenResult = new DefaultDependencyResolverResult(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
@@ -62,7 +62,6 @@ import org.eclipse.aether.util.graph.transformer.ConflictResolver;
 
 import static org.apache.maven.impl.ImplUtils.cast;
 import static org.apache.maven.impl.ImplUtils.map;
-import static org.apache.maven.impl.ImplUtils.nonNull;
 
 @Named
 @Singleton
@@ -72,7 +71,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
     @Override
     public DependencyResolverResult collect(@Nonnull DependencyResolverRequest request)
             throws DependencyResolverException, IllegalArgumentException {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         RequestTraceHelper.ResolverTrace trace = RequestTraceHelper.enter(session, request);
         try {
@@ -168,8 +167,8 @@ public class DefaultDependencyResolver implements DependencyResolver {
     @Override
     public DependencyResolverResult resolve(DependencyResolverRequest request)
             throws DependencyResolverException, ArtifactResolverException {
-        InternalSession session =
-                InternalSession.from(nonNull(request, "request").getSession());
+        InternalSession session = InternalSession.from(
+                Objects.requireNonNull(request, "request cannot be null").getSession());
         RequestTraceHelper.ResolverTrace trace = RequestTraceHelper.enter(session, request);
         try {
             DependencyResolverResult result;

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
@@ -23,7 +23,6 @@ import java.lang.module.ModuleDescriptor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -318,7 +317,7 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
      * @param moduleName name of the module to search
      */
     private boolean containsModule(String moduleName) throws IOException {
-        for (Path path : dispatchedPaths.getOrDefault(JavaPathType.MODULES, Collections.emptyList())) {
+        for (Path path : dispatchedPaths.getOrDefault(JavaPathType.MODULES, List.of())) {
             if (cache.getModuleInfo(path).containsModule(moduleName)) {
                 return true;
             }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultJavaToolchainFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultJavaToolchainFactory.java
@@ -31,6 +31,7 @@ import org.apache.maven.api.Toolchain;
 import org.apache.maven.api.Version;
 import org.apache.maven.api.VersionConstraint;
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Singleton;
@@ -109,22 +110,26 @@ public class DefaultJavaToolchainFactory implements ToolchainFactory {
         }
 
         @Override
+        @Nonnull
         public String getJavaHome() {
             return javaHome;
         }
 
         @Override
+        @Nonnull
         public String getType() {
             return "jdk";
         }
 
         @Override
+        @Nonnull
         public ToolchainModel getModel() {
             return model;
         }
 
         @Override
-        public String findTool(String toolName) {
+        @Nullable
+        public String findTool(@Nonnull String toolName) {
             Path toRet = findTool(toolName, Paths.get(getJavaHome()).normalize());
             if (toRet != null) {
                 return toRet.toAbsolutePath().toString();
@@ -132,7 +137,8 @@ public class DefaultJavaToolchainFactory implements ToolchainFactory {
             return null;
         }
 
-        private static Path findTool(String toolName, Path installDir) {
+        @Nullable
+        private static Path findTool(@Nonnull String toolName, @Nonnull Path installDir) {
             Path bin = installDir.resolve("bin"); // NOI18N
             if (Files.isDirectory(bin)) {
                 if (Os.IS_WINDOWS) {
@@ -150,7 +156,7 @@ public class DefaultJavaToolchainFactory implements ToolchainFactory {
         }
 
         @Override
-        public boolean matchesRequirements(Map<String, String> requirements) {
+        public boolean matchesRequirements(@Nonnull Map<String, String> requirements) {
             for (Map.Entry<String, String> requirement : requirements.entrySet()) {
                 String key = requirement.getKey();
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultLocalRepository.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultLocalRepository.java
@@ -19,18 +19,17 @@
 package org.apache.maven.impl;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 import org.apache.maven.api.LocalRepository;
 import org.apache.maven.api.annotations.Nonnull;
-
-import static org.apache.maven.impl.ImplUtils.nonNull;
 
 public class DefaultLocalRepository implements LocalRepository {
 
     private final @Nonnull org.eclipse.aether.repository.LocalRepository repository;
 
     public DefaultLocalRepository(@Nonnull org.eclipse.aether.repository.LocalRepository repository) {
-        this.repository = nonNull(repository, "repository");
+        this.repository = Objects.requireNonNull(repository, "repository cannot be null");
     }
 
     @Nonnull

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -25,6 +25,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.maven.api.annotations.Nonnull;
@@ -40,7 +41,6 @@ import org.apache.maven.api.services.xml.XmlWriterRequest;
 import org.apache.maven.model.v4.MavenStaxReader;
 import org.apache.maven.model.v4.MavenStaxWriter;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
 import static org.apache.maven.impl.StaxLocation.getLocation;
 import static org.apache.maven.impl.StaxLocation.getMessage;
 
@@ -50,7 +50,7 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
     @Override
     @Nonnull
     public Model read(@Nonnull XmlReaderRequest request) throws XmlReaderException {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         Model model = doRead(request);
         if (isModelVersionGreaterThan400(model)
                 && !model.getNamespaceUri().startsWith("http://maven.apache.org/POM/")) {
@@ -114,8 +114,8 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
 
     @Override
     public void write(XmlWriterRequest<Model> request) throws XmlWriterException {
-        nonNull(request, "request");
-        Model content = nonNull(request.getContent(), "content");
+        Objects.requireNonNull(request, "request cannot be null");
+        Model content = Objects.requireNonNull(request.getContent(), "content");
         Path path = request.getPath();
         OutputStream outputStream = request.getOutputStream();
         Writer writer = request.getWriter();

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
@@ -25,6 +25,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.di.Named;
@@ -38,7 +39,6 @@ import org.apache.maven.api.services.xml.XmlWriterRequest;
 import org.apache.maven.plugin.descriptor.io.PluginDescriptorStaxReader;
 import org.apache.maven.plugin.descriptor.io.PluginDescriptorStaxWriter;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
 import static org.apache.maven.impl.StaxLocation.getLocation;
 import static org.apache.maven.impl.StaxLocation.getMessage;
 
@@ -47,7 +47,7 @@ import static org.apache.maven.impl.StaxLocation.getMessage;
 public class DefaultPluginXmlFactory implements PluginXmlFactory {
     @Override
     public PluginDescriptor read(@Nonnull XmlReaderRequest request) throws XmlReaderException {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         Path path = request.getPath();
         URL url = request.getURL();
         Reader reader = request.getReader();
@@ -78,8 +78,8 @@ public class DefaultPluginXmlFactory implements PluginXmlFactory {
 
     @Override
     public void write(XmlWriterRequest<PluginDescriptor> request) throws XmlWriterException {
-        nonNull(request, "request");
-        PluginDescriptor content = nonNull(request.getContent(), "content");
+        Objects.requireNonNull(request, "request cannot be null");
+        PluginDescriptor content = Objects.requireNonNull(request.getContent(), "content");
         Path path = request.getPath();
         OutputStream outputStream = request.getOutputStream();
         Writer writer = request.getWriter();

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRemoteRepository.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRemoteRepository.java
@@ -28,7 +28,7 @@ public class DefaultRemoteRepository implements RemoteRepository {
     private final org.eclipse.aether.repository.RemoteRepository repository;
 
     public DefaultRemoteRepository(@Nonnull org.eclipse.aether.repository.RemoteRepository repository) {
-        this.repository = repository;
+        this.repository = Objects.requireNonNull(repository, "repository cannot be null");
     }
 
     public org.eclipse.aether.repository.RemoteRepository getRepository() {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRemoteRepository.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRemoteRepository.java
@@ -24,9 +24,10 @@ import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.annotations.Nonnull;
 
 public class DefaultRemoteRepository implements RemoteRepository {
+    @Nonnull
     private final org.eclipse.aether.repository.RemoteRepository repository;
 
-    public DefaultRemoteRepository(org.eclipse.aether.repository.RemoteRepository repository) {
+    public DefaultRemoteRepository(@Nonnull org.eclipse.aether.repository.RemoteRepository repository) {
         this.repository = repository;
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRemoteRepository.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRemoteRepository.java
@@ -23,10 +23,22 @@ import java.util.Objects;
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.annotations.Nonnull;
 
+/**
+ * Default implementation of the RemoteRepository interface.
+ * Wraps an Aether remote repository and provides access to its properties.
+ */
 public class DefaultRemoteRepository implements RemoteRepository {
+    /**
+     * The wrapped Aether remote repository.
+     */
     @Nonnull
     private final org.eclipse.aether.repository.RemoteRepository repository;
 
+    /**
+     * Creates a new wrapper for the given remote repository.
+     *
+     * @param repository the Aether remote repository to wrap
+     */
     public DefaultRemoteRepository(@Nonnull org.eclipse.aether.repository.RemoteRepository repository) {
         this.repository = Objects.requireNonNull(repository, "repository cannot be null");
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRepositoryFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRepositoryFactory.java
@@ -20,6 +20,7 @@ package org.apache.maven.impl;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.maven.api.LocalRepository;
 import org.apache.maven.api.RemoteRepository;
@@ -31,8 +32,6 @@ import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.services.RepositoryFactory;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.repository.RepositoryPolicy;
-
-import static org.apache.maven.impl.ImplUtils.nonNull;
 
 @Named
 @Singleton
@@ -71,11 +70,12 @@ public class DefaultRepositoryFactory implements RepositoryFactory {
             List<RemoteRepository> dominant,
             List<RemoteRepository> recessive,
             boolean processRecessive) {
-        InternalSession internalSession = InternalSession.from(nonNull(session, "session"));
+        InternalSession internalSession =
+                InternalSession.from(Objects.requireNonNull(session, "session cannot be null"));
         List<org.eclipse.aether.repository.RemoteRepository> repos = remoteRepositoryManager.aggregateRepositories(
                 internalSession.getSession(),
-                internalSession.toRepositories(nonNull(dominant, "dominant")),
-                internalSession.toRepositories(nonNull(recessive, "recessive")),
+                internalSession.toRepositories(Objects.requireNonNull(dominant, "dominant cannot be null")),
+                internalSession.toRepositories(Objects.requireNonNull(recessive, "recessive cannot be null")),
                 processRecessive);
         return repos.stream()
                 .<RemoteRepository>map(DefaultRemoteRepository::new)

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultToolchainManager.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultToolchainManager.java
@@ -68,7 +68,7 @@ public class DefaultToolchainManager implements ToolchainManager {
     public List<Toolchain> getToolchains(
             @Nonnull Session session, @Nonnull String type, @Nullable Map<String, String> requirements)
             throws ToolchainManagerException {
-        ToolchainFactory factory = factories.get(Objects.requireNonNull(type, "type"));
+        ToolchainFactory factory = factories.get(Objects.requireNonNull(type, "type cannot be null"));
         if (factory == null) {
             logger.error("Missing toolchain factory for type: " + type + ". Possibly caused by misconfigured project.");
             return List.of();
@@ -99,7 +99,7 @@ public class DefaultToolchainManager implements ToolchainManager {
     }
 
     private Optional<Toolchain> createToolchain(ToolchainModel model) {
-        String type = Objects.requireNonNull(model.getType(), "model.getType()");
+        String type = Objects.requireNonNull(model.getType(), "model.getType() cannot be null");
         ToolchainFactory factory = factories.get(type);
         if (factory != null) {
             try {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultToolchainsXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultToolchainsXmlFactory.java
@@ -37,7 +37,6 @@ import org.apache.maven.api.toolchain.PersistedToolchains;
 import org.apache.maven.toolchain.v4.MavenToolchainsStaxReader;
 import org.apache.maven.toolchain.v4.MavenToolchainsStaxWriter;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
 import static org.apache.maven.impl.StaxLocation.getLocation;
 import static org.apache.maven.impl.StaxLocation.getMessage;
 
@@ -46,7 +45,7 @@ import static org.apache.maven.impl.StaxLocation.getMessage;
 public class DefaultToolchainsXmlFactory implements ToolchainsXmlFactory {
     @Override
     public PersistedToolchains read(@Nonnull XmlReaderRequest request) throws XmlReaderException {
-        Objects.requireNonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         Reader reader = request.getReader();
         InputStream inputStream = request.getInputStream();
         if (reader == null && inputStream == null) {
@@ -71,7 +70,7 @@ public class DefaultToolchainsXmlFactory implements ToolchainsXmlFactory {
 
     @Override
     public void write(XmlWriterRequest<PersistedToolchains> request) throws XmlWriterException {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         PersistedToolchains content = Objects.requireNonNull(request.getContent(), "content");
         OutputStream outputStream = request.getOutputStream();
         Writer writer = request.getWriter();

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultVersionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultVersionParser.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.impl;
 
+import java.util.Objects;
+
 import org.apache.maven.api.Version;
 import org.apache.maven.api.VersionConstraint;
 import org.apache.maven.api.VersionRange;
@@ -26,8 +28,6 @@ import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Singleton;
 import org.apache.maven.api.services.VersionParser;
 import org.apache.maven.api.services.model.ModelVersionParser;
-
-import static org.apache.maven.impl.ImplUtils.nonNull;
 
 /**
  * A wrapper class around a resolver version that works as model version parser as well.
@@ -39,7 +39,7 @@ public class DefaultVersionParser implements VersionParser {
 
     @Inject
     public DefaultVersionParser(ModelVersionParser modelVersionParser) {
-        this.modelVersionParser = nonNull(modelVersionParser, "modelVersionParser");
+        this.modelVersionParser = Objects.requireNonNull(modelVersionParser, "modelVersionParser cannot be null");
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultVersionResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultVersionResolver.java
@@ -19,6 +19,7 @@
 package org.apache.maven.impl;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.maven.api.Repository;
@@ -35,8 +36,6 @@ import org.eclipse.aether.resolution.VersionRequest;
 import org.eclipse.aether.resolution.VersionResolutionException;
 import org.eclipse.aether.resolution.VersionResult;
 
-import static org.apache.maven.impl.ImplUtils.nonNull;
-
 @Named
 @Singleton
 public class DefaultVersionResolver implements VersionResolver {
@@ -50,7 +49,7 @@ public class DefaultVersionResolver implements VersionResolver {
 
     @Override
     public VersionResolverResult resolve(VersionResolverRequest request) throws VersionResolverException {
-        nonNull(request, "request");
+        Objects.requireNonNull(request, "request cannot be null");
         InternalSession session = InternalSession.from(request.getSession());
         return session.request(request, this::doResolve);
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/ExtensibleEnumRegistries.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/ExtensibleEnumRegistries.java
@@ -21,6 +21,7 @@ package org.apache.maven.impl;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,8 +42,6 @@ import org.apache.maven.api.spi.ExtensibleEnumProvider;
 import org.apache.maven.api.spi.LanguageProvider;
 import org.apache.maven.api.spi.PathScopeProvider;
 import org.apache.maven.api.spi.ProjectScopeProvider;
-
-import static org.apache.maven.impl.ImplUtils.nonNull;
 
 public class ExtensibleEnumRegistries {
 
@@ -97,7 +96,8 @@ public class ExtensibleEnumRegistries {
 
         @Override
         public Optional<T> lookup(String id) {
-            return Optional.ofNullable(values.get(nonNull(id, "id").toLowerCase(Locale.ROOT)));
+            return Optional.ofNullable(
+                    values.get(Objects.requireNonNull(id, "id cannot be null").toLowerCase(Locale.ROOT)));
         }
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.annotations.Nullable;
@@ -67,6 +66,6 @@ class ImplUtils {
      */
     @Nonnull
     public static <U, V> List<V> map(@Nonnull Collection<U> list, @Nonnull Function<U, V> mapper) {
-        return list.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
+        return list.stream().map(mapper).filter(Objects::nonNull).toList();
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
@@ -27,32 +27,44 @@ import java.util.stream.Collectors;
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.annotations.Nullable;
 
+/**
+ * Utility methods for Maven implementations.
+ * Provides standardized null checking and type casting functionality.
+ */
 class ImplUtils {
-    public static <T> T nonNull(T t) {
-        if (t == null) {
-            throw new IllegalArgumentException();
-        }
-        return t;
-    }
 
-    public static <T> T nonNull(T t, String name) {
-        if (t == null) {
-            throw new IllegalArgumentException(name + " cannot be null");
-        }
-        return t;
-    }
-
+    /**
+     * Casts an object to the specified type, with validation and error handling.
+     *
+     * @param <T> the target type
+     * @param clazz the class representing the target type
+     * @param o the object to cast
+     * @param name the name of the parameter for error messages
+     * @return the cast object
+     * @throws NullPointerException if the object is null
+     * @throws ClassCastException if the object is not an instance of the target type
+     */
     @Nonnull
     public static <T> T cast(@Nonnull Class<T> clazz, @Nullable Object o, @Nonnull String name) {
         if (!clazz.isInstance(o)) {
             if (o == null) {
-                throw new IllegalArgumentException(name + " is null");
+                throw new NullPointerException(name + " is null");
             }
-            throw new IllegalArgumentException(name + " is not an instance of " + clazz.getName());
+            throw new ClassCastException(name + " is not an instance of " + clazz.getName());
         }
         return clazz.cast(o);
     }
 
+    /**
+     * Maps a collection of elements to a new list using the provided mapping function.
+     * Null values in the resulting list are filtered out.
+     *
+     * @param <U> the input type
+     * @param <V> the output type
+     * @param list the collection to map
+     * @param mapper the mapping function
+     * @return a new list containing the mapped elements, with null values filtered out
+     */
     @Nonnull
     public static <U, V> List<V> map(@Nonnull Collection<U> list, @Nonnull Function<U, V> mapper) {
         return list.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
@@ -24,6 +24,9 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
+
 class ImplUtils {
     public static <T> T nonNull(T t) {
         if (t == null) {
@@ -39,7 +42,8 @@ class ImplUtils {
         return t;
     }
 
-    public static <T> T cast(Class<T> clazz, Object o, String name) {
+    @Nonnull
+    public static <T> T cast(@Nonnull Class<T> clazz, @Nullable Object o, @Nonnull String name) {
         if (!clazz.isInstance(o)) {
             if (o == null) {
                 throw new IllegalArgumentException(name + " is null");
@@ -49,7 +53,8 @@ class ImplUtils {
         return clazz.cast(o);
     }
 
-    public static <U, V> List<V> map(Collection<U> list, Function<U, V> mapper) {
+    @Nonnull
+    public static <U, V> List<V> map(@Nonnull Collection<U> list, @Nonnull Function<U, V> mapper) {
         return list.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
@@ -96,7 +96,7 @@ class PathModularization {
      */
     private PathModularization() {
         filename = "(none)";
-        descriptors = Collections.emptyMap();
+        descriptors = Map.of();
         isModuleHierarchy = false;
     }
 
@@ -151,7 +151,7 @@ class PathModularization {
                         descriptor = ModuleDescriptor.read(in);
                     }
                 }
-                descriptors = Collections.singletonMap(file, descriptor);
+                descriptors = Map.of(file, descriptor);
                 isModuleHierarchy = false;
                 return;
             }
@@ -201,7 +201,7 @@ class PathModularization {
                             descriptor = ModuleDescriptor.read(in);
                         }
                     }
-                    descriptors = Collections.singletonMap(path, descriptor);
+                    descriptors = Map.of(path, descriptor);
                     isModuleHierarchy = false;
                     return;
                 }
@@ -210,14 +210,14 @@ class PathModularization {
                 if (mf != null) {
                     Object name = mf.getMainAttributes().get(AUTO_MODULE_NAME);
                     if (name instanceof String) {
-                        descriptors = Collections.singletonMap(path, name);
+                        descriptors = Map.of(path, name);
                         isModuleHierarchy = false;
                         return;
                     }
                 }
             }
         }
-        descriptors = Collections.emptyMap();
+        descriptors = Map.of();
         isModuleHierarchy = false;
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/SettingsUtilsV4.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/SettingsUtilsV4.java
@@ -38,7 +38,6 @@ package org.apache.maven.impl;
  */
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -69,7 +68,7 @@ public final class SettingsUtilsV4 {
      * @param recessive
      */
     public static Settings merge(Settings dominant, Settings recessive) {
-        return new SettingsMerger().merge(dominant, recessive, true, Collections.emptyMap());
+        return new SettingsMerger().merge(dominant, recessive, true, Map.of());
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/SettingsUtilsV4.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/SettingsUtilsV4.java
@@ -257,14 +257,14 @@ public final class SettingsUtilsV4 {
         if (repos != null) {
             profile.repositories(repos.stream()
                     .map(SettingsUtilsV4::convertFromSettingsRepository)
-                    .collect(Collectors.toList()));
+                    .toList());
         }
 
         List<Repository> pluginRepos = settingsProfile.getPluginRepositories();
         if (pluginRepos != null) {
             profile.pluginRepositories(pluginRepos.stream()
                     .map(SettingsUtilsV4::convertFromSettingsRepository)
-                    .collect(Collectors.toList()));
+                    .toList());
         }
 
         org.apache.maven.api.model.Profile value = profile.build();

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementInjector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementInjector.java
@@ -19,7 +19,6 @@
 package org.apache.maven.impl.model;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +58,7 @@ public class DefaultDependencyManagementInjector implements DependencyManagement
             DependencyManagement dependencyManagement = model.getDependencyManagement();
             if (dependencyManagement != null) {
                 Map<Object, Dependency> dependencies = new HashMap<>();
-                Map<Object, Object> context = Collections.emptyMap();
+                Map<Object, Object> context = Map.of();
 
                 for (Dependency dependency : model.getDependencies()) {
                     Object key = getDependencyKey().apply(dependency);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
@@ -19,7 +19,6 @@
 package org.apache.maven.impl.model;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -133,8 +132,9 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                 targetBuild = Build.newInstance();
             }
 
+            PluginManagement pluginManagement = targetBuild.getPluginManagement();
             Map<Object, Object> context =
-                    Collections.singletonMap(PLUGIN_MANAGEMENT, targetBuild.getPluginManagement());
+                    pluginManagement != null ? Map.of(PLUGIN_MANAGEMENT, pluginManagement) : Map.of();
 
             Build.Builder builder = Build.newBuilder(targetBuild);
             mergePluginContainer_Plugins(builder, targetBuild, source.getBuild(), false, context);
@@ -181,8 +181,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                             Object key = getPluginKey().apply(managedPlugin);
                             Plugin addedPlugin = added.get(key);
                             if (addedPlugin != null) {
-                                Plugin plugin =
-                                        mergePlugin(managedPlugin, addedPlugin, sourceDominant, Collections.emptyMap());
+                                Plugin plugin = mergePlugin(managedPlugin, addedPlugin, sourceDominant, Map.of());
                                 merged.put(key, plugin);
                             }
                         }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1672,7 +1672,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 List<Dependency> dependencies = importMgmt.getDependencies().stream()
                         .filter(candidate -> exclusions.stream().noneMatch(exclusion -> match(exclusion, candidate)))
                         .map(candidate -> addExclusions(candidate, exclusions))
-                        .collect(Collectors.toList());
+                        .toList();
                 importMgmt = importMgmt.withDependencies(dependencies);
             }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
@@ -20,7 +20,6 @@ package org.apache.maven.impl.model;
 
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +53,7 @@ public class DefaultModelInterpolator implements ModelInterpolator {
     private static final String PREFIX_PROJECT = "project.";
     private static final String PREFIX_POM = "pom.";
     private static final List<String> PROJECT_PREFIXES_3_1 = Arrays.asList(PREFIX_POM, PREFIX_PROJECT);
-    private static final List<String> PROJECT_PREFIXES_4_0 = Collections.singletonList(PREFIX_PROJECT);
+    private static final List<String> PROJECT_PREFIXES_4_0 = List.of(PREFIX_PROJECT);
 
     // MNG-1927, MNG-2124, MNG-3355:
     // If the build section is present and the project directory is non-null, we should make

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelNormalizer.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelNormalizer.java
@@ -19,7 +19,6 @@
 package org.apache.maven.impl.model;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,7 +95,7 @@ public class DefaultModelNormalizer implements ModelNormalizer {
     protected static class DuplicateMerger extends MavenModelMerger {
 
         public Plugin mergePlugin(Plugin target, Plugin source) {
-            return super.mergePlugin(target, source, false, Collections.emptyMap());
+            return super.mergePlugin(target, source, false, Map.of());
         }
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultPluginManagementInjector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultPluginManagementInjector.java
@@ -19,7 +19,6 @@
 package org.apache.maven.impl.model;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ public class DefaultPluginManagementInjector implements PluginManagementInjector
             if (!src.isEmpty()) {
                 Map<Object, Plugin> managedPlugins = new LinkedHashMap<>(src.size() * 2);
 
-                Map<Object, Object> context = Collections.emptyMap();
+                Map<Object, Object> context = Map.of();
 
                 for (Plugin element : src) {
                     Object key = getPluginKey().apply(element);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileActivationContext.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileActivationContext.java
@@ -142,10 +142,10 @@ public class DefaultProfileActivationContext implements ProfileActivationContext
     private final RootLocator rootLocator;
     private final Interpolator interpolator;
 
-    private List<String> activeProfileIds = Collections.emptyList();
-    private List<String> inactiveProfileIds = Collections.emptyList();
-    private Map<String, String> systemProperties = Collections.emptyMap();
-    private Map<String, String> userProperties = Collections.emptyMap();
+    private List<String> activeProfileIds = List.of();
+    private List<String> inactiveProfileIds = List.of();
+    private Map<String, String> systemProperties = Map.of();
+    private Map<String, String> userProperties = Map.of();
     private Model model;
 
     private final ThreadLocal<Record> records = new ThreadLocal<>();
@@ -419,10 +419,10 @@ public class DefaultProfileActivationContext implements ProfileActivationContext
     }
 
     private static List<String> unmodifiable(List<String> list) {
-        return list != null ? Collections.unmodifiableList(list) : Collections.emptyList();
+        return list != null ? Collections.unmodifiableList(list) : List.of();
     }
 
     private static Map<String, String> unmodifiable(Map<String, String> map) {
-        return map != null ? Collections.unmodifiableMap(map) : Collections.emptyMap();
+        return map != null ? Collections.unmodifiableMap(map) : Map.of();
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileInjector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileInjector.java
@@ -96,11 +96,11 @@ public class DefaultProfileInjector implements ProfileInjector {
     protected static class ProfileModelMerger extends MavenModelMerger {
 
         public void mergeModelBase(ModelBase.Builder builder, ModelBase target, ModelBase source) {
-            mergeModelBase(builder, target, source, true, Collections.emptyMap());
+            mergeModelBase(builder, target, source, true, Map.of());
         }
 
         public void mergeBuildBase(BuildBase.Builder builder, BuildBase target, BuildBase source) {
-            mergeBuildBase(builder, target, source, true, Collections.emptyMap());
+            mergeBuildBase(builder, target, source, true, Map.of());
         }
 
         @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/FileToRawModelMerger.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/FileToRawModelMerger.java
@@ -20,7 +20,6 @@ package org.apache.maven.impl.model;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.BuildBase;
@@ -90,7 +89,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Dependency> sourceIterator = source.getDependencies().iterator();
         builder.dependencies(target.getDependencies().stream()
                 .map(d -> mergeDependency(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override
@@ -133,7 +132,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Profile> sourceIterator = source.getProfiles().iterator();
         builder.profiles(target.getProfiles().stream()
                 .map(d -> mergeProfile(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override
@@ -146,7 +145,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Dependency> sourceIterator = source.getDependencies().iterator();
         builder.dependencies(target.getDependencies().stream()
                 .map(d -> mergeDependency(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override
@@ -175,7 +174,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Dependency> sourceIterator = source.getDependencies().iterator();
         builder.dependencies(target.getDependencies().stream()
                 .map(d -> mergeDependency(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/Graph.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/Graph.java
@@ -19,7 +19,6 @@
 package org.apache.maven.impl.model;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -34,7 +33,7 @@ class Graph {
 
     synchronized void addEdge(String from, String to) throws CycleDetectedException {
         if (graph.computeIfAbsent(from, l -> new HashSet<>()).add(to)) {
-            List<String> cycle = visitCycle(graph, Collections.singleton(to), new HashMap<>(), new LinkedList<>());
+            List<String> cycle = visitCycle(graph, Set.of(to), new HashMap<>(), new LinkedList<>());
             if (cycle != null) {
                 // remove edge which introduced cycle
                 throw new CycleDetectedException(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/ArtifactDescriptorReaderDelegate.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/ArtifactDescriptorReaderDelegate.java
@@ -19,7 +19,6 @@
 package org.apache.maven.impl.resolver;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -105,7 +104,7 @@ public class ArtifactDescriptorReaderDelegate {
 
         Map<String, String> props = null;
         if (system) {
-            props = Collections.singletonMap(MavenArtifactProperties.LOCAL_PATH, dependency.getSystemPath());
+            props = Map.of(MavenArtifactProperties.LOCAL_PATH, dependency.getSystemPath());
         }
 
         Artifact artifact = new DefaultArtifact(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultVersionRangeResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultVersionRangeResolver.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Named;
@@ -198,7 +199,7 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver {
         try {
             if (metadata != null) {
                 try (SyncContext syncContext = syncContextFactory.newInstance(session, true)) {
-                    syncContext.acquire(null, Collections.singleton(metadata));
+                    syncContext.acquire(null, Set.of(metadata));
 
                     if (metadata.getPath() != null && Files.exists(metadata.getPath())) {
                         try (InputStream in = Files.newInputStream(metadata.getPath())) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultVersionResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultVersionResolver.java
@@ -23,11 +23,11 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.maven.api.Constants;
 import org.apache.maven.api.di.Inject;
@@ -189,7 +189,7 @@ public class DefaultVersionResolver implements VersionResolver {
                     VersionRequest subRequest = new VersionRequest();
                     subRequest.setArtifact(artifact.setVersion(result.getVersion()));
                     if (result.getRepository() instanceof RemoteRepository r) {
-                        subRequest.setRepositories(Collections.singletonList(r));
+                        subRequest.setRepositories(List.of(r));
                     } else {
                         subRequest.setRepositories(request.getRepositories());
                     }
@@ -239,7 +239,7 @@ public class DefaultVersionResolver implements VersionResolver {
         try {
             if (metadata != null) {
                 try (SyncContext syncContext = syncContextFactory.newInstance(session, true)) {
-                    syncContext.acquire(null, Collections.singleton(metadata));
+                    syncContext.acquire(null, Set.of(metadata));
 
                     if (metadata.getPath() != null && Files.exists(metadata.getPath())) {
                         try (InputStream in = Files.newInputStream(metadata.getPath())) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/LocalSnapshotMetadataGenerator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/LocalSnapshotMetadataGenerator.java
@@ -20,8 +20,8 @@ package org.apache.maven.impl.resolver;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.api.Constants;
@@ -64,7 +64,7 @@ class LocalSnapshotMetadataGenerator implements MetadataGenerator {
             }
         }
 
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/MavenMetadata.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/MavenMetadata.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.maven.api.metadata.Metadata;
@@ -134,7 +133,7 @@ abstract class MavenMetadata extends AbstractMetadata implements MergeableMetada
 
     @Override
     public Map<String, String> getProperties() {
-        return Collections.emptyMap();
+        return Map.of();
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/PluginsMetadataGenerator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/PluginsMetadataGenerator.java
@@ -23,9 +23,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.jar.JarFile;
@@ -89,7 +89,7 @@ class PluginsMetadataGenerator implements MetadataGenerator {
 
     @Override
     public Collection<? extends Metadata> prepare(Collection<? extends Artifact> artifacts) {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/RemoteSnapshotMetadataGenerator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/RemoteSnapshotMetadataGenerator.java
@@ -20,8 +20,8 @@ package org.apache.maven.impl.resolver;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.api.Constants;
@@ -104,6 +104,6 @@ class RemoteSnapshotMetadataGenerator implements MetadataGenerator {
 
     @Override
     public Collection<? extends Metadata> finish(Collection<? extends Artifact> artifacts) {
-        return Collections.emptyList();
+        return List.of();
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/VersionsMetadataGenerator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/VersionsMetadataGenerator.java
@@ -20,9 +20,9 @@ package org.apache.maven.impl.resolver;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.api.Constants;
@@ -78,7 +78,7 @@ class VersionsMetadataGenerator implements MetadataGenerator {
 
     @Override
     public Collection<? extends Metadata> prepare(Collection<? extends Artifact> artifacts) {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/UserPropertiesArtifactRelocationSource.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/UserPropertiesArtifactRelocationSource.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Constants;
@@ -185,7 +184,7 @@ public final class UserPropertiesArtifactRelocationSource implements MavenArtifa
                         }
                         return new Relocation(global, s, t);
                     })
-                    .collect(Collectors.toList());
+                    .toList();
             LOGGER.info("Parsed {} user relocations", relocationList.size());
             return new Relocations(relocationList);
         }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven3ScopeManagerConfiguration.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven3ScopeManagerConfiguration.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.aether.artifact.ArtifactProperties;
@@ -83,7 +84,7 @@ public final class Maven3ScopeManagerConfiguration implements ScopeManagerConfig
     @Override
     public BuildScopeSource getBuildScopeSource() {
         return new BuildScopeMatrixSource(
-                Collections.singletonList(CommonBuilds.PROJECT_PATH_MAIN),
+                List.of(CommonBuilds.PROJECT_PATH_MAIN),
                 Arrays.asList(CommonBuilds.BUILD_PATH_COMPILE, CommonBuilds.BUILD_PATH_RUNTIME),
                 CommonBuilds.MAVEN_TEST_BUILD_SCOPE);
     }
@@ -126,13 +127,13 @@ public final class Maven3ScopeManagerConfiguration implements ScopeManagerConfig
                 RS_MAIN_COMPILE,
                 InternalScopeManager.Mode.ELIMINATE,
                 singleton(CommonBuilds.PROJECT_PATH_MAIN, CommonBuilds.BUILD_PATH_COMPILE),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_MAIN_COMPILE_PLUS_RUNTIME,
                 InternalScopeManager.Mode.ELIMINATE,
                 byProjectPath(CommonBuilds.PROJECT_PATH_MAIN),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_MAIN_RUNTIME,
@@ -144,19 +145,19 @@ public final class Maven3ScopeManagerConfiguration implements ScopeManagerConfig
                 RS_MAIN_RUNTIME_PLUS_SYSTEM,
                 InternalScopeManager.Mode.ELIMINATE,
                 singleton(CommonBuilds.PROJECT_PATH_MAIN, CommonBuilds.BUILD_PATH_RUNTIME),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_TEST_COMPILE,
                 InternalScopeManager.Mode.ELIMINATE,
                 select(CommonBuilds.PROJECT_PATH_TEST, CommonBuilds.BUILD_PATH_COMPILE),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_TEST_RUNTIME,
                 InternalScopeManager.Mode.ELIMINATE,
                 select(CommonBuilds.PROJECT_PATH_TEST, CommonBuilds.BUILD_PATH_RUNTIME),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         return result;
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.maven.api.DependencyScope;
@@ -154,13 +155,13 @@ public final class Maven4ScopeManagerConfiguration implements ScopeManagerConfig
                 RS_MAIN_COMPILE,
                 InternalScopeManager.Mode.ELIMINATE,
                 singleton(CommonBuilds.PROJECT_PATH_MAIN, CommonBuilds.BUILD_PATH_COMPILE),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_MAIN_COMPILE_PLUS_RUNTIME,
                 InternalScopeManager.Mode.ELIMINATE,
                 byProjectPath(CommonBuilds.PROJECT_PATH_MAIN),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_MAIN_RUNTIME,
@@ -172,19 +173,19 @@ public final class Maven4ScopeManagerConfiguration implements ScopeManagerConfig
                 RS_MAIN_RUNTIME_PLUS_SYSTEM,
                 InternalScopeManager.Mode.REMOVE,
                 singleton(CommonBuilds.PROJECT_PATH_MAIN, CommonBuilds.BUILD_PATH_RUNTIME),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_TEST_COMPILE,
                 InternalScopeManager.Mode.ELIMINATE,
                 select(CommonBuilds.PROJECT_PATH_TEST, CommonBuilds.BUILD_PATH_COMPILE),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         result.add(internalScopeManager.createResolutionScope(
                 RS_TEST_RUNTIME,
                 InternalScopeManager.Mode.ELIMINATE,
                 select(CommonBuilds.PROJECT_PATH_TEST, CommonBuilds.BUILD_PATH_RUNTIME),
-                Collections.singletonList(system),
+                List.of(system),
                 nonTransitiveDependencyScopes));
         return result;
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/ApiRunner.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/ApiRunner.java
@@ -164,7 +164,7 @@ public class ApiRunner {
         private final Instant startTime = MonotonicClock.now();
 
         DefaultSession(RepositorySystemSession session, RepositorySystem repositorySystem, Lookup lookup) {
-            this(session, repositorySystem, Collections.emptyList(), null, lookup);
+            this(session, repositorySystem, List.of(), null, lookup);
         }
 
         protected DefaultSession(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/ApiRunner.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/ApiRunner.java
@@ -347,17 +347,20 @@ public class ApiRunner {
         return new LifecycleRegistry() {
 
             @Override
+            @Nonnull
             public Iterator<Lifecycle> iterator() {
                 return Collections.emptyIterator();
             }
 
             @Override
-            public Optional<Lifecycle> lookup(String id) {
+            @Nonnull
+            public Optional<Lifecycle> lookup(@Nonnull String id) {
                 return Optional.empty();
             }
 
             @Override
-            public List<String> computePhases(Lifecycle lifecycle) {
+            @Nonnull
+            public List<String> computePhases(@Nonnull Lifecycle lifecycle) {
                 return List.of();
             }
         };

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
@@ -105,7 +105,7 @@ class DefaultModelXmlFactoryTest {
 
     @Test
     void testNullRequest() {
-        assertThrows(IllegalArgumentException.class, () -> factory.read((XmlReaderRequest) null));
+        assertThrows(NullPointerException.class, () -> factory.read((XmlReaderRequest) null));
     }
 
     @Test

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelInterpolatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelInterpolatorTest.java
@@ -25,7 +25,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -224,7 +223,7 @@ class DefaultModelInterpolatorTest {
     public void shouldInterpolateDependencyVersionToSetSameAsProjectVersion() throws Exception {
         Model model = Model.newBuilder()
                 .version("3.8.1")
-                .dependencies(Collections.singletonList(
+                .dependencies(List.of(
                         Dependency.newBuilder().version("${project.version}").build()))
                 .build();
 
@@ -240,8 +239,8 @@ class DefaultModelInterpolatorTest {
     public void testShouldNotInterpolateDependencyVersionWithInvalidReference() throws Exception {
         Model model = Model.newBuilder()
                 .version("3.8.1")
-                .dependencies(Collections.singletonList(
-                        Dependency.newBuilder().version("${something}").build()))
+                .dependencies(
+                        List.of(Dependency.newBuilder().version("${something}").build()))
                 .build();
 
         final SimpleProblemCollector collector = new SimpleProblemCollector();
@@ -257,7 +256,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .dependencies(Collections.singletonList(Dependency.newBuilder()
+                .dependencies(List.of(Dependency.newBuilder()
                         .version("${project.artifactId}-${project.version}")
                         .build()))
                 .build();
@@ -275,7 +274,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .repositories(Collections.singletonList(Repository.newBuilder()
+                .repositories(List.of(Repository.newBuilder()
                         .url("file://localhost/${anotherdir}/temp-repo")
                         .build()))
                 .build();
@@ -301,7 +300,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .repositories(Collections.singletonList(
+                .repositories(List.of(
                         Repository.newBuilder().url("${basedir}/temp-repo").build()))
                 .build();
 
@@ -323,7 +322,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .repositories(Collections.singletonList(
+                .repositories(List.of(
                         Repository.newBuilder().url("${basedir}/temp-repo").build()))
                 .build();
 
@@ -344,7 +343,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .repositories(Collections.singletonList(Repository.newBuilder()
+                .repositories(List.of(Repository.newBuilder()
                         .url("${project.baseUri}/temp-repo")
                         .build()))
                 .build();
@@ -366,7 +365,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .repositories(Collections.singletonList(Repository.newBuilder()
+                .repositories(List.of(Repository.newBuilder()
                         .url("file:${project.rootDirectory}/temp-repo")
                         .build()))
                 .build();
@@ -386,7 +385,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .repositories(Collections.singletonList(Repository.newBuilder()
+                .repositories(List.of(Repository.newBuilder()
                         .url("${project.rootDirectory.uri}/temp-repo")
                         .build()))
                 .build();
@@ -409,7 +408,7 @@ class DefaultModelInterpolatorTest {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
-                .repositories(Collections.singletonList(Repository.newBuilder()
+                .repositories(List.of(Repository.newBuilder()
                         .url("file:///${project.rootDirectory}/temp-repo")
                         .build()))
                 .build();
@@ -500,7 +499,7 @@ class DefaultModelInterpolatorTest {
     public void shouldInterpolateUnprefixedBasedirExpression() throws Exception {
         Path basedir = Paths.get("/test/path");
         Model model = Model.newBuilder()
-                .dependencies(Collections.singletonList(Dependency.newBuilder()
+                .dependencies(List.of(Dependency.newBuilder()
                         .systemPath("${basedir}/artifact.jar")
                         .build()))
                 .build();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.impl.model;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Prerequisites;
@@ -82,20 +82,17 @@ class MavenModelMergerTest {
     // Profiles are neither inherited nor injected
     @Test
     void testMergeModelProfiles() {
-        Model parent = Model.newBuilder()
-                .profiles(Collections.singletonList(Profile.newInstance()))
-                .build();
+        Model parent =
+                Model.newBuilder().profiles(List.of(Profile.newInstance())).build();
         Model model = Model.newInstance();
         Model.Builder builder = Model.newBuilder(model);
         modelMerger.mergeModel_Profiles(builder, model, parent, false, null);
         assertEquals(0, builder.build().getProfiles().size());
 
         Profile modelProfile = Profile.newBuilder().id("MODEL").build();
-        model = Model.newBuilder()
-                .profiles(Collections.singletonList(modelProfile))
-                .build();
+        model = Model.newBuilder().profiles(List.of(modelProfile)).build();
         builder = Model.newBuilder(model);
         modelMerger.mergeModel_Prerequisites(builder, model, parent, false, null);
-        assertEquals(Collections.singletonList(modelProfile), builder.build().getProfiles());
+        assertEquals(List.of(modelProfile), builder.build().getProfiles());
     }
 }

--- a/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.MojoExecution;
@@ -270,7 +269,7 @@ public class MojoExtension extends MavenDIExtension implements ParameterResolver
                     .orElseGet(() -> XmlNode.newInstance("config"));
             List<XmlNode> children = mojoParameters.stream()
                     .map(mp -> XmlNode.newInstance(mp.name(), mp.value()))
-                    .collect(Collectors.toList());
+                    .toList();
             XmlNode config = XmlNode.newInstance("configuration", null, null, children, null);
             pluginConfiguration = XmlService.merge(config, pluginConfiguration);
 

--- a/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/PluginStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/PluginStub.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.api.plugin.testing.stubs;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -51,11 +50,11 @@ public class PluginStub implements Plugin {
 
     org.apache.maven.api.model.Plugin model;
     PluginDescriptor descriptor;
-    List<Lifecycle> lifecycles = Collections.emptyList();
+    List<Lifecycle> lifecycles = List.of();
     ClassLoader classLoader;
     Artifact artifact;
-    List<Dependency> dependencies = Collections.emptyList();
-    Map<String, Dependency> dependenciesMap = Collections.emptyMap();
+    List<Dependency> dependencies = List.of();
+    Map<String, Dependency> dependenciesMap = Map.of();
 
     @Override
     public org.apache.maven.api.model.Plugin getModel() {

--- a/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/ProjectStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/ProjectStub.java
@@ -88,6 +88,7 @@ public class ProjectStub implements Project {
     public Packaging getPackaging() {
         return new Packaging() {
             @Override
+            @Nonnull
             public String id() {
                 return model.getPackaging();
             }
@@ -128,6 +129,7 @@ public class ProjectStub implements Project {
             }
 
             @Override
+            @Nonnull
             public Map<String, PluginContainer> plugins() {
                 return Map.of();
             }
@@ -135,6 +137,7 @@ public class ProjectStub implements Project {
     }
 
     @Override
+    @Nonnull
     public List<ProducedArtifact> getArtifacts() {
         ProducedArtifact pomArtifact = new ProducedArtifactStub(getGroupId(), getArtifactId(), "", getVersion(), "pom");
         return mainArtifact != null ? Arrays.asList(pomArtifact, mainArtifact) : Arrays.asList(pomArtifact);

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/DefaultXmlService.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/DefaultXmlService.java
@@ -312,7 +312,7 @@ public class DefaultXmlService extends XmlService {
                         Iterator<XmlNode> it =
                                 commonChildren.computeIfAbsent(name, n1 -> Stream.of(dominant.children().stream()
                                                 .filter(n2 -> n2.name().equals(n1))
-                                                .collect(Collectors.toList()))
+                                                .toList())
                                         .filter(l -> !l.isEmpty())
                                         .map(List::iterator)
                                         .findFirst()

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -133,7 +133,7 @@ public class HttpServer {
             mapping.setPathSpec("/*");
             mapping.setConstraint(constraint);
 
-            security.setConstraintMappings(Collections.singletonList(mapping));
+            security.setConstraintMappings(List.of(mapping));
             security.setAuthenticator(new BasicAuthenticator());
             security.setLoginService(loginService);
             security.setHandler(handler);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0818WarDepsNotTransitiveTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0818WarDepsNotTransitiveTest.java
@@ -20,7 +20,7 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +58,6 @@ public class MavenITmng0818WarDepsNotTransitiveTest extends AbstractMavenIntegra
         verifier.verifyErrorFreeLog();
 
         Collection<String> artifacts = verifier.loadLines("target/artifacts.txt");
-        assertEquals(Collections.singletonList("org.apache.maven.its.it0080:war:war:0.1"), artifacts);
+        assertEquals(List.of("org.apache.maven.its.it0080:war:war:0.1"), artifacts);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3769ExclusionRelocatedTransdepsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3769ExclusionRelocatedTransdepsTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.it;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -59,7 +58,7 @@ public class MavenITmng3769ExclusionRelocatedTransdepsTest extends AbstractMaven
         verifier.verifyErrorFreeLog();
 
         List<String> artifacts = verifier.loadLines("target/artifacts.txt");
-        assertEquals(Collections.singletonList("org.apache.maven.its.mng3769:dependency:jar:1.0"), artifacts);
+        assertEquals(List.of("org.apache.maven.its.mng3769:dependency:jar:1.0"), artifacts);
 
         List<String> paths = verifier.loadLines("target/test.txt");
         assertEquals(3, paths.size());

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4034ManagedProfileDependencyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4034ManagedProfileDependencyTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -60,6 +59,6 @@ public class MavenITmng4034ManagedProfileDependencyTest extends AbstractMavenInt
         assertEquals(Arrays.asList(new String[0]), artifacts);
 
         artifacts = verifier.loadLines("target/runtime.txt");
-        assertEquals(Collections.singletonList("org.apache.maven.its:maven-core-it-support:jar:1.3"), artifacts);
+        assertEquals(List.of("org.apache.maven.its:maven-core-it-support:jar:1.3"), artifacts);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4070WhitespaceTrimmingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4070WhitespaceTrimmingTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.it;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -58,6 +57,6 @@ public class MavenITmng4070WhitespaceTrimmingTest extends AbstractMavenIntegrati
         verifier.verifyErrorFreeLog();
 
         List<String> artifacts = verifier.loadLines("target/artifacts.txt");
-        assertEquals(Collections.singletonList("org.apache.maven.its.mng4070:a:jar:0.1"), artifacts);
+        assertEquals(List.of("org.apache.maven.its.mng4070:a:jar:0.1"), artifacts);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4129PluginExecutionInheritanceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4129PluginExecutionInheritanceTest.java
@@ -62,9 +62,9 @@ public class MavenITmng4129PluginExecutionInheritanceTest extends AbstractMavenI
         assertEquals(Arrays.asList(new String[] {"inherited-execution", "non-inherited-execution"}), executions);
 
         List<String> executions1 = verifier.loadLines("child-1/target/executions.txt");
-        assertEquals(Collections.singletonList("inherited-execution"), executions1);
+        assertEquals(List.of("inherited-execution"), executions1);
 
         List<String> executions2 = verifier.loadLines("child-2/target/executions.txt");
-        assertEquals(Collections.singletonList("inherited-execution"), executions2);
+        assertEquals(List.of("inherited-execution"), executions2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5669ReadPomsOnce.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5669ReadPomsOnce.java
@@ -73,7 +73,7 @@ public class MavenITmng5669ReadPomsOnce extends AbstractMavenIntegrationTestCase
         List<String> duplicates = sourceMap.entrySet().stream()
                 .filter(entry -> entry.getValue() > 1)
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .toList();
 
         assertTrue(duplicates.isEmpty(), "Duplicate items: " + String.join(System.lineSeparator(), duplicates));
     }
@@ -109,7 +109,7 @@ public class MavenITmng5669ReadPomsOnce extends AbstractMavenIntegrationTestCase
         List<String> duplicates = sourceMap.entrySet().stream()
                 .filter(entry -> entry.getValue() > 1)
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .toList();
 
         assertTrue(duplicates.isEmpty(), "Duplicate items: " + String.join(System.lineSeparator(), duplicates));
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,7 @@ class MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest extends AbstractMaven
             final List<Path> consumerFiles = stream.filter(
                             path -> path.getFileName().toString().contains("consumer")
                                     && path.getFileName().toString().contains("pom"))
-                    .collect(Collectors.toList());
+                    .toList();
             assertTrue(consumerFiles.size() == 0, "Expected no consumer pom file.");
         }
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7804PluginExecutionOrderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7804PluginExecutionOrderTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +53,7 @@ class MavenITmng7804PluginExecutionOrderTest extends AbstractMavenIntegrationTes
 
         List<String> executions = verifier.loadLogLines().stream()
                 .filter(l -> l.contains(" This should be "))
-                .collect(Collectors.toList());
+                .toList();
         assertEquals(4, executions.size());
         assertTrue(executions.get(0).contains("100"));
         assertTrue(executions.get(1).contains("200"));

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-expression/src/test/java/org/apache/maven/plugin/coreit/PropertyUtilTest.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-expression/src/test/java/org/apache/maven/plugin/coreit/PropertyUtilTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -97,7 +98,7 @@ public class PropertyUtilTest {
     @Test
     public void testStoreCycle() {
         Object[] arr = {null};
-        arr[0] = Collections.singleton(Collections.singletonMap("key", arr));
+        arr[0] = Set.of(Collections.singletonMap("key", arr));
 
         Properties props = new Properties();
         PropertyUtil.store(props, "cycle", arr);

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -193,6 +193,7 @@ public class Verifier {
                 // remove it
                 args = args.stream()
                         .filter(s -> !s.startsWith("-Dmaven.repo.local.tail="))
+                        // do not use toList() here, as we need mutability
                         .collect(Collectors.toList());
             }
 

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -586,7 +586,7 @@ public class Verifier {
 
             return l;
         } else {
-            return Collections.singletonList(line);
+            return List.of(line);
         }
     }
 

--- a/src/mdo/java/InputLocation.java
+++ b/src/mdo/java/InputLocation.java
@@ -20,7 +20,6 @@ package ${package};
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -37,7 +36,7 @@ public class InputLocation implements Serializable, InputLocationTracker {
         this.lineNumber = -1;
         this.columnNumber = -1;
         this.source = source;
-        this.locations = Collections.singletonMap(0, this);
+        this.locations = Map.of(0, this);
     }
 
     public InputLocation(int lineNumber, int columnNumber) {
@@ -53,7 +52,7 @@ public class InputLocation implements Serializable, InputLocationTracker {
         this.columnNumber = columnNumber;
         this.source = source;
         this.locations =
-                selfLocationKey != null ? Collections.singletonMap(selfLocationKey, this) : Collections.emptyMap();
+                selfLocationKey != null ? Map.of(selfLocationKey, this) : Map.of();
     }
 
     public InputLocation(int lineNumber, int columnNumber, InputSource source, Map<Object, InputLocation> locations) {

--- a/src/mdo/model-v3.vm
+++ b/src/mdo/model-v3.vm
@@ -209,7 +209,7 @@ public class ${class.name}
         }
       #elseif ( $field.to != "String" && $field.type == "java.util.List" && $field.multiplicity == "*" )
         if (${field.name} == null) {
-            ${field.name} = Collections.emptyList();
+            ${field.name} = List.of();
         }
         if (!Objects.equals(${field.name}, ${pfx}${cap}())) {
             update(getDelegate().with${cap}(

--- a/src/mdo/model-v3.vm
+++ b/src/mdo/model-v3.vm
@@ -213,7 +213,7 @@ public class ${class.name}
         }
         if (!Objects.equals(${field.name}, ${pfx}${cap}())) {
             update(getDelegate().with${cap}(
-                ${field.name}.stream().map(c -> c.getDelegate()).collect(Collectors.toList())));
+                ${field.name}.stream().map(c -> c.getDelegate()).toList()));
             ${field.name}.forEach(e -> e.childrenTracking = this::replace);
         }
       #elseif ( $field.to && $field.to != "String" )
@@ -239,11 +239,11 @@ public class ${class.name}
         #if ( $field.to == "String" )
         update(getDelegate().with${cap}(
                Stream.concat(getDelegate().get${cap}().stream(), Stream.of(${v}))
-                        .collect(Collectors.toList())));
+                        .toList()));
         #else
         update(getDelegate().with${cap}(
                Stream.concat(getDelegate().get${cap}().stream(), Stream.of(${v}.getDelegate()))
-                        .collect(Collectors.toList())));
+                        .toList()));
         ${v}.childrenTracking = this::replace;
         #end
     }
@@ -253,12 +253,12 @@ public class ${class.name}
         update(getDelegate().with${cap}(
                getDelegate().get${cap}().stream()
                         .filter(e -> !Objects.equals(e, ${v}))
-                        .collect(Collectors.toList())));
+                        .toList()));
         #else
         update(getDelegate().with${cap}(
                getDelegate().get${cap}().stream()
                         .filter(e -> !Objects.equals(e, ${v}))
-                        .collect(Collectors.toList())));
+                        .toList()));
         ${v}.childrenTracking = null;
         #end
     }


### PR DESCRIPTION
This PR includes several improvements to modernize the codebase:

1. Replace IllegalArgumentException with ClassCastException for type cast failures
2. Replace IllegalArgumentException with NullPointerException for null checks
3. Use modern Java collections API (toList() instead of collect(Collectors.toList()))
4. Replace custom null checks with Objects.requireNonNull
5. Add @Nonnull and @Nullable annotations throughout the codebase

These changes make the code more maintainable, safer, and aligned with modern Java practices.