### PR TITLE
Improve invoker test

### DIFF
--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
@@ -109,14 +109,20 @@ public abstract class MavenInvokerTestSupport {
                 ByteArrayOutputStream stderr = new ByteArrayOutputStream();
                 List<String> mvnArgs = new ArrayList<>(args);
                 mvnArgs.add(goal);
-                int exitCode = invoker.invoke(
-                        parser.parseInvocation(ParserRequest.mvn(mvnArgs, new JLineMessageBuilderFactory())
-                                .cwd(cwd)
-                                .userHome(userHome)
-                                .stdOut(stdout)
-                                .stdErr(stderr)
-                                .embedded(true)
-                                .build()));
+                int exitCode = -1;
+                Exception exception = null;
+                try {
+                    exitCode = invoker.invoke(
+                            parser.parseInvocation(ParserRequest.mvn(mvnArgs, new JLineMessageBuilderFactory())
+                                    .cwd(cwd)
+                                    .userHome(userHome)
+                                    .stdOut(stdout)
+                                    .stdErr(stderr)
+                                    .embedded(true)
+                                    .build()));
+                } catch (Exception e) {
+                    exception = e;
+                }
 
                 // dump things out
                 System.out.println("===================================================");
@@ -132,7 +138,11 @@ public abstract class MavenInvokerTestSupport {
                 System.err.println("===================================================");
 
                 logs.put(goal, stdout.toString());
-                assertEquals(0, exitCode, "OUT:" + stdout + "\nERR:" + stderr);
+                if (exception != null) {
+                    throw exception;
+                } else {
+                    assertEquals(0, exitCode, "OUT:" + stdout + "\nERR:" + stderr);
+                }
             }
         }
         return logs;


### PR DESCRIPTION
No issue, as this is more about the MavenInvoker UTs. When invocation was throwing (and some test cases expect that), the whole maven output and possible errors were lost, making it hard to figure out in case of unexpected exit.

Now the test always emit, even if (expected) InvocationEx is being thrown.
