### PR TITLE
[MNG-8614] Maven Sisu in Maven 4 same as in Maven 3

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -696,7 +696,7 @@ public class MavenCli {
                 .setClassPathScanning(PlexusConstants.SCANNING_INDEX)
                 .setAutoWiring(true)
                 .setJSR250Lifecycle(true)
-                .setStrictClassPathScanning(true)
+                .setStrictClassPathScanning(false)
                 .setName("maven");
 
         Set<String> exportedArtifacts = new HashSet<>(coreEntry.getExportedArtifacts());
@@ -812,7 +812,7 @@ public class MavenCli {
                 .setClassPathScanning(PlexusConstants.SCANNING_INDEX) //
                 .setAutoWiring(true) //
                 .setJSR250Lifecycle(true) //
-                .setStrictClassPathScanning(true) //
+                .setStrictClassPathScanning(false) //
                 .setName("maven");
 
         DefaultPlexusContainer container = new DefaultPlexusContainer(cc, new AbstractModule() {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
@@ -103,7 +103,7 @@ public class PlexusContainerCapsuleFactory<C extends LookupContext> implements C
                 .setClassPathScanning(PlexusConstants.SCANNING_INDEX)
                 .setAutoWiring(true)
                 .setJSR250Lifecycle(true)
-                .setStrictClassPathScanning(true)
+                .setStrictClassPathScanning(false)
                 .setName("maven");
         customizeContainerConfiguration(context, cc);
 
@@ -282,7 +282,7 @@ public class PlexusContainerCapsuleFactory<C extends LookupContext> implements C
                 .setClassPathScanning(PlexusConstants.SCANNING_INDEX)
                 .setAutoWiring(true)
                 .setJSR250Lifecycle(true)
-                .setStrictClassPathScanning(true)
+                .setStrictClassPathScanning(false)
                 .setName("maven");
 
         DefaultPlexusContainer container = new DefaultPlexusContainer(cc, new AbstractModule() {


### PR DESCRIPTION
The Sisu "strict" flag has issues, but also, it is best and simplest to help transitioning by making Sisu in Maven 4 behave in very same way as it behaves in Maven 3.

---

https://issues.apache.org/jira/browse/MNG-8614