### PR TITLE
[MNG-8719] Restore Maven3 compat: model setInherited(boolean)

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -2550,7 +2550,10 @@
     @Deprecated
     public void unsetInheritanceApplied() {
     }
-
+    @Deprecated
+    public void setInherited(boolean value) {
+      setInherited("true");
+    }
             ]]>
           </code>
         </codeSegment>

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -2550,9 +2550,10 @@
     @Deprecated
     public void unsetInheritanceApplied() {
     }
+
     @Deprecated
     public void setInherited(boolean value) {
-      setInherited("true");
+      setInherited(Boolean.toString(value));
     }
             ]]>
           </code>


### PR DESCRIPTION
Added it as deprecated indirection for legacy code.

It was removed 1y ago probably by mistake by this commit:
https://github.com/apache/maven/commit/2a9f39336cec1d8e52d30cc48503d51ed8672536

---

https://issues.apache.org/jira/browse/MNG-8719