### PR TITLE
[MNG-8713] SourceRoot.directory() default value should include the module when present

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
@@ -44,7 +44,7 @@ public interface SourceRoot {
      *     <code>src/{@linkplain #scope() scope}/{@linkplain #language() language}</code>.
      *   </li><li>
      *     If a module name is present, then the default directory is
-     *     <code>src/{@linkplain #language() language}/{@linkplain #module() module}/{@linkplain #scope() scope}</code>.
+     *     <code>src/{@linkplain #module() module}/{@linkplain #scope() scope}/{@linkplain #language() language}</code>.
      *   </li>
      * </ul>
      *
@@ -52,8 +52,11 @@ public interface SourceRoot {
      * Implementation may override with absolute path instead.
      */
     default Path directory() {
-        return module().map((module) -> Path.of("src", language().id(), module, scope().id()))
-                .orElseGet(() -> Path.of("src", scope().id(), language().id()));
+        Path src = Path.of("src");
+        return module().map(src::resolve)
+                .orElse(src)
+                .resolve(scope().id())
+                .resolve(language().id());
     }
 
     /**

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
@@ -37,11 +37,23 @@ public interface SourceRoot {
      * The path is relative to the <abbr>POM</abbr> file.
      *
      * <h4>Default implementation</h4>
-     * The default value is <code>src/{@linkplain #scope() scope}/{@linkplain #language() language}</code>
-     * as a relative path. Implementation classes may override this default with an absolute path instead.
+     * The default value depends on whether a {@linkplain #module() module name} is specified in this source root:
+     * <ul>
+     *   <li>
+     *     If no module name, then the default directory is
+     *     <code>src/{@linkplain #scope() scope}/{@linkplain #language() language}</code>.
+     *   </li><li>
+     *     If a module name is present, then the default directory is
+     *     <code>src/{@linkplain #language() language}/{@linkplain #module() module}/{@linkplain #scope() scope}</code>.
+     *   </li>
+     * </ul>
+     *
+     * These default values are relative directories.
+     * Implementation classes may override this default with absolute paths instead.
      */
     default Path directory() {
-        return Path.of("src", scope().id(), language().id());
+        return module().map((module) -> Path.of("src", language().id(), module, scope().id()))
+                .orElseGet(() -> Path.of("src", scope().id(), language().id()));
     }
 
     /**

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
@@ -48,8 +48,8 @@ public interface SourceRoot {
      *   </li>
      * </ul>
      *
-     * These default values are relative directories.
-     * Implementation classes may override this default with absolute paths instead.
+     * The default value is relative.
+     * Implementation may override with absolute path instead.
      */
     default Path directory() {
         return module().map((module) -> Path.of("src", language().id(), module, scope().id()))

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -2014,7 +2014,7 @@
         If no source directories are specified, the default values depend on whether module names are specified:
         <ul>
           <li>{@code src/${scope}/${lang}} if no module is specified</li>
-          <li>{@code src/${lang}/${module}/${scope}} if a module is specified</li>
+          <li>{@code src/${module}/${scope}/${lang}} if a module is specified</li>
         </ul>
         where
         {@code ${scope}} is the value of the {@link #scope} element (typically {@code main} or {@code test}),

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -2011,9 +2011,15 @@
         usage (main code, tests, <i>etc.</i>) is specified by the {@code scope} element.
 
         <h2>Default source directories</h2>
-        If no source directories are specified, the defaults are {@code src/${scope}/${lang}} where
-        {@code ${scope}} is the value of the {@link #scope} element (typically {@code main} or {@code test}) and
-        {@code ${lang}} is the value of the {@link #lang} element (typically {@code java} or {@code resources}).
+        If no source directories are specified, the default values depend on whether module names are specified:
+        <ul>
+          <li>{@code src/${scope}/${lang}} if no module is specified</li>
+          <li>{@code src/${lang}/${module}/${scope}} if a module is specified</li>
+        </ul>
+        where
+        {@code ${scope}} is the value of the {@link #scope} element (typically {@code main} or {@code test}),
+        {@code ${lang}} is the value of the {@link #lang} element (typically {@code java} or {@code resources}),
+        and {@code ${module}} is the optional {@link #module} element.
         ]]>
       </description>
       <version>4.1.0+</version>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -79,7 +79,12 @@ public final class DefaultSourceRoot implements SourceRoot {
         if (value != null) {
             directory = baseDir.resolve(value);
         } else {
-            directory = baseDir.resolve("src").resolve(scope.id()).resolve(language.id());
+            Path src = baseDir.resolve("src");
+            if (moduleName != null) {
+                directory = src.resolve(language.id()).resolve(moduleName).resolve(scope.id());
+            } else {
+                directory = src.resolve(scope.id()).resolve(language.id());
+            }
         }
 
         value = nonBlank(source.getTargetVersion());

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -81,10 +81,9 @@ public final class DefaultSourceRoot implements SourceRoot {
         } else {
             Path src = baseDir.resolve("src");
             if (moduleName != null) {
-                directory = src.resolve(language.id()).resolve(moduleName).resolve(scope.id());
-            } else {
-                directory = src.resolve(scope.id()).resolve(language.id());
+                src = src.resolve(language.id());
             }
+            directory = src.resolve(scope.id()).resolve(language.id());
         }
 
         value = nonBlank(source.getTargetVersion());


### PR DESCRIPTION
If a `<source>` element in POM does not provide any value for the `<directory>` element, the default value is currently defined as `src/${scope}/${lang}`. This default value provides the familiar `src/main/java` and `src/test/java` default directories. However, if the `<source>` element contains a `<module>` element, the module name must appear somewhere in the default directory name, otherwise the source code of multi-modular projects will collide.

Different conventions are possible:

* OpenJDK uses `src/${module}/` for the main code and a bazar of directories for the tests with no obvious order.
* [Project Jigsaw: Module System Quick-Start Guide](https://openjdk.org/projects/jigsaw/quick-start) uses `src/${module}/` for main code and does not mention tests.
* [junit5-modular-world](https://github.com/junit-team/junit5-samples/tree/main/junit5-modular-world) uses `src/main/${module}/` for the main code and `src/test/${module}/` for the test code. However, it also uses `module-info.java` in test code, which I would like to discourage.
* NetBeans Ant modular project uses `src/${module}/main` for the main code and `src/${module}/test` for the test code.

I propose the NetBeans's convention, which is implemented in this pull request as a default directory of `src/${lang}/${module}/${scope}` when the `<module>` element is present.

## Alternative
If it is considered too premature to adopt a default directory name for modular project, we should at least throw an exception asking user to specify a directory explicitly if a `<module>` element is present.