### PR TITLE
[POC] Migrate to `Java 21` - infrastructure

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
 
       - name: Checkout maven

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Do you like Apache Maven? Then [donate back to the ASF](https://www.apache.org/f
 Quick Build
 -------
 If you want to bootstrap Maven, you'll need:
-- Java 17+
+- Java 21+
 - Maven 3.6.3 or later
 - Run Maven, specifying a location into which the completed Maven distro should be installed:
     ```

--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -108,7 +108,7 @@ else
 fi
 
 if ! "$JAVACMD" --enable-native-access=ALL-UNNAMED -version >/dev/null 2>&1; then
-  echo "Error: Apache Maven 4.x requires Java 17 or newer to run." >&2
+  echo "Error: Apache Maven 4.x requires Java 21 or newer to run." >&2
   "$JAVACMD" -version >&2
   echo "Please upgrade your Java installation or set JAVA_HOME to point to a compatible JDK." >&2
   exit 1

--- a/apache-maven/src/assembly/maven/bin/mvn.cmd
+++ b/apache-maven/src/assembly/maven/bin/mvn.cmd
@@ -70,10 +70,10 @@ if not exist "%JAVACMD%" (
   goto error
 )
 
-@REM Check Java version by testing the Java 17+ flag
+@REM Check Java version by testing the Java 21+ flag
 "%JAVACMD%" --enable-native-access=ALL-UNNAMED -version >nul 2>&1
 if ERRORLEVEL 1 (
-    echo Error: Apache Maven 4.x requires Java 17 or newer to run. >&2
+    echo Error: Apache Maven 4.x requires Java 21 or newer to run. >&2
     "%JAVACMD%" -version >&2
     echo Please upgrade your Java installation or set JAVA_HOME to point to a compatible JDK. >&2
     goto error

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -2107,7 +2107,7 @@
 
             <p>If a target version, different from the base version, is specified for resources or script files,
             then this value modifies the directory where the files will be copied.
-            For example, if {@code targetVersion} is 17, then the {@code foo/bar.properties}
+            For example, if {@code targetVersion} is 21, then the {@code foo/bar.properties}
             resource file will be copied as {@code META-INF/versions/17/foo/bar.properties}.</p>
 
             <p>This element can be combined with the {@code module} element for specifying sources,

--- a/impl/maven-impl/src/test/resources/poms/factory/props-and-profiles-grand-parent.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/props-and-profiles-grand-parent.xml
@@ -27,7 +27,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <maven.compiler.release>17</maven.compiler.release>
+                <maven.compiler.release>21</maven.compiler.release>
             </properties>
         </profile>
     </profiles>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7737ProfileActivationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7737ProfileActivationTest.java
@@ -53,7 +53,7 @@ class MavenITmng7737ProfileActivationTest extends AbstractMavenIntegrationTestCa
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        // Example output on my Linux Box w/ Java 17
+        // Example output on my Linux Box w/ Java 21
         // The following profiles are active:
         //
         // - settings-active-default (source: external)
@@ -61,6 +61,7 @@ class MavenITmng7737ProfileActivationTest extends AbstractMavenIntegrationTestCa
         // - settings-jdk-8 (source: external)
         // - settings-jdk-11 (source: external)
         // - settings-jdk-17 (source: external)
+        // - settings-jdk-21 (source: external)
         // - settings-os-unix (source: external)
         // - settings-property (source: external)
         // - settings-file-exists-present (source: external)
@@ -69,6 +70,7 @@ class MavenITmng7737ProfileActivationTest extends AbstractMavenIntegrationTestCa
         // - pom-jdk-8 (source: org.apache.maven.its.mng7737:test:0.1)
         // - pom-jdk-11 (source: org.apache.maven.its.mng7737:test:0.1)
         // - pom-jdk-17 (source: org.apache.maven.its.mng7737:test:0.1)
+        // - pom-jdk-21 (source: org.apache.maven.its.mng7737:test:0.1)
         // - pom-os-unix (source: org.apache.maven.its.mng7737:test:0.1)
         // - pom-property (source: org.apache.maven.its.mng7737:test:0.1)
         // - pom-file-exists-present (source: org.apache.maven.its.mng7737:test:0.1)

--- a/its/core-it-suite/src/test/resources/mng-7587-jsr330/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-7587-jsr330/plugin/pom.xml
@@ -69,7 +69,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>17</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <plugin>

--- a/its/core-it-suite/src/test/resources/mng-7737-profiles/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-7737-profiles/pom.xml
@@ -59,6 +59,12 @@ under the License.
       </activation>
     </profile>
     <profile>
+      <id>pom-jdk-21</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+    </profile>
+    <profile>
       <id>pom-os-unix</id>
       <activation>
         <os>

--- a/its/core-it-suite/src/test/resources/mng-7737-profiles/settings.xml
+++ b/its/core-it-suite/src/test/resources/mng-7737-profiles/settings.xml
@@ -49,6 +49,12 @@ under the License.
       </activation>
     </profile>
     <profile>
+      <id>settings-jdk-21</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+    </profile>
+    <profile>
       <id>settings-os-unix</id>
       <activation>
         <os>

--- a/its/core-it-suite/src/test/resources/mng-8336-unknown-packaging/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8336-unknown-packaging/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>maven-repro</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
   </properties>
   <dependencies>
     <dependency>
@@ -20,7 +20,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <release>17</release>
+          <release>21</release>
         </configuration>
       </plugin>
     </plugins>

--- a/its/core-it-suite/src/test/resources/mng-8461/extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8461/extension/pom.xml
@@ -7,8 +7,8 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/pom.xml
@@ -30,7 +30,7 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <javaVersion>17</javaVersion>
+    <javaVersion>21</javaVersion>
     <guiceVersion>6.0.0</guiceVersion>
     <mavenVersion>4.0.0-beta-5</mavenVersion>
     <mavenPluginPluginVersion>4.0.0-beta-1</mavenPluginPluginVersion>

--- a/its/core-it-suite/src/test/resources/mng-8527-consumer-pom/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8527-consumer-pom/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
   <properties>
     <mavenVersion>4.0.0-rc-2</mavenVersion>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>17</javaVersion>
+    <javaVersion>21</javaVersion>
     <maven.compiler.source>${javaVersion}</maven.compiler.source>
     <maven.compiler.target>${javaVersion}</maven.compiler.target>
     <maven.compiler.release>${javaVersion}</maven.compiler.release>
@@ -880,7 +880,7 @@ under the License.</licenseText>
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[17,)</version>
+                  <version>[21,)</version>
                 </requireJavaVersion>
                 <enforceBytecodeVersion>
                   <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>


### PR DESCRIPTION
[POC] Migrate to `Java 21` - infrastructure

depends on:
- https://github.com/apache/maven/pull/2315

enabler for: 
- https://github.com/apache/maven/pull/2281
- https://github.com/apache/maven/pull/2281#pullrequestreview-2813199057

> We need a separate PR for bumping the required JDK to 21. Other PRs can follow and be based on that one.

WOMM

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/9203369a-7227-438a-a6ad-22ca0a67bde5" />
