### PR TITLE
fix spelling leveraging Oxford comma

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -121,7 +121,7 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
         Writer writer = request.getWriter();
         Function<Object, String> inputLocationFormatter = request.getInputLocationFormatter();
         if (writer == null && outputStream == null && path == null) {
-            throw new IllegalArgumentException("writer, outputStream or path must be non null");
+            throw new IllegalArgumentException("writer, output stream, or path must be non-null");
         }
         try {
             MavenStaxWriter w = new MavenStaxWriter();

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPluginXmlFactory.java
@@ -84,7 +84,7 @@ public class DefaultPluginXmlFactory implements PluginXmlFactory {
         OutputStream outputStream = request.getOutputStream();
         Writer writer = request.getWriter();
         if (writer == null && outputStream == null && path == null) {
-            throw new IllegalArgumentException("writer, outputStream or path must be non null");
+            throw new IllegalArgumentException("writer, output stream, or path must be non-null");
         }
         try {
             if (writer != null) {


### PR DESCRIPTION
> comma after outputStream and outputStream --> output stream

https://github.com/apache/maven/pull/2306#discussion_r2083233316

https://github.com/apache/maven/pull/2312/files#r2083278342

enabler for:
- https://github.com/apache/maven/pull/2312

`outputStream or path must be non null` evolves to -> 
`No valid input source given.`

New sentence start with upper case, we well. Especially when talking about Oxford and articles.

but we have inconsistency already.

<img width="45" alt="image" src="https://github.com/user-attachments/assets/65af2779-4b79-4c15-8c1d-b57325dc2984" />
