### PR TITLE
Include module `core-its`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@ under the License.
     <module>impl</module>
     <module>compat</module>
     <module>apache-maven</module>
+    <module>its</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
enabler for: 
- https://github.com/apache/maven/pull/2319

I wonder why it’s not included. I was thinking about this, assuming it might be related to integration tests—and it turned out to be true.

Why not provide this information upfront?

If it’s resource-intensive, it should only run in a dedicated stage.

Ignore whats actually there seems strange:

<img width="1110" alt="image" src="https://github.com/user-attachments/assets/bb52fd38-fbea-46bb-bc9c-3e0cac0e4298" />


`use` it or `loose` it.