### PR TITLE
[MNG-8726] Bump jlineVersion from 3.29.0 to 3.30.0

### DIFF
--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
@@ -226,6 +226,11 @@ public class FastTerminal implements TerminalExt {
     }
 
     @Override
+    public MouseTracking getCurrentMouseTracking() {
+        return getTerminal().getCurrentMouseTracking();
+    }
+
+    @Override
     public boolean trackMouse(MouseTracking mouseTracking) {
         return getTerminal().trackMouse(mouseTracking);
     }
@@ -238,6 +243,16 @@ public class FastTerminal implements TerminalExt {
     @Override
     public MouseEvent readMouseEvent(IntSupplier intSupplier) {
         return getTerminal().readMouseEvent(intSupplier);
+    }
+
+    @Override
+    public MouseEvent readMouseEvent(String prefix) {
+        return getTerminal().readMouseEvent(prefix);
+    }
+
+    @Override
+    public MouseEvent readMouseEvent(IntSupplier reader, String prefix) {
+        return getTerminal().readMouseEvent(reader, prefix);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@ under the License.
     <hamcrestVersion>3.0</hamcrestVersion>
     <jakartaInjectApiVersion>2.0.1</jakartaInjectApiVersion>
     <javaxAnnotationApiVersion>1.3.2</javaxAnnotationApiVersion>
-    <jlineVersion>3.29.0</jlineVersion>
+    <jlineVersion>3.30.0</jlineVersion>
     <junitVersion>5.12.2</junitVersion>
     <jxpathVersion>1.4.0</jxpathVersion>
     <logbackClassicVersion>1.5.18</logbackClassicVersion>


### PR DESCRIPTION
Also, add newly introduced methods to `FastTerminal`.

JLine 3.30.0 release notes:
https://github.com/jline/jline3/releases/tag/jline-3.30.0

---

https://issues.apache.org/jira/browse/MNG-8726
