### PR TITLE
[MNG-8712] dependency version is a requirement, not effective

### DIFF
--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1087,8 +1087,10 @@
           <version>3.0.0+</version>
           <description>
             <![CDATA[
-            The version of the dependency, e.g. <code>3.2.1</code>. In Maven 2, this can also be
-            specified as a range of versions.
+            The version requirement of the dependency, e.g. <code>3.2.1</code> for soft version requirement: the effective version will be resolved based on the usage context.
+            In Maven 2, version requirement can also be specified as a range of versions, e.g. <code>[3.2.0,)</code>: notice this is discouraged, as it may break <i>predictability</i> of resolved version.
+            See <a href="https://s.apache.org/dependendy-version">dependency version requirement documentation</a>
+            and <a href="https://s.apache.org/transitive-dependencies-resolution">transitive dependencies resolution</a> for more details.
             ]]>
           </description>
           <type>String</type>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1087,8 +1087,8 @@
           <version>3.0.0+</version>
           <description>
             <![CDATA[
-            The version requirement of the dependency, e.g. <code>3.2.1</code> for soft version requirement: the effective version will be resolved based on the usage context.
-            Version requirement can also be specified as a range of versions, e.g. <code>[3.2.0,)</code>: notice this is discouraged, as it may break <i>predictability</i> of resolved version.
+            The version requirement of the dependency, e.g. <code>3.2.1</code>. The actual version will be resolved based on the usage context.
+            Version requirement can also be specified as a range of versions, e.g. <code>[3.2.0,)</code>. This is discouraged as it breaks <i>predictability</i> of resolved version.
             See <a href="https://s.apache.org/dependency-version">dependency version requirement documentation</a>
             and <a href="https://s.apache.org/transitive-dependencies-resolution">transitive dependencies resolution</a> for more details.
             ]]>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1088,8 +1088,8 @@
           <description>
             <![CDATA[
             The version requirement of the dependency, e.g. <code>3.2.1</code> for soft version requirement: the effective version will be resolved based on the usage context.
-            In Maven 2, version requirement can also be specified as a range of versions, e.g. <code>[3.2.0,)</code>: notice this is discouraged, as it may break <i>predictability</i> of resolved version.
-            See <a href="https://s.apache.org/dependendy-version">dependency version requirement documentation</a>
+            Version requirement can also be specified as a range of versions, e.g. <code>[3.2.0,)</code>: notice this is discouraged, as it may break <i>predictability</i> of resolved version.
+            See <a href="https://s.apache.org/dependency-version">dependency version requirement documentation</a>
             and <a href="https://s.apache.org/transitive-dependencies-resolution">transitive dependencies resolution</a> for more details.
             ]]>
           </description>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -1088,7 +1088,7 @@
           <description>
             <![CDATA[
             The version requirement of the dependency, e.g. <code>3.2.1</code>. The actual version will be resolved based on the usage context.
-            Version requirement can also be specified as a range of versions, e.g. <code>[3.2.0,)</code>. This is discouraged as it breaks <i>predictability</i> of resolved version.
+            Version requirement can also be specified as a range of versions, e.g. <code>[3.2.0,)</code>. This is discouraged as it may break <i>predictability</i> of resolved version.
             See <a href="https://s.apache.org/dependency-version">dependency version requirement documentation</a>
             and <a href="https://s.apache.org/transitive-dependencies-resolution">transitive dependencies resolution</a> for more details.
             ]]>


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/MNG-8712

hoping this will help users discover how dependency version in `pom.xml` is completely different to every other versions like project or plugin