### PR TITLE
Fix `redundant` code in `DefaultPluginXmlFactory:write`

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
@@ -66,10 +66,9 @@ public class DefaultPluginXmlFactory implements PluginXmlFactory {
                 try (InputStream is = Files.newInputStream(path)) {
                     return xml.read(is, request.isStrict());
                 }
-            } else {
-                try (InputStream is = url.openStream()) {
-                    return xml.read(is, request.isStrict());
-                }
+            }
+            try (InputStream is = url.openStream()) {
+                return xml.read(is, request.isStrict());
             }
         } catch (Exception e) {
             throw new XmlReaderException("Unable to read plugin: " + getMessage(e), getLocation(e), e);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
@@ -25,6 +25,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.di.Named;
@@ -62,12 +63,8 @@ public class DefaultPluginXmlFactory implements PluginXmlFactory {
                 return xml.read(inputStream, request.isStrict());
             } else if (reader != null) {
                 return xml.read(reader, request.isStrict());
-            } else if (path != null) {
-                try (InputStream is = Files.newInputStream(path)) {
-                    return xml.read(is, request.isStrict());
-                }
             }
-            try (InputStream is = url.openStream()) {
+            try (InputStream is = Files.newInputStream(Objects.requireNonNull(path))) {
                 return xml.read(is, request.isStrict());
             }
         } catch (Exception e) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
@@ -48,10 +48,16 @@ public class DefaultPluginXmlFactory implements PluginXmlFactory {
 
     @Override
     public PluginDescriptor read(@Nonnull XmlReaderRequest request) throws XmlReaderException {
-        return read(request, requireNonNull(request).getPath(), request.getURL(), request.getReader(), request.getInputStream());
+        return read(
+                request,
+                requireNonNull(request).getPath(),
+                request.getURL(),
+                request.getReader(),
+                request.getInputStream());
     }
 
-    private static PluginDescriptor read(XmlReaderRequest request, Path path, URL url, Reader reader, InputStream inputStream) {
+    private static PluginDescriptor read(
+            XmlReaderRequest request, Path path, URL url, Reader reader, InputStream inputStream) {
         if (path == null && url == null && reader == null && inputStream == null) {
             throw new IllegalArgumentException("path, url, reader or inputStream must be non null");
         }
@@ -73,7 +79,11 @@ public class DefaultPluginXmlFactory implements PluginXmlFactory {
 
     @Override
     public void write(XmlWriterRequest<PluginDescriptor> request) throws XmlWriterException {
-        write(request.getWriter(), request.getOutputStream(), request.getPath(), requireNonNull(requireNonNull(request, "request").getContent(), "content"));
+        write(
+                request.getWriter(),
+                request.getOutputStream(),
+                request.getPath(),
+                requireNonNull(requireNonNull(request, "request").getContent(), "content"));
     }
 
     private static void write(Writer writer, OutputStream outputStream, Path path, PluginDescriptor content) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPluginXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPluginXmlFactoryTest.java
@@ -60,9 +60,9 @@ class DefaultPluginXmlFactoryReadWriteTest {
 
     private final DefaultPluginXmlFactory sut = new DefaultPluginXmlFactory();
 
-
     @TempDir
     Path tempDir;
+
     @Test
     void readFromInputStreamParsesPluginDescriptorCorrectly() {
         PluginDescriptor descriptor = sut.read(XmlReaderRequest.builder()
@@ -210,15 +210,16 @@ class DefaultPluginXmlFactoryReadWriteTest {
 
     @Test
     void writeWithNoTargetThrowsIllegalArgumentException() {
-        assertEquals("writer, outputStream or path must be non null",
+        assertEquals(
+                "writer, outputStream or path must be non null",
                 assertThrows(
-                        IllegalArgumentException.class,
-                        () -> sut.write(XmlWriterRequest.<PluginDescriptor>builder()
-                                .content(PluginDescriptor.newBuilder()
-                                        .name("No Output Plugin")
-                                        .build())
-                                .build())
-                ).getMessage());
+                                IllegalArgumentException.class,
+                                () -> sut.write(XmlWriterRequest.<PluginDescriptor>builder()
+                                        .content(PluginDescriptor.newBuilder()
+                                                .name("No Output Plugin")
+                                                .build())
+                                        .build()))
+                        .getMessage());
     }
 
     @Test
@@ -231,13 +232,13 @@ class DefaultPluginXmlFactoryReadWriteTest {
         assertTrue(exception.getMessage().contains("Unable to read plugin"));
         assertInstanceOf(Exception.class, exception.getCause());
     }
+
     @Test
     void locateExistingPomWithFilePathShouldReturnSameFileIfRegularFile() throws IOException {
         Path pomFile = Files.createTempFile(tempDir, "pom", ".xml");
         DefaultModelProcessor processor = new DefaultModelProcessor(mock(ModelXmlFactory.class), List.of());
         assertEquals(pomFile, processor.locateExistingPom(pomFile));
     }
-
 
     @Test
     void readFromUrlParsesPluginDescriptorCorrectly(@TempDir Path tempDir) throws Exception {
@@ -246,9 +247,8 @@ class DefaultPluginXmlFactoryReadWriteTest {
         URL url = xmlFile.toUri().toURL();
 
         // Create request with URL using reflection since builder doesn't have url() method
-        XmlReaderRequest request = XmlReaderRequest.builder()
-                .inputStream(url.openStream())
-                .build();
+        XmlReaderRequest request =
+                XmlReaderRequest.builder().inputStream(url.openStream()).build();
 
         PluginDescriptor descriptor = sut.read(request);
 
@@ -257,7 +257,4 @@ class DefaultPluginXmlFactoryReadWriteTest {
         assertEquals("sample-plugin", descriptor.getArtifactId());
         assertEquals("1.0.0", descriptor.getVersion());
     }
-
-
-
 }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPluginXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPluginXmlFactoryTest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.api.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.api.services.xml.XmlReaderException;
+import org.apache.maven.api.services.xml.XmlReaderRequest;
+import org.apache.maven.api.services.xml.XmlWriterException;
+import org.apache.maven.api.services.xml.XmlWriterRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultPluginXmlFactoryTest {
+
+    private DefaultPluginXmlFactory sut;
+    private static final String SAMPLE_PLUGIN_XML =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <plugin>
+              <name>Sample Plugin</name>
+              <groupId>org.example</groupId>
+              <artifactId>sample-plugin</artifactId>
+              <version>1.0.0</version>
+            </plugin>
+            """;
+
+    @BeforeEach
+    void setUp() {
+        sut = new DefaultPluginXmlFactory();
+    }
+
+    @Test
+    void shouldReadFromInputStream() {
+        PluginDescriptor descriptor = sut.read(XmlReaderRequest.builder()
+                .inputStream(new ByteArrayInputStream(SAMPLE_PLUGIN_XML.getBytes()))
+                .build());
+        assertEquals("Sample Plugin", descriptor.getName());
+        assertEquals("org.example", descriptor.getGroupId());
+        assertEquals("sample-plugin", descriptor.getArtifactId());
+        assertEquals("1.0.0", descriptor.getVersion());
+    }
+
+    @Test
+    void shouldReadFromReader() {
+        assertEquals(
+                "Sample Plugin",
+                sut.read(XmlReaderRequest.builder()
+                                .reader(new StringReader(SAMPLE_PLUGIN_XML))
+                                .build())
+                        .getName());
+    }
+
+    @Test
+    void shouldReadFromPath(@TempDir Path tempDir) throws Exception {
+        Path xmlFile = tempDir.resolve("plugin.xml");
+        Files.write(xmlFile, SAMPLE_PLUGIN_XML.getBytes());
+        assertEquals(
+                "Sample Plugin",
+                sut.read(XmlReaderRequest.builder().path(xmlFile).build()).getName());
+    }
+
+    @Test
+    void shouldThrowExceptionOnInvalidInput() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> sut.read(XmlReaderRequest.builder().build()));
+    }
+
+    @Test
+    void shouldWriteToWriter() {
+        StringWriter writer = new StringWriter();
+        sut.write(XmlWriterRequest.<PluginDescriptor>builder()
+                .writer(writer)
+                .content(PluginDescriptor.newBuilder()
+                        .name("Sample Plugin")
+                        .groupId("org.example")
+                        .artifactId("sample-plugin")
+                        .version("1.0.0")
+                        .build())
+                .build());
+        String output = writer.toString();
+        assertTrue(output.contains("<name>Sample Plugin</name>"));
+        assertTrue(output.contains("<groupId>org.example</groupId>"));
+    }
+
+    @Test
+    void shouldWriteToOutputStream() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        sut.write(XmlWriterRequest.<PluginDescriptor>builder()
+                .outputStream(outputStream)
+                .content(PluginDescriptor.newBuilder().name("Sample Plugin").build())
+                .build());
+        assertTrue(outputStream.toString().contains("<name>Sample Plugin</name>"));
+    }
+
+    @Test
+    void shouldWriteToPath(@TempDir Path tempDir) throws Exception {
+        Path xmlFile = tempDir.resolve("output-plugin.xml");
+        sut.write(XmlWriterRequest.<PluginDescriptor>builder()
+                .path(xmlFile)
+                .content(PluginDescriptor.newBuilder().name("Sample Plugin").build())
+                .build());
+        assertTrue(Files.readString(xmlFile).contains("<name>Sample Plugin</name>"));
+    }
+
+    @Test
+    void shouldParseValidXmlString() {
+        PluginDescriptor descriptor = sut.fromXmlString(SAMPLE_PLUGIN_XML);
+        assertEquals("Sample Plugin", descriptor.getName());
+        assertEquals("org.example", descriptor.getGroupId());
+        assertEquals("sample-plugin", descriptor.getArtifactId());
+        assertEquals("1.0.0", descriptor.getVersion());
+    }
+
+    @Test
+    void shouldGenerateValidXmlString() {
+        String xml = sut.toXmlString(PluginDescriptor.newBuilder()
+                .name("Sample Plugin")
+                .groupId("org.example")
+                .artifactId("sample-plugin")
+                .version("1.0.0")
+                .build());
+        assertTrue(xml.contains("<name>Sample Plugin</name>"));
+        assertTrue(xml.contains("<groupId>org.example</groupId>"));
+        assertTrue(xml.contains("<artifactId>sample-plugin</artifactId>"));
+        assertTrue(xml.contains("<version>1.0.0</version>"));
+    }
+
+    @Test
+    void shouldParseXmlUsingStaticMethod() {
+        PluginDescriptor descriptor = DefaultPluginXmlFactory.fromXml(SAMPLE_PLUGIN_XML);
+        assertEquals("Sample Plugin", descriptor.getName());
+        assertEquals("org.example", descriptor.getGroupId());
+        assertEquals("sample-plugin", descriptor.getArtifactId());
+        assertEquals("1.0.0", descriptor.getVersion());
+    }
+
+    @Test
+    void shouldGenerateXmlUsingStaticMethod() {
+        PluginDescriptor descriptor = PluginDescriptor.newBuilder()
+                .name("Sample Plugin")
+                .groupId("org.example")
+                .artifactId("sample-plugin")
+                .version("1.0.0")
+                .build();
+        String xml = DefaultPluginXmlFactory.toXml(descriptor);
+        assertTrue(xml.contains("<name>Sample Plugin</name>"));
+        assertTrue(xml.contains("<groupId>org.example</groupId>"));
+        assertTrue(xml.contains("<artifactId>sample-plugin</artifactId>"));
+        assertTrue(xml.contains("<version>1.0.0</version>"));
+    }
+
+    @Test
+    void shouldThrowXmlWriterExceptionWhenWriteFails() {
+        XmlWriterException exception = assertThrows(
+                XmlWriterException.class,
+                () -> sut.write(XmlWriterRequest.<PluginDescriptor>builder()
+                        .writer(new Writer() {
+                            @Override
+                            public void write(char[] cbuf, int off, int len) {
+                                throw new RuntimeException("Simulated failure");
+                            }
+
+                            @Override
+                            public void flush() {}
+
+                            @Override
+                            public void close() {}
+                        })
+                        .content(PluginDescriptor.newBuilder()
+                                .name("Failing Plugin")
+                                .build())
+                        .build()));
+        assertTrue(exception.getMessage().contains("Unable to write plugin"));
+        assertInstanceOf(RuntimeException.class, exception.getCause());
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenNoWriteTargetProvided() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> sut.write(XmlWriterRequest.<PluginDescriptor>builder()
+                        .content(PluginDescriptor.newBuilder()
+                                .name("No Output Plugin")
+                                .build())
+                        .build()));
+
+        assertEquals("writer, outputStream or path must be non null", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowXmlReaderExceptionOnMalformedXml() {
+        XmlReaderException exception = assertThrows(
+                XmlReaderException.class,
+                () -> sut.read(XmlReaderRequest.builder()
+                        .inputStream(new ByteArrayInputStream("<plugin><name>Broken Plugin".getBytes()))
+                        .build()));
+        assertTrue(exception.getMessage().contains("Unable to read plugin"));
+        assertInstanceOf(Exception.class, exception.getCause());
+    }
+}

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPluginXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPluginXmlFactoryTest.java
@@ -18,14 +18,23 @@
  */
 package org.apache.maven.impl;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.maven.api.plugin.descriptor.PluginDescriptor;
-import org.apache.maven.api.services.xml.*;
+import org.apache.maven.api.services.xml.ModelXmlFactory;
+import org.apache.maven.api.services.xml.XmlReaderException;
+import org.apache.maven.api.services.xml.XmlReaderRequest;
+import org.apache.maven.api.services.xml.XmlWriterException;
+import org.apache.maven.api.services.xml.XmlWriterRequest;
 import org.apache.maven.impl.model.DefaultModelProcessor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -51,6 +60,9 @@ class DefaultPluginXmlFactoryReadWriteTest {
 
     private final DefaultPluginXmlFactory sut = new DefaultPluginXmlFactory();
 
+
+    @TempDir
+    Path tempDir;
     @Test
     void readFromInputStreamParsesPluginDescriptorCorrectly() {
         PluginDescriptor descriptor = sut.read(XmlReaderRequest.builder()
@@ -219,9 +231,6 @@ class DefaultPluginXmlFactoryReadWriteTest {
         assertTrue(exception.getMessage().contains("Unable to read plugin"));
         assertInstanceOf(Exception.class, exception.getCause());
     }
-
-    @TempDir
-    Path tempDir;
     @Test
     void locateExistingPomWithFilePathShouldReturnSameFileIfRegularFile() throws IOException {
         Path pomFile = Files.createTempFile(tempDir, "pom", ".xml");


### PR DESCRIPTION
Fix `redundant` code in `DefaultPluginXmlFactory:write` - avoiding `DRY` increasing `cohesion` lowering `coupling`

- https://github.com/apache/maven/pull/2303

fix `unreachable` code:

https://github.com/apache/maven/blob/6be7a126d5778e781102445658da0b54b97df0e2/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java#L103


imho, this branch can never happen:

<img width="1841" alt="image" src="https://github.com/user-attachments/assets/194e9dd9-e450-4845-af63-8dcfbb6c1cdf" />

## because of early exit check before

This is too defensive over here. The last `if-else` is the actual final possible condition and therefore should just return:

Its `double-trouble` anyway and therefore `DRY violation` -  its a smell in eyes. 🎃

<img width="1664" alt="image" src="https://github.com/user-attachments/assets/02c3a577-ff3a-4ecb-824c-25f36fb2864c" />

<img width="883" alt="image" src="https://github.com/user-attachments/assets/e9475f4d-7b8d-48cf-acda-f273ab5b2386" />

<img width="1820" alt="image" src="https://github.com/user-attachments/assets/0b6514b7-389c-49da-aa37-72f509432fba" />




