### PR TITLE
Modernize codebase with Java improvements - Use modern Java collections API (`toList()` instead of `Collectors.toList()`)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.Service;
@@ -231,7 +230,7 @@ public class BootstrapCoreExtensionManager {
             return result.getArtifactResults().stream()
                     .filter(ArtifactResult::isResolved)
                     .map(ArtifactResult::getArtifact)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (PluginResolutionException | InterpolatorException e) {
             throw new ExtensionResolutionException(extension, e);
         }

--- a/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
@@ -171,14 +170,14 @@ public class RepositoryUtils {
 
         List<Exclusion> excl = Optional.ofNullable(exclusions).orElse(Collections.emptyList()).stream()
                 .map(RepositoryUtils::toExclusion)
-                .collect(Collectors.toList());
+                .toList();
         return new Dependency(result, artifact.getScope(), artifact.isOptional(), excl);
     }
 
     public static List<RemoteRepository> toRepos(List<ArtifactRepository> repos) {
         return Optional.ofNullable(repos).orElse(Collections.emptyList()).stream()
                 .map(RepositoryUtils::toRepo)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public static RemoteRepository toRepo(ArtifactRepository repo) {
@@ -294,7 +293,7 @@ public class RepositoryUtils {
 
         List<Exclusion> exclusions = dependency.getExclusions().stream()
                 .map(RepositoryUtils::toExclusion)
-                .collect(Collectors.toList());
+                .toList();
 
         return new Dependency(
                 artifact,
@@ -326,7 +325,7 @@ public class RepositoryUtils {
     }
 
     public static Collection<Artifact> toArtifacts(Collection<org.apache.maven.artifact.Artifact> artifactsToConvert) {
-        return artifactsToConvert.stream().map(RepositoryUtils::toArtifact).collect(Collectors.toList());
+        return artifactsToConvert.stream().map(RepositoryUtils::toArtifact).toList();
     }
 
     public static WorkspaceRepository getWorkspace(RepositorySystemSession session) {

--- a/impl/maven-core/src/main/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Exclusion;
@@ -40,7 +39,7 @@ public class ExclusionArtifactFilter implements ArtifactFilter {
     public ExclusionArtifactFilter(List<Exclusion> exclusions) {
         this.exclusions = exclusions;
         this.predicates =
-                exclusions.stream().map(ExclusionArtifactFilter::toPredicate).collect(Collectors.toList());
+                exclusions.stream().map(ExclusionArtifactFilter::toPredicate).toList();
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzer.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/DefaultBuildResumptionAnalyzer.java
@@ -23,7 +23,6 @@ import javax.inject.Singleton;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ public class DefaultBuildResumptionAnalyzer implements BuildResumptionAnalyzer {
                 .filter(project -> result.getBuildSummary(project) == null
                         || result.getBuildSummary(project) instanceof BuildFailure)
                 .map(project -> project.getGroupId() + ":" + project.getArtifactId())
-                .collect(Collectors.toList());
+                .toList();
 
         if (remainingProjects.isEmpty()) {
             LOGGER.info("No remaining projects found, resuming the build would not make sense.");

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Session;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -423,13 +422,13 @@ public class MavenSession implements Cloneable {
                 .localRepository(localRepo != null ? localRepo.getAbsolutePath() : null)
                 .interactiveMode(request.isInteractiveMode())
                 .offline(request.isOffline())
-                .proxies(request.getProxies().stream().map(Proxy::getDelegate).collect(Collectors.toList()))
-                .servers(request.getServers().stream().map(Server::getDelegate).collect(Collectors.toList()))
-                .mirrors(request.getMirrors().stream().map(Mirror::getDelegate).collect(Collectors.toList()))
+                .proxies(request.getProxies().stream().map(Proxy::getDelegate).toList())
+                .servers(request.getServers().stream().map(Server::getDelegate).toList())
+                .mirrors(request.getMirrors().stream().map(Mirror::getDelegate).toList())
                 .profiles(request.getProfiles().stream()
                         .map(Profile::getDelegate)
                         .map(SettingsUtilsV4::convertToSettingsProfile)
-                        .collect(Collectors.toList()))
+                        .toList())
                 .activeProfiles(request.getActiveProfiles())
                 .pluginGroups(request.getPluginGroups())
                 .build());

--- a/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultProjectDependencyGraph.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultProjectDependencyGraph.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.project.CycleDetectedException;
@@ -153,7 +152,7 @@ public class DefaultProjectDependencyGraph implements ProjectDependencyGraph {
         return projectIds.stream()
                 .map(projects::get)
                 .sorted(Comparator.comparingInt(order::get))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -231,7 +231,7 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
                 XmlNode dom = server.getDelegate().getConfiguration();
                 List<XmlNode> children = dom.children().stream()
                         .filter(c -> !"wagonProvider".equals(c.name()))
-                        .collect(Collectors.toList());
+                        .toList();
                 dom = XmlNode.newInstance(dom.name(), children);
                 PlexusConfiguration config = XmlPlexusConfiguration.toPlexusConfiguration(dom);
                 configProps.put("aether.transport.wagon.config." + server.getId(), config);

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/CoreUtils.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 class CoreUtils {
 
@@ -37,6 +36,6 @@ class CoreUtils {
     }
 
     public static <U, V> List<V> map(Collection<U> list, Function<U, V> mapper) {
-        return list.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
+        return list.stream().map(mapper).filter(Objects::nonNull).toList();
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.DependencyScope;
@@ -143,7 +142,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
         List<String> allPhases = graph.visitAll();
         Collections.reverse(allPhases);
         List<String> computed =
-                allPhases.stream().filter(s -> !s.startsWith("$")).collect(Collectors.toList());
+                allPhases.stream().filter(s -> !s.startsWith("$")).toList();
         return computed;
     }
 
@@ -211,7 +210,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
                                 && !Lifecycle.DEFAULT.equals(id)
                                 && !Lifecycle.SITE.equals(id))
                         .map(id -> wrap(all.get(id)))
-                        .collect(Collectors.toList());
+                        .toList();
             } catch (ComponentLookupException e) {
                 throw new LookupException(e);
             }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -288,7 +288,7 @@ class DefaultConsumerPomBuilder implements ConsumerPomBuilder {
                     return builder.build(null).build();
                 })
                 .filter(p -> !isEmpty(p))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static boolean isEmpty(Profile profile) {
@@ -324,6 +324,6 @@ class DefaultConsumerPomBuilder implements ConsumerPomBuilder {
     private static List<Repository> pruneRepositories(List<Repository> repositories) {
         return repositories.stream()
                 .filter(r -> !org.apache.maven.api.Repository.CENTRAL_ID.equals(r.getId()))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
@@ -161,7 +161,7 @@ public class DefaultLifecycles {
         return lifecyclesMap.values().stream()
                 .peek(l -> Objects.requireNonNull(l.getId(), "A lifecycle must have an id."))
                 .sorted(Comparator.comparing(Lifecycle::getId, comparator))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Map<String, Lifecycle> lookupLifecycles() {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
@@ -84,7 +83,7 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
                         && !rootProject.getDefaultGoal().isEmpty())) {
             tasks = Stream.of(rootProject.getDefaultGoal().split("\\s+"))
                     .filter(g -> !g.isEmpty())
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         return calculateTaskSegments(session, tasks);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolver.java
@@ -30,7 +30,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.services.MessageBuilderFactory;
@@ -96,7 +95,7 @@ public class LifecycleDependencyResolver {
             projectAndSubmodules.add(project);
             return session.getProjects().stream() // sorted all
                     .filter(projectAndSubmodules::contains)
-                    .collect(Collectors.toList()); // sorted and filtered to what we need
+                    .toList(); // sorted and filtered to what we need
         } else {
             return Collections.singletonList(project);
         }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.execution.MavenSession;
@@ -102,7 +101,7 @@ public class MojoDescriptorCreator {
                                 : null,
                         null,
                         null))
-                .collect(Collectors.toList());
+                .toList();
         return XmlNode.newInstance("configuration", children);
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectBuildList.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectBuildList.java
@@ -55,7 +55,7 @@ public class ProjectBuildList implements Iterable<ProjectSegment> {
      */
     public ProjectBuildList getByTaskSegment(TaskSegment taskSegment) {
         return new ProjectBuildList(
-                items.stream().filter(pb -> taskSegment == pb.getTaskSegment()).collect(Collectors.toList()));
+                items.stream().filter(pb -> taskSegment == pb.getTaskSegment()).toList());
     }
 
     public Map<MavenProject, ProjectSegment> selectSegment(TaskSegment taskSegment) {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/ConcurrentLifecycleStarter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/ConcurrentLifecycleStarter.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
@@ -128,7 +127,7 @@ public class ConcurrentLifecycleStarter implements LifecycleStarter {
                         && !rootProject.getDefaultGoal().isEmpty())) {
             tasks = Stream.of(rootProject.getDefaultGoal().split("\\s+"))
                     .filter(g -> !g.isEmpty())
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         return calculateTaskSegments(session, tasks);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/PluginLifecycle.java
@@ -21,11 +21,11 @@ package org.apache.maven.lifecycle.internal.concurrent;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
 import org.apache.maven.api.model.Plugin;
+import org.apache.maven.api.model.PluginExecution;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 
 class PluginLifecycle implements Lifecycle {
@@ -47,7 +47,7 @@ class PluginLifecycle implements Lifecycle {
     @Override
     public Collection<Phase> phases() {
         return lifecycleOverlay.getPhases().stream()
-                .map(phase -> new Phase() {
+                .<Phase>map(phase -> new Phase() {
                     @Override
                     public String name() {
                         return phase.getId();
@@ -61,11 +61,11 @@ class PluginLifecycle implements Lifecycle {
                                 .version(pluginDescriptor.getVersion())
                                 .configuration(phase.getConfiguration())
                                 .executions(phase.getExecutions().stream()
-                                        .map(exec -> org.apache.maven.api.model.PluginExecution.newBuilder()
+                                        .map(exec -> PluginExecution.newBuilder()
                                                 .goals(exec.getGoals())
                                                 .configuration(exec.getConfiguration())
                                                 .build())
-                                        .collect(Collectors.toList()))
+                                        .toList())
                                 .build());
                     }
 
@@ -84,7 +84,7 @@ class PluginLifecycle implements Lifecycle {
                         return Stream.concat(Stream.of(this), phases().stream().flatMap(Phase::allPhases));
                     }
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/mapping/LifecyclePhase.java
@@ -56,7 +56,7 @@ public class LifecyclePhase {
 
         if (goals != null && !goals.isEmpty()) {
             String[] mojoGoals = goals.split(",");
-            mojos = Arrays.stream(mojoGoals).map(fromGoalIntoLifecycleMojo).collect(Collectors.toList());
+            mojos = Arrays.stream(mojoGoals).map(fromGoalIntoLifecycleMojo).toList();
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.RepositoryUtils;
@@ -240,7 +239,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                             e.getResult().getArtifactResults().stream()
                                     .filter(r -> !r.isResolved())
                                     .flatMap(r -> r.getExceptions().stream()))
-                    .collect(Collectors.toList());
+                    .toList();
             throw new PluginResolutionException(plugin, exceptions, e);
         } finally {
             RequestTraceHelper.exit(trace);

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -36,7 +36,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Constants;
 import org.apache.maven.eventspy.AbstractEventSpy;
@@ -109,7 +108,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
         return Arrays.stream(excludes.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private ValidationReportLevel validationReportLevel(RepositorySystemSession session) {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -505,7 +505,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 return pomFiles.stream()
                         .map(pomFile -> build(pomFile, recursive))
                         .flatMap(List::stream)
-                        .collect(Collectors.toList());
+                        .toList();
             } finally {
                 Thread.currentThread().setContextClassLoader(oldContextClassLoader);
             }
@@ -551,7 +551,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     project.setCollectedProjects(results(r)
                             .filter(cr -> cr != r && cr.getEffectiveModel() != null)
                             .map(cr -> projectIndex.get(cr.getEffectiveModel().getId()))
-                            .collect(Collectors.toList()));
+                            .toList());
 
                     DependencyResolutionResult resolutionResult = null;
                     if (request.isResolveDependencies()) {
@@ -944,7 +944,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
     }
 
     private List<String> getProfileIds(List<Profile> profiles) {
-        return profiles.stream().map(Profile::getId).collect(Collectors.toList());
+        return profiles.stream().map(Profile::getId).toList();
     }
 
     private static ModelSource createStubModelSource(Artifact artifact) {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
@@ -262,11 +262,11 @@ public class ProjectSorter {
     }
 
     public List<String> getDependents(String id) {
-        return graph.getVertex(id).getParents().stream().map(Vertex::getLabel).collect(Collectors.toList());
+        return graph.getVertex(id).getParents().stream().map(Vertex::getLabel).toList();
     }
 
     public List<String> getDependencies(String id) {
-        return graph.getVertex(id).getChildren().stream().map(Vertex::getLabel).collect(Collectors.toList());
+        return graph.getVertex(id).getChildren().stream().map(Vertex::getLabel).toList();
     }
 
     public static String getId(MavenProject project) {

--- a/impl/maven-core/src/main/java/org/apache/maven/resolver/MavenChainedWorkspaceReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/resolver/MavenChainedWorkspaceReader.java
@@ -109,7 +109,7 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
         requireNonNull(readers, "readers");
         // skip possible null entries
         this.readers = Collections.unmodifiableList(
-                new ArrayList<>(readers.stream().filter(Objects::nonNull).collect(Collectors.toList())));
+                new ArrayList<>(readers.stream().filter(Objects::nonNull).toList()));
         Key key = new Key(this.readers);
         this.repository = new WorkspaceRepository(key.getContentType(), key);
     }
@@ -130,7 +130,7 @@ public class MavenChainedWorkspaceReader implements MavenWorkspaceReader {
         private final String type;
 
         Key(Collection<WorkspaceReader> readers) {
-            keys = readers.stream().map(r -> r.getRepository().getKey()).collect(Collectors.toList());
+            keys = readers.stream().map(r -> r.getRepository().getKey()).toList();
             type = readers.stream().map(r -> r.getRepository().getContentType()).collect(Collectors.joining("+"));
         }
 

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.ArtifactCoordinates;
@@ -243,7 +242,7 @@ class TestApi {
         List<Dependency> deps2 = result.getNodes().stream()
                 .map(Node::getDependency)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
         assertEquals(deps, deps2);
         for (Dependency dep : deps2) {
             dep.getVersion();

--- a/impl/maven-core/src/test/java/org/apache/maven/project/harness/Xpp3DomAttributeIterator.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/harness/Xpp3DomAttributeIterator.java
@@ -20,7 +20,6 @@ package org.apache.maven.project.harness;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.commons.jxpath.ri.QName;
 import org.apache.commons.jxpath.ri.model.NodeIterator;
@@ -49,7 +48,7 @@ class Xpp3DomAttributeIterator implements NodeIterator {
 
         this.attributes = this.node.attributes().entrySet().stream()
                 .filter(a -> a.getKey().equals(qname.getName()) || "*".equals(qname.getName()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public NodePointer getNodePointer() {

--- a/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
+++ b/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
@@ -220,7 +220,7 @@ public class InjectorImpl implements Injector {
         if (key.getRawType() == List.class) {
             Set<Binding<Object>> res2 = getBindings(key.getTypeParameter(0));
             if (res2 != null) {
-                List<Supplier<Object>> list = res2.stream().map(this::compile).collect(Collectors.toList());
+                List<Supplier<Object>> list = res2.stream().map(this::compile).toList();
                 //noinspection unchecked
                 return () -> (Q) list(list, Supplier::get);
             }

--- a/impl/maven-di/src/test/java/org/apache/maven/di/impl/TypeUtilsTest.java
+++ b/impl/maven-di/src/test/java/org/apache/maven/di/impl/TypeUtilsTest.java
@@ -19,11 +19,11 @@
 package org.apache.maven.di.impl;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import org.apache.maven.di.Key;
 import org.junit.jupiter.api.Test;
@@ -34,14 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TypeUtilsTest {
 
-    TreeSet<String> aField;
-
     @Test
     void testGetSuperTypes() {
         Type type = new Key<TreeSet<String>>() {}.getType();
         Set<Type> types = Types.getAllSuperTypes(type);
         assertNotNull(types);
-        List<String> typesStr = types.stream().map(Type::toString).sorted().collect(Collectors.toList());
+        List<String> typesStr =
+                new ArrayList<>(types.stream().map(Type::toString).sorted().toList());
         typesStr.remove("java.util.SequencedSet<java.lang.String>");
         typesStr.remove("java.util.SequencedCollection<java.lang.String>");
         assertEquals(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractNode.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractNode.java
@@ -21,7 +21,6 @@ package org.apache.maven.impl;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Node;
 import org.apache.maven.api.NodeVisitor;
@@ -45,7 +44,7 @@ public abstract class AbstractNode implements Node {
     @Override
     public Node filter(Predicate<Node> filter) {
         List<Node> children =
-                getChildren().stream().filter(filter).map(n -> n.filter(filter)).collect(Collectors.toList());
+                getChildren().stream().filter(filter).map(n -> n.filter(filter)).toList();
         return new WrapperNode(this, Collections.unmodifiableList(children));
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/AbstractSession.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.ArtifactCoordinates;
@@ -707,7 +706,7 @@ public abstract class AbstractSession implements InternalSession {
     public Collection<DownloadedArtifact> resolveArtifacts(Artifact... artifacts) {
         ArtifactCoordinatesFactory acf = getService(ArtifactCoordinatesFactory.class);
         List<ArtifactCoordinates> coords =
-                Arrays.stream(artifacts).map(a -> acf.create(this, a)).collect(Collectors.toList());
+                Arrays.stream(artifacts).map(a -> acf.create(this, a)).toList();
         return resolveArtifacts(coords);
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultArtifactResolver.java
@@ -240,7 +240,7 @@ public class DefaultArtifactResolver implements ArtifactResolver {
         @Nonnull
         @Override
         public Collection<DownloadedArtifact> getArtifacts() {
-            return results.values().stream().map(ResultItem::getArtifact).collect(Collectors.toList());
+            return results.values().stream().map(ResultItem::getArtifact).toList();
         }
 
         @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultChecksumAlgorithmService.java
@@ -58,7 +58,7 @@ public class DefaultChecksumAlgorithmService implements ChecksumAlgorithmService
     public Collection<String> getChecksumAlgorithmNames() {
         return checksumAlgorithmFactorySelector.getChecksumAlgorithmFactories().stream()
                 .map(ChecksumAlgorithmFactory::getName)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
@@ -189,7 +189,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
                         .map(Node::getDependency)
                         .filter(Objects::nonNull)
                         .map(Artifact::toCoordinates)
-                        .collect(Collectors.toList());
+                        .toList();
                 Predicate<PathType> filter = request.getPathTypeFilter();
                 if (request.getRequestType() == DependencyResolverRequest.RequestType.FLATTEN) {
                     DefaultDependencyResolverResult flattenResult = new DefaultDependencyResolverResult(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/ImplUtils.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 class ImplUtils {
     public static <T> T nonNull(T t) {
@@ -50,6 +49,6 @@ class ImplUtils {
     }
 
     public static <U, V> List<V> map(Collection<U> list, Function<U, V> mapper) {
-        return list.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
+        return list.stream().map(mapper).filter(Objects::nonNull).toList();
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/SettingsUtilsV4.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/SettingsUtilsV4.java
@@ -257,14 +257,14 @@ public final class SettingsUtilsV4 {
         if (repos != null) {
             profile.repositories(repos.stream()
                     .map(SettingsUtilsV4::convertFromSettingsRepository)
-                    .collect(Collectors.toList()));
+                    .toList());
         }
 
         List<Repository> pluginRepos = settingsProfile.getPluginRepositories();
         if (pluginRepos != null) {
             profile.pluginRepositories(pluginRepos.stream()
                     .map(SettingsUtilsV4::convertFromSettingsRepository)
-                    .collect(Collectors.toList()));
+                    .toList());
         }
 
         org.apache.maven.api.model.Profile value = profile.build();

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1672,7 +1672,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 List<Dependency> dependencies = importMgmt.getDependencies().stream()
                         .filter(candidate -> exclusions.stream().noneMatch(exclusion -> match(exclusion, candidate)))
                         .map(candidate -> addExclusions(candidate, exclusions))
-                        .collect(Collectors.toList());
+                        .toList();
                 importMgmt = importMgmt.withDependencies(dependencies);
             }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/FileToRawModelMerger.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/FileToRawModelMerger.java
@@ -20,7 +20,6 @@ package org.apache.maven.impl.model;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.BuildBase;
@@ -90,7 +89,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Dependency> sourceIterator = source.getDependencies().iterator();
         builder.dependencies(target.getDependencies().stream()
                 .map(d -> mergeDependency(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override
@@ -133,7 +132,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Profile> sourceIterator = source.getProfiles().iterator();
         builder.profiles(target.getProfiles().stream()
                 .map(d -> mergeProfile(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override
@@ -146,7 +145,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Dependency> sourceIterator = source.getDependencies().iterator();
         builder.dependencies(target.getDependencies().stream()
                 .map(d -> mergeDependency(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override
@@ -175,7 +174,7 @@ class FileToRawModelMerger extends MavenMerger {
         Iterator<Dependency> sourceIterator = source.getDependencies().iterator();
         builder.dependencies(target.getDependencies().stream()
                 .map(d -> mergeDependency(d, sourceIterator.next(), sourceDominant, context))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/UserPropertiesArtifactRelocationSource.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/UserPropertiesArtifactRelocationSource.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Constants;
@@ -185,7 +184,7 @@ public final class UserPropertiesArtifactRelocationSource implements MavenArtifa
                         }
                         return new Relocation(global, s, t);
                     })
-                    .collect(Collectors.toList());
+                    .toList();
             LOGGER.info("Parsed {} user relocations", relocationList.size());
             return new Relocations(relocationList);
         }

--- a/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.MojoExecution;
@@ -270,7 +269,7 @@ public class MojoExtension extends MavenDIExtension implements ParameterResolver
                     .orElseGet(() -> XmlNode.newInstance("config"));
             List<XmlNode> children = mojoParameters.stream()
                     .map(mp -> XmlNode.newInstance(mp.name(), mp.value()))
-                    .collect(Collectors.toList());
+                    .toList();
             XmlNode config = XmlNode.newInstance("configuration", null, null, children, null);
             pluginConfiguration = XmlService.merge(config, pluginConfiguration);
 

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/DefaultXmlService.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/DefaultXmlService.java
@@ -312,7 +312,7 @@ public class DefaultXmlService extends XmlService {
                         Iterator<XmlNode> it =
                                 commonChildren.computeIfAbsent(name, n1 -> Stream.of(dominant.children().stream()
                                                 .filter(n2 -> n2.name().equals(n1))
-                                                .collect(Collectors.toList()))
+                                                .toList())
                                         .filter(l -> !l.isEmpty())
                                         .map(List::iterator)
                                         .findFirst()


### PR DESCRIPTION
Modernize codebase with Java improvements - Use modern Java collections API (`toList()` instead of `Collectors.toList()`)

- https://github.com/apache/maven/pull/2277
- #2290
- https://github.com/checkstyle/checkstyle/issues/17000

