### PR TITLE
[POC] `rewrite-maven-plugin`: Migrate to `JUnit 5` from `JUnit 4`

### DIFF
--- a/api/maven-api-core/src/test/java/org/apache/maven/api/MonotonicClockTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/MonotonicClockTest.java
@@ -37,7 +37,7 @@ class MonotonicClockTest {
 
     @Test
     @DisplayName("MonotonicClock singleton instance should always return the same instance")
-    void testSingletonInstance() {
+    void singletonInstance() {
         MonotonicClock clock1 = MonotonicClock.get();
         MonotonicClock clock2 = MonotonicClock.get();
 
@@ -46,7 +46,7 @@ class MonotonicClockTest {
 
     @Test
     @DisplayName("MonotonicClock should always use UTC timezone")
-    void testClockTimezone() {
+    void clockTimezone() {
         MonotonicClock clock = MonotonicClock.get();
 
         assertEquals(ZoneOffset.UTC, clock.getZone(), "Clock should use UTC timezone");
@@ -58,7 +58,7 @@ class MonotonicClockTest {
 
     @Test
     @DisplayName("MonotonicClock should maintain monotonic time progression")
-    void testMonotonicBehavior() throws InterruptedException {
+    void monotonicBehavior() throws InterruptedException {
         Instant first = MonotonicClock.now();
         Thread.sleep(10); // Small delay
         Instant second = MonotonicClock.now();
@@ -71,7 +71,7 @@ class MonotonicClockTest {
 
     @Test
     @DisplayName("MonotonicClock elapsed time should increase")
-    void testElapsedTime() throws InterruptedException {
+    void elapsedTime() throws InterruptedException {
         Duration initial = MonotonicClock.elapsed();
         Thread.sleep(50); // Longer delay for more reliable measurement
         Duration later = MonotonicClock.elapsed();
@@ -84,7 +84,7 @@ class MonotonicClockTest {
 
     @Test
     @DisplayName("MonotonicClock start time should remain constant")
-    void testStartTime() throws InterruptedException {
+    void startTime() throws InterruptedException {
         Instant start1 = MonotonicClock.start();
         Thread.sleep(10);
         Instant start2 = MonotonicClock.start();
@@ -99,7 +99,7 @@ class MonotonicClockTest {
 
         @Test
         @DisplayName("Current time should be after start time")
-        void testCurrentTimeAfterStart() {
+        void currentTimeAfterStart() {
             Instant now = MonotonicClock.now();
             Instant start = MonotonicClock.start();
 
@@ -108,7 +108,7 @@ class MonotonicClockTest {
 
         @Test
         @DisplayName("Elapsed time should match time difference")
-        void testElapsedTimeConsistency() {
+        void elapsedTimeConsistency() {
             MonotonicClock clock = MonotonicClock.get();
             Instant now = clock.instant();
             Duration elapsed = clock.elapsedTime();
@@ -123,7 +123,7 @@ class MonotonicClockTest {
 
     @Test
     @DisplayName("MonotonicClock should handle rapid successive calls")
-    void testRapidCalls() {
+    void rapidCalls() {
         Instant[] instants = new Instant[1000];
         for (int i = 0; i < instants.length; i++) {
             instants[i] = MonotonicClock.now();
@@ -139,7 +139,7 @@ class MonotonicClockTest {
 
     @Test
     @DisplayName("MonotonicClock should maintain reasonable alignment with system time")
-    void testSystemTimeAlignment() {
+    void systemTimeAlignment() {
         Instant monotonic = MonotonicClock.now();
         Instant system = Instant.now();
 

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/services/RequestImplementationTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/services/RequestImplementationTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.mock;
 class RequestImplementationTest {
 
     @Test
-    void testArtifactResolverRequestEquality() {
+    void artifactResolverRequestEquality() {
         Session session = mock(Session.class);
         ArtifactCoordinates coords1 = mock(ArtifactCoordinates.class);
         ArtifactCoordinates coords2 = mock(ArtifactCoordinates.class);
@@ -74,7 +74,7 @@ class RequestImplementationTest {
     }
 
     @Test
-    void testRequestTraceIntegration() {
+    void requestTraceIntegration() {
         Session session = mock(Session.class);
         RequestTrace trace = new RequestTrace("test-context", null, "test-data");
 
@@ -86,7 +86,7 @@ class RequestImplementationTest {
     }
 
     @Test
-    void testDependencyResolverRequestEquality() {
+    void dependencyResolverRequestEquality() {
         Session session = mock(Session.class);
 
         DependencyResolverRequest.DependencyResolverRequestBuilder builder = DependencyResolverRequest.builder();

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/services/RequestTraceTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/services/RequestTraceTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 class RequestTraceTest {
 
     @Test
-    void testRequestTraceCreation() {
+    void requestTraceCreation() {
         RequestTrace parentTrace = new RequestTrace("parent-context", null, "parent-data");
         RequestTrace childTrace = new RequestTrace("child-context", parentTrace, "child-data");
 
@@ -41,7 +41,7 @@ class RequestTraceTest {
     }
 
     @Test
-    void testRequestTraceWithParentContextInheritance() {
+    void requestTraceWithParentContextInheritance() {
         RequestTrace parentTrace = new RequestTrace("parent-context", null, "parent-data");
         RequestTrace childTrace = new RequestTrace(parentTrace, "child-data");
 
@@ -51,14 +51,14 @@ class RequestTraceTest {
     }
 
     @Test
-    void testPredefinedContexts() {
+    void predefinedContexts() {
         assertEquals("plugin", RequestTrace.CONTEXT_PLUGIN);
         assertEquals("project", RequestTrace.CONTEXT_PROJECT);
         assertEquals("bootstrap", RequestTrace.CONTEXT_BOOTSTRAP);
     }
 
     @Test
-    void testNullValues() {
+    void nullValues() {
         RequestTrace trace = new RequestTrace(null, null, null);
         assertNull(trace.context());
         assertNull(trace.parent());
@@ -66,7 +66,7 @@ class RequestTraceTest {
     }
 
     @Test
-    void testChainedTraces() {
+    void chainedTraces() {
         RequestTrace root = new RequestTrace("root", null, "root-data");
         RequestTrace level1 = new RequestTrace("level1", root, "level1-data");
         RequestTrace level2 = new RequestTrace("level2", level1, "level2-data");

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
@@ -43,7 +43,7 @@ class SourcesTest {
     Path tempDir;
 
     @Test
-    void testFromPath() {
+    void fromPath() {
         Path path = Paths.get("/tmp");
         Source source = Sources.fromPath(path);
 
@@ -53,7 +53,7 @@ class SourcesTest {
     }
 
     @Test
-    void testBuildSource() {
+    void buildSource() {
         Path path = Paths.get("/tmp");
         ModelSource source = Sources.buildSource(path);
 
@@ -63,7 +63,7 @@ class SourcesTest {
     }
 
     @Test
-    void testResolvedSource() {
+    void resolvedSource() {
         Path path = Paths.get("/tmp");
         String location = "custom-location";
         ModelSource source = Sources.resolvedSource(path, location);
@@ -75,7 +75,7 @@ class SourcesTest {
     }
 
     @Test
-    void testPathSourceFunctionality() {
+    void pathSourceFunctionality() {
         // Test basic source functionality
         Path path = Paths.get("/tmp");
         Sources.PathSource source = (Sources.PathSource) Sources.fromPath(path);
@@ -89,7 +89,7 @@ class SourcesTest {
     }
 
     @Test
-    void testBuildPathSourceFunctionality() {
+    void buildPathSourceFunctionality() {
         // Test build source functionality
         Path basePath = Paths.get("/tmp");
         ModelSource.ModelLocator locator = mock(ModelSource.ModelLocator.class);
@@ -107,7 +107,7 @@ class SourcesTest {
     }
 
     @Test
-    void testResolvedPathSourceFunctionality() {
+    void resolvedPathSourceFunctionality() {
         // Test resolved source functionality
         Path path = Paths.get("/tmp");
         String location = "custom-location";
@@ -123,7 +123,7 @@ class SourcesTest {
     }
 
     @Test
-    void testStreamReading() throws IOException {
+    void streamReading() throws IOException {
         // Test stream reading functionality
         Path testFile = tempDir.resolve("test.txt");
         String content = "test content";
@@ -137,7 +137,7 @@ class SourcesTest {
     }
 
     @Test
-    void testNullHandling() {
+    void nullHandling() {
         assertThrows(NullPointerException.class, () -> Sources.fromPath(null));
         assertThrows(NullPointerException.class, () -> Sources.buildSource(null));
         assertThrows(NullPointerException.class, () -> Sources.resolvedSource(null, "location"));

--- a/api/maven-api-plugin/src/test/java/org/apache/maven/api/plugin/descriptor/another/ExtendedPluginDescriptorTest.java
+++ b/api/maven-api-plugin/src/test/java/org/apache/maven/api/plugin/descriptor/another/ExtendedPluginDescriptorTest.java
@@ -63,7 +63,7 @@ class ExtendedPluginDescriptorTest {
     }
 
     @Test
-    void testExtendedPluginDescriptor() {
+    void extendedPluginDescriptor() {
         ExtendedPluginDescriptor.Builder builder = new ExtendedPluginDescriptor.Builder();
         // make sure to call the subclasses' builder methods first, otherwise fluent API would not work
         builder.additionalField("additional")

--- a/api/maven-api-settings/src/test/java/org/apache/maven/api/settings/SettingsTest.java
+++ b/api/maven-api-settings/src/test/java/org/apache/maven/api/settings/SettingsTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class SettingsTest {
 
     @Test
-    void testSetLocalRepository() {
+    void setLocalRepository() {
         Settings s = Settings.newInstance();
 
         s = s.withLocalRepository("xxx");

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/ArtifactUtilsTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/ArtifactUtilsTest.java
@@ -41,7 +41,7 @@ class ArtifactUtilsTest {
     }
 
     @Test
-    void testIsSnapshot() {
+    void isSnapshot() {
         assertFalse(ArtifactUtils.isSnapshot(null));
         assertFalse(ArtifactUtils.isSnapshot(""));
         assertFalse(ArtifactUtils.isSnapshot("1.2.3"));
@@ -52,7 +52,7 @@ class ArtifactUtilsTest {
     }
 
     @Test
-    void testToSnapshotVersion() {
+    void toSnapshotVersion() {
         assertEquals("1.2.3", ArtifactUtils.toSnapshotVersion("1.2.3"));
         assertEquals("1.2.3-SNAPSHOT", ArtifactUtils.toSnapshotVersion("1.2.3-SNAPSHOT"));
         assertEquals("1.2.3-SNAPSHOT", ArtifactUtils.toSnapshotVersion("1.2.3-20090413.094722-2"));
@@ -63,7 +63,7 @@ class ArtifactUtilsTest {
      * Tests that the ordering of the map resembles the ordering of the input collection of artifacts.
      */
     @Test
-    void testArtifactMapByVersionlessIdOrdering() throws Exception {
+    void artifactMapByVersionlessIdOrdering() throws Exception {
         List<Artifact> list = new ArrayList<>();
         list.add(newArtifact("b"));
         list.add(newArtifact("a"));

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/DefaultArtifactTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/DefaultArtifactTest.java
@@ -66,7 +66,7 @@ class DefaultArtifactTest {
     }
 
     @Test
-    void testGetVersionReturnsResolvedVersionOnSnapshot() {
+    void getVersionReturnsResolvedVersionOnSnapshot() {
         assertEquals(snapshotResolvedVersion, snapshotArtifact.getVersion());
 
         // this is FOUL!
@@ -76,24 +76,24 @@ class DefaultArtifactTest {
     }
 
     @Test
-    void testGetDependencyConflictId() {
+    void getDependencyConflictId() {
         assertEquals(groupId + ":" + artifactId + ":" + type + ":" + classifier, artifact.getDependencyConflictId());
     }
 
     @Test
-    void testGetDependencyConflictIdNullGroupId() {
+    void getDependencyConflictIdNullGroupId() {
         artifact.setGroupId(null);
         assertEquals(null + ":" + artifactId + ":" + type + ":" + classifier, artifact.getDependencyConflictId());
     }
 
     @Test
-    void testGetDependencyConflictIdNullClassifier() {
+    void getDependencyConflictIdNullClassifier() {
         artifact = new DefaultArtifact(groupId, artifactId, versionRange, scope, type, null, artifactHandler);
         assertEquals(groupId + ":" + artifactId + ":" + type, artifact.getDependencyConflictId());
     }
 
     @Test
-    void testGetDependencyConflictIdNullScope() {
+    void getDependencyConflictIdNullScope() {
         artifact.setScope(null);
         assertEquals(groupId + ":" + artifactId + ":" + type + ":" + classifier, artifact.getDependencyConflictId());
     }
@@ -106,25 +106,25 @@ class DefaultArtifactTest {
     }
 
     @Test
-    void testToStringNullGroupId() {
+    void toStringNullGroupId() {
         artifact.setGroupId(null);
         assertEquals(artifactId + ":" + type + ":" + classifier + ":" + version + ":" + scope, artifact.toString());
     }
 
     @Test
-    void testToStringNullClassifier() {
+    void toStringNullClassifier() {
         artifact = new DefaultArtifact(groupId, artifactId, versionRange, scope, type, null, artifactHandler);
         assertEquals(groupId + ":" + artifactId + ":" + type + ":" + version + ":" + scope, artifact.toString());
     }
 
     @Test
-    void testToStringNullScope() {
+    void toStringNullScope() {
         artifact.setScope(null);
         assertEquals(groupId + ":" + artifactId + ":" + type + ":" + classifier + ":" + version, artifact.toString());
     }
 
     @Test
-    void testComparisonByVersion() {
+    void comparisonByVersion() {
         Artifact artifact1 = new DefaultArtifact(
                 groupId, artifactId, VersionRange.createFromVersion("5.0"), scope, type, classifier, artifactHandler);
         Artifact artifact2 = new DefaultArtifact(
@@ -135,12 +135,12 @@ class DefaultArtifactTest {
 
         Artifact artifact = new DefaultArtifact(
                 groupId, artifactId, VersionRange.createFromVersion("5.0"), scope, type, classifier, artifactHandler);
-        assertTrue(artifact.compareTo(artifact1) == 0);
-        assertTrue(artifact1.compareTo(artifact) == 0);
+        assertEquals(0, artifact.compareTo(artifact1));
+        assertEquals(0, artifact1.compareTo(artifact));
     }
 
     @Test
-    void testNonResolvedVersionRangeConsistentlyYieldsNullVersions() throws Exception {
+    void nonResolvedVersionRangeConsistentlyYieldsNullVersions() throws Exception {
         VersionRange vr = VersionRange.createFromVersionSpec("[1.0,2.0)");
         artifact = new DefaultArtifact(groupId, artifactId, vr, scope, type, null, artifactHandler);
         assertNull(artifact.getVersion());
@@ -148,7 +148,7 @@ class DefaultArtifactTest {
     }
 
     @Test
-    void testMNG7780() throws Exception {
+    void mng7780() throws Exception {
         VersionRange vr = VersionRange.createFromVersionSpec("[1.0,2.0)");
         artifact = new DefaultArtifact(groupId, artifactId, vr, scope, type, null, artifactHandler);
         assertNull(artifact.getVersion());
@@ -161,7 +161,7 @@ class DefaultArtifactTest {
 
     @ParameterizedTest
     @MethodSource("invalidMavenCoordinates")
-    void testIllegalCoordinatesInConstructor(String groupId, String artifactId, String version) {
+    void illegalCoordinatesInConstructor(String groupId, String artifactId, String version) {
         assertThrows(
                 InvalidArtifactRTException.class,
                 () -> new DefaultArtifact(

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -123,17 +123,17 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testVersionsQualifier() {
+    void versionsQualifier() {
         checkVersionsOrder(VERSIONS_QUALIFIER);
     }
 
     @Test
-    void testVersionsNumber() {
+    void versionsNumber() {
         checkVersionsOrder(VERSIONS_NUMBER);
     }
 
     @Test
-    void testVersionsEqual() {
+    void versionsEqual() {
         newComparable("1.0-alpha");
         checkVersionsEqual("1", "1");
         checkVersionsEqual("1", "1.0");
@@ -173,7 +173,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testVersionsHaveSameOrderButAreNotEqual() {
+    void versionsHaveSameOrderButAreNotEqual() {
         checkVersionsHaveSameOrder("1ga", "1");
         checkVersionsHaveSameOrder("1release", "1");
         checkVersionsHaveSameOrder("1final", "1");
@@ -188,7 +188,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testVersionComparing() {
+    void versionComparing() {
         checkVersionsOrder("1", "2");
         checkVersionsOrder("1.5", "2");
         checkVersionsOrder("1", "2.5");
@@ -219,13 +219,13 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testLeadingZeroes() {
+    void leadingZeroes() {
         checkVersionsOrder("0.7", "2");
         checkVersionsOrder("0.2", "1.0.7");
     }
 
     @Test
-    void testDigitGreaterThanNonAscii() {
+    void digitGreaterThanNonAscii() {
         ComparableVersion c1 = new ComparableVersion("1");
         ComparableVersion c2 = new ComparableVersion("é");
         assertTrue(c1.compareTo(c2) > 0, "expected " + "1" + " > " + "\uD835\uDFE4");
@@ -233,7 +233,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testDigitGreaterThanNonBmpCharacters() {
+    void digitGreaterThanNonBmpCharacters() {
         ComparableVersion c1 = new ComparableVersion("1");
         // MATHEMATICAL SANS-SERIF DIGIT TWO
         ComparableVersion c2 = new ComparableVersion("\uD835\uDFE4");
@@ -242,7 +242,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testGetCanonical() {
+    void getCanonical() {
         // MNG-7700
         newComparable("0.x");
         newComparable("0-x");
@@ -256,35 +256,35 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testLexicographicASCIISortOrder() { // Required by Semver 1.0
+    void lexicographicASCIISortOrder() { // Required by Semver 1.0
         ComparableVersion lower = new ComparableVersion("1.0.0-alpha1");
         ComparableVersion upper = new ComparableVersion("1.0.0-ALPHA1");
         // Lower case is equal to upper case. This is *NOT* what Semver 1.0
         // specifies. Here we are explicitly deviating from Semver 1.0.
-        assertTrue(upper.compareTo(lower) == 0, "expected 1.0.0-ALPHA1 == 1.0.0-alpha1");
-        assertTrue(lower.compareTo(upper) == 0, "expected 1.0.0-alpha1 == 1.0.0-ALPHA1");
+        assertEquals(0, upper.compareTo(lower), "expected 1.0.0-ALPHA1 == 1.0.0-alpha1");
+        assertEquals(0, lower.compareTo(upper), "expected 1.0.0-alpha1 == 1.0.0-ALPHA1");
     }
 
     @Test
-    void testCompareLowerCaseToUpperCaseASCII() {
+    void compareLowerCaseToUpperCaseASCII() {
         ComparableVersion lower = new ComparableVersion("1.a");
         ComparableVersion upper = new ComparableVersion("1.A");
         // Lower case is equal to upper case
-        assertTrue(upper.compareTo(lower) == 0, "expected 1.A == 1.a");
-        assertTrue(lower.compareTo(upper) == 0, "expected 1.a == 1.A");
+        assertEquals(0, upper.compareTo(lower), "expected 1.A == 1.a");
+        assertEquals(0, lower.compareTo(upper), "expected 1.a == 1.A");
     }
 
     @Test
-    void testCompareLowerCaseToUpperCaseNonASCII() {
+    void compareLowerCaseToUpperCaseNonASCII() {
         ComparableVersion lower = new ComparableVersion("1.é");
         ComparableVersion upper = new ComparableVersion("1.É");
         // Lower case is equal to upper case
-        assertTrue(upper.compareTo(lower) == 0, "expected 1.É < 1.é");
-        assertTrue(lower.compareTo(upper) == 0, "expected 1.é > 1.É");
+        assertEquals(0, upper.compareTo(lower), "expected 1.É < 1.é");
+        assertEquals(0, lower.compareTo(upper), "expected 1.é > 1.É");
     }
 
     @Test
-    void testCompareDigitToLetter() {
+    void compareDigitToLetter() {
         ComparableVersion seven = new ComparableVersion("7");
         ComparableVersion capitalJ = new ComparableVersion("J");
         ComparableVersion lowerCaseC = new ComparableVersion("c");
@@ -296,7 +296,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testNonAsciiDigits() { // These should not be treated as digits.
+    void nonAsciiDigits() { // These should not be treated as digits.
         ComparableVersion asciiOne = new ComparableVersion("1");
         ComparableVersion arabicEight = new ComparableVersion("\u0668");
         ComparableVersion asciiNine = new ComparableVersion("9");
@@ -307,7 +307,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testLexicographicOrder() {
+    void lexicographicOrder() {
         ComparableVersion aardvark = new ComparableVersion("aardvark");
         ComparableVersion zebra = new ComparableVersion("zebra");
         assertTrue(zebra.compareTo(aardvark) > 0);
@@ -327,7 +327,7 @@ class ComparableVersionTest {
      * <a href="https://netbeans.org/bugzilla/show_bug.cgi?id=226100">226100</a>
      */
     @Test
-    void testMng5568() {
+    void mng5568() {
         String a = "6.1.0";
         String b = "6.1.0rc3";
         String c = "6.1H.5-beta"; // this is the unusual version string, with 'H' in the middle
@@ -341,7 +341,7 @@ class ComparableVersionTest {
      * Test <a href="https://jira.apache.org/jira/browse/MNG-6572">MNG-6572</a> optimization.
      */
     @Test
-    void testMng6572() {
+    void mng6572() {
         String a = "20190126.230843"; // resembles a SNAPSHOT
         String b = "1234567890.12345"; // 10 digit number
         String c = "123456789012345.1H.5-beta"; // 15 digit number
@@ -360,7 +360,7 @@ class ComparableVersionTest {
      * (related to MNG-6572 optimization)
      */
     @Test
-    void testVersionEqualWithLeadingZeroes() {
+    void versionEqualWithLeadingZeroes() {
         // versions with string lengths from 1 to 19
         String[] arr = new String[] {
             "0000000000000000001",
@@ -392,7 +392,7 @@ class ComparableVersionTest {
      * (related to MNG-6572 optimization)
      */
     @Test
-    void testVersionZeroEqualWithLeadingZeroes() {
+    void versionZeroEqualWithLeadingZeroes() {
         // versions with string lengths from 1 to 19
         String[] arr = new String[] {
             "0000000000000000000",
@@ -424,7 +424,7 @@ class ComparableVersionTest {
      * for qualifiers that start with "-0.", which was showing A == C and B == C but A &lt; B.
      */
     @Test
-    void testMng6964() {
+    void mng6964() {
         String a = "1-0.alpha";
         String b = "1-0.beta";
         String c = "1";
@@ -435,7 +435,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testLocaleIndependent() {
+    void localeIndependent() {
         Locale orig = Locale.getDefault();
         Locale[] locales = {Locale.ENGLISH, new Locale("tr"), Locale.getDefault()};
         try {
@@ -449,7 +449,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    void testReuse() {
+    void reuse() {
         ComparableVersion c1 = new ComparableVersion("1");
         c1.parseVersion("2");
 
@@ -464,7 +464,7 @@ class ComparableVersionTest {
      * 1.0.0.X1 &lt; 1.0.0-X2 for any string X
      */
     @Test
-    void testMng7644() {
+    void mng7644() {
         for (String x : new String[] {"abc", "alpha", "a", "beta", "b", "def", "milestone", "m", "RC"}) {
             // 1.0.0.X1 < 1.0.0-X2 for any string x
             checkVersionsOrder("1.0.0." + x + "1", "1.0.0-" + x + "2");
@@ -476,7 +476,7 @@ class ComparableVersionTest {
     }
 
     @Test
-    public void testMng7714() {
+    void mng7714() {
         ComparableVersion f = new ComparableVersion("1.0.final-redhat");
         ComparableVersion sp1 = new ComparableVersion("1.0-sp1-redhat");
         ComparableVersion sp2 = new ComparableVersion("1.0-sp-1-redhat");

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/DefaultArtifactVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/DefaultArtifactVersionTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.artifact.versioning;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test DefaultArtifactVersion.
@@ -48,7 +46,7 @@ class DefaultArtifactVersionTest {
     }
 
     @Test
-    void testVersionParsing() {
+    void versionParsing() {
         checkVersionParsing("1", 1, 0, 0, 0, null);
         checkVersionParsing("1.2", 1, 2, 0, 0, null);
         checkVersionParsing("1.2.3", 1, 2, 3, 0, null);
@@ -85,7 +83,7 @@ class DefaultArtifactVersionTest {
     }
 
     @Test
-    void testVersionComparing() {
+    void versionComparing() {
         assertVersionEqual("1", "1");
         assertVersionOlder("1", "2");
         assertVersionOlder("1.5", "2");
@@ -132,7 +130,7 @@ class DefaultArtifactVersionTest {
     }
 
     @Test
-    void testVersionSnapshotComparing() {
+    void versionSnapshotComparing() {
         assertVersionEqual("1-SNAPSHOT", "1-SNAPSHOT");
         assertVersionOlder("1-SNAPSHOT", "2-SNAPSHOT");
         assertVersionOlder("1.5-SNAPSHOT", "2-SNAPSHOT");
@@ -166,7 +164,7 @@ class DefaultArtifactVersionTest {
     }
 
     @Test
-    void testSnapshotVsReleases() {
+    void snapshotVsReleases() {
         assertVersionOlder("1.0-RC1", "1.0-SNAPSHOT");
         assertVersionOlder("1.0-rc1", "1.0-SNAPSHOT");
         assertVersionOlder("1.0-rc-1", "1.0-SNAPSHOT");
@@ -176,18 +174,18 @@ class DefaultArtifactVersionTest {
     void testHashCode() {
         ArtifactVersion v1 = newArtifactVersion("1");
         ArtifactVersion v2 = newArtifactVersion("1.0");
-        assertTrue(v1.equals(v2));
+        assertEquals(v1, v2);
         assertEquals(v1.hashCode(), v2.hashCode());
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(newArtifactVersion("1").equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, newArtifactVersion("1"));
     }
 
     @Test
-    void testEqualsTypeSafe() {
-        assertFalse(newArtifactVersion("1").equals("non-an-artifact-version-instance"));
+    void equalsTypeSafe() {
+        assertNotEquals("non-an-artifact-version-instance", newArtifactVersion("1"));
     }
 
     private void assertVersionOlder(String left, String right) {
@@ -200,11 +198,7 @@ class DefaultArtifactVersionTest {
     }
 
     private void assertVersionEqual(String left, String right) {
-        assertTrue(
-                newArtifactVersion(left).compareTo(newArtifactVersion(right)) == 0,
-                left + " should be equal to " + right);
-        assertTrue(
-                newArtifactVersion(right).compareTo(newArtifactVersion(left)) == 0,
-                right + " should be equal to " + left);
+        assertEquals(0, newArtifactVersion(left).compareTo(newArtifactVersion(right)), left + " should be equal to " + right);
+        assertEquals(0, newArtifactVersion(right).compareTo(newArtifactVersion(left)), right + " should be equal to " + left);
     }
 }

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
@@ -23,12 +23,7 @@ import java.util.List;
 import org.apache.maven.artifact.Artifact;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests version range construction.
@@ -52,7 +47,7 @@ class VersionRangeTest {
     private static final String CHECK_SELECTED_VERSION = "check selected version";
 
     @Test
-    void testRange() throws InvalidVersionSpecificationException, OverConstrainedVersionException {
+    void range() throws InvalidVersionSpecificationException, OverConstrainedVersionException {
         Artifact artifact = null;
 
         VersionRange range = VersionRange.createFromVersionSpec("(,1.0]");
@@ -156,14 +151,14 @@ class VersionRangeTest {
     }
 
     @Test
-    void testSameUpperAndLowerBoundRoundtrip() throws InvalidVersionSpecificationException {
+    void sameUpperAndLowerBoundRoundtrip() throws InvalidVersionSpecificationException {
         VersionRange range = VersionRange.createFromVersionSpec("[1.0]");
         VersionRange range2 = VersionRange.createFromVersionSpec(range.toString());
         assertEquals(range, range2);
     }
 
     @Test
-    void testInvalidRanges() {
+    void invalidRanges() {
         checkInvalidRange("(1.0)");
         checkInvalidRange("[1.0)");
         checkInvalidRange("(1.0]");
@@ -182,7 +177,7 @@ class VersionRangeTest {
 
     @Test
     @SuppressWarnings("checkstyle:MethodLength")
-    void testIntersections() throws InvalidVersionSpecificationException {
+    void intersections() throws InvalidVersionSpecificationException {
         VersionRange range1 = VersionRange.createFromVersionSpec("1.0");
         VersionRange range2 = VersionRange.createFromVersionSpec("1.1");
         VersionRange mergedRange = range1.restrict(range2);
@@ -664,7 +659,7 @@ class VersionRangeTest {
     }
 
     @Test
-    void testReleaseRangeBoundsContainsSnapshots() throws InvalidVersionSpecificationException {
+    void releaseRangeBoundsContainsSnapshots() throws InvalidVersionSpecificationException {
         VersionRange range = VersionRange.createFromVersionSpec("[1.0,1.2]");
 
         assertTrue(range.containsVersion(new DefaultArtifactVersion("1.1-SNAPSHOT")));
@@ -673,7 +668,7 @@ class VersionRangeTest {
     }
 
     @Test
-    void testSnapshotRangeBoundsCanContainSnapshots() throws InvalidVersionSpecificationException {
+    void snapshotRangeBoundsCanContainSnapshots() throws InvalidVersionSpecificationException {
         VersionRange range = VersionRange.createFromVersionSpec("[1.0,1.2-SNAPSHOT]");
 
         assertTrue(range.containsVersion(new DefaultArtifactVersion("1.1-SNAPSHOT")));
@@ -686,7 +681,7 @@ class VersionRangeTest {
     }
 
     @Test
-    void testSnapshotSoftVersionCanContainSnapshot() throws InvalidVersionSpecificationException {
+    void snapshotSoftVersionCanContainSnapshot() throws InvalidVersionSpecificationException {
         VersionRange range = VersionRange.createFromVersionSpec("1.0-SNAPSHOT");
 
         assertTrue(range.containsVersion(new DefaultArtifactVersion("1.0-SNAPSHOT")));
@@ -700,7 +695,7 @@ class VersionRangeTest {
     }
 
     @Test
-    void testContains() throws InvalidVersionSpecificationException {
+    void contains() throws InvalidVersionSpecificationException {
         ArtifactVersion actualVersion = new DefaultArtifactVersion("2.0.5");
         assertTrue(enforceVersion("2.0.5", actualVersion));
         assertTrue(enforceVersion("2.0.4", actualVersion));
@@ -721,7 +716,7 @@ class VersionRangeTest {
     }
 
     @Test
-    void testCache() throws InvalidVersionSpecificationException {
+    void cache() throws InvalidVersionSpecificationException {
         VersionRange range = VersionRange.createFromVersionSpec("[1.0,1.2]");
         assertSame(range, VersionRange.createFromVersionSpec("[1.0,1.2]")); // same instance from spec cache
 
@@ -735,8 +730,6 @@ class VersionRangeTest {
         restrictions = version.getRestrictions();
         assertEquals(0, restrictions.size(), CHECK_NUM_RESTRICTIONS);
 
-        assertFalse(
-                spec.equals(version),
-                "check !VersionRange.createFromVersionSpec(x).equals(VersionRange.createFromVersion(x))");
+        assertNotEquals(spec, version, "check !VersionRange.createFromVersionSpec(x).equals(VersionRange.createFromVersion(x))");
     }
 }

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemCollectorTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemCollectorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class DefaultProblemCollectorTest {
 
     @Test
-    void testGetProblems() {
+    void getProblems() {
         DefaultProblemCollector collector = new DefaultProblemCollector(null);
         assertNotNull(collector.getProblems());
         assertEquals(0, collector.getProblems().size());
@@ -56,7 +56,7 @@ class DefaultProblemCollectorTest {
     }
 
     @Test
-    void testSetSource() {
+    void setSource() {
         DefaultProblemCollector collector = new DefaultProblemCollector(null);
 
         collector.add(null, "PROBLEM1", -1, -1, null);

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/DefaultProblemTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 class DefaultProblemTest {
 
     @Test
-    void testGetSeverity() {
+    void getSeverity() {
         DefaultProblem problem = new DefaultProblem(null, null, null, -1, -1, null);
         assertEquals(Severity.ERROR, problem.getSeverity());
 
@@ -43,7 +43,7 @@ class DefaultProblemTest {
     }
 
     @Test
-    void testGetLineNumber() {
+    void getLineNumber() {
         DefaultProblem problem = new DefaultProblem(null, null, null, -1, -1, null);
         assertEquals(-1, problem.getLineNumber());
 
@@ -59,7 +59,7 @@ class DefaultProblemTest {
     }
 
     @Test
-    void testGetColumnNumber() {
+    void getColumnNumber() {
         DefaultProblem problem = new DefaultProblem(null, null, null, -1, -1, null);
         assertEquals(-1, problem.getColumnNumber());
 
@@ -75,7 +75,7 @@ class DefaultProblemTest {
     }
 
     @Test
-    void testGetException() {
+    void getException() {
         DefaultProblem problem = new DefaultProblem(null, null, null, -1, -1, null);
         assertNull(problem.getException());
 
@@ -85,7 +85,7 @@ class DefaultProblemTest {
     }
 
     @Test
-    void testGetSource() {
+    void getSource() {
         DefaultProblem problem = new DefaultProblem(null, null, null, -1, -1, null);
         assertEquals("", problem.getSource());
 
@@ -97,7 +97,7 @@ class DefaultProblemTest {
     }
 
     @Test
-    void testGetLocation() {
+    void getLocation() {
         DefaultProblem problem = new DefaultProblem(null, null, null, -1, -1, null);
         assertEquals("", problem.getLocation());
 
@@ -115,7 +115,7 @@ class DefaultProblemTest {
     }
 
     @Test
-    void testGetMessage() {
+    void getMessage() {
         DefaultProblem problem = new DefaultProblem("MESSAGE", null, null, -1, -1, null);
         assertEquals("MESSAGE", problem.getMessage());
 

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/FileSourceTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/FileSourceTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class FileSourceTest {
 
     @Test
-    void testFileSource() {
+    void fileSource() {
         NullPointerException e = assertThrows(
                 NullPointerException.class,
                 () -> new FileSource((File) null),
@@ -39,7 +39,7 @@ class FileSourceTest {
     }
 
     @Test
-    void testGetInputStream() throws Exception {
+    void getInputStream() throws Exception {
         File txtFile = new File("target/test-classes/source.txt");
         FileSource source = new FileSource(txtFile);
 
@@ -51,14 +51,14 @@ class FileSourceTest {
     }
 
     @Test
-    void testGetLocation() {
+    void getLocation() {
         File txtFile = new File("target/test-classes/source.txt");
         FileSource source = new FileSource(txtFile);
         assertEquals(txtFile.getAbsolutePath(), source.getLocation());
     }
 
     @Test
-    void testGetFile() {
+    void getFile() {
         File txtFile = new File("target/test-classes/source.txt");
         FileSource source = new FileSource(txtFile);
         assertEquals(txtFile.getAbsoluteFile(), source.getFile());

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 class ProblemCollectorFactoryTest {
 
     @Test
-    void testNewInstance() {
+    void newInstance() {
         ProblemCollector collector1 = ProblemCollectorFactory.newInstance(null);
 
         Problem problem = new DefaultProblem("MESSAGE1", null, null, -1, -1, null);

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/StringSourceTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/StringSourceTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StringSourceTest {
     @Test
-    void testGetInputStream() throws Exception {
+    void getInputStream() throws Exception {
         StringSource source = new StringSource("Hello World!");
 
         try (InputStream is = source.getInputStream();
@@ -37,7 +37,7 @@ class StringSourceTest {
     }
 
     @Test
-    void testGetLocation() {
+    void getLocation() {
         StringSource source = new StringSource("Hello World!");
         assertEquals("(memory)", source.getLocation());
 
@@ -46,7 +46,7 @@ class StringSourceTest {
     }
 
     @Test
-    void testGetContent() {
+    void getContent() {
         StringSource source = new StringSource(null);
         assertEquals("", source.getContent());
 

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/UrlSourceTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/UrlSourceTest.java
@@ -31,14 +31,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class UrlSourceTest {
 
     @Test
-    void testUrlSource() {
+    void urlSource() {
         NullPointerException e = assertThrows(
                 NullPointerException.class, () -> new UrlSource(null), "Should fail, since you must specify a url");
         assertEquals("url cannot be null", e.getMessage());
     }
 
     @Test
-    void testGetInputStream() throws Exception {
+    void getInputStream() throws Exception {
         URL txtFile = new File("target/test-classes/source.txt").toURI().toURL();
         UrlSource source = new UrlSource(txtFile);
         try (InputStream is = source.getInputStream();
@@ -48,7 +48,7 @@ class UrlSourceTest {
     }
 
     @Test
-    void testGetLocation() throws Exception {
+    void getLocation() throws Exception {
         URL txtFile = new File("target/test-classes/source.txt").toURI().toURL();
         UrlSource source = new UrlSource(txtFile);
         assertEquals(txtFile.toExternalForm(), source.getLocation());

--- a/compat/maven-compat/src/test/java/org/apache/maven/ProjectDependenciesResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/ProjectDependenciesResolverTest.java
@@ -46,7 +46,7 @@ class ProjectDependenciesResolverTest extends AbstractCoreMavenComponentTestCase
     }
 
     @Test
-    void testSystemScopeDependencies() throws Exception {
+    void systemScopeDependencies() throws Exception {
         MavenSession session = createMavenSession(null);
         MavenProject project = session.getCurrentProject();
 
@@ -64,7 +64,7 @@ class ProjectDependenciesResolverTest extends AbstractCoreMavenComponentTestCase
     }
 
     @Test
-    void testSystemScopeDependencyIsPresentInTheCompileClasspathElements() throws Exception {
+    void systemScopeDependencyIsPresentInTheCompileClasspathElements() throws Exception {
         File pom = getProject("it0063");
 
         Properties eps = new Properties();

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/deployer/ArtifactDeployerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/deployer/ArtifactDeployerTest.java
@@ -51,7 +51,7 @@ class ArtifactDeployerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testArtifactInstallation() throws Exception {
+    void artifactInstallation() throws Exception {
         sessionScope.enter();
         try {
             sessionScope.seed(MavenSession.class, mock(MavenSession.class));

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/factory/DefaultArtifactFactoryTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/factory/DefaultArtifactFactoryTest.java
@@ -35,7 +35,7 @@ class DefaultArtifactFactoryTest {
     ArtifactFactory factory;
 
     @Test
-    void testPropagationOfSystemScopeRegardlessOfInheritedScope() {
+    void propagationOfSystemScopeRegardlessOfInheritedScope() {
         Artifact artifact = factory.createDependencyArtifact(
                 "test-grp", "test-artifact", VersionRange.createFromVersion("1.0"), "type", null, "system", "provided");
         Artifact artifact2 = factory.createDependencyArtifact(

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/installer/ArtifactInstallerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/installer/ArtifactInstallerTest.java
@@ -46,7 +46,7 @@ class ArtifactInstallerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testArtifactInstallation() throws Exception {
+    void artifactInstallation() throws Exception {
         sessionScope.enter();
         try {
             sessionScope.seed(MavenSession.class, mock(MavenSession.class));

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/repository/MavenArtifactRepositoryTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/repository/MavenArtifactRepositoryTest.java
@@ -20,8 +20,7 @@ package org.apache.maven.artifact.repository;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Deprecated
 class MavenArtifactRepositoryTest {
@@ -39,18 +38,18 @@ class MavenArtifactRepositoryTest {
     }
 
     @Test
-    void testHashCodeEquals() {
+    void hashCodeEquals() {
         MavenArtifactRepositorySubclass r1 = new MavenArtifactRepositorySubclass("foo");
         MavenArtifactRepositorySubclass r2 = new MavenArtifactRepositorySubclass("foo");
         MavenArtifactRepositorySubclass r3 = new MavenArtifactRepositorySubclass("bar");
 
-        assertTrue(r1.hashCode() == r2.hashCode());
+        assertEquals(r1.hashCode(), r2.hashCode());
         assertFalse(r1.hashCode() == r3.hashCode());
 
-        assertTrue(r1.equals(r2));
-        assertTrue(r2.equals(r1));
+        assertEquals(r1, r2);
+        assertEquals(r2, r1);
 
-        assertFalse(r1.equals(r3));
-        assertFalse(r3.equals(r1));
+        assertNotEquals(r1, r3);
+        assertNotEquals(r3, r1);
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolutionExceptionTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolutionExceptionTest.java
@@ -33,7 +33,7 @@ class ArtifactResolutionExceptionTest {
     private static final String LS = System.lineSeparator();
 
     @Test
-    void testMissingArtifactMessageFormat() {
+    void missingArtifactMessageFormat() {
         String message = "Missing artifact";
         String indentation = "  ";
         String groupId = "aGroupId";

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/ArtifactResolverTest.java
@@ -79,7 +79,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testResolutionOfASingleArtifactWhereTheArtifactIsPresentInTheLocalRepository() throws Exception {
+    void resolutionOfASingleArtifactWhereTheArtifactIsPresentInTheLocalRepository() throws Exception {
         Artifact a = createLocalArtifact("a", "1.0");
 
         artifactResolver.resolve(a, remoteRepositories(), localRepository());
@@ -88,7 +88,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testResolutionOfASingleArtifactWhereTheArtifactIsNotPresentLocallyAndMustBeRetrievedFromTheRemoteRepository()
+    void resolutionOfASingleArtifactWhereTheArtifactIsNotPresentLocallyAndMustBeRetrievedFromTheRemoteRepository()
             throws Exception {
         Artifact b = createRemoteArtifact("b", "1.0-SNAPSHOT");
         deleteLocalArtifact(b);
@@ -103,7 +103,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testTransitiveResolutionWhereAllArtifactsArePresentInTheLocalRepository() throws Exception {
+    void transitiveResolutionWhereAllArtifactsArePresentInTheLocalRepository() throws Exception {
         Artifact g = createLocalArtifact("g", "1.0");
 
         Artifact h = createLocalArtifact("h", "1.0");
@@ -126,7 +126,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
 
     @Test
     void
-            testTransitiveResolutionWhereAllArtifactsAreNotPresentInTheLocalRepositoryAndMustBeRetrievedFromTheRemoteRepository()
+            transitiveResolutionWhereAllArtifactsAreNotPresentInTheLocalRepositoryAndMustBeRetrievedFromTheRemoteRepository()
                     throws Exception {
         Artifact i = createRemoteArtifact("i", "1.0-SNAPSHOT");
         deleteLocalArtifact(i);
@@ -151,7 +151,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testResolutionFailureWhenArtifactNotPresentInRemoteRepository() throws Exception {
+    void resolutionFailureWhenArtifactNotPresentInRemoteRepository() throws Exception {
         Artifact k = createArtifact("k", "1.0");
 
         assertThrows(
@@ -161,7 +161,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testResolutionOfAnArtifactWhereOneRemoteRepositoryIsBadButOneIsGood() throws Exception {
+    void resolutionOfAnArtifactWhereOneRemoteRepositoryIsBadButOneIsGood() throws Exception {
         Artifact l = createRemoteArtifact("l", "1.0-SNAPSHOT");
         deleteLocalArtifact(l);
 
@@ -175,7 +175,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    public void testReadRepoFromModel() throws Exception {
+    void readRepoFromModel() throws Exception {
         Artifact artifact = createArtifact(TestMavenWorkspaceReader.ARTIFACT_ID, TestMavenWorkspaceReader.VERSION);
         ArtifactMetadataSource source = getContainer().lookup(ArtifactMetadataSource.class, "maven");
         ResolutionGroup group = source.retrieve(artifact, localRepository(), new ArrayList<>());
@@ -187,7 +187,7 @@ class ArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testTransitiveResolutionOrder() throws Exception {
+    void transitiveResolutionOrder() throws Exception {
         Artifact m = createLocalArtifact("m", "1.0");
 
         Artifact n = createLocalArtifact("n", "1.0");

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/DefaultArtifactResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/DefaultArtifactResolverTest.java
@@ -50,7 +50,7 @@ class DefaultArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testMNG4738() throws Exception {
+    void mng4738() throws Exception {
         Artifact g = createLocalArtifact("g", "1.0");
         createLocalArtifact("h", "1.0");
         artifactResolver.resolveTransitively(
@@ -89,7 +89,7 @@ class DefaultArtifactResolverTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testLookup() throws Exception {
+    void lookup() throws Exception {
         ArtifactResolver resolver = getContainer().lookup(ArtifactResolver.class, "default");
         assertNotNull(resolver);
     }

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/AndArtifactFilterTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/AndArtifactFilterTest.java
@@ -23,8 +23,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Tests {@link AndArtifactFilter}.
@@ -37,16 +36,16 @@ class AndArtifactFilterTest {
     }
 
     @Test
-    void testEquals() {
+    void equals() {
         AndArtifactFilter filter1 = new AndArtifactFilter();
 
         AndArtifactFilter filter2 = new AndArtifactFilter(Arrays.asList(newSubFilter()));
 
-        assertFalse(filter1.equals(null));
-        assertTrue(filter1.equals(filter1));
+        assertNotEquals(null, filter1);
+        assertEquals(filter1, filter1);
         assertEquals(filter1.hashCode(), filter1.hashCode());
 
-        assertFalse(filter1.equals(filter2));
-        assertFalse(filter2.equals(filter1));
+        assertNotEquals(filter1, filter2);
+        assertNotEquals(filter2, filter1);
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/FilterHashEqualsTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/FilterHashEqualsTest.java
@@ -23,26 +23,26 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  */
 class FilterHashEqualsTest {
 
     @Test
-    void testIncludesExcludesArtifactFilter() {
+    void includesExcludesArtifactFilter() {
         List<String> patterns = Arrays.asList("c", "d", "e");
 
         IncludesArtifactFilter f1 = new IncludesArtifactFilter(patterns);
 
         IncludesArtifactFilter f2 = new IncludesArtifactFilter(patterns);
 
-        assertTrue(f1.equals(f2));
-        assertTrue(f2.equals(f1));
-        assertTrue(f1.hashCode() == f2.hashCode());
+        assertEquals(f1, f2);
+        assertEquals(f2, f1);
+        assertEquals(f1.hashCode(), f2.hashCode());
 
         IncludesArtifactFilter f3 = new IncludesArtifactFilter(Arrays.asList("d", "c", "e"));
-        assertTrue(f1.equals(f3));
-        assertTrue(f1.hashCode() == f3.hashCode());
+        assertEquals(f1, f3);
+        assertEquals(f1.hashCode(), f3.hashCode());
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/OrArtifactFilterTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/OrArtifactFilterTest.java
@@ -23,8 +23,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Tests {@link OrArtifactFilter}.
@@ -38,16 +37,16 @@ class OrArtifactFilterTest {
     }
 
     @Test
-    void testEquals() {
+    void equals() {
         OrArtifactFilter filter1 = new OrArtifactFilter();
 
         OrArtifactFilter filter2 = new OrArtifactFilter(Arrays.asList(newSubFilter()));
 
-        assertFalse(filter1.equals(null));
-        assertTrue(filter1.equals(filter1));
+        assertNotEquals(null, filter1);
+        assertEquals(filter1, filter1);
         assertEquals(filter1.hashCode(), filter1.hashCode());
 
-        assertFalse(filter1.equals(filter2));
-        assertFalse(filter2.equals(filter1));
+        assertNotEquals(filter1, filter2);
+        assertNotEquals(filter2, filter1);
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/ScopeArtifactFilterTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/resolver/filter/ScopeArtifactFilterTest.java
@@ -36,7 +36,7 @@ class ScopeArtifactFilterTest {
     }
 
     @Test
-    void testIncludeCompile() {
+    void includeCompile() {
         ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_COMPILE);
 
         assertTrue(filter.include(newArtifact(Artifact.SCOPE_COMPILE)));
@@ -47,7 +47,7 @@ class ScopeArtifactFilterTest {
     }
 
     @Test
-    void testIncludeCompilePlusRuntime() {
+    void includeCompilePlusRuntime() {
         ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
 
         assertTrue(filter.include(newArtifact(Artifact.SCOPE_COMPILE)));
@@ -58,7 +58,7 @@ class ScopeArtifactFilterTest {
     }
 
     @Test
-    void testIncludeRuntime() {
+    void includeRuntime() {
         ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME);
 
         assertTrue(filter.include(newArtifact(Artifact.SCOPE_COMPILE)));
@@ -69,7 +69,7 @@ class ScopeArtifactFilterTest {
     }
 
     @Test
-    void testIncludeRuntimePlusSystem() {
+    void includeRuntimePlusSystem() {
         ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME_PLUS_SYSTEM);
 
         assertTrue(filter.include(newArtifact(Artifact.SCOPE_COMPILE)));
@@ -80,7 +80,7 @@ class ScopeArtifactFilterTest {
     }
 
     @Test
-    void testIncludeTest() {
+    void includeTest() {
         ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_TEST);
 
         assertTrue(filter.include(newArtifact(Artifact.SCOPE_COMPILE)));

--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/transform/TransformationManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/transform/TransformationManagerTest.java
@@ -40,7 +40,7 @@ class TransformationManagerTest {
     ArtifactTransformationManager tm;
 
     @Test
-    void testTransformationManager() {
+    void transformationManager() {
         List<ArtifactTransformation> tms = tm.getArtifactTransformations();
 
         assertEquals(3, tms.size());

--- a/compat/maven-compat/src/test/java/org/apache/maven/profiles/manager/DefaultProfileManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/profiles/manager/DefaultProfileManagerTest.java
@@ -47,7 +47,7 @@ class DefaultProfileManagerTest {
     }
 
     @Test
-    void testShouldActivateDefaultProfile() throws Exception {
+    void shouldActivateDefaultProfile() throws Exception {
         Profile notActivated = new Profile();
         notActivated.setId("notActivated");
 
@@ -81,7 +81,7 @@ class DefaultProfileManagerTest {
     }
 
     @Test
-    void testShouldNotActivateDefaultProfile() throws Exception {
+    void shouldNotActivateDefaultProfile() throws Exception {
         Profile syspropActivated = new Profile();
         syspropActivated.setId("syspropActivated");
 
@@ -118,7 +118,7 @@ class DefaultProfileManagerTest {
     }
 
     @Test
-    void testShouldNotActivateReversalOfPresentSystemProperty() throws Exception {
+    void shouldNotActivateReversalOfPresentSystemProperty() throws Exception {
         Profile syspropActivated = new Profile();
         syspropActivated.setId("syspropActivated");
 
@@ -144,7 +144,7 @@ class DefaultProfileManagerTest {
     }
 
     @Test
-    void testShouldOverrideAndActivateInactiveProfile() throws Exception {
+    void shouldOverrideAndActivateInactiveProfile() throws Exception {
         Profile syspropActivated = new Profile();
         syspropActivated.setId("syspropActivated");
 
@@ -173,7 +173,7 @@ class DefaultProfileManagerTest {
     }
 
     @Test
-    void testShouldOverrideAndDeactivateActiveProfile() throws Exception {
+    void shouldOverrideAndDeactivateActiveProfile() throws Exception {
         Profile syspropActivated = new Profile();
         syspropActivated.setId("syspropActivated");
 

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/ProjectClasspathTestType.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/ProjectClasspathTestType.java
@@ -52,7 +52,7 @@ class ProjectClasspathTestType extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testProjectClasspath() throws Exception {
+    void projectClasspath() throws Exception {
         File f = getFileForClasspathResource(DIR + "project-with-scoped-dependencies.xml");
 
         MavenProject project = getProjectWithDependencies(f);

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/artifact/DefaultMavenMetadataCacheTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/artifact/DefaultMavenMetadataCacheTest.java
@@ -45,7 +45,7 @@ class DefaultMavenMetadataCacheTest {
     }
 
     @Test
-    void testCacheKey() throws Exception {
+    void cacheKey() throws Exception {
         Artifact a1 = repositorySystem.createArtifact("testGroup", "testArtifact", "1.2.3", "jar");
         @SuppressWarnings("deprecation")
         ArtifactRepository lr1 = new DelegatingLocalArtifactRepository(repositorySystem.createDefaultLocalRepository());

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t00/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t00/ProjectInheritanceTest.java
@@ -51,7 +51,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testProjectInheritance() throws Exception {
+    void projectInheritance() throws Exception {
         MavenProject p4 = getProject(projectFile("p4"));
 
         assertEquals("p4", p4.getName());

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t01/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t01/ProjectInheritanceTest.java
@@ -48,7 +48,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testProjectInheritance() throws Exception {
+    void projectInheritance() throws Exception {
         // ----------------------------------------------------------------------
         // Check p0 value for org name
         // ----------------------------------------------------------------------

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
@@ -65,7 +65,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // need to investigate why it fails on windows
-    void testProjectInheritance() throws Exception {
+    void projectInheritance() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         System.out.println("Local repository is at: " + localRepo.getAbsolutePath());

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t03/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t03/ProjectInheritanceTest.java
@@ -51,7 +51,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testProjectInheritance() throws Exception {
+    void projectInheritance() throws Exception {
         File localRepo = getLocalRepositoryPath();
         File pom0 = new File(localRepo, "p0/pom.xml");
 

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t04/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t04/ProjectInheritanceTest.java
@@ -55,7 +55,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testDependencyManagementOverridesTransitiveDependencyVersion() throws Exception {
+    void dependencyManagementOverridesTransitiveDependencyVersion() throws Exception {
         File localRepo = getLocalRepositoryPath();
         File pom0 = new File(localRepo, "p0/pom.xml");
         File pom0Basedir = pom0.getParentFile();
@@ -69,14 +69,13 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
         Set set = project1.getArtifacts();
         assertNotNull(set, "No artifacts");
         assertTrue(set.size() > 0, "No Artifacts");
-        assertTrue(set.size() == 3, "Set size should be 3, is " + set.size());
+        assertEquals(3, set.size(), "Set size should be 3, is " + set.size());
 
         for (Object aSet : set) {
             Artifact artifact = (Artifact) aSet;
             System.out.println("Artifact: " + artifact.getDependencyConflictId() + " " + artifact.getVersion()
                     + " Optional=" + (artifact.isOptional() ? "true" : "false"));
-            assertTrue(
-                    artifact.getVersion().equals("1.0"), "Incorrect version for " + artifact.getDependencyConflictId());
+            assertEquals("1.0", artifact.getVersion(), "Incorrect version for " + artifact.getDependencyConflictId());
         }
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t05/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t05/ProjectInheritanceTest.java
@@ -49,7 +49,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testDependencyManagement() throws Exception {
+    void dependencyManagement() throws Exception {
         File localRepo = getLocalRepositoryPath();
         File pom0 = new File(localRepo, "p0/pom.xml");
 
@@ -70,8 +70,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
             Artifact artifact = (Artifact) aSet;
             System.out.println("Artifact: " + artifact.getDependencyConflictId() + " " + artifact.getVersion()
                     + " Scope: " + artifact.getScope());
-            assertTrue(
-                    artifact.getVersion().equals("1.0"), "Incorrect version for " + artifact.getDependencyConflictId());
+            assertEquals("1.0", artifact.getVersion(), "Incorrect version for " + artifact.getDependencyConflictId());
         }
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t06/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t06/ProjectInheritanceTest.java
@@ -50,7 +50,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testDependencyManagement() throws Exception {
+    void dependencyManagement() throws Exception {
         File localRepo = getLocalRepositoryPath();
         File pom0 = new File(localRepo, "p0/pom.xml");
 
@@ -67,14 +67,13 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
         assertNotNull(set, "No artifacts");
         assertTrue(set.size() > 0, "No Artifacts");
         Iterator iter = set.iterator();
-        assertTrue(set.size() == 4, "Set size should be 4, is " + set.size());
+        assertEquals(4, set.size(), "Set size should be 4, is " + set.size());
 
         while (iter.hasNext()) {
             Artifact artifact = (Artifact) iter.next();
             System.out.println("Artifact: " + artifact.getDependencyConflictId() + " " + artifact.getVersion()
                     + " Optional=" + (artifact.isOptional() ? "true" : "false"));
-            assertTrue(
-                    artifact.getVersion().equals("1.0"), "Incorrect version for " + artifact.getDependencyConflictId());
+            assertEquals("1.0", artifact.getVersion(), "Incorrect version for " + artifact.getDependencyConflictId());
         }
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t07/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t07/ProjectInheritanceTest.java
@@ -26,10 +26,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.inheritance.AbstractProjectInheritanceTestCase;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A test which demonstrates maven's dependency management
@@ -50,7 +47,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testDependencyManagement() throws Exception {
+    void dependencyManagement() throws Exception {
         File localRepo = getLocalRepositoryPath();
         File pom0 = new File(localRepo, "p0/pom.xml");
 
@@ -66,15 +63,14 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
         Set set = project1.getArtifacts();
         assertNotNull(set, "No artifacts");
         assertTrue(set.size() > 0, "No Artifacts");
-        assertTrue(set.size() == 3, "Set size should be 3, is " + set.size());
+        assertEquals(3, set.size(), "Set size should be 3, is " + set.size());
 
         for (Object aSet : set) {
             Artifact artifact = (Artifact) aSet;
-            assertFalse(artifact.getArtifactId().equals("t07-d"));
+            assertNotEquals("t07-d", artifact.getArtifactId());
             System.out.println("Artifact: " + artifact.getDependencyConflictId() + " " + artifact.getVersion()
                     + " Optional=" + (artifact.isOptional() ? "true" : "false"));
-            assertTrue(
-                    artifact.getVersion().equals("1.0"), "Incorrect version for " + artifact.getDependencyConflictId());
+            assertEquals("1.0", artifact.getVersion(), "Incorrect version for " + artifact.getDependencyConflictId());
         }
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t08/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t08/ProjectInheritanceTest.java
@@ -50,7 +50,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testDependencyManagement() throws Exception {
+    void dependencyManagement() throws Exception {
         File localRepo = getLocalRepositoryPath();
         File pom0 = new File(localRepo, "p0/pom.xml");
 
@@ -68,14 +68,13 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
         assertNotNull(set, "No artifacts");
         assertTrue(set.size() > 0, "No Artifacts");
         Iterator iter = set.iterator();
-        assertTrue(set.size() == 4, "Set size should be 4, is " + set.size());
+        assertEquals(4, set.size(), "Set size should be 4, is " + set.size());
 
         while (iter.hasNext()) {
             Artifact artifact = (Artifact) iter.next();
             System.out.println("Artifact: " + artifact.getDependencyConflictId() + " " + artifact.getVersion()
                     + " Optional=" + (artifact.isOptional() ? "true" : "false"));
-            assertTrue(
-                    artifact.getVersion().equals("1.0"), "Incorrect version for " + artifact.getDependencyConflictId());
+            assertEquals("1.0", artifact.getVersion(), "Incorrect version for " + artifact.getDependencyConflictId());
         }
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t09/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t09/ProjectInheritanceTest.java
@@ -62,7 +62,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
      * a &amp; b only.
      */
     @Test
-    void testDependencyManagementExclusionsExcludeTransitively() throws Exception {
+    void dependencyManagementExclusionsExcludeTransitively() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         File pom0 = new File(localRepo, "p0/pom.xml");
@@ -79,7 +79,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
 
         assertNotNull(map, "No artifacts");
         assertTrue(map.size() > 0, "No Artifacts");
-        assertTrue(map.size() == 2, "Set size should be 2, is " + map.size());
+        assertEquals(2, map.size(), "Set size should be 2, is " + map.size());
 
         assertTrue(map.containsKey("maven-test:t09-a"), "maven-test:t09-a is not in the project");
         assertTrue(map.containsKey("maven-test:t09-b"), "maven-test:t09-b is not in the project");
@@ -97,7 +97,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
      * @throws Exception
      */
     @Test
-    void testDependencyManagementExclusionDoesNotOverrideGloballyForTransitives() throws Exception {
+    void dependencyManagementExclusionDoesNotOverrideGloballyForTransitives() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         File pom0 = new File(localRepo, "p0/pom.xml");
@@ -112,7 +112,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
         Map map = project2.getArtifactMap();
         assertNotNull(map, "No artifacts");
         assertTrue(map.size() > 0, "No Artifacts");
-        assertTrue(map.size() == 4, "Set size should be 4, is " + map.size());
+        assertEquals(4, map.size(), "Set size should be 4, is " + map.size());
 
         assertTrue(map.containsKey("maven-test:t09-a"), "maven-test:t09-a is not in the project");
         assertTrue(map.containsKey("maven-test:t09-b"), "maven-test:t09-b is not in the project");

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t10/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t10/ProjectInheritanceTest.java
@@ -56,7 +56,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testDependencyManagementOverridesTransitiveDependencyVersion() throws Exception {
+    void dependencyManagementOverridesTransitiveDependencyVersion() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         File pom0 = new File(localRepo, "p0/pom.xml");
@@ -72,7 +72,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
         Map map = project1.getArtifactMap();
         assertNotNull(map, "No artifacts");
         assertTrue(map.size() > 0, "No Artifacts");
-        assertTrue(map.size() == 3, "Set size should be 3, is " + map.size());
+        assertEquals(3, map.size(), "Set size should be 3, is " + map.size());
 
         Artifact a = (Artifact) map.get("maven-test:t10-a");
         Artifact b = (Artifact) map.get("maven-test:t10-b");
@@ -84,12 +84,12 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
 
         // inherited from depMgmt
         System.out.println(a.getScope());
-        assertTrue(a.getScope().equals("test"), "Incorrect scope for " + a.getDependencyConflictId());
+        assertEquals("test", a.getScope(), "Incorrect scope for " + a.getDependencyConflictId());
 
         // transitive dep, overridden b depMgmt
-        assertTrue(b.getScope().equals("runtime"), "Incorrect scope for " + b.getDependencyConflictId());
+        assertEquals("runtime", b.getScope(), "Incorrect scope for " + b.getDependencyConflictId());
 
         // direct dep, overrides depMgmt
-        assertTrue(c.getScope().equals("runtime"), "Incorrect scope for " + c.getDependencyConflictId());
+        assertEquals("runtime", c.getScope(), "Incorrect scope for " + c.getDependencyConflictId());
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
@@ -47,7 +47,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testDependencyManagementDoesNotOverrideScopeOfCurrentArtifact() throws Exception {
+    void dependencyManagementDoesNotOverrideScopeOfCurrentArtifact() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         File pom0 = new File(localRepo, "p0/pom.xml");

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12/ProjectInheritanceTest.java
@@ -48,7 +48,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testFalsePluginExecutionInheritValue() throws Exception {
+    void falsePluginExecutionInheritValue() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         File pom0 = new File(localRepo, "p0/pom.xml");

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12scm/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12scm/ProjectInheritanceTest.java
@@ -43,7 +43,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    void testScmInfoCalculatedCorrectlyOnParentAndChildRead() throws Exception {
+    void scmInfoCalculatedCorrectlyOnParentAndChildRead() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         File pom0 = new File(localRepo, "p0/pom.xml");
@@ -61,7 +61,7 @@ class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     }
 
     @Test
-    void testScmInfoCalculatedCorrectlyOnChildOnlyRead() throws Exception {
+    void scmInfoCalculatedCorrectlyOnChildOnlyRead() throws Exception {
         File localRepo = getLocalRepositoryPath();
 
         File pom1 = new File(localRepo, "p0/modules/p1/pom.xml");

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/path/DefaultPathTranslatorTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/path/DefaultPathTranslatorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DefaultPathTranslatorTest {
 
     @Test
-    void testAlignToBasedirWhereBasedirExpressionIsTheCompleteValue() {
+    void alignToBasedirWhereBasedirExpressionIsTheCompleteValue() {
         File basedir = new File(System.getProperty("java.io.tmpdir"), "test").getAbsoluteFile();
 
         String aligned = new DefaultPathTranslator().alignToBaseDirectory("${basedir}", basedir);
@@ -37,7 +37,7 @@ class DefaultPathTranslatorTest {
     }
 
     @Test
-    void testAlignToBasedirWhereBasedirExpressionIsTheValuePrefix() {
+    void alignToBasedirWhereBasedirExpressionIsTheValuePrefix() {
         File basedir = new File(System.getProperty("java.io.tmpdir"), "test").getAbsoluteFile();
 
         String aligned = new DefaultPathTranslator().alignToBaseDirectory("${basedir}/dir", basedir);
@@ -46,7 +46,7 @@ class DefaultPathTranslatorTest {
     }
 
     @Test
-    void testUnalignToBasedirWherePathEqualsBasedir() {
+    void unalignToBasedirWherePathEqualsBasedir() {
         File basedir = new File(System.getProperty("java.io.tmpdir"), "test").getAbsoluteFile();
 
         String unaligned = new DefaultPathTranslator().unalignFromBaseDirectory(basedir.getAbsolutePath(), basedir);

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/DefaultMirrorSelectorTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/DefaultMirrorSelectorTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @Deprecated
 class DefaultMirrorSelectorTest {
     @Test
-    void testMirrorWithMirrorOfPatternContainingANegationIsNotSelected() {
+    void mirrorWithMirrorOfPatternContainingANegationIsNotSelected() {
         ArtifactRepository repository = new DefaultArtifactRepository("snapshots.repo", "http://whatever", null);
         String pattern = "external:*, !snapshots.repo";
         assertFalse(DefaultMirrorSelector.matchPattern(repository, pattern));

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
@@ -116,7 +116,7 @@ class LegacyRepositorySystemTest {
     }
 
     @Test
-    void testThatASystemScopedDependencyIsNotResolvedFromRepositories() throws Exception {
+    void thatASystemScopedDependencyIsNotResolvedFromRepositories() throws Exception {
         //
         // We should get a whole slew of dependencies resolving this artifact transitively
         //
@@ -231,7 +231,7 @@ class LegacyRepositorySystemTest {
     }
 
     @Test
-    void testLocalRepositoryBasedir() throws Exception {
+    void localRepositoryBasedir() throws Exception {
         File localRepoDir = new File("").getAbsoluteFile();
 
         ArtifactRepository localRepo = repositorySystem.createLocalRepository(localRepoDir);

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/MirrorProcessorTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/MirrorProcessorTest.java
@@ -45,7 +45,7 @@ class MirrorProcessorTest {
     private ArtifactRepositoryFactory repositorySystem;
 
     @Test
-    void testExternalURL() {
+    void externalURL() {
         assertTrue(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "http://somehost")));
         assertTrue(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "http://somehost:9090/somepath")));
         assertTrue(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "ftp://somehost")));
@@ -67,7 +67,7 @@ class MirrorProcessorTest {
     }
 
     @Test
-    void testMirrorLookup() {
+    void mirrorLookup() {
         Mirror mirrorA = newMirror("a", "a", "http://a");
         Mirror mirrorB = newMirror("b", "b", "http://b");
 
@@ -81,7 +81,7 @@ class MirrorProcessorTest {
     }
 
     @Test
-    void testMirrorWildcardLookup() {
+    void mirrorWildcardLookup() {
         Mirror mirrorA = newMirror("a", "a", "http://a");
         Mirror mirrorB = newMirror("b", "b", "http://b");
         Mirror mirrorC = newMirror("c", "*", "http://wildcard");
@@ -96,7 +96,7 @@ class MirrorProcessorTest {
     }
 
     @Test
-    void testMirrorStopOnFirstMatch() {
+    void mirrorStopOnFirstMatch() {
         // exact matches win first
         Mirror mirrorA2 = newMirror("a2", "a,b", "http://a2");
         Mirror mirrorA = newMirror("a", "a", "http://a");
@@ -124,7 +124,7 @@ class MirrorProcessorTest {
     }
 
     @Test
-    void testPatterns() {
+    void patterns() {
         assertTrue(DefaultMirrorSelector.matchPattern(getRepo("a"), "*"));
         assertTrue(DefaultMirrorSelector.matchPattern(getRepo("a"), "*,"));
         assertTrue(DefaultMirrorSelector.matchPattern(getRepo("a"), ",*,"));
@@ -160,7 +160,7 @@ class MirrorProcessorTest {
     }
 
     @Test
-    void testPatternsWithExternal() {
+    void patternsWithExternal() {
         assertTrue(DefaultMirrorSelector.matchPattern(getRepo("a", "http://localhost"), "*"));
         assertFalse(DefaultMirrorSelector.matchPattern(getRepo("a", "http://localhost"), "external:*"));
 
@@ -174,7 +174,7 @@ class MirrorProcessorTest {
     }
 
     @Test
-    void testLayoutPattern() {
+    void layoutPattern() {
         assertTrue(DefaultMirrorSelector.matchesLayout("default", null));
         assertTrue(DefaultMirrorSelector.matchesLayout("default", ""));
         assertTrue(DefaultMirrorSelector.matchesLayout("default", "*"));
@@ -193,7 +193,7 @@ class MirrorProcessorTest {
     }
 
     @Test
-    void testMirrorLayoutConsideredForMatching() {
+    void mirrorLayoutConsideredForMatching() {
         ArtifactRepository repo = getRepo("a");
 
         Mirror mirrorA = newMirror("a", "a", null, "http://a");

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
@@ -61,7 +61,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testArtifact() throws Exception {
+    void artifact() throws Exception {
         ArtifactRepository remoteRepository = remoteRepository();
 
         ArtifactRepository localRepository = localRepository();
@@ -89,7 +89,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testMissingArtifact() throws Exception {
+    void missingArtifact() throws Exception {
         ArtifactRepository remoteRepository = remoteRepository();
 
         ArtifactRepository localRepository = localRepository();
@@ -114,7 +114,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testPom() throws Exception {
+    void pom() throws Exception {
         ArtifactRepository remoteRepository = remoteRepository();
 
         ArtifactRepository localRepository = localRepository();
@@ -142,7 +142,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testMissingPom() throws Exception {
+    void missingPom() throws Exception {
         ArtifactRepository remoteRepository = remoteRepository();
 
         ArtifactRepository localRepository = localRepository();
@@ -167,7 +167,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testMetadata() throws Exception {
+    void metadata() throws Exception {
         ArtifactRepository remoteRepository = remoteRepository();
 
         ArtifactRepository localRepository = localRepository();
@@ -195,7 +195,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testMissingMetadata() throws Exception {
+    void missingMetadata() throws Exception {
         ArtifactRepository remoteRepository = remoteRepository();
 
         ArtifactRepository localRepository = localRepository();
@@ -221,7 +221,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     }
 
     @Test
-    void testArtifactTouchFileName() throws Exception {
+    void artifactTouchFileName() throws Exception {
         ArtifactRepository localRepository = localRepository();
 
         Artifact a = artifactFactory.createArtifactWithClassifier("groupId", "a", "0.0.1-SNAPSHOT", "jar", null);

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultWagonManagerTest.java
@@ -72,7 +72,7 @@ class DefaultWagonManagerTest {
     private ArtifactRepositoryFactory artifactRepositoryFactory;
 
     @Test
-    void testUnnecessaryRepositoryLookup() throws Exception {
+    void unnecessaryRepositoryLookup() throws Exception {
         Artifact artifact = createTestPomArtifact("target/test-data/get-missing-pom");
 
         List<ArtifactRepository> repos = new ArrayList<>();
@@ -104,7 +104,7 @@ class DefaultWagonManagerTest {
     }
 
     @Test
-    void testGetMissingJar() throws TransferFailedException, UnsupportedProtocolException, IOException {
+    void getMissingJar() throws TransferFailedException, UnsupportedProtocolException, IOException {
         Artifact artifact = createTestArtifact("target/test-data/get-missing-jar", "jar");
 
         ArtifactRepository repo = createStringRepo();
@@ -115,7 +115,7 @@ class DefaultWagonManagerTest {
     }
 
     @Test
-    void testGetMissingJarForced() throws TransferFailedException, UnsupportedProtocolException, IOException {
+    void getMissingJarForced() throws TransferFailedException, UnsupportedProtocolException, IOException {
         Artifact artifact = createTestArtifact("target/test-data/get-missing-jar", "jar");
 
         ArtifactRepository repo = createStringRepo();
@@ -126,7 +126,7 @@ class DefaultWagonManagerTest {
     }
 
     @Test
-    void testGetRemoteJar()
+    void getRemoteJar()
             throws TransferFailedException, ResourceDoesNotExistException, UnsupportedProtocolException, IOException {
         Artifact artifact = createTestArtifact("target/test-data/get-remote-jar", "jar");
 
@@ -176,7 +176,7 @@ class DefaultWagonManagerTest {
     }
 
     @Test
-    void testDefaultWagonManager() throws Exception {
+    void defaultWagonManager() throws Exception {
         assertWagon("a");
 
         assertWagon("b");
@@ -192,7 +192,7 @@ class DefaultWagonManagerTest {
      * Check that transfer listeners are properly removed after getArtifact and putArtifact
      */
     @Test
-    void testWagonTransferListenerRemovedAfterGetArtifactAndPutArtifact() throws Exception {
+    void wagonTransferListenerRemovedAfterGetArtifactAndPutArtifact() throws Exception {
         Artifact artifact = createTestArtifact("target/test-data/transfer-listener", "jar");
         ArtifactRepository repo = createStringRepo();
         StringWagon wagon = (StringWagon) wagonManager.getWagon("string");
@@ -226,7 +226,7 @@ class DefaultWagonManagerTest {
      */
     @Disabled
     @Test
-    void testChecksumVerification() throws Exception {
+    void checksumVerification() throws Exception {
         ArtifactRepositoryPolicy policy = new ArtifactRepositoryPolicy(
                 true, ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS, ArtifactRepositoryPolicy.CHECKSUM_POLICY_FAIL);
 
@@ -283,7 +283,7 @@ class DefaultWagonManagerTest {
     }
 
     @Test
-    void testPerLookupInstantiation() throws Exception {
+    void perLookupInstantiation() throws Exception {
         String protocol = "perlookup";
 
         Wagon one = wagonManager.getWagon(protocol);

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/LegacyRepositorySystemTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/LegacyRepositorySystemTest.java
@@ -43,14 +43,14 @@ class LegacyRepositorySystemTest {
     private LegacyRepositorySystem repositorySystem;
 
     @Test
-    void testThatLocalRepositoryWithSpacesIsProperlyHandled() throws Exception {
+    void thatLocalRepositoryWithSpacesIsProperlyHandled() throws Exception {
         File basedir = new File("target/spacy path").getAbsoluteFile();
         ArtifactRepository repo = repositorySystem.createLocalRepository(basedir);
         assertEquals(basedir, new File(repo.getBasedir()));
     }
 
     @Test
-    void testAuthenticationHandling() {
+    void authenticationHandling() {
         Server server = new Server();
         server.setId("repository");
         server.setUsername("jason");

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
@@ -86,7 +86,7 @@ class DefaultArtifactCollectorTest {
 
     @Test
     @Disabled("works, but we don't fail on cycles presently")
-    void testCircularDependencyNotIncludingCurrentProject()
+    void circularDependencyNotIncludingCurrentProject()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
@@ -99,7 +99,7 @@ class DefaultArtifactCollectorTest {
 
     @Test
     @Disabled("works, but we don't fail on cycles presently")
-    void testCircularDependencyIncludingCurrentProject()
+    void circularDependencyIncludingCurrentProject()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
@@ -111,7 +111,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveWithFilter() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveWithFilter() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
         ArtifactSpec c = a.addDependency("c", "3.0");
@@ -131,7 +131,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveCorrectDependenciesWhenDifferentDependenciesOnNearest()
+    void resolveCorrectDependenciesWhenDifferentDependenciesOnNearest()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
@@ -152,7 +152,7 @@ class DefaultArtifactCollectorTest {
 
     @Test
     @Disabled
-    void testResolveCorrectDependenciesWhenDifferentDependenciesOnNewest()
+    void resolveCorrectDependenciesWhenDifferentDependenciesOnNewest()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         // TODO use newest conflict resolver
         ArtifactSpec a = createArtifactSpec("a", "1.0");
@@ -174,7 +174,7 @@ class DefaultArtifactCollectorTest {
 
     @Test
     @Disabled
-    void testResolveCorrectDependenciesWhenDifferentDependenciesOnNewestVersionReplaced()
+    void resolveCorrectDependenciesWhenDifferentDependenciesOnNewestVersionReplaced()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         // TODO use newest conflict resolver
         ArtifactSpec a = createArtifactSpec("a", "1.0");
@@ -195,7 +195,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveNearestNewestIsNearest() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveNearestNewestIsNearest() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
         ArtifactSpec c = a.addDependency("c", "3.0");
@@ -211,7 +211,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveNearestOldestIsNearest() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveNearestOldestIsNearest() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
         ArtifactSpec c = a.addDependency("c", "2.0");
@@ -227,7 +227,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveLocalNewestIsLocal() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveLocalNewestIsLocal() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         a.addDependency("b", "2.0");
         ArtifactSpec b = createArtifactSpec("b", "3.0");
@@ -238,7 +238,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveLocalOldestIsLocal() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveLocalOldestIsLocal() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         a.addDependency("b", "3.0");
         ArtifactSpec b = createArtifactSpec("b", "2.0");
@@ -249,7 +249,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveLocalWithNewerVersionButLesserScope()
+    void resolveLocalWithNewerVersionButLesserScope()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("commons-logging", "1.0");
         a.addDependency("junit", "3.7");
@@ -263,7 +263,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveLocalWithNewerVersionButLesserScopeResolvedFirst()
+    void resolveLocalWithNewerVersionButLesserScopeResolvedFirst()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec b = createArtifactSpec("junit", "3.8.1", Artifact.SCOPE_TEST);
         ArtifactSpec a = createArtifactSpec("commons-logging", "1.0");
@@ -277,7 +277,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveNearestWithRanges() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveNearestWithRanges() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
         ArtifactSpec c = a.addDependency("c", "2.0");
@@ -294,7 +294,7 @@ class DefaultArtifactCollectorTest {
 
     @Test
     @SuppressWarnings("checkstyle:UnusedLocalVariable")
-    void testResolveRangeWithManagedVersion() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveRangeWithManagedVersion() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "[1.0,3.0]");
 
@@ -307,7 +307,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testCompatibleRanges() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void compatibleRanges() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
         a.addDependency("c", "[2.0,2.5]");
@@ -324,7 +324,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testIncompatibleRanges() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void incompatibleRanges() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
         a.addDependency("c", "[2.4,3.0]");
@@ -337,7 +337,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testUnboundedRangeWhenVersionUnavailable()
+    void unboundedRangeWhenVersionUnavailable()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "1.0");
@@ -350,7 +350,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testUnboundedRangeBelowLastRelease() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void unboundedRangeBelowLastRelease() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         createArtifactSpec("c", "1.5");
         ArtifactSpec c = createArtifactSpec("c", "2.0");
@@ -364,7 +364,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testUnboundedRangeAboveLastRelease() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void unboundedRangeAboveLastRelease() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         createArtifactSpec("c", "2.0");
         a.addDependency("c", "[10.0,)");
@@ -375,7 +375,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveManagedVersion() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void resolveManagedVersion() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         a.addDependency("b", "3.0", Artifact.SCOPE_RUNTIME);
 
@@ -387,7 +387,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testCollectChangesVersionOfOriginatingArtifactIfInDependencyManagementHasDifferentVersion()
+    void collectChangesVersionOfOriginatingArtifactIfInDependencyManagementHasDifferentVersion()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
 
@@ -404,7 +404,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveCompileScopeOverTestScope()
+    void resolveCompileScopeOverTestScope()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec c = createArtifactSpec("c", "3.0", Artifact.SCOPE_TEST);
@@ -422,7 +422,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveRuntimeScopeOverTestScope()
+    void resolveRuntimeScopeOverTestScope()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec c = createArtifactSpec("c", "3.0", Artifact.SCOPE_TEST);
@@ -440,7 +440,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveCompileScopeOverRuntimeScope()
+    void resolveCompileScopeOverRuntimeScope()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec root = createArtifactSpec("root", "1.0");
         ArtifactSpec a = root.addDependency("a", "1.0");
@@ -460,7 +460,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveCompileScopeOverProvidedScope()
+    void resolveCompileScopeOverProvidedScope()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec c = createArtifactSpec("c", "3.0", Artifact.SCOPE_PROVIDED);
@@ -478,7 +478,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testResolveRuntimeScopeOverProvidedScope()
+    void resolveRuntimeScopeOverProvidedScope()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec c = createArtifactSpec("c", "3.0", Artifact.SCOPE_PROVIDED);
@@ -496,7 +496,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testProvidedScopeNotTransitive() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void providedScopeNotTransitive() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0", Artifact.SCOPE_PROVIDED);
         ArtifactSpec b = createArtifactSpec("b", "1.0");
         b.addDependency("c", "3.0", Artifact.SCOPE_PROVIDED);
@@ -506,7 +506,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testOptionalNotTransitive() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void optionalNotTransitive() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = createArtifactSpec("b", "1.0");
         b.addDependency("c", "3.0", true);
@@ -516,7 +516,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testOptionalIncludedAtRoot() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void optionalIncludedAtRoot() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
 
         ArtifactSpec b = createArtifactSpec("b", "1.0", true);
@@ -526,7 +526,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testScopeUpdate() throws InvalidVersionSpecificationException, ArtifactResolutionException {
+    void scopeUpdate() throws InvalidVersionSpecificationException, ArtifactResolutionException {
         /* farthest = compile */
         checkScopeUpdate(Artifact.SCOPE_COMPILE, Artifact.SCOPE_COMPILE, Artifact.SCOPE_COMPILE);
         checkScopeUpdate(Artifact.SCOPE_COMPILE, Artifact.SCOPE_PROVIDED, Artifact.SCOPE_COMPILE);
@@ -627,7 +627,7 @@ class DefaultArtifactCollectorTest {
 
     @Test
     @Disabled
-    void testOptionalNotTransitiveButVersionIsInfluential()
+    void optionalNotTransitiveButVersionIsInfluential()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = createArtifactSpec("b", "1.0");
@@ -648,7 +648,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testTestScopeNotTransitive() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void testScopeNotTransitive() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0", Artifact.SCOPE_TEST);
         ArtifactSpec b = createArtifactSpec("b", "1.0");
         b.addDependency("c", "3.0", Artifact.SCOPE_TEST);
@@ -658,7 +658,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    void testSnapshotNotIncluded() throws ArtifactResolutionException, InvalidVersionSpecificationException {
+    void snapshotNotIncluded() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         a.addDependency("b", "[1.0,)");
         createArtifactSpec("b", "1.0-SNAPSHOT");
@@ -677,7 +677,7 @@ class DefaultArtifactCollectorTest {
     @Test
     @Disabled("that one does not work")
     @SuppressWarnings("checkstyle:UnusedLocalVariable")
-    void testOverConstrainedVersionException()
+    void overConstrainedVersionException()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         a.addDependency("b", "[1.0, 2.0)");

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/FarthestConflictResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/FarthestConflictResolverTest.java
@@ -44,7 +44,7 @@ class FarthestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepth() {
+    void depth() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
@@ -60,7 +60,7 @@ class FarthestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepthReversed() {
+    void depthReversed() {
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
         ResolutionNode a1n = createResolutionNode(a1);
@@ -76,7 +76,7 @@ class FarthestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqual() {
+    void equal() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode a2n = createResolutionNode(a2);
 
@@ -91,7 +91,7 @@ class FarthestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqualReversed() {
+    void equalReversed() {
         ResolutionNode a2n = createResolutionNode(a2);
         ResolutionNode a1n = createResolutionNode(a1);
 

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolverTest.java
@@ -44,7 +44,7 @@ class NearestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepth() {
+    void depth() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
@@ -60,7 +60,7 @@ class NearestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepthReversed() {
+    void depthReversed() {
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
         ResolutionNode a1n = createResolutionNode(a1);
@@ -76,7 +76,7 @@ class NearestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqual() {
+    void equal() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode a2n = createResolutionNode(a2);
 
@@ -91,7 +91,7 @@ class NearestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqualReversed() {
+    void equalReversed() {
         ResolutionNode a2n = createResolutionNode(a2);
         ResolutionNode a1n = createResolutionNode(a1);
 

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NewestConflictResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/NewestConflictResolverTest.java
@@ -44,7 +44,7 @@ class NewestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepth() {
+    void depth() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
@@ -60,7 +60,7 @@ class NewestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepthReversed() {
+    void depthReversed() {
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
         ResolutionNode a1n = createResolutionNode(a1);
@@ -76,7 +76,7 @@ class NewestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqual() {
+    void equal() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode a2n = createResolutionNode(a2);
 
@@ -91,7 +91,7 @@ class NewestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqualReversed() {
+    void equalReversed() {
         ResolutionNode a2n = createResolutionNode(a2);
         ResolutionNode a1n = createResolutionNode(a1);
 

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/OldestConflictResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/conflict/OldestConflictResolverTest.java
@@ -44,7 +44,7 @@ class OldestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepth() {
+    void depth() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
@@ -60,7 +60,7 @@ class OldestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testDepthReversed() {
+    void depthReversed() {
         ResolutionNode b1n = createResolutionNode(b1);
         ResolutionNode a2n = createResolutionNode(a2, b1n);
         ResolutionNode a1n = createResolutionNode(a1);
@@ -76,7 +76,7 @@ class OldestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqual() {
+    void equal() {
         ResolutionNode a1n = createResolutionNode(a1);
         ResolutionNode a2n = createResolutionNode(a2);
 
@@ -91,7 +91,7 @@ class OldestConflictResolverTest extends AbstractConflictResolverTest {
      * </pre>
      */
     @Test
-    void testEqualReversed() {
+    void equalReversed() {
         ResolutionNode a2n = createResolutionNode(a2);
         ResolutionNode a1n = createResolutionNode(a1);
 

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultClasspathTransformationTestType.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultClasspathTransformationTestType.java
@@ -76,7 +76,7 @@ class DefaultClasspathTransformationTestType {
 
     // ------------------------------------------------------------------------------------------
     @Test
-    void testCompileClasspathTransform() throws Exception {
+    void compileClasspathTransform() throws Exception {
         ClasspathContainer res;
 
         res = transform.transform(graph, ArtifactScopeEnum.compile, false);
@@ -88,7 +88,7 @@ class DefaultClasspathTransformationTestType {
 
     // ------------------------------------------------------------------------------------------
     @Test
-    void testRuntimeClasspathTransform() throws Exception {
+    void runtimeClasspathTransform() throws Exception {
         ClasspathContainer res;
 
         res = transform.transform(graph, ArtifactScopeEnum.runtime, false);
@@ -103,7 +103,7 @@ class DefaultClasspathTransformationTestType {
 
     // ------------------------------------------------------------------------------------------
     @Test
-    void testTestClasspathTransform() throws Exception {
+    void testClasspathTransform() throws Exception {
         ClasspathContainer res;
 
         res = transform.transform(graph, ArtifactScopeEnum.test, false);

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolutionPolicyTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolutionPolicyTest.java
@@ -45,7 +45,7 @@ class DefaultGraphConflictResolutionPolicyTest {
 
     // ------------------------------------------------------------------------------------------
     @Test
-    void testDefaultPolicy() throws Exception {
+    void defaultPolicy() throws Exception {
         MetadataGraphEdge res;
 
         res = policy.apply(e1, e2);

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolverTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/metadata/DefaultGraphConflictResolverTest.java
@@ -76,7 +76,7 @@ class DefaultGraphConflictResolverTest {
 
     // ------------------------------------------------------------------------------------------
     @Test
-    void testCompileResolution() throws Exception {
+    void compileResolution() throws Exception {
         MetadataGraph res;
 
         res = resolver.resolveConflicts(graph, ArtifactScopeEnum.compile);
@@ -118,7 +118,7 @@ class DefaultGraphConflictResolverTest {
 
     // ------------------------------------------------------------------------------------------
     @Test
-    void testRuntimeResolution() throws Exception {
+    void runtimeResolution() throws Exception {
         MetadataGraph res;
 
         res = resolver.resolveConflicts(graph, ArtifactScopeEnum.runtime);
@@ -159,7 +159,7 @@ class DefaultGraphConflictResolverTest {
 
     // ------------------------------------------------------------------------------------------
     @Test
-    void testTestResolution() throws Exception {
+    void testResolution() throws Exception {
         MetadataGraph res;
 
         res = resolver.resolveConflicts(graph, ArtifactScopeEnum.test);

--- a/compat/maven-compat/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.maven.api.toolchain.ToolchainModel;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DefaultToolchainManagerTest {
+    private AutoCloseable mocks;
     // Mocks to inject into toolchainManager
     @Mock
     private Logger logger;
@@ -67,7 +69,7 @@ class DefaultToolchainManagerTest {
 
     @BeforeEach
     void onSetup() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
 
         Map<String, ToolchainFactory> factories = new HashMap<>();
         factories.put("basic", toolchainFactoryBasicType);
@@ -81,7 +83,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testNoModels() {
+    void noModels() {
         MavenSession session = mock(MavenSession.class);
         MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
         when(session.getRequest()).thenReturn(executionRequest);
@@ -92,7 +94,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testModelNoFactory() {
+    void modelNoFactory() {
         MavenSession session = mock(MavenSession.class);
         MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
         List<ToolchainModel> toolchainModels = new ArrayList<>();
@@ -109,7 +111,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testModelAndFactory() {
+    void modelAndFactory() {
         MavenSession session = mock(MavenSession.class);
         List<ToolchainModel> toolchainModels = List.of(
                 ToolchainModel.newBuilder().type("basic").build(),
@@ -128,7 +130,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testModelsAndFactory() {
+    void modelsAndFactory() {
         MavenSession session = mock(MavenSession.class);
         Session sessionv4 = mock(Session.class);
         when(session.getSession()).thenReturn(sessionv4);
@@ -149,7 +151,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testRequirements() throws Exception {
+    void requirements() throws Exception {
         MavenSession session = mock(MavenSession.class);
         MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
         when(session.getRequest()).thenReturn(executionRequest);
@@ -174,7 +176,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testToolchainsForAvailableType() throws Exception {
+    void toolchainsForAvailableType() throws Exception {
         // prepare
         MavenSession session = mock(MavenSession.class);
         MavenExecutionRequest req = new DefaultMavenExecutionRequest();
@@ -196,7 +198,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testToolchainsForUnknownType() throws Exception {
+    void toolchainsForUnknownType() throws Exception {
         // prepare
         MavenSession session = mock(MavenSession.class);
         MavenExecutionRequest req = new DefaultMavenExecutionRequest();
@@ -216,7 +218,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testToolchainsForConfiguredType() throws Exception {
+    void toolchainsForConfiguredType() throws Exception {
         // prepare
         MavenSession session = mock(MavenSession.class);
         MavenExecutionRequest req = new DefaultMavenExecutionRequest();
@@ -247,7 +249,7 @@ class DefaultToolchainManagerTest {
     }
 
     @Test
-    void testMisconfiguredToolchain() throws Exception {
+    void misconfiguredToolchain() throws Exception {
         // prepare
         MavenSession session = mock(MavenSession.class);
         MavenExecutionRequest req = new DefaultMavenExecutionRequest();
@@ -260,5 +262,10 @@ class DefaultToolchainManagerTest {
 
         // verify
         assertEquals(0, basics.length);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/toolchain/DefaultToolchainTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/toolchain/DefaultToolchainTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import org.apache.maven.toolchain.java.DefaultJavaToolChain;
 import org.apache.maven.toolchain.model.ToolchainModel;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -35,11 +36,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 class DefaultToolchainTest {
+    private AutoCloseable mocks;
     private final Logger logger = mock(Logger.class);
 
     @BeforeEach
     void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
     }
 
     private DefaultToolchain newDefaultToolchain(ToolchainModel model) {
@@ -61,14 +63,14 @@ class DefaultToolchainTest {
     }
 
     @Test
-    void testGetModel() {
+    void getModel() {
         ToolchainModel model = new ToolchainModel();
         DefaultToolchain toolchain = newDefaultToolchain(model);
         assertEquals(model, toolchain.getModel());
     }
 
     @Test
-    void testGetType() {
+    void getType() {
         ToolchainModel model = new ToolchainModel();
         DefaultToolchain toolchain = newDefaultToolchain(model, "TYPE");
         assertEquals("TYPE", toolchain.getType());
@@ -79,14 +81,14 @@ class DefaultToolchainTest {
     }
 
     @Test
-    void testGetLogger() {
+    void getLogger() {
         ToolchainModel model = new ToolchainModel();
         DefaultToolchain toolchain = newDefaultToolchain(model);
         assertEquals(logger, toolchain.getLog());
     }
 
     @Test
-    void testMissingRequirementProperty() {
+    void missingRequirementProperty() {
         ToolchainModel model = new ToolchainModel();
         model.setType("TYPE");
         DefaultToolchain toolchain = newDefaultToolchain(model);
@@ -96,7 +98,7 @@ class DefaultToolchainTest {
     }
 
     @Test
-    void testNonMatchingRequirementProperty() {
+    void nonMatchingRequirementProperty() {
         ToolchainModel model = new ToolchainModel();
         model.setType("TYPE");
         DefaultToolchain toolchain = newDefaultToolchain(model);
@@ -107,7 +109,7 @@ class DefaultToolchainTest {
     }
 
     @Test
-    void testEquals() {
+    void equals() {
         ToolchainModel tm1 = new ToolchainModel();
         tm1.setType("jdk");
         tm1.addProvide("version", "1.5");
@@ -135,5 +137,10 @@ class DefaultToolchainTest {
         assertNotEquals(tc1, tc2);
         assertNotEquals(tc2, tc1);
         assertEquals(tc2, tc2);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
@@ -33,7 +33,7 @@ class RequirementMatcherFactoryTest {
      * Test of createExactMatcher method, of class RequirementMatcherFactory.
      */
     @Test
-    void testCreateExactMatcher() {
+    void createExactMatcher() {
         RequirementMatcher matcher;
         matcher = RequirementMatcherFactory.createExactMatcher("foo");
         assertFalse(matcher.matches("bar"));
@@ -46,7 +46,7 @@ class RequirementMatcherFactoryTest {
      * Test of createVersionMatcher method, of class RequirementMatcherFactory.
      */
     @Test
-    void testCreateVersionMatcher() {
+    void createVersionMatcher() {
         RequirementMatcher matcher;
         matcher = RequirementMatcherFactory.createVersionMatcher("1.5.2");
         assertFalse(matcher.matches("1.5"));

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerDocumentationTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/CLIManagerDocumentationTest.java
@@ -113,7 +113,7 @@ class CLIManagerDocumentationTest {
     }
 
     @Test
-    void testOptionsAsHtml() throws IOException {
+    void optionsAsHtml() throws IOException {
         Path options = Paths.get("target/test-classes/options.html");
         Files.writeString(options, getOptionsAsHtml(), StandardCharsets.UTF_8);
     }

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/CLIReportingUtilsTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/CLIReportingUtilsTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class CLIReportingUtilsTest {
 
     @Test
-    void testFormatDuration() {
+    void formatDuration() {
         assertEquals("0.001 s", CLIReportingUtils.formatDuration(1));
         assertEquals("0.999 s", CLIReportingUtils.formatDuration(1000 - 1));
         assertEquals("1.000 s", CLIReportingUtils.formatDuration(1000));

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/CleanArgumentTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/CleanArgumentTest.java
@@ -45,7 +45,7 @@ class CleanArgumentTest {
     }
 
     @Test
-    void testCleanArgsShouldNotTouchCorrectlyQuotedArgumentsUsingDoubleQuotes() {
+    void cleanArgsShouldNotTouchCorrectlyQuotedArgumentsUsingDoubleQuotes() {
         String information = "-Dinformation=\"The Information is important.\"";
         String[] args = {information};
         String[] cleanArgs = CleanArgument.cleanArgs(args);
@@ -54,7 +54,7 @@ class CleanArgumentTest {
     }
 
     @Test
-    void testCleanArgsShouldNotTouchCorrectlyQuotedArgumentsUsingSingleQuotes() {
+    void cleanArgsShouldNotTouchCorrectlyQuotedArgumentsUsingSingleQuotes() {
         String information = "-Dinformation='The Information is important.'";
         String[] args = {information};
         String[] cleanArgs = CleanArgument.cleanArgs(args);

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -134,7 +134,7 @@ class MavenCliTest {
     }
 
     @Test
-    void testDetermineProjectActivation() throws ParseException {
+    void determineProjectActivation() throws ParseException {
         final CommandLineParser parser = new DefaultParser();
 
         final Options options = new Options();
@@ -161,7 +161,7 @@ class MavenCliTest {
     }
 
     @Test
-    void testCalculateDegreeOfConcurrency() {
+    void calculateDegreeOfConcurrency() {
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("0"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("-1"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("0x4"));
@@ -183,7 +183,7 @@ class MavenCliTest {
     }
 
     @Test
-    void testMavenConfig() throws Exception {
+    void mavenConfig() throws Exception {
         System.setProperty(
                 MavenCli.MULTIMODULE_PROJECT_DIRECTORY, new File("src/test/projects/config").getCanonicalPath());
         CliRequest request = new CliRequest(new String[0], null);
@@ -201,7 +201,7 @@ class MavenCliTest {
     }
 
     @Test
-    void testMavenConfigInvalid() throws Exception {
+    void mavenConfigInvalid() throws Exception {
         System.setProperty(
                 MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
                 new File("src/test/projects/config-illegal").getCanonicalPath());
@@ -225,7 +225,7 @@ class MavenCliTest {
      * @throws Exception in case of failure.
      */
     @Test
-    void testMVNConfigurationThreadCanBeOverwrittenViaCommandLine() throws Exception {
+    void mvnConfigurationThreadCanBeOverwrittenViaCommandLine() throws Exception {
         System.setProperty(
                 MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
                 new File("src/test/projects/mavenConfigProperties").getCanonicalPath());
@@ -252,7 +252,7 @@ class MavenCliTest {
      * @throws Exception
      */
     @Test
-    void testMVNConfigurationDefinedPropertiesCanBeOverwrittenViaCommandLine() throws Exception {
+    void mvnConfigurationDefinedPropertiesCanBeOverwrittenViaCommandLine() throws Exception {
         System.setProperty(
                 MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
                 new File("src/test/projects/mavenConfigProperties").getCanonicalPath());
@@ -281,7 +281,7 @@ class MavenCliTest {
      * @throws Exception
      */
     @Test
-    void testMVNConfigurationCLIRepeatedPropertiesLastWins() throws Exception {
+    void mvnConfigurationCLIRepeatedPropertiesLastWins() throws Exception {
         System.setProperty(
                 MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
                 new File("src/test/projects/mavenConfigProperties").getCanonicalPath());
@@ -310,7 +310,7 @@ class MavenCliTest {
      * @throws Exception
      */
     @Test
-    void testMVNConfigurationFunkyArguments() throws Exception {
+    void mvnConfigurationFunkyArguments() throws Exception {
         System.setProperty(
                 MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
                 new File("src/test/projects/mavenConfigProperties").getCanonicalPath());
@@ -338,7 +338,7 @@ class MavenCliTest {
     }
 
     @Test
-    void testStyleColors() throws Exception {
+    void styleColors() throws Exception {
         assumeTrue(MessageUtils.isColorEnabled(), "ANSI not supported");
         CliRequest request;
 
@@ -407,7 +407,7 @@ class MavenCliTest {
      * Verifies MNG-6558
      */
     @Test
-    void testToolchainsBuildingEvents() throws Exception {
+    void toolchainsBuildingEvents() throws Exception {
         final EventSpyDispatcher eventSpyDispatcherMock = mock(EventSpyDispatcher.class);
         MavenCli customizedMavenCli = new MavenCli() {
             @Override
@@ -489,7 +489,7 @@ class MavenCliTest {
      * @throws Exception cli invocation.
      */
     @Test
-    void testVersionStringWithoutAnsi() throws Exception {
+    void versionStringWithoutAnsi() throws Exception {
         // given
         // - request with version and batch mode
         CliRequest cliRequest = new CliRequest(new String[] {"--version", "--batch-mode"}, null);
@@ -579,13 +579,13 @@ class MavenCliTest {
     }
 
     @Test
-    public void findRootProjectWithAttribute() {
+    void findRootProjectWithAttribute() {
         Path test = Paths.get("src/test/projects/root-attribute");
         assertEquals(test, new DefaultRootLocator().findRoot(test.resolve("child")));
     }
 
     @Test
-    public void testPropertiesInterpolation() throws Exception {
+    void propertiesInterpolation() throws Exception {
         FileSystem fs = Jimfs.newFileSystem(Configuration.windows());
 
         Path mavenHome = fs.getPath("C:\\maven");
@@ -643,14 +643,14 @@ class MavenCliTest {
     }
 
     @Test
-    public void testEmptyProfile() throws Exception {
+    void emptyProfile() throws Exception {
         CliRequest request = new CliRequest(new String[] {"-P", ""}, null);
         cli.cli(request);
         cli.populateRequest(request);
     }
 
     @Test
-    public void testEmptyProject() throws Exception {
+    void emptyProject() throws Exception {
         CliRequest request = new CliRequest(new String[] {"-pl", ""}, null);
         cli.cli(request);
         cli.populateRequest(request);
@@ -658,7 +658,7 @@ class MavenCliTest {
 
     @ParameterizedTest
     @MethodSource("activateBatchModeArguments")
-    public void activateBatchMode(boolean ciEnv, String[] cliArgs, boolean isBatchMode) throws Exception {
+    void activateBatchMode(boolean ciEnv, String[] cliArgs, boolean isBatchMode) throws Exception {
         CliRequest request = new CliRequest(cliArgs, null);
         if (ciEnv) {
             request.getSystemProperties().put("env.CI", "true");
@@ -685,7 +685,7 @@ class MavenCliTest {
 
     @ParameterizedTest
     @MethodSource("calculateTransferListenerArguments")
-    public void calculateTransferListener(boolean ciEnv, String[] cliArgs, Class<TransferListener> expectedSubClass)
+    void calculateTransferListener(boolean ciEnv, String[] cliArgs, Class<TransferListener> expectedSubClass)
             throws Exception {
         CliRequest request = new CliRequest(cliArgs, null);
         if (ciEnv) {

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/event/ExecutionEventLoggerTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/event/ExecutionEventLoggerTest.java
@@ -65,7 +65,7 @@ class ExecutionEventLoggerTest {
     }
 
     @Test
-    void testProjectStarted() {
+    void projectStarted() {
         // prepare
         File basedir = new File("").getAbsoluteFile();
         ExecutionEvent event = mock(ExecutionEvent.class);
@@ -98,7 +98,7 @@ class ExecutionEventLoggerTest {
     }
 
     @Test
-    void testProjectStartedOverflow() {
+    void projectStartedOverflow() {
         // prepare
         File basedir = new File("").getAbsoluteFile();
         ExecutionEvent event = mock(ExecutionEvent.class);
@@ -130,7 +130,7 @@ class ExecutionEventLoggerTest {
     }
 
     @Test
-    void testTerminalWidth() {
+    void terminalWidth() {
         // prepare
         Logger logger = mock(Logger.class);
         when(logger.isInfoEnabled()).thenReturn(true);
@@ -170,7 +170,7 @@ class ExecutionEventLoggerTest {
     }
 
     @Test
-    void testProjectStartedNoPom() {
+    void projectStartedNoPom() {
         // prepare
         File basedir = new File("").getAbsoluteFile();
         ExecutionEvent event = mock(ExecutionEvent.class);
@@ -196,7 +196,7 @@ class ExecutionEventLoggerTest {
     }
 
     @Test
-    void testMultiModuleProjectProgress() {
+    void multiModuleProjectProgress() {
         // prepare
         MavenProject project1 = generateMavenProject("Apache Maven Embedder 1");
         MavenProject project2 = generateMavenProject("Apache Maven Embedder 2");
@@ -229,7 +229,7 @@ class ExecutionEventLoggerTest {
     }
 
     @Test
-    void testMultiModuleProjectResumeFromProgress() {
+    void multiModuleProjectResumeFromProgress() {
         // prepare
         MavenProject project1 = generateMavenProject("Apache Maven Embedder 1");
         MavenProject project2 = generateMavenProject("Apache Maven Embedder 2");

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/props/MavenPropertiesLoaderTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/props/MavenPropertiesLoaderTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class MavenPropertiesLoaderTest {
 
     @Test
-    void testIncludes() throws Exception {
+    void includes() throws Exception {
         FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
 
         Path mavenHome = fs.getPath("/maven");
@@ -62,7 +62,7 @@ class MavenPropertiesLoaderTest {
     }
 
     @Test
-    void testIncludes3() throws Exception {
+    void includes3() throws Exception {
         FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
 
         Path mavenHome = fs.getPath("/maven");

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/props/MavenPropertiesTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/props/MavenPropertiesTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit tests on <code>MavenProperties</code>.
  */
 @Deprecated
-public class MavenPropertiesTest {
+class MavenPropertiesTest {
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
     private static final String COMMENT = "# comment";
@@ -65,13 +65,13 @@ public class MavenPropertiesTest {
      * @see junit.framework.TestCase#setUp()
      */
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         properties = new MavenProperties();
         properties.load(new StringReader(TEST_PROPERTIES));
     }
 
     @Test
-    public void testSpaces() throws Exception {
+    void spaces() throws Exception {
         String config = "\n" + "\n"
                 + "    \n"
                 + "                \n"
@@ -164,7 +164,7 @@ public class MavenPropertiesTest {
     }
 
     @Test
-    public void testConfigInterpolation() throws IOException {
+    void configInterpolation() throws IOException {
         String config = "a=$\\\\\\\\{var}\n" + "ab=${a}b\n" + "abc=${ab}c";
         Map<String, String> expected = Map.of("a", "$\\{var}", "ab", "$\\{var}b", "abc", "$\\{var}bc");
 
@@ -186,13 +186,13 @@ public class MavenPropertiesTest {
      * @throws Exception
      */
     @Test
-    public void testGettingProperty() throws Exception {
+    void gettingProperty() throws Exception {
         Object o2 = properties.get("test");
         assertEquals("test", o2);
     }
 
     @Test
-    public void testLoadSave() throws IOException {
+    void loadSave() throws IOException {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         pw.println("# ");
@@ -225,7 +225,7 @@ public class MavenPropertiesTest {
     }
 
     @Test
-    public void testJavaUtilPropertiesCompatibility() throws Exception {
+    void javaUtilPropertiesCompatibility() throws Exception {
         MavenProperties properties = new MavenProperties();
         properties.load(new StringReader(TEST_PROPERTIES));
 
@@ -246,7 +246,7 @@ public class MavenPropertiesTest {
     private static final String RESULT1 = COMMENT + LINE_SEPARATOR + KEY1A + " = " + VALUE1 + LINE_SEPARATOR;
 
     @Test
-    public void testSaveComment1() throws Exception {
+    void saveComment1() throws Exception {
         properties.put(KEY1, COMMENT, VALUE1);
         StringWriter sw = new StringWriter();
         properties.save(sw);
@@ -257,7 +257,7 @@ public class MavenPropertiesTest {
     private static final String RESULT1A = COMMENT + LINE_SEPARATOR + KEY2A + " = " + VALUE1 + LINE_SEPARATOR;
 
     @Test
-    public void testSaveComment1a() throws Exception {
+    void saveComment1a() throws Exception {
         properties.put(KEY2, COMMENT, VALUE1);
         StringWriter sw = new StringWriter();
         properties.save(sw);
@@ -269,7 +269,7 @@ public class MavenPropertiesTest {
             COMMENT + LINE_SEPARATOR + COMMENT + LINE_SEPARATOR + KEY1A + " = " + VALUE1 + LINE_SEPARATOR;
 
     @Test
-    public void testSaveComment2() throws Exception {
+    void saveComment2() throws Exception {
         properties.put(KEY1, List.of(new String[] {COMMENT, COMMENT}), VALUE1);
         StringWriter sw = new StringWriter();
         properties.save(sw);
@@ -281,7 +281,7 @@ public class MavenPropertiesTest {
             + "\\" + LINE_SEPARATOR + VALUE1 + LINE_SEPARATOR;
 
     @Test
-    public void testSaveComment3() throws Exception {
+    void saveComment3() throws Exception {
         properties.put(KEY1, List.of(new String[] {COMMENT, COMMENT}), List.of(new String[] {VALUE1, VALUE1}));
         StringWriter sw = new StringWriter();
         properties.save(sw);
@@ -294,7 +294,7 @@ public class MavenPropertiesTest {
     }
 
     @Test
-    public void testEntrySetValue() throws Exception {
+    void entrySetValue() throws Exception {
         properties.put(KEY1, VALUE1);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -320,7 +320,7 @@ public class MavenPropertiesTest {
     }
 
     @Test
-    public void testMultiValueEscaping() throws IOException {
+    void multiValueEscaping() throws IOException {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         pw.println("fruits                           apple, banana, pear, \\");
@@ -384,7 +384,7 @@ public class MavenPropertiesTest {
     }
 
     @Test
-    public void testUpdate() throws Exception {
+    void update() throws Exception {
         MavenProperties p1 = new MavenProperties();
         p1.put(
                 "fruits",
@@ -416,7 +416,7 @@ public class MavenPropertiesTest {
     }
 
     @Test
-    public void testSubstitution() throws IOException {
+    void substitution() throws IOException {
         String str = "port = 4141" + LINE_SEPARATOR + "host = localhost"
                 + LINE_SEPARATOR + "url = https://${host}:${port}/service"
                 + LINE_SEPARATOR;

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/transfer/FileSizeFormatTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/transfer/FileSizeFormatTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class FileSizeFormatTest {
 
     @Test
-    void testNegativeSize() {
+    void negativeSize() {
         FileSizeFormat format = new FileSizeFormat();
 
         long negativeSize = -100L;
@@ -36,7 +36,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testSize() {
+    void size() {
         FileSizeFormat format = new FileSizeFormat();
 
         assertEquals("0 B", format.format(0L));
@@ -62,7 +62,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testSizeWithSelectedScaleUnit() {
+    void sizeWithSelectedScaleUnit() {
         FileSizeFormat format = new FileSizeFormat();
 
         assertEquals("0 B", format.format(0L));
@@ -151,7 +151,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testNegativeProgressedSize() {
+    void negativeProgressedSize() {
         FileSizeFormat format = new FileSizeFormat();
 
         long negativeProgressedSize = -100L;
@@ -159,14 +159,14 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testNegativeProgressedSizeBiggerThanSize() {
+    void negativeProgressedSizeBiggerThanSize() {
         FileSizeFormat format = new FileSizeFormat();
 
         assertThrows(IllegalArgumentException.class, () -> format.formatProgress(100L, 10L));
     }
 
     @Test
-    void testProgressedSizeWithoutSize() {
+    void progressedSizeWithoutSize() {
         FileSizeFormat format = new FileSizeFormat();
 
         assertEquals("0 B", format.formatProgress(0L, -1L));
@@ -176,14 +176,14 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testProgressedBothZero() {
+    void progressedBothZero() {
         FileSizeFormat format = new FileSizeFormat();
 
         assertEquals("0 B", format.formatProgress(0L, 0L));
     }
 
     @Test
-    void testProgressedSizeWithSize() {
+    void progressedSizeWithSize() {
         FileSizeFormat format = new FileSizeFormat();
 
         assertEquals("0/800 B", format.formatProgress(0L, 800L));

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/ComplexActivationTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/ComplexActivationTest.java
@@ -37,7 +37,7 @@ class ComplexActivationTest {
     }
 
     @Test
-    void testAndConditionInActivation() throws Exception {
+    void andConditionInActivation() throws Exception {
         Properties sysProperties = new Properties();
         sysProperties.setProperty("myproperty", "test");
 

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderFactoryTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderFactoryTest.java
@@ -45,7 +45,7 @@ class DefaultModelBuilderFactoryTest {
     }
 
     @Test
-    void testCompleteWiring() throws Exception {
+    void completeWiring() throws Exception {
         ModelBuilder builder = new DefaultModelBuilderFactory().newInstance();
         assertNotNull(builder);
 
@@ -65,7 +65,7 @@ class DefaultModelBuilderFactoryTest {
     }
 
     @Test
-    void testPomChanges() throws Exception {
+    void pomChanges() throws Exception {
         ModelBuilder builder = new DefaultModelBuilderFactory().newInstance();
         assertNotNull(builder);
         File pom = getPom("simple");

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/DefaultModelBuilderTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  */
 @Deprecated
-public class DefaultModelBuilderTest {
+class DefaultModelBuilderTest {
 
     private static final String BASE1_ID = "thegroup:base1:pom";
     private static final String BASE1_ID2 = "thegroup:base1:1";
@@ -77,7 +77,7 @@ public class DefaultModelBuilderTest {
             + "</project>\n";
 
     @Test
-    public void testCycleInImports() throws Exception {
+    void cycleInImports() throws Exception {
         ModelBuilder builder = new DefaultModelBuilderFactory().newInstance();
         assertNotNull(builder);
 

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -39,18 +39,18 @@ class FileModelSourceTest {
      * Test of equals method, of class FileModelSource.
      */
     @Test
-    void testEquals() throws Exception {
+    void equals() throws Exception {
         File tempFile = createTempFile("pomTest");
         FileModelSource instance = new FileModelSource(tempFile);
 
-        assertFalse(instance.equals(null));
-        assertFalse(instance.equals(new Object()));
-        assertTrue(instance.equals(instance));
-        assertTrue(instance.equals(new FileModelSource(tempFile)));
+        assertNotEquals(null, instance);
+        assertNotEquals(instance, new Object());
+        assertEquals(instance, instance);
+        assertEquals(instance, new FileModelSource(tempFile));
     }
 
     @Test
-    void testWindowsPaths() throws Exception {
+    void windowsPaths() throws Exception {
         assumeTrue(Os.isFamily("Windows"));
 
         File upperCaseFile = createTempFile("TESTE");
@@ -60,7 +60,7 @@ class FileModelSourceTest {
         FileModelSource upperCaseFileSource = new FileModelSource(upperCaseFile);
         FileModelSource lowerCaseFileSource = new FileModelSource(lowerCaseFile);
 
-        assertTrue(upperCaseFileSource.equals(lowerCaseFileSource));
+        assertEquals(upperCaseFileSource, lowerCaseFileSource);
     }
 
     private File createTempFile(String name) throws IOException {

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileToRawModelMergerTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileToRawModelMergerTest.java
@@ -38,7 +38,7 @@ class FileToRawModelMergerTest {
      * Ensures that all list-merge methods are overridden
      */
     @Test
-    void testOverriddenMergeMethods() {
+    void overriddenMergeMethods() {
         List<String> methodNames = Stream.of(MavenMerger.class.getDeclaredMethods())
                 .filter(m -> m.getName().startsWith("merge"))
                 .filter(m -> {

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/GraphTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/GraphTest.java
@@ -30,17 +30,17 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Deprecated
-public class GraphTest {
+class GraphTest {
 
     @Test
-    void testCycle() throws Graph.CycleDetectedException {
+    void cycle() throws Graph.CycleDetectedException {
         Graph graph = new Graph();
         graph.addEdge("a1", "a2");
         assertThrows(Graph.CycleDetectedException.class, () -> graph.addEdge("a2", "a1"));
     }
 
     @Test
-    public void testPerf() throws IOException {
+    void perf() throws IOException {
         List<String[]> data = new ArrayList<>();
         String k = null;
         for (String line : Files.readAllLines(Paths.get("src/test/resources/dag.txt"))) {

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/inheritance/DefaultInheritanceAssemblerTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/inheritance/DefaultInheritanceAssemblerTest.java
@@ -60,7 +60,7 @@ class DefaultInheritanceAssemblerTest {
     }
 
     @Test
-    void testPluginConfiguration() throws Exception {
+    void pluginConfiguration() throws Exception {
         testInheritance("plugin-configuration");
     }
 
@@ -70,7 +70,7 @@ class DefaultInheritanceAssemblerTest {
      * @throws IOException Model read problem
      */
     @Test
-    void testUrls() throws Exception {
+    void urls() throws Exception {
         testInheritance("urls");
     }
 
@@ -79,7 +79,7 @@ class DefaultInheritanceAssemblerTest {
      * @throws IOException Model read problem
      */
     @Test
-    void testFlatUrls() throws IOException {
+    void flatUrls() throws IOException {
         testInheritance("flat-urls");
     }
 
@@ -88,7 +88,7 @@ class DefaultInheritanceAssemblerTest {
      * @throws Exception
      */
     @Test
-    void testNoAppendUrls() throws Exception {
+    void noAppendUrls() throws Exception {
         testInheritance("no-append-urls");
     }
 
@@ -97,7 +97,7 @@ class DefaultInheritanceAssemblerTest {
      * @throws Exception
      */
     @Test
-    void testNoAppendUrls2() throws Exception {
+    void noAppendUrls2() throws Exception {
         testInheritance("no-append-urls2");
     }
 
@@ -106,7 +106,7 @@ class DefaultInheritanceAssemblerTest {
      * @throws Exception
      */
     @Test
-    void testNoAppendUrls3() throws Exception {
+    void noAppendUrls3() throws Exception {
         testInheritance("no-append-urls3");
     }
 
@@ -117,7 +117,7 @@ class DefaultInheritanceAssemblerTest {
      * @throws IOException Model read problem
      */
     @Test
-    void testFlatTrickyUrls() throws IOException {
+    void flatTrickyUrls() throws IOException {
         // parent references child with artifactId (which is not directory name)
         // then relative path calculation will fail during build from disk but success when calculated from repo
         try {
@@ -154,7 +154,7 @@ class DefaultInheritanceAssemblerTest {
     }
 
     @Test
-    void testWithEmptyUrl() throws IOException {
+    void withEmptyUrl() throws IOException {
         testInheritance("empty-urls", false);
     }
 
@@ -195,7 +195,7 @@ class DefaultInheritanceAssemblerTest {
     }
 
     @Test
-    void testModulePathNotArtifactId() throws IOException {
+    void modulePathNotArtifactId() throws IOException {
         Model parent = getModel("module-path-not-artifactId-parent");
 
         Model child = getModel("module-path-not-artifactId-child");

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testDefaultBuildTimestampFormatShouldFormatTimeIn24HourFormat() {
+    public void defaultBuildTimestampFormatShouldFormatTimeIn24HourFormat() {
         Calendar cal = Calendar.getInstance();
         cal.setTimeZone(MavenBuildTimestamp.DEFAULT_BUILD_TIME_ZONE);
         cal.set(Calendar.HOUR, 12);
@@ -110,7 +110,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testDefaultBuildTimestampFormatWithLocalTimeZoneMidnightRollover() {
+    public void defaultBuildTimestampFormatWithLocalTimeZoneMidnightRollover() {
         Calendar cal = Calendar.getInstance();
         cal.setTimeZone(TimeZone.getTimeZone("Europe/Berlin"));
 
@@ -134,7 +134,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldNotThrowExceptionOnReferenceToNonExistentValue() throws Exception {
+    public void shouldNotThrowExceptionOnReferenceToNonExistentValue() throws Exception {
         Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
                 .scm(org.apache.maven.api.model.Scm.newBuilder()
                         .connection("${test}/somepath")
@@ -151,7 +151,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldThrowExceptionOnRecursiveScmConnectionReference() throws Exception {
+    public void shouldThrowExceptionOnRecursiveScmConnectionReference() throws Exception {
         var model = new Model(org.apache.maven.api.model.Model.newBuilder()
                 .scm(org.apache.maven.api.model.Scm.newBuilder()
                         .connection("${project.scm.connection}/somepath")
@@ -166,7 +166,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldNotThrowExceptionOnReferenceToValueContainingNakedExpression() throws Exception {
+    public void shouldNotThrowExceptionOnReferenceToValueContainingNakedExpression() throws Exception {
         Map<String, String> props = new HashMap<>();
         props.put("test", "test");
         Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
@@ -224,7 +224,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldNotInterpolateDependencyVersionWithInvalidReference() throws Exception {
+    public void shouldNotInterpolateDependencyVersionWithInvalidReference() throws Exception {
         Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
                 .version("3.8.1")
                 .dependencies(Collections.singletonList(org.apache.maven.api.model.Dependency.newBuilder()
@@ -242,7 +242,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testTwoReferences() throws Exception {
+    public void twoReferences() throws Exception {
         Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
@@ -261,7 +261,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testBasedir() throws Exception {
+    public void basedir() throws Exception {
         Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
@@ -281,7 +281,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testBaseUri() throws Exception {
+    public void baseUri() throws Exception {
         Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
@@ -300,7 +300,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testEnvars() throws Exception {
+    public void envars() throws Exception {
         context.put("env.HOME", "/path/to/home");
 
         Map<String, String> modelProperties = new HashMap<>();
@@ -403,7 +403,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testRecursiveExpressionCycleNPE() throws Exception {
+    public void recursiveExpressionCycleNPE() throws Exception {
         Map<String, String> props = new HashMap<>();
         props.put("aa", "${bb}");
         props.put("bb", "${aa}");
@@ -421,7 +421,7 @@ public abstract class AbstractModelInterpolatorTest {
     }
 
     @Test
-    public void testRecursiveExpressionCycleBaseDir() throws Exception {
+    public void recursiveExpressionCycleBaseDir() throws Exception {
         Map<String, String> props = new HashMap<>();
         props.put("basedir", "${basedir}");
         DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/MavenBuildTimestampTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/MavenBuildTimestampTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Deprecated
 class MavenBuildTimestampTest {
     @Test
-    void testMavenBuildTimestampUsesUTC() {
+    void mavenBuildTimestampUsesUTC() {
         Properties interpolationProperties = new Properties();
         interpolationProperties.put("maven.build.timestamp.format", "yyyyMMdd'T'HHmm'Z'");
         MavenBuildTimestamp timestamp = new MavenBuildTimestamp(new Date(), interpolationProperties);

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/reflection/ReflectionValueExtractorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/reflection/ReflectionValueExtractorTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * ReflectionValueExtractorTest class.
  */
 @Deprecated
-public class ReflectionValueExtractorTest {
+class ReflectionValueExtractorTest {
     private Project project;
 
     /**
@@ -87,7 +87,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    void testValueExtraction() throws Exception {
+    void valueExtraction() throws Exception {
         // ----------------------------------------------------------------------
         // Top level values
         // ----------------------------------------------------------------------
@@ -172,7 +172,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testValueExtractorWithAInvalidExpression() throws Exception {
+    void valueExtractorWithAInvalidExpression() throws Exception {
         assertNull(ReflectionValueExtractor.evaluate("project.foo", project));
         assertNull(ReflectionValueExtractor.evaluate("project.dependencies[10]", project));
         assertNull(ReflectionValueExtractor.evaluate("project.dependencies[0].foo", project));
@@ -184,7 +184,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testMappedDottedKey() throws Exception {
+    void mappedDottedKey() throws Exception {
         Map<String, String> map = new HashMap<String, String>();
         map.put("a.b", "a.b-value");
 
@@ -197,7 +197,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIndexedMapped() throws Exception {
+    void indexedMapped() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("a", "a-value");
         List<Object> list = new ArrayList<Object>();
@@ -212,7 +212,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testMappedIndexed() throws Exception {
+    void mappedIndexed() throws Exception {
         List<Object> list = new ArrayList<Object>();
         list.add("a-value");
         Map<Object, Object> map = new HashMap<Object, Object>();
@@ -226,7 +226,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testMappedMissingDot() throws Exception {
+    void mappedMissingDot() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("a", new ValueHolder("a-value"));
         assertNull(ReflectionValueExtractor.evaluate("h.value(a)value", new ValueHolder(map)));
@@ -238,7 +238,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIndexedMissingDot() throws Exception {
+    void indexedMissingDot() throws Exception {
         List<Object> list = new ArrayList<Object>();
         list.add(new ValueHolder("a-value"));
         assertNull(ReflectionValueExtractor.evaluate("h.value[0]value", new ValueHolder(list)));
@@ -250,7 +250,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testDotDot() throws Exception {
+    void dotDot() throws Exception {
         assertNull(ReflectionValueExtractor.evaluate("h..value", new ValueHolder("value")));
     }
 
@@ -260,7 +260,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testBadIndexedSyntax() throws Exception {
+    void badIndexedSyntax() throws Exception {
         List<Object> list = new ArrayList<Object>();
         list.add("a-value");
         Object value = new ValueHolder(list);
@@ -279,7 +279,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testBadMappedSyntax() throws Exception {
+    void badMappedSyntax() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("a", "a-value");
         Object value = new ValueHolder(map);
@@ -296,7 +296,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIllegalIndexedType() throws Exception {
+    void illegalIndexedType() throws Exception {
         try {
             ReflectionValueExtractor.evaluate("h.value[1]", new ValueHolder("string"));
         } catch (Exception e) {
@@ -310,7 +310,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIllegalMappedType() throws Exception {
+    void illegalMappedType() throws Exception {
         try {
             ReflectionValueExtractor.evaluate("h.value(key)", new ValueHolder("string"));
         } catch (Exception e) {
@@ -324,7 +324,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testTrimRootToken() throws Exception {
+    void trimRootToken() throws Exception {
         assertNull(ReflectionValueExtractor.evaluate("project", project, true));
     }
 
@@ -334,7 +334,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testArtifactMap() throws Exception {
+    void artifactMap() throws Exception {
         assertEquals(
                 "g0",
                 ((Artifact) ReflectionValueExtractor.evaluate("project.artifactMap(g0:a0:c0)", project)).getGroupId());
@@ -566,7 +566,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testRootPropertyRegression() throws Exception {
+    void rootPropertyRegression() throws Exception {
         Project project = new Project();
         project.setDescription("c:\\\\org\\apache\\test");
         Object evalued = ReflectionValueExtractor.evaluate("description", project);

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/path/DefaultUrlNormalizerTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/path/DefaultUrlNormalizerTest.java
@@ -35,19 +35,19 @@ class DefaultUrlNormalizerTest {
     }
 
     @Test
-    void testNullSafe() {
+    void nullSafe() {
         assertNull(normalize(null));
     }
 
     @Test
-    void testTrailingSlash() {
+    void trailingSlash() {
         assertEquals("", normalize(""));
         assertEquals("http://server.org/dir", normalize("http://server.org/dir"));
         assertEquals("http://server.org/dir/", normalize("http://server.org/dir/"));
     }
 
     @Test
-    void testRemovalOfParentRefs() {
+    void removalOfParentRefs() {
         assertEquals("http://server.org/child", normalize("http://server.org/parent/../child"));
         assertEquals("http://server.org/child", normalize("http://server.org/grand/parent/../../child"));
 
@@ -56,7 +56,7 @@ class DefaultUrlNormalizerTest {
     }
 
     @Test
-    void testPreservationOfDoubleSlashes() {
+    void preservationOfDoubleSlashes() {
         assertEquals("scm:hg:ssh://localhost//home/user", normalize("scm:hg:ssh://localhost//home/user"));
         assertEquals("file:////UNC/server", normalize("file:////UNC/server"));
         assertEquals(

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/DefaultProfileSelectorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/DefaultProfileSelectorTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests {@link DefaultProfileSelector}.
  */
 @Deprecated
-public class DefaultProfileSelectorTest {
+class DefaultProfileSelectorTest {
     private Profile newProfile(String id) {
         Activation activation = new Activation();
         Profile profile = new Profile();
@@ -45,7 +45,7 @@ public class DefaultProfileSelectorTest {
     }
 
     @Test
-    void testThrowingActivator() {
+    void throwingActivator() {
         DefaultProfileSelector selector = new DefaultProfileSelector();
         selector.addProfileActivator(new ProfileActivator() {
             @Override

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/FileProfileActivatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/FileProfileActivatorTest.java
@@ -71,7 +71,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testRootDirectoryWithNull() {
+    void rootDirectoryWithNull() {
         context.setProjectDirectory(null);
 
         IllegalStateException e = assertThrows(
@@ -81,7 +81,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testRootDirectory() {
+    void rootDirectory() {
         assertActivation(false, newExistsProfile("${project.rootDirectory}/someFile.txt"), context);
         assertActivation(true, newMissingProfile("${project.rootDirectory}/someFile.txt"), context);
         assertActivation(true, newExistsProfile("${project.rootDirectory}"), context);
@@ -91,7 +91,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveNoFileWithShortBasedir() {
+    void isActiveNoFileWithShortBasedir() {
         assertActivation(false, newExistsProfile(null), context);
         assertActivation(false, newExistsProfile("someFile.txt"), context);
         assertActivation(false, newExistsProfile("${basedir}/someFile.txt"), context);
@@ -102,7 +102,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveNoFile() {
+    void isActiveNoFile() {
         assertActivation(false, newExistsProfile(null), context);
         assertActivation(false, newExistsProfile("someFile.txt"), context);
         assertActivation(false, newExistsProfile("${project.basedir}/someFile.txt"), context);
@@ -113,7 +113,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveExistsFileExists() {
+    void isActiveExistsFileExists() {
         assertActivation(true, newExistsProfile("file.txt"), context);
         assertActivation(true, newExistsProfile("${project.basedir}"), context);
         assertActivation(true, newExistsProfile("${project.basedir}/" + "file.txt"), context);
@@ -124,7 +124,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveExistsLeavesFileUnchanged() {
+    void isActiveExistsLeavesFileUnchanged() {
         Profile profile = newExistsProfile("file.txt");
         assertEquals("file.txt", profile.getActivation().getFile().getExists());
 

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/JdkVersionProfileActivatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/JdkVersionProfileActivatorTest.java
@@ -59,7 +59,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testNullSafe() throws Exception {
+    void nullSafe() throws Exception {
         Profile p = Profile.newInstance();
 
         assertActivation(false, p, newContext(null, null));
@@ -70,7 +70,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testPrefix() throws Exception {
+    void prefix() throws Exception {
         Profile profile = newProfile("1.4");
 
         assertActivation(true, profile, newContext(null, newProperties("1.4")));
@@ -84,7 +84,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testPrefixNegated() throws Exception {
+    void prefixNegated() throws Exception {
         Profile profile = newProfile("!1.4");
 
         assertActivation(false, profile, newContext(null, newProperties("1.4")));
@@ -98,7 +98,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeInclusiveBounds() throws Exception {
+    void versionRangeInclusiveBounds() throws Exception {
         Profile profile = newProfile("[1.5,1.6]");
 
         assertActivation(false, profile, newContext(null, newProperties("1.4")));
@@ -119,7 +119,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeExclusiveBounds() throws Exception {
+    void versionRangeExclusiveBounds() throws Exception {
         Profile profile = newProfile("(1.3,1.6)");
 
         assertActivation(false, profile, newContext(null, newProperties("1.3")));
@@ -141,7 +141,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeInclusiveLowerBound() throws Exception {
+    void versionRangeInclusiveLowerBound() throws Exception {
         Profile profile = newProfile("[1.5,)");
 
         assertActivation(false, profile, newContext(null, newProperties("1.4")));
@@ -162,7 +162,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeExclusiveUpperBound() throws Exception {
+    void versionRangeExclusiveUpperBound() throws Exception {
         Profile profile = newProfile("(,1.6)");
 
         assertActivation(true, profile, newContext(null, newProperties("1.5")));
@@ -178,7 +178,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testRubbishJavaVersion() {
+    void rubbishJavaVersion() {
         Profile profile = newProfile("[1.8,)");
 
         assertActivationWithProblems(profile, newContext(null, newProperties("Pūteketeke")), "invalid JDK version");

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivatorTest.java
@@ -56,7 +56,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testVersionStringComparison() throws Exception {
+    void versionStringComparison() throws Exception {
         Profile profile = newProfile(ActivationOS.newBuilder().version("6.5.0-1014-aws"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -66,7 +66,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testVersionRegexMatching() throws Exception {
+    void versionRegexMatching() throws Exception {
         Profile profile = newProfile(ActivationOS.newBuilder().version("regex:.*aws"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -76,7 +76,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testName() {
+    void name() {
         Profile profile = newProfile(ActivationOS.newBuilder().name("windows"));
 
         assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -84,7 +84,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testNegatedName() {
+    void negatedName() {
         Profile profile = newProfile(ActivationOS.newBuilder().name("!windows"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -92,7 +92,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testArch() {
+    void arch() {
         Profile profile = newProfile(ActivationOS.newBuilder().arch("amd64"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -100,7 +100,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testNegatedArch() {
+    void negatedArch() {
         Profile profile = newProfile(ActivationOS.newBuilder().arch("!amd64"));
 
         assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -108,7 +108,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testFamily() {
+    void family() {
         Profile profile = newProfile(ActivationOS.newBuilder().family("windows"));
 
         assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -116,7 +116,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testNegatedFamily() {
+    void negatedFamily() {
         Profile profile = newProfile(ActivationOS.newBuilder().family("!windows"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -124,7 +124,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testAllOsConditions() {
+    void allOsConditions() {
         Profile profile = newProfile(ActivationOS.newBuilder()
                 .family("windows")
                 .name("windows")
@@ -138,7 +138,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    public void testCapitalOsName() {
+    void capitalOsName() {
         Profile profile = newProfile(ActivationOS.newBuilder()
                 .family("Mac")
                 .name("Mac OS X")

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/PropertyProfileActivatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/PropertyProfileActivatorTest.java
@@ -57,7 +57,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testNullSafe() throws Exception {
+    void nullSafe() throws Exception {
         Profile p = Profile.newInstance();
 
         assertActivation(false, p, newContext(null, null));
@@ -68,7 +68,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNameOnlyUserProperty() throws Exception {
+    void withNameOnlyUserProperty() throws Exception {
         Profile profile = newProfile("prop", null);
 
         assertActivation(true, profile, newContext(newProperties("prop", "value"), null));
@@ -79,7 +79,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNameOnlySystemProperty() throws Exception {
+    void withNameOnlySystemProperty() throws Exception {
         Profile profile = newProfile("prop", null);
 
         assertActivation(true, profile, newContext(null, newProperties("prop", "value")));
@@ -90,7 +90,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedNameOnlyUserProperty() throws Exception {
+    void withNegatedNameOnlyUserProperty() throws Exception {
         Profile profile = newProfile("!prop", null);
 
         assertActivation(false, profile, newContext(newProperties("prop", "value"), null));
@@ -101,7 +101,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedNameOnlySystemProperty() throws Exception {
+    void withNegatedNameOnlySystemProperty() throws Exception {
         Profile profile = newProfile("!prop", null);
 
         assertActivation(false, profile, newContext(null, newProperties("prop", "value")));
@@ -112,7 +112,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithValueUserProperty() throws Exception {
+    void withValueUserProperty() throws Exception {
         Profile profile = newProfile("prop", "value");
 
         assertActivation(true, profile, newContext(newProperties("prop", "value"), null));
@@ -123,7 +123,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithValueSystemProperty() throws Exception {
+    void withValueSystemProperty() throws Exception {
         Profile profile = newProfile("prop", "value");
 
         assertActivation(true, profile, newContext(null, newProperties("prop", "value")));
@@ -134,7 +134,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedValueUserProperty() throws Exception {
+    void withNegatedValueUserProperty() throws Exception {
         Profile profile = newProfile("prop", "!value");
 
         assertActivation(false, profile, newContext(newProperties("prop", "value"), null));
@@ -145,7 +145,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedValueSystemProperty() throws Exception {
+    void withNegatedValueSystemProperty() throws Exception {
         Profile profile = newProfile("prop", "!value");
 
         assertActivation(false, profile, newContext(null, newProperties("prop", "value")));
@@ -156,7 +156,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithValueUserPropertyDominantOverSystemProperty() throws Exception {
+    void withValueUserPropertyDominantOverSystemProperty() throws Exception {
         Profile profile = newProfile("prop", "value");
 
         Properties props1 = newProperties("prop", "value");

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -116,7 +116,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingModelVersion() throws Exception {
+    void missingModelVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-modelVersion-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -125,7 +125,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadModelVersion() throws Exception {
+    void badModelVersion() throws Exception {
         SimpleProblemCollector result =
                 validateRaw("bad-modelVersion.xml", ModelBuildingRequest.VALIDATION_LEVEL_STRICT);
 
@@ -135,7 +135,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testModelVersionMessage() throws Exception {
+    void modelVersionMessage() throws Exception {
         SimpleProblemCollector result =
                 validateRaw("modelVersion-4_0.xml", ModelBuildingRequest.VALIDATION_LEVEL_STRICT);
 
@@ -145,7 +145,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingArtifactId() throws Exception {
+    void missingArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -154,7 +154,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingGroupId() throws Exception {
+    void missingGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-groupId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -163,7 +163,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidCoordinateIds() throws Exception {
+    void invalidCoordinateIds() throws Exception {
         SimpleProblemCollector result = validate("invalid-coordinate-ids-pom.xml");
 
         assertViolations(result, 0, 2, 0);
@@ -178,7 +178,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingType() throws Exception {
+    void missingType() throws Exception {
         SimpleProblemCollector result = validate("missing-type-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -187,7 +187,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingVersion() throws Exception {
+    void missingVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-version-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -196,7 +196,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidAggregatorPackaging() throws Exception {
+    void invalidAggregatorPackaging() throws Exception {
         SimpleProblemCollector result = validate("invalid-aggregator-packaging-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -205,7 +205,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyArtifactId() throws Exception {
+    void missingDependencyArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -216,7 +216,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyGroupId() throws Exception {
+    void missingDependencyGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-groupId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -227,7 +227,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyVersion() throws Exception {
+    void missingDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-version-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -238,7 +238,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyManagementArtifactId() throws Exception {
+    void missingDependencyManagementArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-mgmt-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -249,7 +249,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyManagementGroupId() throws Exception {
+    void missingDependencyManagementGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-mgmt-groupId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -260,7 +260,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingAll() throws Exception {
+    void missingAll() throws Exception {
         SimpleProblemCollector result = validate("missing-1-pom.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -275,7 +275,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginArtifactId() throws Exception {
+    void missingPluginArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -286,7 +286,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testEmptyPluginVersion() throws Exception {
+    void emptyPluginVersion() throws Exception {
         SimpleProblemCollector result = validate("empty-plugin-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -298,7 +298,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingRepositoryId() throws Exception {
+    void missingRepositoryId() throws Exception {
         SimpleProblemCollector result =
                 validateRaw("missing-repository-id-pom.xml", ModelBuildingRequest.VALIDATION_LEVEL_STRICT);
 
@@ -321,7 +321,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingResourceDirectory() throws Exception {
+    void missingResourceDirectory() throws Exception {
         SimpleProblemCollector result = validate("missing-resource-directory-pom.xml");
 
         assertViolations(result, 0, 2, 0);
@@ -336,7 +336,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadPluginDependencyScope() throws Exception {
+    void badPluginDependencyScope() throws Exception {
         SimpleProblemCollector result = validate("bad-plugin-dependency-scope.xml");
 
         assertViolations(result, 0, 3, 0);
@@ -349,7 +349,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyScope() throws Exception {
+    void badDependencyScope() throws Exception {
         SimpleProblemCollector result = validate("bad-dependency-scope.xml");
 
         assertViolations(result, 0, 0, 2);
@@ -360,7 +360,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyManagementScope() throws Exception {
+    void badDependencyManagementScope() throws Exception {
         SimpleProblemCollector result = validate("bad-dependency-management-scope.xml");
 
         assertViolations(result, 0, 0, 1);
@@ -369,7 +369,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyVersion() throws Exception {
+    void badDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-dependency-version.xml");
 
         assertViolations(result, 0, 2, 0);
@@ -382,7 +382,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicateModule() throws Exception {
+    void duplicateModule() throws Exception {
         SimpleProblemCollector result = validate("duplicate-module.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -391,7 +391,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicateProfileId() throws Exception {
+    void duplicateProfileId() throws Exception {
         SimpleProblemCollector result = validateRaw("duplicate-profile-id.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -400,7 +400,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadPluginVersion() throws Exception {
+    void badPluginVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-plugin-version.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -417,7 +417,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDistributionManagementStatus() throws Exception {
+    void distributionManagementStatus() throws Exception {
         SimpleProblemCollector result = validate("distribution-management-status.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -426,7 +426,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testIncompleteParent() throws Exception {
+    void incompleteParent() throws Exception {
         SimpleProblemCollector result = validateRaw("incomplete-parent.xml");
 
         assertViolations(result, 3, 0, 0);
@@ -436,7 +436,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testHardCodedSystemPath() throws Exception {
+    void hardCodedSystemPath() throws Exception {
         SimpleProblemCollector result = validateRaw("hard-coded-system-path.xml");
 
         assertViolations(result, 0, 0, 1);
@@ -464,7 +464,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testEmptyModule() throws Exception {
+    void emptyModule() throws Exception {
         SimpleProblemCollector result = validate("empty-module.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -473,7 +473,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicatePlugin() throws Exception {
+    void duplicatePlugin() throws Exception {
         SimpleProblemCollector result = validateRaw("duplicate-plugin.xml");
 
         assertViolations(result, 0, 0, 4);
@@ -485,7 +485,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicatePluginExecution() throws Exception {
+    void duplicatePluginExecution() throws Exception {
         SimpleProblemCollector result = validateRaw("duplicate-plugin-execution.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -497,7 +497,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testReservedRepositoryId() throws Exception {
+    void reservedRepositoryId() throws Exception {
         SimpleProblemCollector result = validate("reserved-repository-id.xml");
 
         assertViolations(result, 0, 0, 4);
@@ -510,7 +510,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginDependencyGroupId() throws Exception {
+    void missingPluginDependencyGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-dependency-groupId.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -519,7 +519,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginDependencyArtifactId() throws Exception {
+    void missingPluginDependencyArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-dependency-artifactId.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -528,7 +528,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginDependencyVersion() throws Exception {
+    void missingPluginDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-dependency-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -537,7 +537,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadPluginDependencyVersion() throws Exception {
+    void badPluginDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-plugin-dependency-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -546,7 +546,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadVersion() throws Exception {
+    void badVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-version.xml");
 
         assertViolations(result, 0, 0, 1);
@@ -555,7 +555,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadSnapshotVersion() throws Exception {
+    void badSnapshotVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-snapshot-version.xml");
 
         assertViolations(result, 0, 0, 1);
@@ -564,7 +564,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadRepositoryId() throws Exception {
+    void badRepositoryId() throws Exception {
         SimpleProblemCollector result = validate("bad-repository-id.xml");
 
         assertViolations(result, 0, 0, 4);
@@ -583,7 +583,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyExclusionId() throws Exception {
+    void badDependencyExclusionId() throws Exception {
         SimpleProblemCollector result =
                 validateEffective("bad-dependency-exclusion-id.xml", ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0);
 
@@ -603,7 +603,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyExclusionId() throws Exception {
+    void missingDependencyExclusionId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-exclusion-id.xml");
 
         assertViolations(result, 0, 0, 2);
@@ -617,7 +617,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadImportScopeType() throws Exception {
+    void badImportScopeType() throws Exception {
         SimpleProblemCollector result = validateRaw("bad-import-scope-type.xml");
 
         assertViolations(result, 0, 0, 1);
@@ -628,7 +628,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadImportScopeClassifier() throws Exception {
+    void badImportScopeClassifier() throws Exception {
         SimpleProblemCollector result = validateRaw("bad-import-scope-classifier.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -639,7 +639,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testSystemPathRefersToProjectBasedir() throws Exception {
+    void systemPathRefersToProjectBasedir() throws Exception {
         SimpleProblemCollector result = validateRaw("basedir-system-path.xml");
 
         assertViolations(result, 0, 0, 2);
@@ -671,7 +671,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidVersionInPluginManagement() throws Exception {
+    void invalidVersionInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/missing-plugin-version-pluginManagement.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -682,7 +682,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidGroupIdInPluginManagement() throws Exception {
+    void invalidGroupIdInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/missing-groupId-pluginManagement.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -693,7 +693,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidArtifactIdInPluginManagement() throws Exception {
+    void invalidArtifactIdInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/missing-artifactId-pluginManagement.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -704,7 +704,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidGroupAndArtifactIdInPluginManagement() throws Exception {
+    void invalidGroupAndArtifactIdInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/missing-ga-pluginManagement.xml");
 
         assertViolations(result, 2, 0, 0);
@@ -719,14 +719,14 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingReportPluginVersion() throws Exception {
+    void missingReportPluginVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-report-version-pom.xml");
 
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testDeprecatedDependencyMetaversionsLatestAndRelease() throws Exception {
+    void deprecatedDependencyMetaversionsLatestAndRelease() throws Exception {
         SimpleProblemCollector result = validateRaw("deprecated-dependency-metaversions-latest-and-release.xml");
 
         assertViolations(result, 0, 0, 2);
@@ -740,7 +740,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testSelfReferencingDependencyInRawModel() throws Exception {
+    void selfReferencingDependencyInRawModel() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/self-referencing.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -751,38 +751,38 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testSelfReferencingDependencyWithClassifierInRawModel() throws Exception {
+    void selfReferencingDependencyWithClassifierInRawModel() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/self-referencing-classifier.xml");
 
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlySha1() throws Exception {
+    void ciFriendlySha1() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-sha1.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyRevision() throws Exception {
+    void ciFriendlyRevision() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-revision.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyChangeList() throws Exception {
+    void ciFriendlyChangeList() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-changelist.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyAllExpressions() throws Exception {
+    void ciFriendlyAllExpressions() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-all-expressions.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyBad() throws Exception {
+    void ciFriendlyBad() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/bad-ci-friendly.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -791,7 +791,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testCiFriendlyBadSha1Plus() throws Exception {
+    void ciFriendlyBadSha1Plus() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/bad-ci-friendly-sha1plus.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -800,7 +800,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testCiFriendlyBadSha1Plus2() throws Exception {
+    void ciFriendlyBadSha1Plus2() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/bad-ci-friendly-sha1plus2.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -809,7 +809,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testParentVersionLATEST() throws Exception {
+    void parentVersionLATEST() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/bad-parent-version-latest.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -818,7 +818,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testParentVersionRELEASE() throws Exception {
+    void parentVersionRELEASE() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/bad-parent-version-release.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ActivationFileTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ActivationFileTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code ActivationFile}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ActivationFileTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new ActivationFile().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new ActivationFile().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new ActivationFile());
 
         new ActivationFile().equals(new ActivationFile());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         ActivationFile thing = new ActivationFile();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new ActivationFile().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ActivationOSTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ActivationOSTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code ActivationOS}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ActivationOSTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new ActivationOS().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new ActivationOS().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new ActivationOS());
 
         new ActivationOS().equals(new ActivationOS());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         ActivationOS thing = new ActivationOS();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new ActivationOS().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ActivationPropertyTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ActivationPropertyTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code ActivationProperty}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ActivationPropertyTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new ActivationProperty().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new ActivationProperty().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new ActivationProperty());
 
         new ActivationProperty().equals(new ActivationProperty());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         ActivationProperty thing = new ActivationProperty();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new ActivationProperty().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ActivationTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ActivationTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Activation}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ActivationTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Activation().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Activation().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Activation());
 
         new Activation().equals(new Activation());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Activation thing = new Activation();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Activation().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/BuildTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Build}.
@@ -31,30 +29,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BuildTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Build().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Build().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Build());
 
         new Build().equals(new Build());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Build thing = new Build();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Build().toString());
     }
 
     @Test
-    public void testToStringNotNonsense() {
+    void toStringNotNonsense() {
         Build build = new Build();
 
         String s = build.toString();

--- a/compat/maven-model/src/test/java/org/apache/maven/model/CiManagementTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/CiManagementTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code CiManagement}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CiManagementTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new CiManagement().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new CiManagement().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new CiManagement());
 
         new CiManagement().equals(new CiManagement());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         CiManagement thing = new CiManagement();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new CiManagement().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ContributorTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ContributorTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Contributor}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ContributorTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Contributor().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Contributor().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Contributor());
 
         new Contributor().equals(new Contributor());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Contributor thing = new Contributor();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Contributor().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/DependencyManagementTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/DependencyManagementTest.java
@@ -20,10 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code DependencyManagement}.
@@ -32,30 +29,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DependencyManagementTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new DependencyManagement().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new DependencyManagement().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new DependencyManagement());
 
         new DependencyManagement().equals(new DependencyManagement());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         DependencyManagement thing = new DependencyManagement();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new DependencyManagement().toString());
     }
 
     @Test
-    void testDependencies() {
+    void dependencies() {
         DependencyManagement dm = new DependencyManagement();
         Dependency d1 = new Dependency();
         d1.setGroupId("myGroupId");

--- a/compat/maven-model/src/test/java/org/apache/maven/model/DependencyTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/DependencyTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Dependency}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DependencyTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Dependency().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Dependency().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Dependency());
 
         new Dependency().equals(new Dependency());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Dependency thing = new Dependency();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Dependency().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/DeploymentRepositoryTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/DeploymentRepositoryTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code DeploymentRepository}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DeploymentRepositoryTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new DeploymentRepository().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new DeploymentRepository().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new DeploymentRepository());
 
         new DeploymentRepository().equals(new DeploymentRepository());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         DeploymentRepository thing = new DeploymentRepository();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new DeploymentRepository().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/DeveloperTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Developer}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DeveloperTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Developer().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Developer().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Developer());
 
         new Developer().equals(new Developer());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Developer thing = new Developer();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Developer().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/DistributionManagementTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/DistributionManagementTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code DistributionManagement}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DistributionManagementTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new DistributionManagement().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new DistributionManagement().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new DistributionManagement());
 
         new DistributionManagement().equals(new DistributionManagement());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         DistributionManagement thing = new DistributionManagement();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new DistributionManagement().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ExclusionTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ExclusionTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Exclusion}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ExclusionTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Exclusion().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Exclusion().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Exclusion());
 
         new Exclusion().equals(new Exclusion());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Exclusion thing = new Exclusion();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Exclusion().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ExtensionTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ExtensionTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Extension}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ExtensionTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Extension().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Extension().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Extension());
 
         new Extension().equals(new Extension());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Extension thing = new Extension();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Extension().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/IssueManagementTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code IssueManagement}.
@@ -31,30 +29,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class IssueManagementTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new IssueManagement().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new IssueManagement().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new IssueManagement());
 
         new IssueManagement().equals(new IssueManagement());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         IssueManagement thing = new IssueManagement();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new IssueManagement().toString());
     }
 
     @Test
-    public void testToStringNotNonsense() {
+    void toStringNotNonsense() {
         IssueManagement im = new IssueManagement();
         im.setSystem("Velociraptor");
         im.setUrl("https://velo.localdomain");

--- a/compat/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/LicenseTest.java
@@ -20,10 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code License}.
@@ -32,30 +29,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LicenseTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new License().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new License().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new License());
 
         new License().equals(new License());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         License thing = new License();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new License().toString());
     }
 
     @Test
-    public void testToStringNotNonsense() {
+    void toStringNotNonsense() {
         License license = new License();
         license.setName("Unlicense");
         license.setUrl("http://lic.localdomain");

--- a/compat/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/MailingListTest.java
@@ -20,10 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code MailingList}.
@@ -32,30 +29,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MailingListTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new MailingList().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new MailingList().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new MailingList());
 
         new MailingList().equals(new MailingList());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         MailingList thing = new MailingList();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new MailingList().toString());
     }
 
     @Test
-    public void testToStringNotNonsense() {
+    void toStringNotNonsense() {
         MailingList list = new MailingList();
         list.setName("modello-dev");
 

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
@@ -32,12 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ModelTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Model().hashCode();
     }
 
     @Test
-    void testBuild() {
+    void build() {
         Model model = new Model();
         Build build = new Build();
         build.setOutputDirectory("myOutputDirectory");
@@ -50,20 +50,20 @@ class ModelTest {
     }
 
     @Test
-    void testEqualsNullSafe() {
+    void equalsNullSafe() {
         assertNotEquals(null, new Model());
 
         new Model().equals(new Model());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Model thing = new Model();
         assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Model().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/NotifierTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/NotifierTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Notifier}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class NotifierTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Notifier().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Notifier().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Notifier());
 
         new Notifier().equals(new Notifier());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Notifier thing = new Notifier();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Notifier().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/OrganizationTest.java
@@ -20,10 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Organization}.
@@ -32,30 +29,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class OrganizationTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Organization().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Organization().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Organization());
 
         new Organization().equals(new Organization());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Organization thing = new Organization();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Organization().toString());
     }
 
     @Test
-    public void testToStringNotNonsense11() {
+    void toStringNotNonsense11() {
         Organization org = new Organization();
         org.setName("Testing Maven Unit");
         org.setUrl("https://maven.localdomain");
@@ -64,7 +61,7 @@ class OrganizationTest {
     }
 
     @Test
-    public void testToStringNotNonsense10() {
+    void toStringNotNonsense10() {
         Organization org = new Organization();
         org.setName("Testing Maven Unit");
 
@@ -72,7 +69,7 @@ class OrganizationTest {
     }
 
     @Test
-    public void testToStringNotNonsense01() {
+    void toStringNotNonsense01() {
         Organization org = new Organization();
         org.setUrl("https://maven.localdomain");
 
@@ -80,7 +77,7 @@ class OrganizationTest {
     }
 
     @Test
-    public void testToStringNotNonsense00() {
+    void toStringNotNonsense00() {
         Organization org = new Organization();
 
         assertEquals("Organization {name=null, url=null}", org.toString());

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ParentTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ParentTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Parent}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ParentTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Parent().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Parent().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Parent());
 
         new Parent().equals(new Parent());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Parent thing = new Parent();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Parent().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/PluginConfigurationTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/PluginConfigurationTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code PluginConfiguration}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PluginConfigurationTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new PluginConfiguration().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new PluginConfiguration().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new PluginConfiguration());
 
         new PluginConfiguration().equals(new PluginConfiguration());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         PluginConfiguration thing = new PluginConfiguration();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new PluginConfiguration().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/PluginContainerTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/PluginContainerTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code PluginContainer}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PluginContainerTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new PluginContainer().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new PluginContainer().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new PluginContainer());
 
         new PluginContainer().equals(new PluginContainer());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         PluginContainer thing = new PluginContainer();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new PluginContainer().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/PluginExecutionTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/PluginExecutionTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code PluginExecution}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PluginExecutionTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new PluginExecution().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new PluginExecution().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new PluginExecution());
 
         new PluginExecution().equals(new PluginExecution());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         PluginExecution thing = new PluginExecution();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new PluginExecution().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/PluginManagementTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/PluginManagementTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code PluginManagement}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PluginManagementTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new PluginManagement().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new PluginManagement().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new PluginManagement());
 
         new PluginManagement().equals(new PluginManagement());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         PluginManagement thing = new PluginManagement();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new PluginManagement().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/PluginTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/PluginTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Plugin}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PluginTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Plugin().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Plugin().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Plugin());
 
         new Plugin().equals(new Plugin());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Plugin thing = new Plugin();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Plugin().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/PrerequisitesTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/PrerequisitesTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Prerequisites}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PrerequisitesTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Prerequisites().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Prerequisites().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Prerequisites());
 
         new Prerequisites().equals(new Prerequisites());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Prerequisites thing = new Prerequisites();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Prerequisites().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ProfileTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ProfileTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Profile}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ProfileTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Profile().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Profile().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Profile());
 
         new Profile().equals(new Profile());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Profile thing = new Profile();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Profile().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/RelocationTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/RelocationTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Relocation}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RelocationTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Relocation().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Relocation().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Relocation());
 
         new Relocation().equals(new Relocation());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Relocation thing = new Relocation();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Relocation().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ReportPluginTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ReportPluginTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code ReportPlugin}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReportPluginTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new ReportPlugin().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new ReportPlugin().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new ReportPlugin());
 
         new ReportPlugin().equals(new ReportPlugin());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         ReportPlugin thing = new ReportPlugin();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new ReportPlugin().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ReportSetTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ReportSetTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code ReportSet}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReportSetTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new ReportSet().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new ReportSet().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new ReportSet());
 
         new ReportSet().equals(new ReportSet());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         ReportSet thing = new ReportSet();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new ReportSet().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ReportingTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ReportingTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Reporting}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReportingTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Reporting().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Reporting().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Reporting());
 
         new Reporting().equals(new Reporting());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Reporting thing = new Reporting();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Reporting().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/RepositoryPolicyTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/RepositoryPolicyTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code RepositoryPolicy}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RepositoryPolicyTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new RepositoryPolicy().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new RepositoryPolicy().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new RepositoryPolicy());
 
         new RepositoryPolicy().equals(new RepositoryPolicy());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         RepositoryPolicy thing = new RepositoryPolicy();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new RepositoryPolicy().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/RepositoryTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/RepositoryTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Repository}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RepositoryTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Repository().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Repository().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Repository());
 
         new Repository().equals(new Repository());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Repository thing = new Repository();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Repository().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ResourceTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ResourceTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Resource}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ResourceTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Resource().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Resource().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Resource());
 
         new Resource().equals(new Resource());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Resource thing = new Resource();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Resource().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ScmTest.java
@@ -20,10 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Scm}.
@@ -31,30 +28,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ScmTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Scm().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Scm().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Scm());
 
         new Scm().equals(new Scm());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Scm thing = new Scm();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Scm().toString());
     }
 
     @Test
-    public void testToStringNotNonsense() {
+    void toStringNotNonsense() {
         Scm scm = new Scm();
         scm.setConnection("scm:git:git://git.localdomain/model");
 

--- a/compat/maven-model/src/test/java/org/apache/maven/model/SerializationTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/SerializationTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class SerializationTest {
 
     @Test
-    void testModelSerialization() throws Exception {
+    void modelSerialization() throws Exception {
         Model model;
         try (InputStream is = getClass().getResourceAsStream("/xml/pom.xml")) {
             model = new MavenXpp3Reader().read(is);
@@ -56,7 +56,7 @@ class SerializationTest {
     }
 
     @Test
-    void testModelPropertiesAndListSerialization() throws Exception {
+    void modelPropertiesAndListSerialization() throws Exception {
         Model model;
         try (InputStream is = getClass().getResourceAsStream("/xml/pom.xml")) {
             model = new MavenXpp3Reader().read(is);

--- a/compat/maven-model/src/test/java/org/apache/maven/model/SiteTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/SiteTest.java
@@ -20,9 +20,7 @@ package org.apache.maven.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@code Site}.
@@ -31,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SiteTest {
 
     @Test
-    void testHashCodeNullSafe() {
+    void hashCodeNullSafe() {
         new Site().hashCode();
     }
 
     @Test
-    void testEqualsNullSafe() {
-        assertFalse(new Site().equals(null));
+    void equalsNullSafe() {
+        assertNotEquals(null, new Site());
 
         new Site().equals(new Site());
     }
 
     @Test
-    void testEqualsIdentity() {
+    void equalsIdentity() {
         Site thing = new Site();
-        assertTrue(thing.equals(thing));
+        assertEquals(thing, thing);
     }
 
     @Test
-    void testToStringNullSafe() {
+    void toStringNullSafe() {
         assertNotNull(new Site().toString());
     }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/v4/MavenModelVersionTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/v4/MavenModelVersionTest.java
@@ -42,30 +42,30 @@ class MavenModelVersionTest {
     }
 
     @Test
-    void testV4Model() {
+    void v4Model() {
         assertEquals("4.0.0", new MavenModelVersion().getModelVersion(model));
     }
 
     @Test
-    void testV4ModelVersion() {
+    void v4ModelVersion() {
         Model m = model.withModelVersion("4.1.0");
         assertEquals("4.0.0", new MavenModelVersion().getModelVersion(m));
     }
 
     @Test
-    void testV4ModelRoot() {
+    void v4ModelRoot() {
         Model m = model.withRoot(true);
         assertEquals("4.1.0", new MavenModelVersion().getModelVersion(m));
     }
 
     @Test
-    void testV4ModelPreserveModelVersion() {
+    void v4ModelPreserveModelVersion() {
         Model m = model.withPreserveModelVersion(true);
         assertEquals("4.1.0", new MavenModelVersion().getModelVersion(m));
     }
 
     @Test
-    void testV4ModelPriority() {
+    void v4ModelPriority() {
         Model m = model.withBuild(Build.newInstance()
                 .withPlugins(Collections.singleton(Plugin.newInstance()
                         .withExecutions(Collections.singleton(

--- a/compat/maven-model/src/test/java/org/apache/maven/model/v4/ModelXmlTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/v4/ModelXmlTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class ModelXmlTest {
 
     @Test
-    void testXmlRoundtripWithProperties() throws Exception {
+    void xmlRoundtripWithProperties() throws Exception {
         Map<String, String> props = new LinkedHashMap<>();
         props.put("javax.version", "3.1.0");
         props.put("mockito.version", "1.10.19");
@@ -55,7 +55,7 @@ class ModelXmlTest {
     }
 
     @Test
-    void testNamespaceInXmlNode() throws XMLStreamException {
+    void namespaceInXmlNode() throws XMLStreamException {
         String xml = "<project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
                 + "         xmlns=\"http://maven.apache.org/POM/4.0.0\"\n"
                 + "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/POM/4.0.0\">\n"

--- a/compat/maven-plugin-api/src/test/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilderTest.java
+++ b/compat/maven-plugin-api/src/test/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilderTest.java
@@ -46,7 +46,7 @@ class PluginDescriptorBuilderTest {
     }
 
     @Test
-    void testBuildReader() throws Exception {
+    void buildReader() throws Exception {
         PluginDescriptor pd = build("/plugin.xml");
 
         assertEquals("org.apache.maven.plugins", pd.getGroupId());

--- a/compat/maven-repository-metadata/src/test/java/org/apache/maven/artifact/repository/metadata/MetadataTest.java
+++ b/compat/maven-repository-metadata/src/test/java/org/apache/maven/artifact/repository/metadata/MetadataTest.java
@@ -215,7 +215,7 @@ class MetadataTest {
     /*-- END test "groupId/artifactId/version" metadata ---*/
 
     @Test
-    void testRoundtrip() throws Exception {
+    void roundtrip() throws Exception {
         Metadata source = new Metadata(org.apache.maven.api.metadata.Metadata.newBuilder(
                         createMetadataFromArtifact(artifact).getDelegate(), true)
                 .modelEncoding("UTF-16")

--- a/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderTest.java
+++ b/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.verify;
 class DefaultArtifactDescriptorReaderTest extends AbstractRepositoryTestCase {
 
     @Test
-    void testMng5459() throws Exception {
+    void mng5459() throws Exception {
         // prepare
         DefaultArtifactDescriptorReader reader =
                 (DefaultArtifactDescriptorReader) getContainer().lookup(ArtifactDescriptorReader.class);

--- a/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
+++ b/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
@@ -51,7 +51,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    public void testResolveParentThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
+    void resolveParentThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("ut.simple");
         parent.setArtifactId("artifact");
@@ -66,7 +66,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    public void testResolveParentThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
+    void resolveParentThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("ut.simple");
         parent.setArtifactId("artifact");
@@ -81,7 +81,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveParentThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
+    void resolveParentThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("ut.simple");
         parent.setArtifactId("artifact");
@@ -95,7 +95,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception {
+    void resolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("ut.simple");
         parent.setArtifactId("artifact");
@@ -106,7 +106,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception {
+    void resolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("ut.simple");
         parent.setArtifactId("artifact");
@@ -117,7 +117,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveDependencyThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
+    void resolveDependencyThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("ut.simple");
         dependency.setArtifactId("artifact");
@@ -132,7 +132,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveDependencyThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
+    void resolveDependencyThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("ut.simple");
         dependency.setArtifactId("artifact");
@@ -146,7 +146,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveDependencyThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
+    void resolveDependencyThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("ut.simple");
         dependency.setArtifactId("artifact");
@@ -160,7 +160,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception {
+    void resolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("ut.simple");
         dependency.setArtifactId("artifact");
@@ -171,7 +171,7 @@ final class DefaultModelResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception {
+    void resolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("ut.simple");
         dependency.setArtifactId("artifact");

--- a/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
+++ b/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
@@ -33,7 +33,7 @@ class DefaultVersionResolverTest extends AbstractRepositoryTestCase {
     private DefaultVersionResolver versionResolver;
 
     @Test
-    void testResolveSeparateInstalledClassifiedNonUniqueVersionedArtifacts() throws Exception {
+    void resolveSeparateInstalledClassifiedNonUniqueVersionedArtifacts() throws Exception {
         VersionRequest requestB = new VersionRequest();
         requestB.addRepository(newTestRepository());
         Artifact artifactB =
@@ -55,7 +55,7 @@ class DefaultVersionResolverTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveSeparateInstalledClassifiedNonVersionedArtifacts() throws Exception {
+    void resolveSeparateInstalledClassifiedNonVersionedArtifacts() throws Exception {
         VersionRequest requestA = new VersionRequest();
         requestA.addRepository(newTestRepository());
         String versionA = "07.20.3-20120809.112124-88";

--- a/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RepositorySystemTest.java
+++ b/compat/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/RepositorySystemTest.java
@@ -41,20 +41,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RepositorySystemTest extends AbstractRepositoryTestCase {
     @Test
-    void testResolveVersionRange() throws Exception {
+    void resolveVersionRange() throws Exception {
         // VersionRangeResult resolveVersionRange( RepositorySystemSession session, VersionRangeRequest request )
         //                throws VersionRangeResolutionException;
 
     }
 
     @Test
-    void testResolveVersion() throws Exception {
+    void resolveVersion() throws Exception {
         // VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
         //                throws VersionResolutionException;
     }
 
     @Test
-    void testReadArtifactDescriptor() throws Exception {
+    void readArtifactDescriptor() throws Exception {
         Artifact artifact = new DefaultArtifact("ut.simple:artifact:extension:classifier:1.0");
 
         ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
@@ -113,7 +113,7 @@ class RepositorySystemTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testCollectDependencies() throws Exception {
+    void collectDependencies() throws Exception {
         Artifact artifact = new DefaultArtifact("ut.simple:artifact:extension:classifier:1.0");
         // notice: extension and classifier not really used in this test...
 
@@ -130,7 +130,7 @@ class RepositorySystemTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveArtifact() throws Exception {
+    void resolveArtifact() throws Exception {
         Artifact artifact = new DefaultArtifact("ut.simple:artifact:1.0");
 
         ArtifactRequest artifactRequest = new ArtifactRequest();
@@ -160,7 +160,7 @@ class RepositorySystemTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveArtifacts() throws Exception {
+    void resolveArtifacts() throws Exception {
         ArtifactRequest req1 = new ArtifactRequest();
         req1.setArtifact(new DefaultArtifact("ut.simple:artifact:1.0"));
         req1.addRepository(newTestRepository());
@@ -184,31 +184,31 @@ class RepositorySystemTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testResolveMetadata() throws Exception {
+    void resolveMetadata() throws Exception {
         // List<MetadataResult> resolveMetadata( RepositorySystemSession session,
         //                                      Collection<? extends MetadataRequest> requests );
     }
 
     @Test
-    void testInstall() throws Exception {
+    void install() throws Exception {
         // InstallResult install( RepositorySystemSession session, InstallRequest request )
         //                throws InstallationException;
         // release, snapshot unique ou non unique, attachment
     }
 
     @Test
-    void testDeploy() throws Exception {
+    void deploy() throws Exception {
         // DeployResult deploy( RepositorySystemSession session, DeployRequest request )
         //                throws DeploymentException;
     }
 
     @Test
-    void testNewLocalRepositoryManager() throws Exception {
+    void newLocalRepositoryManager() throws Exception {
         // LocalRepositoryManager newLocalRepositoryManager( LocalRepository localRepository );
     }
 
     @Test
-    void testNewSyncContext() throws Exception {
+    void newSyncContext() throws Exception {
         // SyncContext newSyncContext( RepositorySystemSession session, boolean shared );
     }
 }

--- a/compat/maven-settings-builder/src/test/java/org/apache/maven/settings/building/DefaultSettingsBuilderFactoryTest.java
+++ b/compat/maven-settings-builder/src/test/java/org/apache/maven/settings/building/DefaultSettingsBuilderFactoryTest.java
@@ -33,7 +33,7 @@ class DefaultSettingsBuilderFactoryTest {
     }
 
     @Test
-    void testCompleteWiring() throws Exception {
+    void completeWiring() throws Exception {
         SettingsBuilder builder = new DefaultSettingsBuilderFactory().newInstance();
         assertNotNull(builder);
 

--- a/compat/maven-settings-builder/src/test/java/org/apache/maven/settings/validation/DefaultSettingsValidatorTest.java
+++ b/compat/maven-settings-builder/src/test/java/org/apache/maven/settings/validation/DefaultSettingsValidatorTest.java
@@ -57,7 +57,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidate() {
+    void validate() {
         Settings model = new Settings();
         Profile prof = new Profile();
         prof.setId("xxx");
@@ -84,7 +84,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidateMirror() throws Exception {
+    void validateMirror() throws Exception {
         Settings settings = new Settings();
         Mirror mirror = new Mirror();
         mirror.setId("local");
@@ -105,7 +105,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidateRepository() throws Exception {
+    void validateRepository() throws Exception {
         Profile profile = new Profile();
         Repository repo = new Repository();
         repo.setId("local");
@@ -131,7 +131,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidateUniqueServerId() throws Exception {
+    void validateUniqueServerId() throws Exception {
         Settings settings = new Settings();
         Server server1 = new Server();
         server1.setId("test");
@@ -148,7 +148,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidateUniqueProfileId() throws Exception {
+    void validateUniqueProfileId() throws Exception {
         Settings settings = new Settings();
         Profile profile1 = new Profile();
         profile1.setId("test");
@@ -166,7 +166,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidateUniqueRepositoryId() throws Exception {
+    void validateUniqueRepositoryId() throws Exception {
         Settings settings = new Settings();
         Profile profile = new Profile();
         profile.setId("pro");
@@ -190,7 +190,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidateUniqueProxyId() throws Exception {
+    void validateUniqueProxyId() throws Exception {
         Settings settings = new Settings();
         Proxy proxy = new Proxy();
         String id = "foo";
@@ -208,7 +208,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidateProxy() throws Exception {
+    void validateProxy() throws Exception {
         Settings settings = new Settings();
         Proxy proxy1 = new Proxy();
         settings.addProxy(proxy1);

--- a/compat/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/DefaultToolchainsBuilderTest.java
+++ b/compat/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/DefaultToolchainsBuilderTest.java
@@ -74,7 +74,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testBuildEmptyRequest() throws Exception {
+    void buildEmptyRequest() throws Exception {
         ToolchainsBuildingRequest request = new DefaultToolchainsBuildingRequest();
         ToolchainsBuildingResult result = toolchainBuilder.build(request);
         assertNotNull(result.getEffectiveToolchains());
@@ -83,7 +83,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testBuildRequestWithUserToolchains() throws Exception {
+    void buildRequestWithUserToolchains() throws Exception {
         Properties props = new Properties();
         props.put("key", "user_value");
         ToolchainModel toolchain = new ToolchainModel();
@@ -113,7 +113,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testBuildRequestWithGlobalToolchains() throws Exception {
+    void buildRequestWithGlobalToolchains() throws Exception {
         Properties props = new Properties();
         props.put("key", "global_value");
         ToolchainModel toolchain = new ToolchainModel();
@@ -143,7 +143,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testBuildRequestWithBothToolchains() throws Exception {
+    void buildRequestWithBothToolchains() throws Exception {
         Properties props = new Properties();
         props.put("key", "user_value");
         ToolchainModel toolchain = new ToolchainModel();
@@ -192,7 +192,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testStrictToolchainsParseException() throws Exception {
+    void strictToolchainsParseException() throws Exception {
         ToolchainsBuildingRequest request = new DefaultToolchainsBuildingRequest();
         request.setGlobalToolchainsSource(new StringSource(""));
         ToolchainsParseException parseException = new ToolchainsParseException("MESSAGE", 4, 2);
@@ -209,7 +209,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testIOException() throws Exception {
+    void iOException() throws Exception {
         Source src = mock(Source.class);
         IOException ioException = new IOException("MESSAGE");
         doThrow(ioException).when(src).getInputStream();
@@ -229,7 +229,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testEnvironmentVariablesAreInterpolated() throws Exception {
+    void environmentVariablesAreInterpolated() throws Exception {
         Properties props = new Properties();
         props.put("key", "${env.testKey}");
         Xpp3Dom configurationChild = new Xpp3Dom("jdkHome");
@@ -265,7 +265,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testNonExistingEnvironmentVariablesAreNotInterpolated() throws Exception {
+    void nonExistingEnvironmentVariablesAreNotInterpolated() throws Exception {
         Properties props = new Properties();
         props.put("key", "${env.testNonExistingKey}");
         ToolchainModel toolchain = new ToolchainModel();
@@ -291,7 +291,7 @@ class DefaultToolchainsBuilderTest {
     }
 
     @Test
-    void testEnvironmentVariablesWithSpecialCharactersAreInterpolated() throws Exception {
+    void environmentVariablesWithSpecialCharactersAreInterpolated() throws Exception {
         Properties props = new Properties();
         props.put("key", "${env.testSpecialCharactersKey}");
         ToolchainModel toolchain = new ToolchainModel();

--- a/compat/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/ToolchainsBuildingExceptionTest.java
+++ b/compat/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/building/ToolchainsBuildingExceptionTest.java
@@ -31,13 +31,13 @@ class ToolchainsBuildingExceptionTest {
     private static final String LS = System.lineSeparator();
 
     @Test
-    void testNoProblems() {
+    void noProblems() {
         ToolchainsBuildingException e = new ToolchainsBuildingException(Collections.emptyList());
         assertEquals("0 problems were encountered while building the effective toolchains" + LS, e.getMessage());
     }
 
     @Test
-    void testOneProblem() {
+    void oneProblem() {
         ProblemCollector problemCollector = ProblemCollectorFactory.newInstance(null);
         problemCollector.add(Problem.Severity.ERROR, "MESSAGE", 3, 5, new Exception());
         ToolchainsBuildingException e = new ToolchainsBuildingException(problemCollector.getProblems());
@@ -48,7 +48,7 @@ class ToolchainsBuildingExceptionTest {
     }
 
     @Test
-    void testUnknownPositionAndSource() {
+    void unknownPositionAndSource() {
         ProblemCollector problemCollector = ProblemCollectorFactory.newInstance(null);
         problemCollector.add(Problem.Severity.ERROR, "MESSAGE", -1, -1, new Exception());
         ToolchainsBuildingException e = new ToolchainsBuildingException(problemCollector.getProblems());
@@ -58,7 +58,7 @@ class ToolchainsBuildingExceptionTest {
     }
 
     @Test
-    void testUnknownPosition() {
+    void unknownPosition() {
         ProblemCollector problemCollector = ProblemCollectorFactory.newInstance(null);
         problemCollector.setSource("SOURCE");
         problemCollector.add(Problem.Severity.ERROR, "MESSAGE", -1, -1, new Exception());

--- a/compat/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/merge/MavenToolchainMergerTest.java
+++ b/compat/maven-toolchain-builder/src/test/java/org/apache/maven/toolchain/merge/MavenToolchainMergerTest.java
@@ -36,7 +36,7 @@ class MavenToolchainMergerTest {
     private DefaultToolchainsReader reader = new DefaultToolchainsReader();
 
     @Test
-    void testMergeNulls() {
+    void mergeNulls() {
         merger.merge(null, null, null);
 
         PersistedToolchains pt = new PersistedToolchains();
@@ -45,7 +45,7 @@ class MavenToolchainMergerTest {
     }
 
     @Test
-    void testMergeJdk() throws Exception {
+    void mergeJdk() throws Exception {
         try (InputStream isDominant = MavenToolchainMergerTest.class.getResourceAsStream("toolchains-jdks.xml");
                 InputStream isRecessive = MavenToolchainMergerTest.class.getResourceAsStream("toolchains-jdks.xml")) {
             PersistedToolchains dominant = read(isDominant);
@@ -58,7 +58,7 @@ class MavenToolchainMergerTest {
     }
 
     @Test
-    void testMergeJdkExtra() throws Exception {
+    void mergeJdkExtra() throws Exception {
         try (InputStream jdksIS = MavenToolchainMergerTest.class.getResourceAsStream("toolchains-jdks.xml");
                 InputStream jdksExtraIS =
                         MavenToolchainMergerTest.class.getResourceAsStream("toolchains-jdks-extra.xml")) {
@@ -85,7 +85,7 @@ class MavenToolchainMergerTest {
     }
 
     @Test
-    void testMergeJdkExtend() throws Exception {
+    void mergeJdkExtend() throws Exception {
         try (InputStream jdksIS = MavenToolchainMergerTest.class.getResourceAsStream("toolchains-jdks.xml");
                 InputStream jdksExtendIS =
                         MavenToolchainMergerTest.class.getResourceAsStream("toolchains-jdks-extend.xml")) {

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/cisupport/CIDetectorHelperTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/cisupport/CIDetectorHelperTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CIDetectorHelperTest {
+class CIDetectorHelperTest {
     private static final Set<String> ALL =
             Set.of("CIRCLECI", "CI", "WORKSPACE", "GITHUB_ACTIONS", "TEAMCITY_VERSION", "TRAVIS");
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Local UT.
  */
 @Order(200)
-public class MavenInvokerTest extends MavenInvokerTestSupport {
+class MavenInvokerTest extends MavenInvokerTestSupport {
     @Override
     protected Invoker createInvoker(ClassWorld classWorld) {
         return new MavenInvoker(

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvokerTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Resident UT.
  */
 @Order(100)
-public class ResidentMavenInvokerTest extends MavenInvokerTestSupport {
+class ResidentMavenInvokerTest extends MavenInvokerTestSupport {
 
     @Override
     protected Invoker createInvoker(ClassWorld classWorld) {

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/transfer/ConsoleMavenTransferListenerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/transfer/ConsoleMavenTransferListenerTest.java
@@ -42,7 +42,7 @@ class ConsoleMavenTransferListenerTest {
     private CountDownLatch endLatch;
 
     @Test
-    void testTransferProgressedWithPrintResourceNames() throws Exception {
+    void transferProgressedWithPrintResourceNames() throws Exception {
         int size = 1000;
         ExecutorService service = Executors.newFixedThreadPool(size * 2);
         try {

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/transfer/FileSizeFormatTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/transfer/FileSizeFormatTest.java
@@ -49,7 +49,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testNegativeSize() {
+    void negativeSize() {
         FileSizeFormat format = new FileSizeFormat();
         assertThrows(IllegalArgumentException.class, () -> format.format(-100L));
     }
@@ -80,7 +80,7 @@ class FileSizeFormatTest {
 
     @ParameterizedTest
     @MethodSource("sizeTestData")
-    void testSize(long input, String expected) {
+    void size(long input, String expected) {
         FileSizeFormat format = new FileSizeFormat();
         assertEquals(expected, format.format(input));
     }
@@ -177,7 +177,7 @@ class FileSizeFormatTest {
 
     @ParameterizedTest
     @MethodSource("sizeWithScaleUnitTestData")
-    void testSizeWithSelectedScaleUnit(long input, ScaleUnit unit, String expected) {
+    void sizeWithSelectedScaleUnit(long input, ScaleUnit unit, String expected) {
         FileSizeFormat format = new FileSizeFormat();
         if (unit == null) {
             assertEquals(expected, format.format(input));
@@ -187,7 +187,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testNegativeProgressedSize() {
+    void negativeProgressedSize() {
         FileSizeFormat format = new FileSizeFormat();
 
         long negativeProgressedSize = -100L;
@@ -195,7 +195,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testNegativeProgressedSizeBiggerThanSize() {
+    void negativeProgressedSizeBiggerThanSize() {
         FileSizeFormat format = new FileSizeFormat();
 
         assertThrows(IllegalArgumentException.class, () -> format.formatProgress(100L, 10L));
@@ -211,7 +211,7 @@ class FileSizeFormatTest {
 
     @ParameterizedTest
     @MethodSource("progressedSizeWithoutSizeTestData")
-    void testProgressedSizeWithoutSize(long progressedSize, String expected) {
+    void progressedSizeWithoutSize(long progressedSize, String expected) {
         FileSizeFormat format = new FileSizeFormat();
         assertEquals(expected, format.formatProgress(progressedSize, -1L));
     }
@@ -253,13 +253,13 @@ class FileSizeFormatTest {
 
     @ParameterizedTest
     @MethodSource("progressedSizeWithSizeTestData")
-    void testProgressedSizeWithSize(long progressedSize, long totalSize, String expected) {
+    void progressedSizeWithSize(long progressedSize, long totalSize, String expected) {
         FileSizeFormat format = new FileSizeFormat();
         assertEquals(expected, format.formatProgress(progressedSize, totalSize));
     }
 
     @Test
-    void testFormatRate() {
+    void formatRate() {
         FileSizeFormat format = new FileSizeFormat();
 
         // Test bytes per second
@@ -284,7 +284,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testFormatRateThresholds() {
+    void formatRateThresholds() {
         FileSizeFormat format = new FileSizeFormat();
 
         // Test value less than 0.05
@@ -318,7 +318,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testFormatRateEdgeCases() {
+    void formatRateEdgeCases() {
         FileSizeFormat format = new FileSizeFormat();
 
         // Test zero rate
@@ -338,7 +338,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testFormatRateLargeValues() {
+    void formatRateLargeValues() {
         FileSizeFormat format = new FileSizeFormat();
 
         // Test large but valid rates
@@ -353,7 +353,7 @@ class FileSizeFormatTest {
     }
 
     @Test
-    void testFormatRateInvalidValues() {
+    void formatRateInvalidValues() {
         FileSizeFormat format = new FileSizeFormat();
 
         // Test negative rate

--- a/impl/maven-core/src/test/java/org/apache/maven/DefaultMavenTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/DefaultMavenTest.java
@@ -62,7 +62,7 @@ class DefaultMavenTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testEnsureResolverSessionHasMavenWorkspaceReader() throws Exception {
+    void ensureResolverSessionHasMavenWorkspaceReader() throws Exception {
         WsrClassCatcher wsrClassCatcher =
                 (WsrClassCatcher) getContainer().lookup(AbstractMavenLifecycleParticipant.class, "WsrClassCatcher");
         Maven maven = getContainer().lookup(Maven.class);
@@ -78,7 +78,7 @@ class DefaultMavenTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testThatErrorDuringProjectDependencyGraphCreationAreStored() throws Exception {
+    void thatErrorDuringProjectDependencyGraphCreationAreStored() throws Exception {
         MavenExecutionRequest request =
                 createMavenExecutionRequest(getProject("cyclic-reference")).setGoals(asList("validate"));
 
@@ -88,7 +88,7 @@ class DefaultMavenTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testMavenProjectNoDuplicateArtifacts() throws Exception {
+    void mavenProjectNoDuplicateArtifacts() throws Exception {
         MavenProjectHelper mavenProjectHelper = getContainer().lookup(MavenProjectHelper.class);
         MavenProject mavenProject = new MavenProject();
         mavenProject.setArtifact(new DefaultArtifact("g", "a", "1.0", Artifact.SCOPE_TEST, "jar", "", null));

--- a/impl/maven-core/src/test/java/org/apache/maven/MavenLifecycleParticipantTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/MavenLifecycleParticipantTest.java
@@ -95,7 +95,7 @@ class MavenLifecycleParticipantTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testDependencyInjection() throws Exception {
+    void dependencyInjection() throws Exception {
         PlexusContainer container = getContainer();
 
         ComponentDescriptor<? extends AbstractMavenLifecycleParticipant> cd =
@@ -122,7 +122,7 @@ class MavenLifecycleParticipantTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testReactorDependencyInjection() throws Exception {
+    void reactorDependencyInjection() throws Exception {
         List<String> reactorOrder =
                 getReactorOrder("lifecycle-participant-reactor-dependency-injection", InjectReactorDependency.class);
         assertEquals(Arrays.asList("parent", "module-b", "module-a"), reactorOrder);

--- a/impl/maven-core/src/test/java/org/apache/maven/artifact/handler/ArtifactHandlerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/artifact/handler/ArtifactHandlerTest.java
@@ -39,7 +39,7 @@ class ArtifactHandlerTest {
 
     @Test
     @SuppressWarnings("checkstyle:UnusedLocalVariable")
-    void testAptConsistency() throws Exception {
+    void aptConsistency() throws Exception {
         File apt = getTestFile("src/site/apt/artifact-handlers.apt");
 
         List<String> lines = Files.readAllLines(apt.toPath());

--- a/impl/maven-core/src/test/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilterTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilterTest.java
@@ -47,7 +47,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeExact() {
+    void excludeExact() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.maven");
         exclusion.setArtifactId("maven-core");
@@ -57,7 +57,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeNoMatch() {
+    void excludeNoMatch() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.maven");
         exclusion.setArtifactId("maven-model");
@@ -67,7 +67,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeGroupIdWildcard() {
+    void excludeGroupIdWildcard() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("maven-core");
@@ -77,7 +77,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeGroupIdWildcardNoMatch() {
+    void excludeGroupIdWildcardNoMatch() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("maven-compat");
@@ -87,7 +87,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeArtifactIdWildcard() {
+    void excludeArtifactIdWildcard() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.maven");
         exclusion.setArtifactId("*");
@@ -97,7 +97,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeArtifactIdWildcardNoMatch() {
+    void excludeArtifactIdWildcardNoMatch() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("org.apache.groovy");
         exclusion.setArtifactId("*");
@@ -107,7 +107,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeAllWildcard() {
+    void excludeAllWildcard() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("*");
@@ -117,7 +117,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testMultipleExclusionsExcludeArtifactIdWildcard() {
+    void multipleExclusionsExcludeArtifactIdWildcard() {
         Exclusion exclusion1 = new Exclusion();
         exclusion1.setGroupId("org.apache.groovy");
         exclusion1.setArtifactId("*");
@@ -132,7 +132,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testMultipleExclusionsExcludeGroupIdWildcard() {
+    void multipleExclusionsExcludeGroupIdWildcard() {
         Exclusion exclusion1 = new Exclusion();
         exclusion1.setGroupId("*");
         exclusion1.setArtifactId("maven-model");
@@ -147,7 +147,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeWithGlob() {
+    void excludeWithGlob() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("*");
         exclusion.setArtifactId("maven-*");
@@ -158,7 +158,7 @@ class ExclusionArtifactFilterTest {
     }
 
     @Test
-    void testExcludeWithGlobStar() {
+    void excludeWithGlobStar() {
         Exclusion exclusion = new Exclusion();
         exclusion.setGroupId("**");
         exclusion.setArtifactId("maven-**");

--- a/impl/maven-core/src/test/java/org/apache/maven/classrealm/DefaultClassRealmManagerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/classrealm/DefaultClassRealmManagerTest.java
@@ -96,7 +96,7 @@ class DefaultClassRealmManagerTest {
     }
 
     @Test
-    void testDebugEnabled() throws PlexusContainerException {
+    void debugEnabled() throws PlexusContainerException {
         Logger logger = mock(Logger.class);
         when(logger.isDebugEnabled()).thenReturn(true);
 
@@ -130,7 +130,7 @@ class DefaultClassRealmManagerTest {
     }
 
     @Test
-    void testDebugDisabled() throws PlexusContainerException {
+    void debugDisabled() throws PlexusContainerException {
         Logger logger = mock(Logger.class);
         when(logger.isDebugEnabled()).thenReturn(false);
 

--- a/impl/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorPathTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorPathTest.java
@@ -59,7 +59,7 @@ class DefaultBeanConfiguratorPathTest {
     }
 
     @Test
-    void testMinimal() throws BeanConfigurationException {
+    void minimal() throws BeanConfigurationException {
         SomeBean bean = new SomeBean();
 
         Xpp3Dom config = toConfig("<file>test</file>");
@@ -73,7 +73,7 @@ class DefaultBeanConfiguratorPathTest {
     }
 
     @Test
-    void testPreAndPostProcessing() throws BeanConfigurationException {
+    void preAndPostProcessing() throws BeanConfigurationException {
         SomeBean bean = new SomeBean();
 
         Xpp3Dom config = toConfig("<file>${test}</file>");
@@ -97,7 +97,7 @@ class DefaultBeanConfiguratorPathTest {
     }
 
     @Test
-    void testChildConfigurationElement() throws BeanConfigurationException {
+    void childConfigurationElement() throws BeanConfigurationException {
         SomeBean bean = new SomeBean();
 
         Xpp3Dom config = toConfig("<wrapper><file>test</file></wrapper>");

--- a/impl/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/configuration/DefaultBeanConfiguratorTest.java
@@ -57,7 +57,7 @@ class DefaultBeanConfiguratorTest {
     }
 
     @Test
-    void testMinimal() throws BeanConfigurationException {
+    void minimal() throws BeanConfigurationException {
         SomeBean bean = new SomeBean();
 
         Xpp3Dom config = toConfig("<file>test</file>");
@@ -71,7 +71,7 @@ class DefaultBeanConfiguratorTest {
     }
 
     @Test
-    void testPreAndPostProcessing() throws BeanConfigurationException {
+    void preAndPostProcessing() throws BeanConfigurationException {
         SomeBean bean = new SomeBean();
 
         Xpp3Dom config = toConfig("<file>${test}</file>");
@@ -95,7 +95,7 @@ class DefaultBeanConfiguratorTest {
     }
 
     @Test
-    void testChildConfigurationElement() throws BeanConfigurationException {
+    void childConfigurationElement() throws BeanConfigurationException {
         SomeBean bean = new SomeBean();
 
         Xpp3Dom config = toConfig("<wrapper><file>test</file></wrapper>");

--- a/impl/maven-core/src/test/java/org/apache/maven/di/DiTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/di/DiTest.java
@@ -73,7 +73,7 @@ public class DiTest {
         }
 
         @Test
-        void testPlexus() throws Exception {
+        void plexus() throws Exception {
             List<ModelParser> parsers = container.lookupList(ModelParser.class);
             assertNotNull(parsers);
             assertEquals(1, parsers.size());
@@ -83,7 +83,7 @@ public class DiTest {
         }
 
         @Test
-        void testGuice() throws Exception {
+        void guice() throws Exception {
             List<Binding<ModelParser>> parsers =
                     container.lookup(Injector.class).findBindingsByType(TypeLiteral.get(ModelParser.class));
             assertNotNull(parsers);
@@ -91,7 +91,7 @@ public class DiTest {
         }
 
         @Test
-        void testDI() throws Exception {
+        void di() throws Exception {
             DiInjected diInjected = new DiInjected();
             container.lookup(org.apache.maven.di.Injector.class).injectInstance(diInjected);
             assertNotNull(diInjected.parser);
@@ -144,7 +144,7 @@ public class DiTest {
         }
 
         @Test
-        void testPlexus() throws Exception {
+        void plexus() throws Exception {
             List<ModelParser> parsers = container.lookupList(ModelParser.class);
             assertNotNull(parsers);
             assertEquals(1, parsers.size());
@@ -154,7 +154,7 @@ public class DiTest {
         }
 
         @Test
-        void testGuice() throws Exception {
+        void guice() throws Exception {
             List<Binding<ModelParser>> parsers2 =
                     container.lookup(Injector.class).findBindingsByType(TypeLiteral.get(ModelParser.class));
             assertNotNull(parsers2);
@@ -163,7 +163,7 @@ public class DiTest {
 
         @Test
         @EnabledIf("org.apache.maven.di.DiTest#testShouldNotHaveDuplicates")
-        void testDI() throws Exception {
+        void di() throws Exception {
             DiInjected diInjected = new DiInjected();
             container.lookup(org.apache.maven.di.Injector.class).injectInstance(diInjected);
             assertNotNull(diInjected.parser);
@@ -216,7 +216,7 @@ public class DiTest {
         }
 
         @Test
-        void testPlexus() throws Exception {
+        void plexus() throws Exception {
             List<ModelParser> parsers = container.lookupList(ModelParser.class);
             assertNotNull(parsers);
             assertEquals(1, parsers.size());
@@ -226,7 +226,7 @@ public class DiTest {
         }
 
         @Test
-        void testGuice() throws Exception {
+        void guice() throws Exception {
             List<Binding<ModelParser>> parsers =
                     container.lookup(Injector.class).findBindingsByType(TypeLiteral.get(ModelParser.class));
             assertNotNull(parsers);
@@ -235,7 +235,7 @@ public class DiTest {
 
         @Test
         @EnabledIf("org.apache.maven.di.DiTest#testShouldNotHaveDuplicates")
-        void testDI() throws Exception {
+        void di() throws Exception {
             DiInjected diInjected = new DiInjected();
             container.lookup(org.apache.maven.di.Injector.class).injectInstance(diInjected);
             assertNotNull(diInjected.parser);
@@ -295,7 +295,7 @@ public class DiTest {
         }
 
         @Test
-        void testPlexus() throws Exception {
+        void plexus() throws Exception {
             List<ModelParser> parsers = container.lookupList(ModelParser.class);
             assertNotNull(parsers);
             assertEquals(1, parsers.size());
@@ -305,7 +305,7 @@ public class DiTest {
         }
 
         @Test
-        void testGuice() throws Exception {
+        void guice() throws Exception {
             List<Binding<ModelParser>> parsers =
                     container.lookup(Injector.class).findBindingsByType(TypeLiteral.get(ModelParser.class));
             assertNotNull(parsers);
@@ -313,7 +313,7 @@ public class DiTest {
         }
 
         @Test
-        void testDI() throws Exception {
+        void di() throws Exception {
             DiInjected diInjected = new DiInjected();
             container.lookup(org.apache.maven.di.Injector.class).injectInstance(diInjected);
             assertNotNull(diInjected.parser);

--- a/impl/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
@@ -47,7 +47,7 @@ class DefaultExceptionHandlerTest {
      * </p>
      */
     @Test
-    void testJdk7ipv6() {
+    void jdk7ipv6() {
         ConnectException connEx = new ConnectException("Connection refused: connect");
         IOException ioEx = new IOException("Unable to establish loopback connection", connEx);
         MojoExecutionException mojoEx =
@@ -61,7 +61,7 @@ class DefaultExceptionHandlerTest {
     }
 
     @Test
-    void testHandleExceptionAetherClassNotFound() {
+    void handleExceptionAetherClassNotFound() {
         Throwable cause2 = new NoClassDefFoundError("org/sonatype/aether/RepositorySystem");
         Plugin plugin = new Plugin();
         Exception cause = new PluginContainerException(plugin, null, null, cause2);
@@ -79,7 +79,7 @@ class DefaultExceptionHandlerTest {
     }
 
     @Test
-    void testHandleExceptionNoClassDefFoundErrorNull() {
+    void handleExceptionNoClassDefFoundErrorNull() {
         Throwable cause2 = new NoClassDefFoundError();
         Plugin plugin = new Plugin();
         Exception cause = new PluginContainerException(plugin, null, null, cause2);
@@ -97,7 +97,7 @@ class DefaultExceptionHandlerTest {
     }
 
     @Test
-    void testHandleExceptionLoopInCause() {
+    void handleExceptionLoopInCause() {
         // Some broken exception that does return "this" as getCause
         AtomicReference<Throwable> causeRef = new AtomicReference<>(null);
         Exception cause2 = new RuntimeException("loop") {
@@ -125,7 +125,7 @@ class DefaultExceptionHandlerTest {
     }
 
     @Test
-    void testHandleExceptionSelfReferencing() {
+    void handleExceptionSelfReferencing() {
         RuntimeException boom3 = new RuntimeException("BOOM3");
         RuntimeException boom2 = new RuntimeException("BOOM2", boom3);
         RuntimeException boom1 = new RuntimeException("BOOM1", boom2);

--- a/impl/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulatorTest.java
@@ -37,7 +37,7 @@ class DefaultMavenExecutionRequestPopulatorTest {
     MavenExecutionRequestPopulator testee;
 
     @Test
-    void testPluginRepositoryInjection() throws Exception {
+    void pluginRepositoryInjection() throws Exception {
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
 
         Repository r = new Repository();

--- a/impl/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
  */
 class DefaultMavenExecutionTest {
     @Test
-    void testCopyDefault() {
+    void copyDefault() {
         MavenExecutionRequest original = new DefaultMavenExecutionRequest();
         MavenExecutionRequest copy = DefaultMavenExecutionRequest.copy(original);
         assertNotNull(copy);
@@ -41,7 +41,7 @@ class DefaultMavenExecutionTest {
     }
 
     @Test
-    void testResultWithNullTopologicallySortedProjectsIsEmptyList() {
+    void resultWithNullTopologicallySortedProjectsIsEmptyList() {
         MavenExecutionResult result = new DefaultMavenExecutionResult();
         result.setTopologicallySortedProjects(null);
         List<MavenProject> projects = result.getTopologicallySortedProjects();

--- a/impl/maven-core/src/test/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/execution/scope/internal/MojoExecutionScopeTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MojoExecutionScopeTest {
     @Test
-    void testNestedEnter() throws Exception {
+    void nestedEnter() throws Exception {
         MojoExecutionScope scope = new MojoExecutionScope();
 
         scope.enter();
@@ -55,7 +55,7 @@ class MojoExecutionScopeTest {
     }
 
     @Test
-    void testMultiKeyInstance() throws Exception {
+    void multiKeyInstance() throws Exception {
         MojoExecutionScope scope = new MojoExecutionScope();
         scope.enter();
 

--- a/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
@@ -282,7 +282,7 @@ class DefaultGraphBuilderTest {
     @ParameterizedTest
     @MethodSource("parameters")
     @SuppressWarnings("checkstyle:ParameterNumber")
-    void testGetReactorProjects(
+    void getReactorProjects(
             String parameterDescription,
             List<String> parameterActiveRequiredProjects,
             List<String> parameterActiveOptionalProjects,
@@ -337,7 +337,7 @@ class DefaultGraphBuilderTest {
     }
 
     @Test
-    void testProcessPackagingAttribute() throws ProjectBuildingException {
+    void processPackagingAttribute() throws ProjectBuildingException {
         graphBuilder = new DefaultGraphBuilder(
                 mock(BuildResumptionDataRepository.class),
                 pomlessCollectionStrategy,

--- a/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultProjectDependencyGraphTest.java
@@ -53,7 +53,7 @@ class DefaultProjectDependencyGraphTest {
     private final MavenProject transitiveOnly = createProject(Arrays.asList(toDependency(depender3)), "depender5");
 
     @Test
-    void testNonTransitiveFiltering() throws DuplicateProjectException, CycleDetectedException {
+    void nonTransitiveFiltering() throws DuplicateProjectException, CycleDetectedException {
         ProjectDependencyGraph graph = new FilteredProjectDependencyGraph(
                 new DefaultProjectDependencyGraph(Arrays.asList(aProject, bProject, cProject)),
                 Arrays.asList(aProject, cProject));
@@ -65,7 +65,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testGetSortedProjects() throws DuplicateProjectException, CycleDetectedException {
+    void getSortedProjects() throws DuplicateProjectException, CycleDetectedException {
         ProjectDependencyGraph graph = new DefaultProjectDependencyGraph(Arrays.asList(depender1, aProject));
         final List<MavenProject> sortedProjects = graph.getSortedProjects();
         assertEquals(aProject, sortedProjects.get(0));
@@ -73,7 +73,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testVerifyExpectedParentStructure() throws CycleDetectedException, DuplicateProjectException {
+    void verifyExpectedParentStructure() throws CycleDetectedException, DuplicateProjectException {
         // This test verifies the baseline structure used in subsequent tests. If this fails, the rest will fail.
         ProjectDependencyGraph graph = threeProjectsDependingOnASingle();
         final List<MavenProject> sortedProjects = graph.getSortedProjects();
@@ -84,7 +84,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testVerifyThatDownstreamProjectsComeInSortedOrder() throws CycleDetectedException, DuplicateProjectException {
+    void verifyThatDownstreamProjectsComeInSortedOrder() throws CycleDetectedException, DuplicateProjectException {
         final List<MavenProject> downstreamProjects =
                 threeProjectsDependingOnASingle().getDownstreamProjects(aProject, true);
         assertEquals(depender1, downstreamProjects.get(0));
@@ -93,7 +93,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testTransitivesInOrder() throws CycleDetectedException, DuplicateProjectException {
+    void transitivesInOrder() throws CycleDetectedException, DuplicateProjectException {
         final ProjectDependencyGraph graph =
                 new DefaultProjectDependencyGraph(Arrays.asList(depender1, depender4, depender2, depender3, aProject));
 
@@ -105,7 +105,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testNonTransitivesInOrder() throws CycleDetectedException, DuplicateProjectException {
+    void nonTransitivesInOrder() throws CycleDetectedException, DuplicateProjectException {
         final ProjectDependencyGraph graph =
                 new DefaultProjectDependencyGraph(Arrays.asList(depender1, depender4, depender2, depender3, aProject));
 
@@ -117,7 +117,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testWithTransitiveOnly() throws CycleDetectedException, DuplicateProjectException {
+    void withTransitiveOnly() throws CycleDetectedException, DuplicateProjectException {
         final ProjectDependencyGraph graph = new DefaultProjectDependencyGraph(
                 Arrays.asList(depender1, transitiveOnly, depender2, depender3, aProject));
 
@@ -129,7 +129,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testWithMissingTransitiveOnly() throws CycleDetectedException, DuplicateProjectException {
+    void withMissingTransitiveOnly() throws CycleDetectedException, DuplicateProjectException {
         final ProjectDependencyGraph graph = new DefaultProjectDependencyGraph(
                 Arrays.asList(depender1, transitiveOnly, depender2, depender3, aProject));
 
@@ -140,7 +140,7 @@ class DefaultProjectDependencyGraphTest {
     }
 
     @Test
-    void testGetUpstreamProjects() throws CycleDetectedException, DuplicateProjectException {
+    void getUpstreamProjects() throws CycleDetectedException, DuplicateProjectException {
         ProjectDependencyGraph graph = threeProjectsDependingOnASingle();
         final List<MavenProject> downstreamProjects = graph.getUpstreamProjects(depender1, true);
         assertEquals(aProject, downstreamProjects.get(0));

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/MultilineMessageHelperTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/MultilineMessageHelperTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class MultilineMessageHelperTest {
 
     @Test
-    void testBuilderCommon() {
+    void builderCommon() {
         List<String> msgs = new ArrayList<>();
         msgs.add("*****************************************************************");
         msgs.add("* Your build is requesting parallel execution, but project      *");
@@ -51,7 +51,7 @@ class MultilineMessageHelperTest {
     }
 
     @Test
-    void testMojoExecutor() {
+    void mojoExecutor() {
         List<String> msgs = new ArrayList<>();
         msgs.add("*****************************************************************");
         msgs.add("* An aggregator Mojo is already executing in parallel build,    *");

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
  * UT for {@link DefaultRepositorySystemSessionFactory}.
  */
 @PlexusTest
-public class DefaultRepositorySystemSessionFactoryTest {
+class DefaultRepositorySystemSessionFactoryTest {
     @Inject
     protected MavenRepositorySystem mavenRepositorySystem;
 

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultChecksumAlgorithmServiceTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultChecksumAlgorithmServiceTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DefaultChecksumAlgorithmServiceTest {
+class DefaultChecksumAlgorithmServiceTest {
     private static Map<String, ChecksumAlgorithmFactory> getChecksumAlgorithmFactories() {
         HashMap<String, ChecksumAlgorithmFactory> result = new HashMap<>();
         result.put(Sha512ChecksumAlgorithmFactory.NAME, new Sha512ChecksumAlgorithmFactory());

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-public class DefaultSessionTest {
+class DefaultSessionTest {
 
     @Test
-    void testRootDirectoryWithNull() {
+    void rootDirectoryWithNull() {
         RepositorySystemSession rss = new DefaultRepositorySystemSession(h -> false);
         DefaultMavenExecutionRequest mer = new DefaultMavenExecutionRequest();
         MavenSession ms = new MavenSession(null, rss, mer, null);
@@ -50,7 +50,7 @@ public class DefaultSessionTest {
     }
 
     @Test
-    void testRootDirectory() {
+    void rootDirectory() {
         RepositorySystemSession rss = new DefaultRepositorySystemSession(h -> false);
         DefaultMavenExecutionRequest mer = new DefaultMavenExecutionRequest();
         MavenSession ms = new MavenSession(null, rss, mer, null);

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/PropertiesAsMapTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/PropertiesAsMapTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PropertiesAsMapTest {
 
     @Test
-    void testPropertiesAsMap() {
+    void propertiesAsMap() {
         Properties props = new Properties();
         props.setProperty("foo1", "bar1");
         props.setProperty("foo2", "bar2");

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/TestApi.java
@@ -149,7 +149,7 @@ class TestApi {
     }
 
     @Test
-    void testCreateAndResolveArtifact() {
+    void createAndResolveArtifact() {
         ArtifactCoordinates coords =
                 session.createArtifactCoordinates("org.codehaus.plexus", "plexus-utils", "1.4.5", "pom");
 
@@ -162,7 +162,7 @@ class TestApi {
     }
 
     @Test
-    void testBuildProject() {
+    void buildProject() {
         Artifact artifact = session.createArtifact("org.codehaus.plexus", "plexus-utils", "1.4.5", "pom");
 
         Project project = project(artifact);
@@ -170,7 +170,7 @@ class TestApi {
     }
 
     @Test
-    void testCollectArtifactDependencies() {
+    void collectArtifactDependencies() {
         Artifact artifact =
                 session.createArtifact("org.codehaus.plexus", "plexus-container-default", "1.0-alpha-32", "jar");
         Node root = session.collectDependencies(artifact, PathScope.MAIN_RUNTIME);
@@ -178,7 +178,7 @@ class TestApi {
     }
 
     @Test
-    void testResolveArtifactCoordinatesDependencies() {
+    void resolveArtifactCoordinatesDependencies() {
         DependencyCoordinates coords = session.createDependencyCoordinates(
                 session.createArtifactCoordinates("org.apache.maven.core.test", "test-extension", "1", "jar"));
 
@@ -218,7 +218,7 @@ class TestApi {
     }
 
     @Test
-    void testMetadataGeneratorFactory() throws ComponentLookupException {
+    void metadataGeneratorFactory() throws ComponentLookupException {
         List<MetadataGeneratorFactory> factories = plexusContainer.lookupList(MetadataGeneratorFactory.class);
         assertNotNull(factories);
         factories.forEach(f -> System.out.println(f.getClass().getName()));
@@ -226,7 +226,7 @@ class TestApi {
     }
 
     @Test
-    void testProjectDependencies() {
+    void projectDependencies() {
         Artifact pom = session.createArtifact("org.codehaus.plexus", "plexus-container-default", "1.0-alpha-32", "pom");
 
         Project project = project(pom);

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
+class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
 
     @Inject
     ConsumerPomBuilder builder;
@@ -89,7 +89,7 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testTrivialConsumer() throws Exception {
+    void trivialConsumer() throws Exception {
         InternalMavenSession.from(InternalSession.from(session))
                 .getMavenSession()
                 .getRequest()
@@ -114,7 +114,7 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testSimpleConsumer() throws Exception {
+    void simpleConsumer() throws Exception {
         MavenExecutionRequest request = InternalMavenSession.from(InternalSession.from(session))
                 .getMavenSession()
                 .getRequest();
@@ -142,7 +142,7 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
     }
 
     @Test
-    void testScmInheritance() throws Exception {
+    void scmInheritance() throws Exception {
         Model model = Model.newBuilder()
                 .scm(Scm.newBuilder()
                         .connection("scm:git:https://github.com/apache/maven-project.git")

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -49,35 +49,35 @@ class DefaultLifecyclesTest {
     private DefaultLifecycles defaultLifeCycles;
 
     @Test
-    void testDefaultLifecycles() {
+    void defaultLifecycles() {
         final List<Lifecycle> lifecycles = defaultLifeCycles.getLifeCycles();
         assertThat(lifecycles, hasSize(3));
         assertThat(DefaultLifecycles.STANDARD_LIFECYCLES, arrayWithSize(3));
     }
 
     @Test
-    void testDefaultLifecycle() {
+    void defaultLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("default");
         assertThat(lifecycle.getId(), is("default"));
         assertThat(lifecycle.getPhases(), hasSize(54));
     }
 
     @Test
-    void testCleanLifecycle() {
+    void cleanLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("clean");
         assertThat(lifecycle.getId(), is("clean"));
         assertThat(lifecycle.getPhases(), hasSize(3));
     }
 
     @Test
-    void testSiteLifecycle() {
+    void siteLifecycle() {
         final Lifecycle lifecycle = getLifeCycleById("site");
         assertThat(lifecycle.getId(), is("site"));
         assertThat(lifecycle.getPhases(), hasSize(6));
     }
 
     @Test
-    void testCustomLifecycle() throws ComponentLookupException {
+    void customLifecycle() throws ComponentLookupException {
         List<Lifecycle> myLifecycles = new ArrayList<>();
         Lifecycle myLifecycle =
                 new Lifecycle("etl", Arrays.asList("extract", "transform", "load"), Collections.emptyMap());

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorSubModulesTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorSubModulesTest.java
@@ -65,7 +65,7 @@ class LifecycleExecutorSubModulesTest extends AbstractCoreMavenComponentTestCase
     }
 
     @Test
-    void testCreation() throws Exception {
+    void creation() throws Exception {
         assertNotNull(defaultLifeCycles);
         assertNotNull(mojoExecutor);
         assertNotNull(lifeCycleBuilder);

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
@@ -78,7 +78,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     // -----------------------------------------------------------------------------------------------
 
     @Test
-    void testCalculationOfBuildPlanWithIndividualTaskWherePluginIsSpecifiedInThePom() throws Exception {
+    void calculationOfBuildPlanWithIndividualTaskWherePluginIsSpecifiedInThePom() throws Exception {
         // We are doing something like "mvn resources:resources" where no version is specified but this
         // project we are working on has the version specified in the POM so the version should come from there.
         File pom = getProject("project-basic");
@@ -100,7 +100,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testCalculationOfBuildPlanWithIndividualTaskOfTheCleanLifecycle() throws Exception {
+    void calculationOfBuildPlanWithIndividualTaskOfTheCleanLifecycle() throws Exception {
         // We are doing something like "mvn clean:clean" where no version is specified but this
         // project we are working on has the version specified in the POM so the version should come from there.
         File pom = getProject("project-basic");
@@ -122,7 +122,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testCalculationOfBuildPlanWithIndividualTaskOfTheCleanCleanGoal() throws Exception {
+    void calculationOfBuildPlanWithIndividualTaskOfTheCleanCleanGoal() throws Exception {
         // We are doing something like "mvn clean:clean" where no version is specified but this
         // project we are working on has the version specified in the POM so the version should come from there.
         File pom = getProject("project-basic");
@@ -153,7 +153,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
 
     // We need to take in multiple lifecycles
     @Test
-    public void testCalculationOfBuildPlanTasksOfTheCleanLifecycleAndTheInstallLifecycle() throws Exception {
+    void calculationOfBuildPlanTasksOfTheCleanLifecycleAndTheInstallLifecycle() throws Exception {
         File pom = getProject("project-with-additional-lifecycle-elements");
         MavenSession session = createMavenSession(pom);
         assertEquals(
@@ -192,7 +192,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
 
     // We need to take in multiple lifecycles
     @Test
-    public void testCalculationOfBuildPlanWithMultipleExecutionsOfModello() throws Exception {
+    void calculationOfBuildPlanWithMultipleExecutionsOfModello() throws Exception {
         File pom = getProject("project-with-multiple-executions");
         MavenSession session = createMavenSession(pom);
         assertEquals(
@@ -251,7 +251,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testLifecycleQueryingUsingADefaultLifecyclePhase() throws Exception {
+    void lifecycleQueryingUsingADefaultLifecyclePhase() throws Exception {
         File pom = getProject("project-with-additional-lifecycle-elements");
         MavenSession session = createMavenSession(pom);
         assertEquals(
@@ -285,14 +285,14 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testLifecyclePluginsRetrievalForDefaultLifecycle() throws Exception {
+    void lifecyclePluginsRetrievalForDefaultLifecycle() throws Exception {
         List<Plugin> plugins = new ArrayList<>(lifecycleExecutor.getPluginsBoundByDefaultToAllLifecycles("jar"));
 
         assertThat(plugins.toString(), plugins, hasSize(8));
     }
 
     @Test
-    void testPluginConfigurationCreation() throws Exception {
+    void pluginConfigurationCreation() throws Exception {
         File pom = getProject("project-with-additional-lifecycle-elements");
         MavenSession session = createMavenSession(pom);
         MojoDescriptor mojoDescriptor = mojoDescriptorCreator.getMojoDescriptor(
@@ -316,7 +316,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testInvalidGoalName() throws Exception {
+    void invalidGoalName() throws Exception {
         File pom = getProject("project-basic");
         MavenSession session = createMavenSession(pom);
         MojoNotFoundException e = assertThrows(
@@ -334,7 +334,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testPluginPrefixRetrieval() throws Exception {
+    void pluginPrefixRetrieval() throws Exception {
         File pom = getProject("project-basic");
         MavenSession session = createMavenSession(pom);
         Plugin plugin = mojoDescriptorCreator.findPluginForPrefix("resources", session);
@@ -345,7 +345,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     // Prefixes
 
     @Test
-    void testFindingPluginPrefixForCleanClean() throws Exception {
+    void findingPluginPrefixForCleanClean() throws Exception {
         File pom = getProject("project-basic");
         MavenSession session = createMavenSession(pom);
         Plugin plugin = mojoDescriptorCreator.findPluginForPrefix("clean", session);
@@ -353,7 +353,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testSetupMojoExecution() throws Exception {
+    void setupMojoExecution() throws Exception {
         File pom = getProject("mojo-configuration");
 
         MavenSession session = createMavenSession(pom);
@@ -373,7 +373,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testExecutionListeners() throws Exception {
+    void executionListeners() throws Exception {
         final File pom = getProject("project-basic");
         final MavenSession session = createMavenSession(pom);
         session.setProjectDependencyGraph(new ProjectDependencyGraph() {

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/MavenExecutionPlanTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/MavenExecutionPlanTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class MavenExecutionPlanTest {
 
     @Test
-    void testFindLastInPhase() throws Exception {
+    void findLastInPhase() throws Exception {
         MavenExecutionPlan plan = LifecycleExecutionPlanCalculatorStub.getProjectAExecutionPlan();
 
         ExecutionPlanItem expected = plan.findLastInPhase("package");
@@ -42,7 +42,7 @@ class MavenExecutionPlanTest {
     }
 
     @Test
-    void testThreadSafeMojos() throws Exception {
+    void threadSafeMojos() throws Exception {
         MavenExecutionPlan plan = LifecycleExecutionPlanCalculatorStub.getProjectAExecutionPlan();
         final Set<Plugin> unSafePlugins = plan.getNonThreadSafePlugins();
         // There is only a single threadsafe plugin here...
@@ -50,7 +50,7 @@ class MavenExecutionPlanTest {
     }
 
     @Test
-    void testFindLastWhenFirst() throws Exception {
+    void findLastWhenFirst() throws Exception {
         MavenExecutionPlan plan = LifecycleExecutionPlanCalculatorStub.getProjectAExecutionPlan();
 
         ExecutionPlanItem beerPhase = plan.findLastInPhase(
@@ -59,7 +59,7 @@ class MavenExecutionPlanTest {
     }
 
     @Test
-    void testFindLastInPhaseMisc() throws Exception {
+    void findLastInPhaseMisc() throws Exception {
         MavenExecutionPlan plan = LifecycleExecutionPlanCalculatorStub.getProjectAExecutionPlan();
 
         assertNull(plan.findLastInPhase("pacXkage"));

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/BuildListCalculatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/BuildListCalculatorTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 class BuildListCalculatorTest {
 
     @Test
-    void testCalculateProjectBuilds() throws Exception {
+    void calculateProjectBuilds() throws Exception {
         LifecycleTaskSegmentCalculator lifecycleTaskSegmentCalculator = getTaskSegmentCalculator();
         BuildListCalculator buildListCalculator = new BuildListCalculator();
         final MavenSession session = ProjectDependencyGraphStub.getMavenSession();

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ConcurrencyDependencyGraphTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ConcurrencyDependencyGraphTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class ConcurrencyDependencyGraphTest {
     @Test
-    void testConcurrencyGraphPrimaryVersion()
+    void concurrencyGraphPrimaryVersion()
             throws InvalidPluginDescriptorException, PluginVersionResolutionException, PluginDescriptorParsingException,
                     NoPluginFoundForPrefixException, MojoNotFoundException, PluginNotFoundException,
                     PluginResolutionException, LifecyclePhaseNotFoundException, LifecycleNotFoundException {
@@ -79,7 +79,7 @@ class ConcurrencyDependencyGraphTest {
     }
 
     @Test
-    void testConcurrencyGraphDifferentCompletionOrder()
+    void concurrencyGraphDifferentCompletionOrder()
             throws InvalidPluginDescriptorException, PluginVersionResolutionException, PluginDescriptorParsingException,
                     NoPluginFoundForPrefixException, MojoNotFoundException, PluginNotFoundException,
                     PluginResolutionException, LifecyclePhaseNotFoundException, LifecycleNotFoundException {

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolverTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleDependencyResolverTest.java
@@ -46,7 +46,7 @@ class LifecycleDependencyResolverTest extends AbstractCoreMavenComponentTestCase
     }
 
     @Test
-    void testCachedReactorProjectDependencies() throws Exception {
+    void cachedReactorProjectDependencies() throws Exception {
         MavenSession session = createMavenSession(
                 new File("src/test/projects/lifecycle-dependency-resolver/pom.xml"), new Properties(), true);
         Collection<String> scopesToCollect = null;

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class LifecycleExecutionPlanCalculatorTest extends AbstractCoreMavenComponentTestCase {
 
     @Test
-    void testCalculateExecutionPlanWithGoalTasks() throws Exception {
+    void calculateExecutionPlanWithGoalTasks() throws Exception {
         MojoDescriptorCreator mojoDescriptorCreator = createMojoDescriptorCreator();
         LifecycleExecutionPlanCalculator lifecycleExecutionPlanCalculator =
                 createExecutionPlaceCalculator(mojoDescriptorCreator);

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleModuleBuilderTest.java
@@ -49,7 +49,7 @@ class LifecycleModuleBuilderTest {
     PlexusContainer container;
 
     @Test
-    void testCurrentProject() throws Exception {
+    void currentProject() throws Exception {
         List<MavenProject> currentProjects = new ArrayList<>();
         MojoExecutorStub mojoExecutor = new MojoExecutorStub() {
             @Override

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleTaskSegmentCalculatorImplTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleTaskSegmentCalculatorImplTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 class LifecycleTaskSegmentCalculatorImplTest {
     @Test
-    void testCalculateProjectBuilds() throws Exception {
+    void calculateProjectBuilds() throws Exception {
         LifecycleTaskSegmentCalculator lifecycleTaskSegmentCalculator = getTaskSegmentCalculator();
         BuildListCalculator buildListCalculator = new BuildListCalculator();
         final MavenSession session = ProjectDependencyGraphStub.getMavenSession();

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/PhaseRecorderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/PhaseRecorderTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class PhaseRecorderTest {
     @Test
-    void testObserveExecution() throws Exception {
+    void observeExecution() throws Exception {
         PhaseRecorder phaseRecorder = new PhaseRecorder(ProjectDependencyGraphStub.A);
         MavenExecutionPlan plan = LifecycleExecutionPlanCalculatorStub.getProjectAExecutionPlan();
         final List<MojoExecution> executions = plan.getMojoExecutions();

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ProjectBuildListTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/ProjectBuildListTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class ProjectBuildListTest {
     @Test
-    void testGetByTaskSegment() throws Exception {
+    void getByTaskSegment() throws Exception {
         final MavenSession session = ProjectDependencyGraphStub.getMavenSession();
         ProjectBuildList projectBuildList = ProjectDependencyGraphStub.getProjectBuildList(session);
         TaskSegment taskSegment = projectBuildList.get(0).getTaskSegment();

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/BuilderCommonTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/BuilderCommonTest.java
@@ -40,7 +40,7 @@ class BuilderCommonTest {
     private Logger logger = mock(Logger.class);
 
     @Test
-    void testResolveBuildPlan() throws Exception {
+    void resolveBuildPlan() throws Exception {
         MavenSession original = ProjectDependencyGraphStub.getMavenSession();
 
         final TaskSegment taskSegment1 = new TaskSegment(false);
@@ -55,7 +55,7 @@ class BuilderCommonTest {
     }
 
     @Test
-    void testDefaultBindingPluginsWarning() throws Exception {
+    void defaultBindingPluginsWarning() throws Exception {
         MavenSession original = ProjectDependencyGraphStub.getMavenSession();
 
         final TaskSegment taskSegment1 = new TaskSegment(false);
@@ -79,13 +79,13 @@ class BuilderCommonTest {
     }
 
     @Test
-    void testHandleBuildError() throws Exception {}
+    void handleBuildError() throws Exception {}
 
     @Test
-    void testAttachToThread() throws Exception {}
+    void attachToThread() throws Exception {}
 
     @Test
-    void testGetKey() throws Exception {}
+    void getKey() throws Exception {}
 
     public BuilderCommon getBuilderCommon(Logger logger) {
         final LifecycleDebugLogger debugLogger = new LifecycleDebugLogger();

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ConcurrencyDependencyGraphTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/builder/multithreaded/ConcurrencyDependencyGraphTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ConcurrencyDependencyGraphTest {
 
     @Test
-    void testGraph() throws Exception {
+    void graph() throws Exception {
 
         ProjectBuildList projectBuildList =
                 ProjectDependencyGraphStub.getProjectBuildList(ProjectDependencyGraphStub.getMavenSession());

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BuildPlanCreatorTest {
 
     @Test
-    void testMulti() {
+    void multi() {
         MavenProject project = new MavenProject();
         project.setCollectedProjects(List.of());
         Map<MavenProject, List<MavenProject>> projects = Collections.singletonMap(project, Collections.emptyList());
@@ -47,7 +47,7 @@ class BuildPlanCreatorTest {
     }
 
     @Test
-    void testCondense() {
+    void condense() {
         MavenProject p1 = new MavenProject();
         p1.setCollectedProjects(List.of());
         p1.setArtifactId("p1");
@@ -83,7 +83,7 @@ class BuildPlanCreatorTest {
     }
 
     @Test
-    void testAlias() {
+    void alias() {
         MavenProject p1 = new MavenProject();
         p1.setArtifactId("p1");
         p1.setCollectedProjects(List.of());
@@ -94,7 +94,7 @@ class BuildPlanCreatorTest {
     }
 
     @Test
-    void testAllPhase() {
+    void allPhase() {
         MavenProject c1 = new MavenProject();
         c1.setArtifactId("c1");
         c1.setCollectedProjects(List.of());

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/ProjectDependencyGraphStubTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/ProjectDependencyGraphStubTest.java
@@ -34,27 +34,27 @@ class ProjectDependencyGraphStubTest {
     ProjectDependencyGraphStub stub = new ProjectDependencyGraphStub();
 
     @Test
-    void testADependencies() {
+    void aDependencies() {
         final List<MavenProject> mavenProjects = stub.getUpstreamProjects(ProjectDependencyGraphStub.A, false);
         assertEquals(0, mavenProjects.size());
     }
 
     @Test
-    void testBDependencies() {
+    void bDependencies() {
         final List<MavenProject> bProjects = stub.getUpstreamProjects(ProjectDependencyGraphStub.B, false);
         assertEquals(1, bProjects.size());
         assertTrue(bProjects.contains(ProjectDependencyGraphStub.A));
     }
 
     @Test
-    void testCDependencies() {
+    void cDependencies() {
         final List<MavenProject> cProjects = stub.getUpstreamProjects(ProjectDependencyGraphStub.C, false);
         assertEquals(1, cProjects.size());
         assertTrue(cProjects.contains(ProjectDependencyGraphStub.A));
     }
 
     @Test
-    void testXDependencies() {
+    void xDependencies() {
         final List<MavenProject> cProjects = stub.getUpstreamProjects(ProjectDependencyGraphStub.X, false);
         assertEquals(2, cProjects.size());
         assertTrue(cProjects.contains(ProjectDependencyGraphStub.C));

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/mapping/LifecyclePhaseTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/mapping/LifecyclePhaseTest.java
@@ -47,7 +47,7 @@ class LifecyclePhaseTest {
     }
 
     @Test
-    void testSet() {
+    void set() {
         LifecyclePhase phase = new LifecyclePhase();
         assertNull(phase.getMojos());
 

--- a/impl/maven-core/src/test/java/org/apache/maven/model/ModelBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/model/ModelBuilderTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @PlexusTest
-public class ModelBuilderTest {
+class ModelBuilderTest {
 
     @Inject
     ProjectBuilder projectBuilder;
@@ -65,7 +65,7 @@ public class ModelBuilderTest {
     RepositorySystem repositorySystem;
 
     @Test
-    void testModelBuilder() throws Exception {
+    void modelBuilder() throws Exception {
         MavenExecutionRequest mavenRequest = new DefaultMavenExecutionRequest();
         mavenRequest.setLocalRepository(mavenRepositorySystem.createLocalRepository(new File("target/test-repo/")));
         mavenRequest.setRootDirectory(Paths.get("src/test/resources/projects/tree"));

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginManagerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginManagerTest.java
@@ -48,7 +48,7 @@ class PluginManagerTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testPluginLoading() throws Exception {
+    void pluginLoading() throws Exception {
         MavenSession session = createMavenSession(null);
         Plugin plugin = new Plugin();
         plugin.setGroupId("org.apache.maven.its.plugins");
@@ -60,7 +60,7 @@ class PluginManagerTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testMojoDescriptorRetrieval() throws Exception {
+    void mojoDescriptorRetrieval() throws Exception {
         MavenSession session = createMavenSession(null);
         String goal = "it";
         Plugin plugin = new Plugin();
@@ -88,7 +88,7 @@ class PluginManagerTest extends AbstractCoreMavenComponentTestCase {
     // test a build where projects use different versions of the same plugin
 
     @Test
-    void testThatPluginDependencyThatHasSystemScopeIsResolved() throws Exception {
+    void thatPluginDependencyThatHasSystemScopeIsResolved() throws Exception {
         MavenSession session = createMavenSession(getProject("project-contributing-system-scope-plugin-dep"));
         MavenProject project = session.getCurrentProject();
         Plugin plugin = project.getPlugin("org.apache.maven.its.plugins:maven-it-plugin");
@@ -128,7 +128,7 @@ class PluginManagerTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testPluginRealmCache() throws Exception {
+    void pluginRealmCache() throws Exception {
         RepositoryRequest repositoryRequest = new DefaultRepositoryRequest();
         repositoryRequest.setLocalRepository(getLocalRepository());
         repositoryRequest.setRemoteRepositories(getPluginArtifactRepositories());
@@ -167,7 +167,7 @@ class PluginManagerTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testBuildExtensionsPluginLoading() throws Exception {
+    void buildExtensionsPluginLoading() throws Exception {
         RepositoryRequest repositoryRequest = new DefaultRepositoryRequest();
         repositoryRequest.setLocalRepository(getLocalRepository());
         repositoryRequest.setRemoteRepositories(getPluginArtifactRepositories());

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExceptionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExceptionTest.java
@@ -37,7 +37,7 @@ class PluginParameterExceptionTest {
     private static final String LS = System.lineSeparator();
 
     @Test
-    void testMissingRequiredStringArrayTypeParameter() {
+    void missingRequiredStringArrayTypeParameter() {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();
         mojoDescriptor.setGoal("goal");
         PluginDescriptor pluginDescriptor = new PluginDescriptor();
@@ -69,7 +69,7 @@ class PluginParameterExceptionTest {
     }
 
     @Test
-    void testMissingRequiredCollectionTypeParameter() {
+    void missingRequiredCollectionTypeParameter() {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();
         mojoDescriptor.setGoal("goal");
         PluginDescriptor pluginDescriptor = new PluginDescriptor();
@@ -101,7 +101,7 @@ class PluginParameterExceptionTest {
     }
 
     @Test
-    void testMissingRequiredMapTypeParameter() {
+    void missingRequiredMapTypeParameter() {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();
         mojoDescriptor.setGoal("goal");
         PluginDescriptor pluginDescriptor = new PluginDescriptor();
@@ -133,7 +133,7 @@ class PluginParameterExceptionTest {
     }
 
     @Test
-    void testMissingRequiredPropertiesTypeParameter() {
+    void missingRequiredPropertiesTypeParameter() {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();
         mojoDescriptor.setGoal("goal");
         PluginDescriptor pluginDescriptor = new PluginDescriptor();

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorTest.java
@@ -79,7 +79,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     private Path rootDirectory;
 
     @Test
-    void testPluginDescriptorExpressionReference() throws Exception {
+    void pluginDescriptorExpressionReference() throws Exception {
         MojoExecution exec = newMojoExecution();
 
         MavenSession session = newMavenSession();
@@ -95,7 +95,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testPluginArtifactsExpressionReference() throws Exception {
+    void pluginArtifactsExpressionReference() throws Exception {
         MojoExecution exec = newMojoExecution();
 
         Artifact depArtifact = createArtifact("group", "artifact", "1");
@@ -119,7 +119,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testPluginArtifactMapExpressionReference() throws Exception {
+    void pluginArtifactMapExpressionReference() throws Exception {
         MojoExecution exec = newMojoExecution();
 
         Artifact depArtifact = createArtifact("group", "artifact", "1");
@@ -146,7 +146,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testPluginArtifactIdExpressionReference() throws Exception {
+    void pluginArtifactIdExpressionReference() throws Exception {
         MojoExecution exec = newMojoExecution();
 
         MavenSession session = newMavenSession();
@@ -162,7 +162,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testValueExtractionWithAPomValueContainingAPath() throws Exception {
+    void valueExtractionWithAPomValueContainingAPath() throws Exception {
         String expected = getTestFile("target/test-classes/target/classes").getCanonicalPath();
 
         Build build = new Build();
@@ -183,7 +183,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testEscapedVariablePassthrough() throws Exception {
+    void escapedVariablePassthrough() throws Exception {
         String var = "${var}";
 
         Model model = new Model();
@@ -199,7 +199,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testEscapedVariablePassthroughInLargerExpression() throws Exception {
+    void escapedVariablePassthroughInLargerExpression() throws Exception {
         String var = "${var}";
         String key = var + " with version: ${project.version}";
 
@@ -216,7 +216,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testMultipleSubExpressionsInLargerExpression() throws Exception {
+    void multipleSubExpressionsInLargerExpression() throws Exception {
         String key = "${project.artifactId} with version: ${project.version}";
 
         Model model = new Model();
@@ -233,7 +233,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testMissingPOMPropertyRefInLargerExpression() throws Exception {
+    void missingPOMPropertyRefInLargerExpression() throws Exception {
         String expr = "/path/to/someproject-${baseVersion}";
 
         MavenProject project = new MavenProject(new Model());
@@ -246,7 +246,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testPOMPropertyExtractionWithMissingProjectWithDotNotation() throws Exception {
+    void pomPropertyExtractionWithMissingProjectWithDotNotation() throws Exception {
         String key = "m2.name";
         String checkValue = "value";
 
@@ -266,7 +266,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testBasedirExtractionWithMissingProject() throws Exception {
+    void basedirExtractionWithMissingProject() throws Exception {
         ExpressionEvaluator ee = createExpressionEvaluator(null, null, new Properties());
 
         Object value = ee.evaluate("${basedir}");
@@ -275,7 +275,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testValueExtractionFromSystemPropertiesWithMissingProject() throws Exception {
+    void valueExtractionFromSystemPropertiesWithMissingProject() throws Exception {
         String sysprop = "PPEET_sysprop1";
 
         Properties executionProperties = new Properties();
@@ -298,7 +298,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
                 "${PPEET_nonexisting_ps_property}-suffix",
                 "prefix-${PPEET_nonexisting_ps_property}-suffix",
             })
-    void testValueExtractionOfMissingPrefixedSuffixedProperty(String missingPropertyExpression) throws Exception {
+    void valueExtractionOfMissingPrefixedSuffixedProperty(String missingPropertyExpression) throws Exception {
         Properties executionProperties = new Properties();
 
         ExpressionEvaluator ee = createExpressionEvaluator(null, null, executionProperties);
@@ -309,7 +309,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testValueExtractionOfMissingProperty() throws Exception {
+    void valueExtractionOfMissingProperty() throws Exception {
         Properties executionProperties = new Properties();
 
         ExpressionEvaluator ee = createExpressionEvaluator(null, null, executionProperties);
@@ -320,7 +320,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testValueExtractionFromSystemPropertiesWithMissingProjectWithDotNotation() throws Exception {
+    void valueExtractionFromSystemPropertiesWithMissingProjectWithDotNotation() throws Exception {
         String sysprop = "PPEET.sysprop2";
 
         Properties executionProperties = new Properties();
@@ -349,7 +349,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testLocalRepositoryExtraction() throws Exception {
+    void localRepositoryExtraction() throws Exception {
         ExpressionEvaluator expressionEvaluator =
                 createExpressionEvaluator(createDefaultProject(), null, new Properties());
         Object value = expressionEvaluator.evaluate("${localRepository}");
@@ -358,7 +358,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testTwoExpressions() throws Exception {
+    void twoExpressions() throws Exception {
         Build build = new Build();
         build.setDirectory("expected-directory");
         build.setFinalName("expected-finalName");
@@ -375,7 +375,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testShouldExtractPluginArtifacts() throws Exception {
+    void shouldExtractPluginArtifacts() throws Exception {
         PluginDescriptor pd = new PluginDescriptor();
 
         Artifact artifact = createArtifact("testGroup", "testArtifact", "1.0");
@@ -399,13 +399,13 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testRootDirectoryNotPrefixed() throws Exception {
+    void rootDirectoryNotPrefixed() throws Exception {
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), null, new Properties());
         assertNull(ee.evaluate("${rootDirectory}"));
     }
 
     @Test
-    void testRootDirectoryWithNull() throws Exception {
+    void rootDirectoryWithNull() throws Exception {
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), null, new Properties());
         Exception e = assertThrows(Exception.class, () -> ee.evaluate("${session.rootDirectory}"));
         e = assertInstanceOf(IntrospectionException.class, e.getCause());
@@ -414,14 +414,14 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    void testRootDirectory() throws Exception {
+    void rootDirectory() throws Exception {
         this.rootDirectory = Paths.get("myRootDirectory");
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), null, new Properties());
         assertInstanceOf(Path.class, ee.evaluate("${session.rootDirectory}"));
     }
 
     @Test
-    public void testUri() throws Exception {
+    void uri() throws Exception {
         Path path = Paths.get("").toAbsolutePath();
 
         MavenSession mavenSession = createMavenSession(null);
@@ -434,7 +434,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    public void testPath() throws Exception {
+    void path() throws Exception {
         Path path = Paths.get("").toAbsolutePath();
 
         MavenSession mavenSession = createMavenSession(null);
@@ -447,7 +447,7 @@ class PluginParameterExpressionEvaluatorTest extends AbstractCoreMavenComponentT
     }
 
     @Test
-    public void testPluginInjection() throws Exception {
+    void pluginInjection() throws Exception {
         Path path = Paths.get("rép➜α").toAbsolutePath();
 
         MavenSession mavenSession = createMavenSession(null);

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/PluginParameterExpressionEvaluatorV4Test.java
@@ -82,7 +82,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  */
-public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenComponentTestCase {
+class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenComponentTestCase {
     private static final String FS = File.separator;
 
     @Inject
@@ -91,7 +91,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     private Path rootDirectory;
 
     @Test
-    public void testPluginDescriptorExpressionReference() throws Exception {
+    void pluginDescriptorExpressionReference() throws Exception {
         Session session = newSession();
         MojoExecution exec = newMojoExecution(session);
 
@@ -107,7 +107,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testPluginArtifactsExpressionReference() throws Exception {
+    void pluginArtifactsExpressionReference() throws Exception {
         Session session = newSession();
         MojoExecution exec = newMojoExecution(session);
 
@@ -126,7 +126,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testPluginArtifactMapExpressionReference() throws Exception {
+    void pluginArtifactMapExpressionReference() throws Exception {
         Session session = newSession();
 
         MojoExecution exec = newMojoExecution(session);
@@ -148,7 +148,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testPluginArtifactIdExpressionReference() throws Exception {
+    void pluginArtifactIdExpressionReference() throws Exception {
         Session session = newSession();
 
         MojoExecution exec = newMojoExecution(session);
@@ -165,7 +165,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testValueExtractionWithAPomValueContainingAPath() throws Exception {
+    void valueExtractionWithAPomValueContainingAPath() throws Exception {
         String expected = getTestFile("target/test-classes/target/classes").getCanonicalPath();
 
         Build build = new Build();
@@ -186,7 +186,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testEscapedVariablePassthrough() throws Exception {
+    void escapedVariablePassthrough() throws Exception {
         String var = "${var}";
 
         MavenProject project = createDefaultProject();
@@ -200,7 +200,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testEscapedVariablePassthroughInLargerExpression() throws Exception {
+    void escapedVariablePassthroughInLargerExpression() throws Exception {
         String var = "${var}";
         String key = var + " with version: ${project.version}";
 
@@ -215,7 +215,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testMultipleSubExpressionsInLargerExpression() throws Exception {
+    void multipleSubExpressionsInLargerExpression() throws Exception {
         String key = "${project.artifactId} with version: ${project.version}";
 
         MavenProject project = createDefaultProject();
@@ -230,7 +230,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testMissingPOMPropertyRefInLargerExpression() throws Exception {
+    void missingPOMPropertyRefInLargerExpression() throws Exception {
         String expr = "/path/to/someproject-${baseVersion}";
 
         MavenProject project = createDefaultProject();
@@ -243,7 +243,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testPOMPropertyExtractionWithMissingProjectWithDotNotation() throws Exception {
+    void pomPropertyExtractionWithMissingProjectWithDotNotation() throws Exception {
         String key = "m2.name";
         String checkValue = "value";
 
@@ -258,7 +258,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testValueExtractionFromSystemPropertiesWithMissingProject() throws Exception {
+    void valueExtractionFromSystemPropertiesWithMissingProject() throws Exception {
         String sysprop = "PPEET_sysprop1";
 
         Properties executionProperties = new Properties();
@@ -275,7 +275,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testValueExtractionFromSystemPropertiesWithMissingProjectWithDotNotation() throws Exception {
+    void valueExtractionFromSystemPropertiesWithMissingProjectWithDotNotation() throws Exception {
         String sysprop = "PPEET.sysprop2";
 
         Properties executionProperties = new Properties();
@@ -311,7 +311,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testTwoExpressions() throws Exception {
+    void twoExpressions() throws Exception {
         MavenProject project = createDefaultProject();
         Build build = project.getBuild();
         build.setDirectory("expected-directory");
@@ -325,7 +325,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testShouldExtractPluginArtifacts() throws Exception {
+    void shouldExtractPluginArtifacts() throws Exception {
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), new Properties());
 
         Object value = ee.evaluate("${mojo.plugin.dependencies}");
@@ -343,13 +343,13 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    void testRootDirectoryNotPrefixed() throws Exception {
+    void rootDirectoryNotPrefixed() throws Exception {
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), new Properties());
         assertNull(ee.evaluate("${rootDirectory}"));
     }
 
     @Test
-    void testRootDirectoryWithNull() throws Exception {
+    void rootDirectoryWithNull() throws Exception {
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), new Properties());
         Exception e = assertThrows(Exception.class, () -> ee.evaluate("${session.rootDirectory}"));
         e = assertInstanceOf(IntrospectionException.class, e.getCause());
@@ -358,7 +358,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    void testRootDirectory() throws Exception {
+    void rootDirectory() throws Exception {
         this.rootDirectory = Paths.get("myRootDirectory");
         ExpressionEvaluator ee = createExpressionEvaluator(createDefaultProject(), new Properties());
         assertInstanceOf(Path.class, ee.evaluate("${session.rootDirectory}"));
@@ -431,7 +431,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testUri() throws Exception {
+    void uri() throws Exception {
         Path path = Paths.get("").toAbsolutePath();
 
         MavenSession mavenSession = createMavenSession(null);
@@ -444,7 +444,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testPath() throws Exception {
+    void path() throws Exception {
         Path path = Paths.get("").toAbsolutePath();
 
         MavenSession mavenSession = createMavenSession(null);
@@ -457,7 +457,7 @@ public class PluginParameterExpressionEvaluatorV4Test extends AbstractCoreMavenC
     }
 
     @Test
-    public void testPluginInjection() throws Exception {
+    void pluginInjection() throws Exception {
         Path path = Paths.get("rép➜α").toAbsolutePath();
 
         MavenSession mavenSession = createMavenSession(null);

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/DefaultLegacySupportTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/DefaultLegacySupportTest.java
@@ -34,7 +34,7 @@ class DefaultLegacySupportTest {
     final DefaultLegacySupport defaultLegacySupport = new DefaultLegacySupport();
 
     @Test
-    void testSetSession() throws Exception {
+    void setSession() throws Exception {
 
         MavenExecutionRequest mavenExecutionRequest = new DefaultMavenExecutionRequest();
         MavenSession m1 = new MavenSession(null, null, mavenExecutionRequest, null);

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteCheckerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginJavaPrerequisiteCheckerTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MavenPluginJavaPrerequisiteCheckerTest {
 
     @Test
-    void testMatchesVersion() {
+    void matchesVersion() {
         MavenPluginJavaPrerequisiteChecker checker = new MavenPluginJavaPrerequisiteChecker(new GenericVersionScheme());
         assertTrue(checker.matchesVersion("1.0", "1.8"));
         assertTrue(checker.matchesVersion("1.8", "9.0.1+11"));

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginValidatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/MavenPluginValidatorTest.java
@@ -44,7 +44,7 @@ class MavenPluginValidatorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testValidate() {
+    void validate() {
         Artifact plugin = new DefaultArtifact(
                 "org.apache.maven.its.plugins",
                 "maven-it-plugin",
@@ -63,7 +63,7 @@ class MavenPluginValidatorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testInvalidGroupId() {
+    void invalidGroupId() {
         Artifact plugin = new DefaultArtifact(
                 "org.apache.maven.its.plugins",
                 "maven-it-plugin",
@@ -82,7 +82,7 @@ class MavenPluginValidatorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testInvalidArtifactId() {
+    void invalidArtifactId() {
         Artifact plugin = new DefaultArtifact(
                 "org.apache.maven.its.plugins",
                 "maven-it-plugin",
@@ -101,7 +101,7 @@ class MavenPluginValidatorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testInvalidVersion() {
+    void invalidVersion() {
         Artifact plugin = new DefaultArtifact(
                 "org.apache.maven.its.plugins",
                 "maven-it-plugin",

--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -78,7 +78,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Check that we can build ok from the middle pom of a (parent,child,grandchild) hierarchy
      */
     @Test
-    void testBuildFromMiddlePom() throws Exception {
+    void buildFromMiddlePom() throws Exception {
         File f1 = getTestFile("src/test/resources/projects/grandchild-check/child/pom.xml");
         File f2 = getTestFile("src/test/resources/projects/grandchild-check/child/grandchild/pom.xml");
 
@@ -91,7 +91,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
 
     @Disabled("Maven 4 does not allow duplicate plugin declarations")
     @Test
-    void testDuplicatePluginDefinitionsMerged() throws Exception {
+    void duplicatePluginDefinitionsMerged() throws Exception {
         File f1 = getTestFile("src/test/resources/projects/duplicate-plugins-merged-pom.xml");
 
         MavenProject project = getProject(f1);
@@ -102,7 +102,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testFutureModelVersion() throws Exception {
+    void futureModelVersion() throws Exception {
         File f1 = getTestFile("src/test/resources/projects/future-model-version-pom.xml");
 
         ProjectBuildingException e = assertThrows(
@@ -111,7 +111,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testPastModelVersion() throws Exception {
+    void pastModelVersion() throws Exception {
         // a Maven 1.x pom will not even
         // update the resource if we stop supporting modelVersion 4.0.0
         File f1 = getTestFile("src/test/resources/projects/past-model-version-pom.xml");
@@ -122,7 +122,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testFutureSchemaModelVersion() throws Exception {
+    void futureSchemaModelVersion() throws Exception {
         File f1 = getTestFile("src/test/resources/projects/future-schema-model-version-pom.xml");
 
         ProjectBuildingException e = assertThrows(
@@ -131,7 +131,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testBuildStubModelForMissingRemotePom() throws Exception {
+    void buildStubModelForMissingRemotePom() throws Exception {
         Artifact pom = repositorySystem.createProjectArtifact("org.apache.maven.its", "missing", "0.1");
         MavenProject project = getProject(pom, true);
 
@@ -150,7 +150,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testPartialResultUponBadDependencyDeclaration() throws Exception {
+    void partialResultUponBadDependencyDeclaration() throws Exception {
         File pomFile = getTestFile("src/test/resources/projects/bad-dependency.xml");
 
         ProjectBuildingRequest request = newBuildingRequest();
@@ -175,7 +175,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether local version range parent references are built correctly.
      */
     @Test
-    void testBuildValidParentVersionRangeLocally() throws Exception {
+    void buildValidParentVersionRangeLocally() throws Exception {
         File f1 = getTestFile("src/test/resources/projects/parent-version-range-local-valid/child/pom.xml");
 
         final MavenProject childProject = getProject(f1);
@@ -192,7 +192,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether local version range parent references are built correctly.
      */
     @Test
-    void testBuildParentVersionRangeLocallyWithoutChildVersion() throws Exception {
+    void buildParentVersionRangeLocallyWithoutChildVersion() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-local-child-without-version/child/pom.xml");
 
@@ -207,7 +207,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether local version range parent references are built correctly.
      */
     @Test
-    void testBuildParentVersionRangeLocallyWithChildProjectVersionExpression() throws Exception {
+    void buildParentVersionRangeLocallyWithChildProjectVersionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-local-child-project-version-expression/child/pom.xml");
 
@@ -222,7 +222,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether local version range parent references are built correctly.
      */
     @Test
-    public void testBuildParentVersionRangeLocallyWithChildProjectParentVersionExpression() throws Exception {
+    void buildParentVersionRangeLocallyWithChildProjectParentVersionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-local-child-project-parent-version-expression/child/pom.xml");
 
@@ -240,7 +240,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * @throws Exception
      */
     @Test
-    public void testBuildParentVersionRangeLocallyWithChildRevisionExpression() throws Exception {
+    void buildParentVersionRangeLocallyWithChildRevisionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-local-child-revision-expression/child/pom.xml");
 
@@ -253,7 +253,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether external version range parent references are built correctly.
      */
     @Test
-    void testBuildParentVersionRangeExternally() throws Exception {
+    void buildParentVersionRangeExternally() throws Exception {
         File f1 = getTestFile("src/test/resources/projects/parent-version-range-external-valid/pom.xml");
 
         final MavenProject childProject = this.getProjectFromRemoteRepository(f1);
@@ -270,7 +270,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether external version range parent references are built correctly.
      */
     @Test
-    void testBuildParentVersionRangeExternallyWithoutChildVersion() throws Exception {
+    void buildParentVersionRangeExternallyWithoutChildVersion() throws Exception {
         File f1 =
                 getTestFile("src/test/resources/projects/parent-version-range-external-child-without-version/pom.xml");
 
@@ -285,7 +285,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether external version range parent references are built correctly.
      */
     @Test
-    void testBuildParentVersionRangeExternallyWithChildProjectVersionExpression() throws Exception {
+    void buildParentVersionRangeExternallyWithChildProjectVersionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-external-child-project-version-expression/pom.xml");
 
@@ -328,7 +328,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testActivatedProfileBySource() throws Exception {
+    void activatedProfileBySource() throws Exception {
         File testPom = getTestFile("src/test/resources/projects/pom-with-profiles/pom.xml");
 
         ProjectBuildingRequest request = newBuildingRequest();
@@ -346,7 +346,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testActivatedDefaultProfileBySource() throws Exception {
+    void activatedDefaultProfileBySource() throws Exception {
         File testPom = getTestFile("src/test/resources/projects/pom-with-profiles/pom.xml");
 
         ProjectBuildingRequest request = newBuildingRequest();
@@ -375,7 +375,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testActivatedExternalProfileBySource() throws Exception {
+    void activatedExternalProfileBySource() throws Exception {
         File testPom = getTestFile("src/test/resources/projects/pom-with-profiles/pom.xml");
 
         ProjectBuildingRequest request = newBuildingRequest();
@@ -421,7 +421,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testActivatedProfileIsResolved() throws Exception {
+    void activatedProfileIsResolved() throws Exception {
         File testPom = getTestFile("src/test/resources/projects/pom-with-profiles/pom.xml");
 
         ProjectBuildingRequest request = newBuildingRequest();
@@ -437,7 +437,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testActivatedProfileByDefaultIsResolved() throws Exception {
+    void activatedProfileByDefaultIsResolved() throws Exception {
         File testPom = getTestFile("src/test/resources/projects/pom-with-profiles/pom.xml");
 
         ProjectBuildingRequest request = newBuildingRequest();
@@ -455,7 +455,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether external version range parent references are built correctly.
      */
     @Test
-    public void testBuildParentVersionRangeExternallyWithChildPomVersionExpression() throws Exception {
+    void buildParentVersionRangeExternallyWithChildPomVersionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-external-child-pom-version-expression/pom.xml");
 
@@ -471,7 +471,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether external version range parent references are built correctly.
      */
     @Test
-    public void testBuildParentVersionRangeExternallyWithChildPomParentVersionExpression() throws Exception {
+    void buildParentVersionRangeExternallyWithChildPomParentVersionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-external-child-pom-parent-version-expression/pom.xml");
 
@@ -487,7 +487,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether external version range parent references are built correctly.
      */
     @Test
-    public void testBuildParentVersionRangeExternallyWithChildProjectParentVersionExpression() throws Exception {
+    void buildParentVersionRangeExternallyWithChildProjectParentVersionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-external-child-project-parent-version-expression/pom.xml");
 
@@ -503,7 +503,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
      * Tests whether external version range parent references are built correctly.
      */
     @Test
-    public void testBuildParentVersionRangeExternallyWithChildRevisionExpression() throws Exception {
+    void buildParentVersionRangeExternallyWithChildRevisionExpression() throws Exception {
         File f1 = getTestFile(
                 "src/test/resources/projects/parent-version-range-external-child-revision-expression/pom.xml");
 
@@ -513,7 +513,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    public void testParentVersionResolvedFromNestedProperties() throws Exception {
+    void parentVersionResolvedFromNestedProperties() throws Exception {
         File f1 = getTestFile("src/test/resources/projects/pom-parent-version-from-nested-properties/pom.xml");
         ProjectBuildingRequest request = newBuildingRequest();
         MavenSession session =
@@ -528,7 +528,7 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    public void testSubprojectDiscovery() throws Exception {
+    void subprojectDiscovery() throws Exception {
         File pom = getTestFile("src/test/resources/projects/subprojects-discover/pom.xml");
         ProjectBuildingRequest configuration = newBuildingRequest();
         InternalSession internalSession = InternalSession.from(configuration.getRepositorySession());

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ExtensionDescriptorBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ExtensionDescriptorBuilderTest.java
@@ -56,7 +56,7 @@ class ExtensionDescriptorBuilderTest {
     }
 
     @Test
-    void testEmptyDescriptor() throws Exception {
+    void emptyDescriptor() throws Exception {
         String xml = "<extension></extension>";
 
         ExtensionDescriptor ed = builder.build(toStream(xml));
@@ -69,7 +69,7 @@ class ExtensionDescriptorBuilderTest {
     }
 
     @Test
-    void testCompleteDescriptor() throws Exception {
+    void completeDescriptor() throws Exception {
         String xml = "<?xml version='1.0' encoding='UTF-8'?>" + "<extension>" + "<exportedPackages>"
                 + "<exportedPackage>a</exportedPackage>" + "<exportedPackage>b</exportedPackage>"
                 + "<exportedPackage>c</exportedPackage>" + "</exportedPackages>" + "<exportedArtifacts>"

--- a/impl/maven-core/src/test/java/org/apache/maven/project/GraphTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/GraphTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GraphTest {
+class GraphTest {
 
     @Test
-    public void testGraph() throws CycleDetectedException {
+    void graph() throws CycleDetectedException {
         Graph graph = new Graph();
         graph.addVertex("a");
         assertEquals(1, graph.getVertices().size());
@@ -93,7 +93,7 @@ public class GraphTest {
     }
 
     @Test
-    public void testCycleDetection() throws Exception {
+    void cycleDetection() throws Exception {
         Graph graph1 = new Graph();
         addEdge(graph1, "a", "b");
         addEdge(graph1, "b", "c");
@@ -143,7 +143,7 @@ public class GraphTest {
     }
 
     @Test
-    public void testDfs() throws CycleDetectedException {
+    void dfs() throws CycleDetectedException {
         Graph graph1 = new Graph();
         addEdge(graph1, "a", "b");
         addEdge(graph1, "b", "c");

--- a/impl/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MavenProjectTest extends AbstractMavenProjectTestCase {
 
     @Test
-    void testShouldInterpretChildPathAdjustmentBasedOnModulePaths() throws IOException {
+    void shouldInterpretChildPathAdjustmentBasedOnModulePaths() throws IOException {
         Model parentModel = new Model();
         parentModel.addModule("../child");
 
@@ -63,7 +63,7 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testIdentityProtoInheritance() {
+    void identityProtoInheritance() {
         Parent parent = new Parent();
 
         parent.setGroupId("test-group");
@@ -86,7 +86,7 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testEmptyConstructor() {
+    void emptyConstructor() {
         MavenProject project = new MavenProject();
 
         assertEquals(
@@ -108,29 +108,29 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testCloneWithDependencyManagement() throws Exception {
+    void cloneWithDependencyManagement() throws Exception {
         File f = getFileForClasspathResource("dependencyManagement-pom.xml");
         MavenProject projectToClone = getProjectWithDependencies(f);
         DependencyManagement dep = projectToClone.getDependencyManagement();
         assertNotNull(dep, "No dependencyManagement");
         List<?> list = dep.getDependencies();
         assertNotNull(list, "No dependencies");
-        assertTrue(!list.isEmpty(), "Empty dependency list");
+        assertFalse(list.isEmpty(), "Empty dependency list");
 
         Map<?, ?> map = projectToClone.getManagedVersionMap();
         assertNotNull(map, "No ManagedVersionMap");
-        assertTrue(!map.isEmpty(), "ManagedVersionMap is empty");
+        assertFalse(map.isEmpty(), "ManagedVersionMap is empty");
 
         MavenProject clonedProject = projectToClone.clone();
         assertEquals("maven-core", clonedProject.getArtifactId());
         Map<?, ?> clonedMap = clonedProject.getManagedVersionMap();
         assertNotNull(clonedMap, "ManagedVersionMap not copied");
-        assertTrue(!clonedMap.isEmpty(), "ManagedVersionMap is empty");
+        assertFalse(clonedMap.isEmpty(), "ManagedVersionMap is empty");
         assertTrue(clonedMap.containsKey("maven-test:maven-test-b:jar"), "ManagedVersionMap does not contain test key");
     }
 
     @Test
-    void testGetModulePathAdjustment() throws IOException {
+    void getModulePathAdjustment() throws IOException {
         Model moduleModel = new Model();
 
         MavenProject module = new MavenProject(moduleModel);
@@ -148,7 +148,7 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testCloneWithDistributionManagement() throws Exception {
+    void cloneWithDistributionManagement() throws Exception {
 
         File f = getFileForClasspathResource("distributionManagement-pom.xml");
         MavenProject projectToClone = getProject(f);
@@ -159,7 +159,7 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testCloneWithActiveProfile() throws Exception {
+    void cloneWithActiveProfile() throws Exception {
 
         File f = getFileForClasspathResource("withActiveByDefaultProfile-pom.xml");
         MavenProject projectToClone = getProject(f);
@@ -180,7 +180,7 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testCloneWithBaseDir() throws Exception {
+    void cloneWithBaseDir() throws Exception {
         File f = getFileForClasspathResource("canonical-pom.xml");
         MavenProject projectToClone = getProject(f);
         projectToClone.setPomFile(new File(new File(f.getParentFile(), "target"), "flattened.xml"));
@@ -191,7 +191,7 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testUndefinedOutputDirectory() throws Exception {
+    void undefinedOutputDirectory() throws Exception {
         MavenProject p = new MavenProject();
         assertNoNulls(p.getCompileClasspathElements());
         assertNoNulls(p.getSystemClasspathElements());
@@ -200,7 +200,7 @@ class MavenProjectTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testAddDotFile() {
+    void addDotFile() {
         MavenProject project = new MavenProject();
 
         File basedir = new File(System.getProperty("java.io.tmpdir"));

--- a/impl/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
@@ -96,7 +96,7 @@ class PomConstructionTest {
      * @throws Exception in case of issue
      */
     @Test
-    void testEmptyUrl() throws Exception {
+    void emptyUrl() throws Exception {
         buildPom("empty-distMng-repo-url");
     }
 
@@ -107,7 +107,7 @@ class PomConstructionTest {
      */
     /* MNG-786*/
     @Test
-    void testProfileModules() throws Exception {
+    void profileModules() throws Exception {
         PomTestWrapper pom = buildPom("profile-module", "a");
         assertEquals("test-prop", pom.getValue("properties[1]/b")); // verifies profile applied
         assertEquals(4, ((List<?>) pom.getValue("modules")).size());
@@ -123,20 +123,20 @@ class PomConstructionTest {
      * @throws Exception in case of issue
      */
     @Test
-    void testParentInheritance() throws Exception {
+    void parentInheritance() throws Exception {
         buildPom("parent-inheritance/sub");
     }
 
     /*MNG-3995*/
     @Test
-    void testExecutionConfigurationJoin() throws Exception {
+    void executionConfigurationJoin() throws Exception {
         PomTestWrapper pom = buildPom("execution-configuration-join");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions[1]/configuration[1]/fileset[1]")).size());
     }
 
     /*MNG-3803*/
     @Test
-    void testPluginConfigProperties() throws Exception {
+    void pluginConfigProperties() throws Exception {
         PomTestWrapper pom = buildPom("plugin-config-properties");
         assertEquals(
                 "my.property", pom.getValue("build/plugins[1]/configuration[1]/systemProperties[1]/property[1]/name"));
@@ -144,7 +144,7 @@ class PomConstructionTest {
 
     /*MNG-3900*/
     @Test
-    void testProfilePropertiesInterpolation() throws Exception {
+    void profilePropertiesInterpolation() throws Exception {
         PomTestWrapper pom = buildPom("profile-properties-interpolation", "interpolation-profile");
         assertEquals("PASSED", pom.getValue("properties[1]/test"));
         assertEquals("PASSED", pom.getValue("properties[1]/property"));
@@ -176,7 +176,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testBuildPluginInterpolation() throws Exception {
+    void buildPluginInterpolation() throws Exception {
         PomTestWrapper pom = buildPom("plugin-interpolation-build", "activeProfile");
         Model originalModel = pom.getMavenProject().getOriginalModel();
 
@@ -271,7 +271,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testReportingPluginInterpolation() throws Exception {
+    void reportingPluginInterpolation() throws Exception {
         PomTestWrapper pom = buildPom("plugin-interpolation-reporting", "activeProfile");
         Model originalModel = pom.getMavenProject().getOriginalModel();
 
@@ -353,21 +353,21 @@ class PomConstructionTest {
     // to validate the properties. We also need a way to navigate from the Tex specification documents to
     // the test in question and vice versa. A little Eclipse plugin would do the trick.
     @Test
-    public void testThatExecutionsWithoutIdsAreMergedAndTheChildWins() throws Exception {
+    void thatExecutionsWithoutIdsAreMergedAndTheChildWins() throws Exception {
         PomTestWrapper tester = buildPom("micromailer");
         assertModelEquals(tester, "child-descriptor", "build/plugins[1]/executions[1]/goals[1]");
     }
 
     /*MNG-4010*/
     @Test
-    void testDuplicateExclusionsDependency() throws Exception {
+    void duplicateExclusionsDependency() throws Exception {
         PomTestWrapper pom = buildPom("duplicate-exclusions-dependency/sub");
         assertEquals(1, ((List<?>) pom.getValue("dependencies[1]/exclusions")).size());
     }
 
     /*MNG-4008*/
     @Test
-    void testMultipleFilters() throws Exception {
+    void multipleFilters() throws Exception {
         PomTestWrapper pom = buildPom("multiple-filters");
         assertEquals(4, ((List<?>) pom.getValue("build/filters")).size());
     }
@@ -434,7 +434,7 @@ class PomConstructionTest {
     */
 
     @Test
-    void testDuplicateDependenciesCauseLastDeclarationToBePickedInLenientMode() throws Exception {
+    void duplicateDependenciesCauseLastDeclarationToBePickedInLenientMode() throws Exception {
         PomTestWrapper pom = buildPom("unique-dependency-key/deps", true, null, null);
         assertEquals(1, ((List<?>) pom.getValue("dependencies")).size());
         assertEquals("0.2", pom.getValue("dependencies[1]/version"));
@@ -442,7 +442,7 @@ class PomConstructionTest {
 
     /* MNG-3567*/
     @Test
-    void testParentInterpolation() throws Exception {
+    void parentInterpolation() throws Exception {
         PomTestWrapper pom = buildPom("parent-interpolation/sub");
         pom = new PomTestWrapper(pom.getMavenProject().getParent());
         assertEquals("1.3.0-SNAPSHOT", pom.getValue("build/plugins[1]/version"));
@@ -450,14 +450,14 @@ class PomConstructionTest {
 
     /* MNG-3567*/
     @Test
-    void testPluginManagementInherited() throws Exception {
+    void pluginManagementInherited() throws Exception {
         PomTestWrapper pom = buildPom("pluginmanagement-inherited/sub");
         assertEquals("1.0-alpha-21", pom.getValue("build/plugins[1]/version"));
     }
 
     /* MNG-2174*/
     @Test
-    void testPluginManagementDependencies() throws Exception {
+    void pluginManagementDependencies() throws Exception {
         PomTestWrapper pom = buildPom("plugin-management-dependencies/sub", "test");
         assertEquals("1.0-alpha-21", pom.getValue("build/plugins[1]/version"));
         assertEquals("1.0", pom.getValue("build/plugins[1]/dependencies[1]/version"));
@@ -465,7 +465,7 @@ class PomConstructionTest {
 
     /* MNG-3877*/
     @Test
-    void testReportingInterpolation() throws Exception {
+    void reportingInterpolation() throws Exception {
         PomTestWrapper pom = buildPom("reporting-interpolation");
         assertEquals(
                 createPath(Arrays.asList(
@@ -480,14 +480,14 @@ class PomConstructionTest {
     }
 
     @Test
-    void testPluginOrder() throws Exception {
+    void pluginOrder() throws Exception {
         PomTestWrapper pom = buildPom("plugin-order");
         assertEquals("plexus-component-metadata", pom.getValue("build/plugins[1]/artifactId"));
         assertEquals("maven-surefire-plugin", pom.getValue("build/plugins[2]/artifactId"));
     }
 
     @Test
-    void testErroneousJoiningOfDifferentPluginsWithEqualDependencies() throws Exception {
+    void erroneousJoiningOfDifferentPluginsWithEqualDependencies() throws Exception {
         PomTestWrapper pom = buildPom("equal-plugin-deps");
         assertEquals("maven-it-plugin-a", pom.getValue("build/plugins[1]/artifactId"));
         assertEquals(1, ((List<?>) pom.getValue("build/plugins[1]/dependencies")).size());
@@ -497,7 +497,7 @@ class PomConstructionTest {
 
     /** MNG-3821 */
     @Test
-    void testErroneousJoiningOfDifferentPluginsWithEqualExecutionIds() throws Exception {
+    void erroneousJoiningOfDifferentPluginsWithEqualExecutionIds() throws Exception {
         PomTestWrapper pom = buildPom("equal-plugin-exec-ids");
         assertEquals("maven-it-plugin-a", pom.getValue("build/plugins[1]/artifactId"));
         assertEquals(1, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
@@ -511,7 +511,7 @@ class PomConstructionTest {
 
     /** MNG-3998 */
     @Test
-    void testExecutionConfiguration() throws Exception {
+    void executionConfiguration() throws Exception {
         PomTestWrapper pom = buildPom("execution-configuration");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("src/main/mdo/nexus.xml", (pom.getValue("build/plugins[1]/executions[1]/configuration[1]/model")));
@@ -520,7 +520,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testSingleConfigurationInheritance() throws Exception {
+    void singleConfigurationInheritance() throws Exception {
         PomTestWrapper pom = buildPom("single-configuration-inheritance");
 
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions[1]/configuration[1]/rules")).size());
@@ -534,7 +534,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testConfigWithPluginManagement() throws Exception {
+    void configWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("config-with-plugin-mng");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals(
@@ -544,7 +544,7 @@ class PomConstructionTest {
 
     /** MNG-3965 */
     @Test
-    void testExecutionConfigurationSubcollections() throws Exception {
+    void executionConfigurationSubcollections() throws Exception {
         PomTestWrapper pom = buildPom("execution-configuration-subcollections");
         assertEquals(
                 2,
@@ -554,26 +554,26 @@ class PomConstructionTest {
 
     /** MNG-3985 */
     @Test
-    void testMultipleRepositories() throws Exception {
+    void multipleRepositories() throws Exception {
         PomTestWrapper pom = buildPom("multiple-repos/sub");
         assertEquals(2, ((List<?>) pom.getValue("repositories")).size());
     }
 
     /** MNG-3965 */
     @Test
-    void testMultipleExecutionIds() throws Exception {
+    void multipleExecutionIds() throws Exception {
         PomTestWrapper pom = buildPom("dual-execution-ids/sub");
         assertEquals(1, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
     }
 
     /** MNG-3997 */
     @Test
-    void testConsecutiveEmptyElements() throws Exception {
+    void consecutiveEmptyElements() throws Exception {
         buildPom("consecutive_empty_elements");
     }
 
     @Test
-    void testOrderOfGoalsFromPluginExecutionWithoutPluginManagement() throws Exception {
+    void orderOfGoalsFromPluginExecutionWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-goals-order/wo-plugin-mgmt");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions[1]/goals")).size());
         assertEquals("b", pom.getValue("build/plugins[1]/executions[1]/goals[1]"));
@@ -585,7 +585,7 @@ class PomConstructionTest {
 
     /* MNG-3886*/
     @Test
-    void testOrderOfGoalsFromPluginExecutionWithPluginManagement() throws Exception {
+    void orderOfGoalsFromPluginExecutionWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-goals-order/w-plugin-mgmt");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions[1]/goals")).size());
         assertEquals("b", pom.getValue("build/plugins[1]/executions[1]/goals[1]"));
@@ -596,7 +596,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testOrderOfPluginExecutionsWithoutPluginManagement() throws Exception {
+    void orderOfPluginExecutionsWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-order/wo-plugin-mgmt");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("b", pom.getValue("build/plugins[1]/executions[1]/id"));
@@ -608,7 +608,7 @@ class PomConstructionTest {
 
     /* MNG-3887 */
     @Test
-    void testOrderOfPluginExecutionsWithPluginManagement() throws Exception {
+    void orderOfPluginExecutionsWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-order/w-plugin-mgmt");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("b", pom.getValue("build/plugins[1]/executions[1]/id"));
@@ -619,27 +619,27 @@ class PomConstructionTest {
     }
 
     @Test
-    void testMergeOfPluginExecutionsWhenChildInheritsPluginVersion() throws Exception {
+    void mergeOfPluginExecutionsWhenChildInheritsPluginVersion() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-merging-wo-version/sub");
         assertEquals(4, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
     }
 
     /* MNG-3943*/
     @Test
-    void testMergeOfPluginExecutionsWhenChildAndParentUseDifferentPluginVersions() throws Exception {
+    void mergeOfPluginExecutionsWhenChildAndParentUseDifferentPluginVersions() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-merging-version-insensitive/sub");
         assertEquals(4, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
     }
 
     @Test
-    void testInterpolationWithXmlMarkup() throws Exception {
+    void interpolationWithXmlMarkup() throws Exception {
         PomTestWrapper pom = buildPom("xml-markup-interpolation");
         assertEquals("<?xml version='1.0'?>Tom&Jerry", pom.getValue("properties/xmlTest"));
     }
 
     /* MNG-3925 */
     @Test
-    void testOrderOfMergedPluginExecutionsWithoutPluginManagement() throws Exception {
+    void orderOfMergedPluginExecutionsWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("merged-plugin-exec-order/wo-plugin-mgmt/sub");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("parent-1", pom.getValue("build/plugins[1]/executions[1]/goals[1]"));
@@ -650,7 +650,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testOrderOfMergedPluginExecutionsWithPluginManagement() throws Exception {
+    void orderOfMergedPluginExecutionsWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("merged-plugin-exec-order/w-plugin-mgmt/sub");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("parent-1", pom.getValue("build/plugins[1]/executions[1]/goals[1]"));
@@ -662,7 +662,7 @@ class PomConstructionTest {
 
     /* MNG-3984*/
     @Test
-    void testDifferentContainersWithSameId() throws Exception {
+    void differentContainersWithSameId() throws Exception {
         PomTestWrapper pom = buildPom("join-different-containers-same-id");
         assertEquals(1, ((List<?>) pom.getValue("build/plugins[1]/executions[1]/goals")).size());
         assertEquals(
@@ -674,7 +674,7 @@ class PomConstructionTest {
 
     /* MNG-3937*/
     @Test
-    void testOrderOfMergedPluginExecutionGoalsWithoutPluginManagement() throws Exception {
+    void orderOfMergedPluginExecutionGoalsWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("merged-plugin-exec-goals-order/wo-plugin-mgmt/sub");
 
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions[1]/goals")).size());
@@ -686,7 +686,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testOrderOfMergedPluginExecutionGoalsWithPluginManagement() throws Exception {
+    void orderOfMergedPluginExecutionGoalsWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("merged-plugin-exec-goals-order/w-plugin-mgmt/sub");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/executions[1]/goals")).size());
         assertEquals("child-a", pom.getValue("build/plugins[1]/executions[1]/goals[1]"));
@@ -698,7 +698,7 @@ class PomConstructionTest {
 
     /*MNG-3938*/
     @Test
-    void testOverridingOfInheritedPluginExecutionsWithoutPluginManagement() throws Exception {
+    void overridingOfInheritedPluginExecutionsWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-merging/wo-plugin-mgmt/sub");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("child-default", pom.getValue("build/plugins[1]/executions[@id='default']/phase"));
@@ -707,7 +707,7 @@ class PomConstructionTest {
 
     /* MNG-3938 */
     @Test
-    void testOverridingOfInheritedPluginExecutionsWithPluginManagement() throws Exception {
+    void overridingOfInheritedPluginExecutionsWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-merging/w-plugin-mgmt/sub");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("child-default", pom.getValue("build/plugins[1]/executions[@id='default']/phase"));
@@ -716,7 +716,7 @@ class PomConstructionTest {
 
     /* MNG-3906*/
     @Test
-    void testOrderOfMergedPluginDependenciesWithoutPluginManagement() throws Exception {
+    void orderOfMergedPluginDependenciesWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("merged-plugin-class-path-order/wo-plugin-mgmt/sub");
 
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/dependencies")).size());
@@ -734,7 +734,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testOrderOfMergedPluginDependenciesWithPluginManagement() throws Exception {
+    void orderOfMergedPluginDependenciesWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("merged-plugin-class-path-order/w-plugin-mgmt/sub");
         assertEquals(5, ((List<?>) pom.getValue("build/plugins[1]/dependencies")).size());
         assertEquals("c", pom.getValue("build/plugins[1]/dependencies[1]/artifactId"));
@@ -750,7 +750,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testInterpolationOfNestedBuildDirectories() throws Exception {
+    void interpolationOfNestedBuildDirectories() throws Exception {
         PomTestWrapper pom = buildPom("nested-build-dir-interpolation");
         assertEquals(
                 new File(pom.getBasedir(), "target/classes/dir0"), new File((String) pom.getValue("properties/dir0")));
@@ -760,7 +760,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testAppendArtifactIdOfChildToInheritedUrls() throws Exception {
+    void appendArtifactIdOfChildToInheritedUrls() throws Exception {
         PomTestWrapper pom = buildPom("url-inheritance/sub");
         assertEquals("https://parent.url/child", pom.getValue("url"));
         assertEquals("https://parent.url/org", pom.getValue("organization/url"));
@@ -778,7 +778,7 @@ class PomConstructionTest {
 
     /* MNG-3846*/
     @Test
-    void testAppendArtifactIdOfParentAndChildToInheritedUrls() throws Exception {
+    void appendArtifactIdOfParentAndChildToInheritedUrls() throws Exception {
         PomTestWrapper pom = buildPom("url-inheritance/another-parent/sub");
         assertEquals("https://parent.url/ap/child", pom.getValue("url"));
         assertEquals("https://parent.url/org", pom.getValue("organization/url"));
@@ -795,7 +795,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testNonInheritedElementsInSubtreesOverriddenByChild() throws Exception {
+    void nonInheritedElementsInSubtreesOverriddenByChild() throws Exception {
         PomTestWrapper pom = buildPom("limited-inheritance/child");
         assertNull(pom.getValue("organization/url"));
         assertNull(pom.getValue("issueManagement/system"));
@@ -816,7 +816,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testXmlTextCoalescing() throws Exception {
+    void xmlTextCoalescing() throws Exception {
         PomTestWrapper pom = buildPom("xml-coalesce-text");
         assertEquals("A  Test  Project Property", pom.getValue("properties/prop0"));
         assertEquals("That's a test!", pom.getValue("properties/prop1"));
@@ -830,7 +830,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testFullInterpolationOfNestedExpressions() throws Exception {
+    void fullInterpolationOfNestedExpressions() throws Exception {
         PomTestWrapper pom = buildPom("full-interpolation");
         for (int i = 0; i < 24; i++) {
             String index = ((i < 10) ? "0" : "") + i;
@@ -839,7 +839,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testInterpolationWithBasedirAlignedDirectories() throws Exception {
+    void interpolationWithBasedirAlignedDirectories() throws Exception {
         PomTestWrapper pom = buildPom("basedir-aligned-interpolation");
         assertEquals(
                 new File(pom.getBasedir(), "src/main/java"),
@@ -866,7 +866,7 @@ class PomConstructionTest {
 
     /* MNG-3944*/
     @Test
-    void testInterpolationOfBasedirInPomWithUnusualName() throws Exception {
+    void interpolationOfBasedirInPomWithUnusualName() throws Exception {
         PomTestWrapper pom = buildPom("basedir-interpolation/pom-with-unusual-name.xml");
         assertEquals(pom.getBasedir(), new File(pom.getValue("properties/prop0").toString()));
         assertEquals(pom.getBasedir(), new File(pom.getValue("properties/prop1").toString()));
@@ -874,13 +874,13 @@ class PomConstructionTest {
 
     /* MNG-3979 */
     @Test
-    void testJoiningOfContainersWhenChildHasEmptyElements() throws Exception {
+    void joiningOfContainersWhenChildHasEmptyElements() throws Exception {
         PomTestWrapper pom = buildPom("id-container-joining-with-empty-elements/sub");
         assertNotNull(pom);
     }
 
     @Test
-    void testOrderOfPluginConfigurationElementsWithoutPluginManagement() throws Exception {
+    void orderOfPluginConfigurationElementsWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-config-order/wo-plugin-mgmt");
         assertEquals("one", pom.getValue("build/plugins[1]/configuration/stringParams/stringParam[1]"));
         assertEquals("two", pom.getValue("build/plugins[1]/configuration/stringParams/stringParam[2]"));
@@ -890,7 +890,7 @@ class PomConstructionTest {
 
     /* MNG-3827*/
     @Test
-    void testOrderOfPluginConfigurationElementsWithPluginManagement() throws Exception {
+    void orderOfPluginConfigurationElementsWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-config-order/w-plugin-mgmt");
         assertEquals("one", pom.getValue("build/plugins[1]/configuration/stringParams/stringParam[1]"));
         assertEquals("two", pom.getValue("build/plugins[1]/configuration/stringParams/stringParam[2]"));
@@ -899,7 +899,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testOrderOfPluginExecutionConfigurationElementsWithoutPluginManagement() throws Exception {
+    void orderOfPluginExecutionConfigurationElementsWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-config-order/wo-plugin-mgmt");
         String prefix = "build/plugins[1]/executions[1]/configuration/";
         assertEquals("one", pom.getValue(prefix + "stringParams/stringParam[1]"));
@@ -912,7 +912,7 @@ class PomConstructionTest {
 
     /* MNG-3864*/
     @Test
-    void testOrderOfPluginExecutionConfigurationElementsWithPluginManagement() throws Exception {
+    void orderOfPluginExecutionConfigurationElementsWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-config-order/w-plugin-mgmt");
         String prefix = "build/plugins[1]/executions[1]/configuration/";
         assertEquals("one", pom.getValue(prefix + "stringParams/stringParam[1]"));
@@ -925,7 +925,7 @@ class PomConstructionTest {
 
     /* MNG-3836*/
     @Test
-    void testMergeOfInheritedPluginConfiguration() throws Exception {
+    void mergeOfInheritedPluginConfiguration() throws Exception {
         PomTestWrapper pom = buildPom("plugin-config-merging/child");
 
         String prefix = "build/plugins[1]/configuration/";
@@ -943,13 +943,13 @@ class PomConstructionTest {
 
     /* MNG-2591 */
     @Test
-    void testAppendOfInheritedPluginConfigurationWithNoProfile() throws Exception {
+    void appendOfInheritedPluginConfigurationWithNoProfile() throws Exception {
         testAppendOfInheritedPluginConfiguration("no-profile");
     }
 
     /* MNG-2591*/
     @Test
-    void testAppendOfInheritedPluginConfigurationWithActiveProfile() throws Exception {
+    void appendOfInheritedPluginConfigurationWithActiveProfile() throws Exception {
         testAppendOfInheritedPluginConfiguration("with-profile");
     }
 
@@ -978,7 +978,7 @@ class PomConstructionTest {
 
     /* MNG-4000 */
     @Test
-    void testMultiplePluginExecutionsWithAndWithoutIdsWithoutPluginManagement() throws Exception {
+    void multiplePluginExecutionsWithAndWithoutIdsWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-w-and-wo-id/wo-plugin-mgmt");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("log-string", pom.getValue("build/plugins[1]/executions[1]/goals[1]"));
@@ -986,7 +986,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testMultiplePluginExecutionsWithAndWithoutIdsWithPluginManagement() throws Exception {
+    void multiplePluginExecutionsWithAndWithoutIdsWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-w-and-wo-id/w-plugin-mgmt");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins[1]/executions")).size());
         assertEquals("log-string", pom.getValue("build/plugins[1]/executions[1]/goals[1]"));
@@ -994,7 +994,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testDependencyOrderWithoutPluginManagement() throws Exception {
+    void dependencyOrderWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("dependency-order/wo-plugin-mgmt");
         assertEquals(4, ((List<?>) pom.getValue("dependencies")).size());
         assertEquals("a", pom.getValue("dependencies[1]/artifactId"));
@@ -1004,7 +1004,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testDependencyOrderWithPluginManagement() throws Exception {
+    void dependencyOrderWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("dependency-order/w-plugin-mgmt");
         assertEquals(4, ((List<?>) pom.getValue("dependencies")).size());
         assertEquals("a", pom.getValue("dependencies[1]/artifactId"));
@@ -1014,7 +1014,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testBuildDirectoriesUsePlatformSpecificFileSeparator() throws Exception {
+    void buildDirectoriesUsePlatformSpecificFileSeparator() throws Exception {
         PomTestWrapper pom = buildPom("platform-file-separator");
         assertPathWithNormalizedFileSeparators(pom.getValue("build/directory"));
         assertPathWithNormalizedFileSeparators(pom.getValue("build/outputDirectory"));
@@ -1029,7 +1029,7 @@ class PomConstructionTest {
 
     /* MNG-4008 */
     @Test
-    void testMergedFilterOrder() throws Exception {
+    void mergedFilterOrder() throws Exception {
         PomTestWrapper pom = buildPom("merged-filter-order/sub");
 
         assertEquals(7, ((List<?>) pom.getValue("build/filters")).size());
@@ -1044,7 +1044,7 @@ class PomConstructionTest {
 
     /** MNG-4027*/
     @Test
-    void testProfileInjectedDependencies() throws Exception {
+    void profileInjectedDependencies() throws Exception {
         PomTestWrapper pom = buildPom("profile-injected-dependencies");
         assertEquals(4, ((List<?>) pom.getValue("dependencies")).size());
         assertEquals("a", pom.getValue("dependencies[1]/artifactId"));
@@ -1055,13 +1055,13 @@ class PomConstructionTest {
 
     /** IT-0021*/
     @Test
-    void testProfileDependenciesMultipleProfiles() throws Exception {
+    void profileDependenciesMultipleProfiles() throws Exception {
         PomTestWrapper pom = buildPom("profile-dependencies-multiple-profiles", "profile-1", "profile-2");
         assertEquals(2, ((List<?>) pom.getValue("dependencies")).size());
     }
 
     @Test
-    void testDependencyInheritance() throws Exception {
+    void dependencyInheritance() throws Exception {
         PomTestWrapper pom = buildPom("dependency-inheritance/sub");
         assertEquals(1, ((List<?>) pom.getValue("dependencies")).size());
         assertEquals("4.13.1", pom.getValue("dependencies[1]/version"));
@@ -1069,7 +1069,7 @@ class PomConstructionTest {
 
     /** MNG-4034 */
     @Test
-    void testManagedProfileDependency() throws Exception {
+    void managedProfileDependency() throws Exception {
         PomTestWrapper pom = this.buildPom("managed-profile-dependency/sub", "maven-core-it");
         assertEquals(1, ((List<?>) pom.getValue("dependencies")).size());
         assertEquals("org.apache.maven.its", pom.getValue("dependencies[1]/groupId"));
@@ -1082,21 +1082,21 @@ class PomConstructionTest {
 
     /** MNG-4040 */
     @Test
-    void testProfileModuleInheritance() throws Exception {
+    void profileModuleInheritance() throws Exception {
         PomTestWrapper pom = this.buildPom("profile-module-inheritance/sub", "dist");
         assertEquals(0, ((List<?>) pom.getValue("modules")).size());
     }
 
     /** MNG-3621 */
     @Test
-    void testUncPath() throws Exception {
+    void uncPath() throws Exception {
         PomTestWrapper pom = this.buildPom("unc-path/sub");
         assertEquals("file:////host/site/test-child", pom.getValue("distributionManagement/site/url"));
     }
 
     /** MNG-2006 */
     @Test
-    void testUrlAppendWithChildPathAdjustment() throws Exception {
+    void urlAppendWithChildPathAdjustment() throws Exception {
         PomTestWrapper pom = this.buildPom("url-append/child");
         assertEquals("https://project.url/child", pom.getValue("url"));
         assertEquals("https://viewvc.project.url/child", pom.getValue("scm/url"));
@@ -1107,20 +1107,20 @@ class PomConstructionTest {
 
     /** MNG-0479 */
     @Test
-    void testRepoInheritance() throws Exception {
+    void repoInheritance() throws Exception {
         PomTestWrapper pom = this.buildPom("repo-inheritance");
         assertEquals(1, ((List<?>) pom.getValue("repositories")).size());
         assertEquals("it0043", pom.getValue("repositories[1]/name"));
     }
 
     @Test
-    void testEmptyScm() throws Exception {
+    void emptyScm() throws Exception {
         PomTestWrapper pom = this.buildPom("empty-scm");
         assertNull(pom.getValue("scm"));
     }
 
     @Test
-    void testPluginConfigurationUsingAttributesWithoutPluginManagement() throws Exception {
+    void pluginConfigurationUsingAttributesWithoutPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-config-attributes/wo-plugin-mgmt");
         assertEquals("src", pom.getValue("build/plugins[1]/configuration/domParam/copy/@todir"));
         assertEquals("true", pom.getValue("build/plugins[1]/configuration/domParam/copy/@overwrite"));
@@ -1131,7 +1131,7 @@ class PomConstructionTest {
 
     /** MNG-4053*/
     @Test
-    void testPluginConfigurationUsingAttributesWithPluginManagement() throws Exception {
+    void pluginConfigurationUsingAttributesWithPluginManagement() throws Exception {
         PomTestWrapper pom = buildPom("plugin-config-attributes/w-plugin-mgmt");
         assertEquals("src", pom.getValue("build/plugins[1]/configuration/domParam/copy/@todir"));
         assertEquals("true", pom.getValue("build/plugins[1]/configuration/domParam/copy/@overwrite"));
@@ -1141,7 +1141,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testPluginConfigurationUsingAttributesWithPluginManagementAndProfile() throws Exception {
+    void pluginConfigurationUsingAttributesWithPluginManagementAndProfile() throws Exception {
         PomTestWrapper pom = buildPom("plugin-config-attributes/w-profile", "maven-core-it");
         assertEquals("src", pom.getValue("build/plugins[1]/configuration/domParam/copy/@todir"));
         assertEquals("true", pom.getValue("build/plugins[1]/configuration/domParam/copy/@overwrite"));
@@ -1151,7 +1151,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testPomEncoding() throws Exception {
+    void pomEncoding() throws Exception {
         PomTestWrapper pom = buildPom("pom-encoding/utf-8");
         assertEquals("TEST-CHARS: \u00DF\u0131\u03A3\u042F\u05D0\u20AC", pom.getValue("description"));
         pom = buildPom("pom-encoding/latin-1");
@@ -1160,14 +1160,14 @@ class PomConstructionTest {
 
     /* MNG-4070 */
     @Test
-    void testXmlWhitespaceHandling() throws Exception {
+    void xmlWhitespaceHandling() throws Exception {
         PomTestWrapper pom = buildPom("xml-whitespace/sub");
         assertEquals("org.apache.maven.its.mng4070", pom.getValue("groupId"));
     }
 
     /* MNG-3760*/
     @Test
-    void testInterpolationOfBaseUri() throws Exception {
+    void interpolationOfBaseUri() throws Exception {
         PomTestWrapper pom = buildPom("baseuri-interpolation/pom.xml");
         assertNotEquals(
                 pom.getBasedir().toURI().toString(),
@@ -1176,7 +1176,7 @@ class PomConstructionTest {
 
     /* MNG-6386 */
     @Test
-    void testInterpolationOfRfc3986BaseUri() throws Exception {
+    void interpolationOfRfc3986BaseUri() throws Exception {
         PomTestWrapper pom = buildPom("baseuri-interpolation/pom.xml");
         String prop1 = pom.getValue("properties/prop1").toString();
         assertEquals(pom.getBasedir().toPath().toUri().toASCIIString(), prop1);
@@ -1185,7 +1185,7 @@ class PomConstructionTest {
 
     /* MNG-3811*/
     @Test
-    void testReportingPluginConfig() throws Exception {
+    void reportingPluginConfig() throws Exception {
         PomTestWrapper pom = buildPom("reporting-plugin-config/sub");
 
         assertEquals(3, ((List<?>) pom.getValue("reporting/plugins[1]/configuration/stringParams")).size());
@@ -1198,28 +1198,28 @@ class PomConstructionTest {
     }
 
     @Test
-    void testPropertiesNoDuplication() throws Exception {
+    void propertiesNoDuplication() throws Exception {
         PomTestWrapper pom = buildPom("properties-no-duplication/sub");
         assertEquals(4, ((Properties) pom.getValue("properties")).size());
         assertEquals("child", pom.getValue("properties/pomProfile"));
     }
 
     @Test
-    void testPomInheritance() throws Exception {
+    void pomInheritance() throws Exception {
         PomTestWrapper pom = buildPom("pom-inheritance/child-1");
         assertEquals("parent-description", pom.getValue("description"));
         assertEquals("jar", pom.getValue("packaging"));
     }
 
     @Test
-    void testCompleteModelWithoutParent() throws Exception {
+    void completeModelWithoutParent() throws Exception {
         PomTestWrapper pom = buildPom("complete-model/wo-parent");
 
         testCompleteModel(pom);
     }
 
     @Test
-    void testCompleteModelWithParent() throws Exception {
+    void completeModelWithParent() throws Exception {
         PomTestWrapper pom = buildPom("complete-model/w-parent/sub");
 
         testCompleteModel(pom);
@@ -1433,13 +1433,13 @@ class PomConstructionTest {
 
     /* MNG-2309*/
     @Test
-    void testProfileInjectionOrder() throws Exception {
+    void profileInjectionOrder() throws Exception {
         PomTestWrapper pom = buildPom("profile-injection-order", "pom-a", "pom-b", "pom-e", "pom-c", "pom-d");
         assertEquals("e", pom.getValue("properties[1]/pomProperty"));
     }
 
     @Test
-    void testPropertiesInheritance() throws Exception {
+    void propertiesInheritance() throws Exception {
         PomTestWrapper pom = buildPom("properties-inheritance/sub");
         assertEquals("parent-property", pom.getValue("properties/parentProperty"));
         assertEquals("child-property", pom.getValue("properties/childProperty"));
@@ -1448,7 +1448,7 @@ class PomConstructionTest {
 
     /* MNG-4102*/
     @Test
-    void testInheritedPropertiesInterpolatedWithValuesFromChildWithoutProfiles() throws Exception {
+    void inheritedPropertiesInterpolatedWithValuesFromChildWithoutProfiles() throws Exception {
         PomTestWrapper pom = buildPom("inherited-properties-interpolation/no-profile/sub");
 
         assertEquals("CHILD", pom.getValue("properties/overridden"));
@@ -1457,7 +1457,7 @@ class PomConstructionTest {
 
     /* MNG-4102 */
     @Test
-    void testInheritedPropertiesInterpolatedWithValuesFromChildWithActiveProfiles() throws Exception {
+    void inheritedPropertiesInterpolatedWithValuesFromChildWithActiveProfiles() throws Exception {
         PomTestWrapper pom = buildPom("inherited-properties-interpolation/active-profile/sub");
 
         assertEquals(1, pom.getMavenProject().getModel().getProfiles().size());
@@ -1469,7 +1469,7 @@ class PomConstructionTest {
 
     /* MNG-3545 */
     @Test
-    void testProfileDefaultActivation() throws Exception {
+    void profileDefaultActivation() throws Exception {
         PomTestWrapper pom = buildPom("profile-default-deactivation", "profile4");
         assertEquals(1, pom.getMavenProject().getActiveProfiles().size());
         assertEquals(1, ((List<?>) pom.getValue("build/plugins")).size());
@@ -1478,7 +1478,7 @@ class PomConstructionTest {
 
     /* MNG-1995 */
     @Test
-    void testBooleanInterpolation() throws Exception {
+    void booleanInterpolation() throws Exception {
         PomTestWrapper pom = buildPom("boolean-interpolation");
         assertEquals(true, pom.getValue("repositories[1]/releases/enabled"));
         assertEquals(true, pom.getValue("build/resources[1]/filtering"));
@@ -1486,7 +1486,7 @@ class PomConstructionTest {
 
     /* MNG-3899 */
     @Test
-    void testBuildExtensionInheritance() throws Exception {
+    void buildExtensionInheritance() throws Exception {
         PomTestWrapper pom = buildPom("build-extension-inheritance/sub");
         assertEquals(3, ((List<?>) pom.getValue("build/extensions")).size());
         assertEquals("b", pom.getValue("build/extensions[1]/artifactId"));
@@ -1497,7 +1497,7 @@ class PomConstructionTest {
 
     /*MNG-1957*/
     @Test
-    void testJdkActivation() throws Exception {
+    void jdkActivation() throws Exception {
         Properties props = new Properties();
         props.put("java.version", "1.5.0_15");
 
@@ -1510,14 +1510,14 @@ class PomConstructionTest {
 
     /* MNG-2174 */
     @Test
-    void testProfilePluginMngDependencies() throws Exception {
+    void profilePluginMngDependencies() throws Exception {
         PomTestWrapper pom = buildPom("profile-plugin-mng-dependencies/sub", "maven-core-it");
         assertEquals("a", pom.getValue("build/plugins[1]/dependencies[1]/artifactId"));
     }
 
     /** MNG-4116 */
     @Test
-    void testPercentEncodedUrlsMustNotBeDecoded() throws Exception {
+    void percentEncodedUrlsMustNotBeDecoded() throws Exception {
         PomTestWrapper pom = this.buildPom("url-no-decoding");
         assertEquals("https://maven.apache.org/spacy%20path", pom.getValue("url"));
         assertEquals("https://svn.apache.org/viewvc/spacy%20path", pom.getValue("scm/url"));
@@ -1535,7 +1535,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testPluginManagementInheritance() throws Exception {
+    void pluginManagementInheritance() throws Exception {
         PomTestWrapper pom = this.buildPom("plugin-management-inheritance");
         assertEquals(
                 "0.1-stub-SNAPSHOT",
@@ -1543,50 +1543,50 @@ class PomConstructionTest {
     }
 
     @Test
-    void testProfilePlugins() throws Exception {
+    void profilePlugins() throws Exception {
         PomTestWrapper pom = this.buildPom("profile-plugins", "standard");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins")).size());
         assertEquals("maven-assembly2-plugin", pom.getValue("build/plugins[2]/artifactId"));
     }
 
     @Test
-    void testPluginInheritanceSimple() throws Exception {
+    void pluginInheritanceSimple() throws Exception {
         PomTestWrapper pom = this.buildPom("plugin-inheritance-simple/sub");
         assertEquals(2, ((List<?>) pom.getValue("build/plugins")).size());
     }
 
     @Test
-    void testPluginManagementDuplicate() throws Exception {
+    void pluginManagementDuplicate() throws Exception {
         PomTestWrapper pom = this.buildPom("plugin-management-duplicate/sub");
         assertEquals(7, ((List<?>) pom.getValue("build/pluginManagement/plugins")).size());
     }
 
     @Test
-    void testDistributionManagement() throws Exception {
+    void distributionManagement() throws Exception {
         PomTestWrapper pom = this.buildPom("distribution-management");
         assertEquals("legacy", pom.getValue("distributionManagement/repository/layout"));
     }
 
     @Test
-    void testDependencyScopeInheritance() throws Exception {
+    void dependencyScopeInheritance() throws Exception {
         PomTestWrapper pom = buildPom("dependency-scope-inheritance/sub");
         String scope = (String) pom.getValue("dependencies[1]/scope");
         assertEquals("compile", scope);
     }
 
     @Test
-    void testDependencyScope() throws Exception {
+    void dependencyScope() throws Exception {
         buildPom("dependency-scope/sub");
     }
 
     // This will fail on a validation error if incorrect
     @Test
-    public void testDependencyManagementWithInterpolation() throws Exception {
+    void dependencyManagementWithInterpolation() throws Exception {
         buildPom("dependency-management-with-interpolation/sub");
     }
 
     @Test
-    void testInterpolationWithSystemProperty() throws Exception {
+    void interpolationWithSystemProperty() throws Exception {
         Properties sysProps = new Properties();
         sysProps.setProperty("system.property", "PASSED");
         PomTestWrapper pom = buildPom("system-property-interpolation", sysProps, null);
@@ -1595,7 +1595,7 @@ class PomConstructionTest {
 
     /* MNG-4129 */
     @Test
-    void testPluginExecutionInheritanceWhenChildDoesNotDeclarePlugin() throws Exception {
+    void pluginExecutionInheritanceWhenChildDoesNotDeclarePlugin() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-inheritance/wo-merge");
         @SuppressWarnings("unchecked")
         List<PluginExecution> executions = (List<PluginExecution>) pom.getValue(
@@ -1605,7 +1605,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testPluginExecutionInheritanceWhenChildDoesDeclarePluginAsWell() throws Exception {
+    void pluginExecutionInheritanceWhenChildDoesDeclarePluginAsWell() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-inheritance/w-merge");
         @SuppressWarnings("unchecked")
         List<PluginExecution> executions = (List<PluginExecution>) pom.getValue(
@@ -1616,7 +1616,7 @@ class PomConstructionTest {
 
     /* MNG-4193 */
     @Test
-    void testValidationErrorUponNonUniqueArtifactRepositoryId() throws Exception {
+    void validationErrorUponNonUniqueArtifactRepositoryId() throws Exception {
         assertThrows(
                 ProjectBuildingException.class,
                 () -> buildPom("unique-repo-id/artifact-repo"),
@@ -1625,7 +1625,7 @@ class PomConstructionTest {
 
     /* MNG-4193 */
     @Test
-    void testValidationErrorUponNonUniquePluginRepositoryId() throws Exception {
+    void validationErrorUponNonUniquePluginRepositoryId() throws Exception {
         assertThrows(
                 ProjectBuildingException.class,
                 () -> buildPom("unique-repo-id/plugin-repo"),
@@ -1634,7 +1634,7 @@ class PomConstructionTest {
 
     /* MNG-4193 */
     @Test
-    void testValidationErrorUponNonUniqueArtifactRepositoryIdInProfile() throws Exception {
+    void validationErrorUponNonUniqueArtifactRepositoryIdInProfile() throws Exception {
         assertThrows(
                 ProjectBuildingException.class,
                 () -> buildPom("unique-repo-id/artifact-repo-in-profile"),
@@ -1643,7 +1643,7 @@ class PomConstructionTest {
 
     /* MNG-4193 */
     @Test
-    void testValidationErrorUponNonUniquePluginRepositoryIdInProfile() throws Exception {
+    void validationErrorUponNonUniquePluginRepositoryIdInProfile() throws Exception {
         assertThrows(
                 ProjectBuildingException.class,
                 () -> buildPom("unique-repo-id/plugin-repo-in-profile"),
@@ -1652,13 +1652,13 @@ class PomConstructionTest {
 
     /** MNG-3843 */
     @Test
-    void testPrerequisitesAreNotInherited() throws Exception {
+    void prerequisitesAreNotInherited() throws Exception {
         PomTestWrapper pom = buildPom("prerequisites-inheritance/child");
         assertSame(null, pom.getValue("prerequisites"));
     }
 
     @Test
-    void testLicensesAreInheritedButNotAggregated() throws Exception {
+    void licensesAreInheritedButNotAggregated() throws Exception {
         PomTestWrapper pom = buildPom("licenses-inheritance/child-2");
         assertEquals(1, ((List<?>) pom.getValue("licenses")).size());
         assertEquals("child-license", pom.getValue("licenses[1]/name"));
@@ -1666,28 +1666,28 @@ class PomConstructionTest {
     }
 
     @Test
-    void testDevelopersAreInheritedButNotAggregated() throws Exception {
+    void developersAreInheritedButNotAggregated() throws Exception {
         PomTestWrapper pom = buildPom("developers-inheritance/child-2");
         assertEquals(1, ((List<?>) pom.getValue("developers")).size());
         assertEquals("child-developer", pom.getValue("developers[1]/name"));
     }
 
     @Test
-    void testContributorsAreInheritedButNotAggregated() throws Exception {
+    void contributorsAreInheritedButNotAggregated() throws Exception {
         PomTestWrapper pom = buildPom("contributors-inheritance/child-2");
         assertEquals(1, ((List<?>) pom.getValue("contributors")).size());
         assertEquals("child-contributor", pom.getValue("contributors[1]/name"));
     }
 
     @Test
-    void testMailingListsAreInheritedButNotAggregated() throws Exception {
+    void mailingListsAreInheritedButNotAggregated() throws Exception {
         PomTestWrapper pom = buildPom("mailing-lists-inheritance/child-2");
         assertEquals(1, ((List<?>) pom.getValue("mailingLists")).size());
         assertEquals("child-mailing-list", pom.getValue("mailingLists[1]/name"));
     }
 
     @Test
-    void testPluginInheritanceOrder() throws Exception {
+    void pluginInheritanceOrder() throws Exception {
         PomTestWrapper pom = buildPom("plugin-inheritance-order/child");
 
         assertEquals("maven-it-plugin-log-file", pom.getValue("build/plugins[1]/artifactId"));
@@ -1700,7 +1700,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testCliPropsDominateProjectPropsDuringInterpolation() throws Exception {
+    void cliPropsDominateProjectPropsDuringInterpolation() throws Exception {
         Properties props = new Properties();
         props.setProperty("testProperty", "PASSED");
         PomTestWrapper pom = buildPom("interpolation-cli-wins", null, props);
@@ -1709,7 +1709,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testParentPomPackagingMustBePom() throws Exception {
+    void parentPomPackagingMustBePom() throws Exception {
         assertThrows(
                 ProjectBuildingException.class,
                 () -> buildPom("parent-pom-packaging/sub"),
@@ -1718,7 +1718,7 @@ class PomConstructionTest {
 
     /** MNG-522, MNG-3018 */
     @Test
-    void testManagedPluginConfigurationAppliesToImplicitPluginsIntroducedByPackaging() throws Exception {
+    void managedPluginConfigurationAppliesToImplicitPluginsIntroducedByPackaging() throws Exception {
         PomTestWrapper pom = buildPom("plugin-management-for-implicit-plugin/child");
         assertEquals(
                 "passed.txt",
@@ -1729,7 +1729,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testDefaultPluginsExecutionContributedByPackagingExecuteBeforeUserDefinedExecutions() throws Exception {
+    void defaultPluginsExecutionContributedByPackagingExecuteBeforeUserDefinedExecutions() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-order-and-default-exec");
         @SuppressWarnings("unchecked")
         List<PluginExecution> executions =
@@ -1743,7 +1743,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testPluginDeclarationsRetainPomOrderAfterInjectionOfDefaultPlugins() throws Exception {
+    void pluginDeclarationsRetainPomOrderAfterInjectionOfDefaultPlugins() throws Exception {
         PomTestWrapper pom = buildPom("plugin-exec-order-with-lifecycle");
         @SuppressWarnings("unchecked")
         List<Plugin> plugins = (List<Plugin>) pom.getValue("build/plugins");
@@ -1764,7 +1764,7 @@ class PomConstructionTest {
 
     /** MNG-4415 */
     @Test
-    void testPluginOrderAfterMergingWithInheritedPlugins() throws Exception {
+    void pluginOrderAfterMergingWithInheritedPlugins() throws Exception {
         PomTestWrapper pom = buildPom("plugin-inheritance-merge-order/sub");
 
         List<String> expected = new ArrayList<>();
@@ -1791,7 +1791,7 @@ class PomConstructionTest {
 
     /** MNG-4416 */
     @Test
-    void testPluginOrderAfterMergingWithInjectedPlugins() throws Exception {
+    void pluginOrderAfterMergingWithInjectedPlugins() throws Exception {
         PomTestWrapper pom = buildPom("plugin-injection-merge-order");
 
         List<String> expected = new ArrayList<>();
@@ -1817,7 +1817,7 @@ class PomConstructionTest {
     }
 
     @Test
-    void testProjectArtifactIdIsNotInheritedButMandatory() throws Exception {
+    void projectArtifactIdIsNotInheritedButMandatory() throws Exception {
         assertThrows(
                 ProjectBuildingException.class,
                 () -> buildPom("artifact-id-inheritance/child"),

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -60,7 +60,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testSystemScopeDependencyIsPresentInTheCompileClasspathElements() throws Exception {
+    void systemScopeDependencyIsPresentInTheCompileClasspathElements() throws Exception {
         File pom = getProject("it0063");
 
         Properties eps = new Properties();
@@ -76,7 +76,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testBuildFromModelSource() throws Exception {
+    void buildFromModelSource() throws Exception {
         File pomFile = new File("src/test/resources/projects/modelsource/module01/pom.xml");
         MavenSession mavenSession = createMavenSession(pomFile);
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
@@ -89,7 +89,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testVersionlessManagedDependency() throws Exception {
+    void versionlessManagedDependency() throws Exception {
         File pomFile = new File("src/test/resources/projects/versionless-managed-dependency.xml");
         MavenSession mavenSession = createMavenSession(null);
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
@@ -107,7 +107,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testResolveDependencies() throws Exception {
+    void resolveDependencies() throws Exception {
         File pomFile = new File("src/test/resources/projects/basic-resolveDependencies.xml");
         MavenSession mavenSession = createMavenSession(null);
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
@@ -141,7 +141,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testDontResolveDependencies() throws Exception {
+    void dontResolveDependencies() throws Exception {
         File pomFile = new File("src/test/resources/projects/basic-resolveDependencies.xml");
         MavenSession mavenSession = createMavenSession(null);
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
@@ -163,7 +163,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testReadModifiedPoms(@TempDir Path tempDir) throws Exception {
+    void readModifiedPoms(@TempDir Path tempDir) throws Exception {
         // TODO a similar test should be created to test the dependency management (basically all usages
         // of DefaultModelBuilder.getCache() are affected by MNG-6530
 
@@ -191,7 +191,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testReadErroneousMavenProjectContainsReference() throws Exception {
+    void readErroneousMavenProjectContainsReference() throws Exception {
         File pomFile = new File("src/test/resources/projects/artifactMissingVersion/pom.xml").getAbsoluteFile();
         MavenSession mavenSession = createMavenSession(null);
         mavenSession.getRequest().setRootDirectory(pomFile.getParentFile().toPath());
@@ -224,7 +224,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testReadInvalidPom() throws Exception {
+    void readInvalidPom() throws Exception {
         File pomFile = new File("src/test/resources/projects/badPom.xml").getAbsoluteFile();
         MavenSession mavenSession = createMavenSession(null);
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
@@ -251,7 +251,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testReadParentAndChildWithRegularVersionSetParentFile() throws Exception {
+    void readParentAndChildWithRegularVersionSetParentFile() throws Exception {
         List<File> toRead = new ArrayList<>(2);
         File parentPom = getProject("MNG-6723");
         toRead.add(parentPom);
@@ -304,7 +304,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testBuildProperties() throws Exception {
+    void buildProperties() throws Exception {
         File file = new File(getProject("MNG-6716").getParentFile(), "project/pom.xml");
         MavenSession mavenSession = createMavenSession(null);
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
@@ -321,7 +321,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testPropertyInPluginManagementGroupId() throws Exception {
+    void propertyInPluginManagementGroupId() throws Exception {
         File pom = getProject("MNG-6983");
 
         MavenSession session = createMavenSession(pom);
@@ -333,7 +333,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testBuildFromModelSourceResolvesBasedir() throws Exception {
+    void buildFromModelSourceResolvesBasedir() throws Exception {
         File pomFile = new File("src/test/resources/projects/modelsourcebasedir/pom.xml");
         MavenSession mavenSession = createMavenSession(null);
         ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
@@ -355,7 +355,7 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
-    void testLocationTrackingResolution() throws Exception {
+    void locationTrackingResolution() throws Exception {
         File pom = getProject("MNG-7648");
 
         MavenSession session = createMavenSession(pom);

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
@@ -56,7 +56,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveParentThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
+    void resolveParentThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("org.apache");
         parent.setArtifactId("apache");
@@ -71,7 +71,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveParentThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
+    void resolveParentThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("org.apache");
         parent.setArtifactId("apache");
@@ -85,7 +85,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveParentThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
+    void resolveParentThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("org.apache");
         parent.setArtifactId("apache");
@@ -99,7 +99,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception {
+    void resolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("org.apache");
         parent.setArtifactId("apache");
@@ -110,7 +110,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception {
+    void resolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception {
         final Parent parent = new Parent();
         parent.setGroupId("org.apache");
         parent.setArtifactId("apache");
@@ -121,7 +121,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveDependencyThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
+    void resolveDependencyThrowsUnresolvableModelExceptionWhenNotFound() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("org.apache");
         dependency.setArtifactId("apache");
@@ -136,7 +136,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveDependencyThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
+    void resolveDependencyThrowsUnresolvableModelExceptionWhenNoMatchingVersionFound() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("org.apache");
         dependency.setArtifactId("apache");
@@ -150,7 +150,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveDependencyThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
+    void resolveDependencyThrowsUnresolvableModelExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("org.apache");
         dependency.setArtifactId("apache");
@@ -164,7 +164,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception {
+    void resolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("org.apache");
         dependency.setArtifactId("apache");
@@ -175,7 +175,7 @@ class ProjectModelResolverTest extends AbstractMavenProjectTestCase {
     }
 
     @Test
-    void testResolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception {
+    void resolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception {
         final Dependency dependency = new Dependency();
         dependency.setGroupId("org.apache");
         dependency.setArtifactId("apache");

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectSorterTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectSorterTest.java
@@ -95,7 +95,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testShouldNotFailWhenPluginDepReferencesCurrentProject() throws Exception {
+    void shouldNotFailWhenPluginDepReferencesCurrentProject() throws Exception {
         MavenProject project = createProject("group", "artifact", "1.0");
 
         Build build = project.getModel().getBuild();
@@ -112,7 +112,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testShouldNotFailWhenManagedPluginDepReferencesCurrentProject() throws Exception {
+    void shouldNotFailWhenManagedPluginDepReferencesCurrentProject() throws Exception {
         MavenProject project = createProject("group", "artifact", "1.0");
 
         Build build = project.getModel().getBuild();
@@ -133,7 +133,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testShouldNotFailWhenProjectReferencesNonExistentProject() throws Exception {
+    void shouldNotFailWhenProjectReferencesNonExistentProject() throws Exception {
         MavenProject project = createProject("group", "artifact", "1.0");
 
         Build build = project.getModel().getBuild();
@@ -146,7 +146,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testMatchingArtifactIdsDifferentGroupIds() throws Exception {
+    void matchingArtifactIdsDifferentGroupIds() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
         MavenProject project1 = createProject("groupId1", "artifactId", "1.0");
         projects.add(project1);
@@ -161,7 +161,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testMatchingGroupIdsDifferentArtifactIds() throws Exception {
+    void matchingGroupIdsDifferentArtifactIds() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
         MavenProject project1 = createProject("groupId", "artifactId1", "1.0");
         projects.add(project1);
@@ -176,7 +176,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testMatchingIdsAndVersions() throws Exception {
+    void matchingIdsAndVersions() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
         MavenProject project1 = createProject("groupId", "artifactId", "1.0");
         projects.add(project1);
@@ -190,7 +190,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testMatchingIdsAndDifferentVersions() throws Exception {
+    void matchingIdsAndDifferentVersions() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
         MavenProject project1 = createProject("groupId", "artifactId", "1.0");
         projects.add(project1);
@@ -203,7 +203,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testPluginDependenciesInfluenceSorting() throws Exception {
+    void pluginDependenciesInfluenceSorting() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
 
         MavenProject parentProject = createProject("groupId", "parent", "1.0");
@@ -247,7 +247,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testPluginDependenciesInfluenceSortingDeclarationInParent() throws Exception {
+    void pluginDependenciesInfluenceSortingDeclarationInParent() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
 
         MavenProject parentProject = createProject("groupId", "parent-declarer", "1.0");
@@ -281,7 +281,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testPluginVersionsAreConsidered() throws Exception {
+    void pluginVersionsAreConsidered() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
 
         MavenProject pluginProjectA = createProject("group", "plugin-a", "2.0-SNAPSHOT");
@@ -299,7 +299,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testDependencyPrecedesProjectThatUsesSpecificDependencyVersion() throws Exception {
+    void dependencyPrecedesProjectThatUsesSpecificDependencyVersion() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
 
         MavenProject usingProject = createProject("group", "project", "1.0");
@@ -316,7 +316,7 @@ class ProjectSorterTest {
     }
 
     @Test
-    void testDependencyPrecedesProjectThatUsesUnresolvedDependencyVersion() throws Exception {
+    void dependencyPrecedesProjectThatUsesUnresolvedDependencyVersion() throws Exception {
         List<MavenProject> projects = new ArrayList<>();
 
         MavenProject usingProject = createProject("group", "project", "1.0");

--- a/impl/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCacheTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/artifact/DefaultProjectArtifactsCacheTest.java
@@ -39,7 +39,7 @@ class DefaultProjectArtifactsCacheTest {
     }
 
     @Test
-    void testProjectDependencyOrder() throws Exception {
+    void projectDependencyOrder() throws Exception {
         ProjectArtifactsCache.Key project1 = new ProjectArtifactsCache.Key() {};
 
         Set<Artifact> artifacts = new LinkedHashSet<>(4);

--- a/impl/maven-core/src/test/java/org/apache/maven/project/canonical/CanonicalProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/canonical/CanonicalProjectBuilderTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 class CanonicalProjectBuilderTest extends AbstractMavenProjectTestCase {
     @Test
-    void testProjectBuilder() throws Exception {
+    void projectBuilder() throws Exception {
         File f = getFileForClasspathResource("canonical-pom.xml");
 
         MavenProject project = getProject(f);

--- a/impl/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/rtinfo/internal/DefaultRuntimeInformationTest.java
@@ -35,14 +35,14 @@ class DefaultRuntimeInformationTest {
     RuntimeInformation rtInfo;
 
     @Test
-    void testGetMavenVersion() {
+    void getMavenVersion() {
         String mavenVersion = rtInfo.getMavenVersion();
         assertNotNull(mavenVersion);
-        assertTrue(!mavenVersion.isEmpty());
+        assertFalse(mavenVersion.isEmpty());
     }
 
     @Test
-    void testIsMavenVersion() {
+    void isMavenVersion() {
         assertTrue(rtInfo.isMavenVersion("2.0"));
         assertFalse(rtInfo.isMavenVersion("9.9"));
 

--- a/impl/maven-core/src/test/java/org/apache/maven/session/scope/SessionScopeProxyTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/session/scope/SessionScopeProxyTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @PlexusTest
 @ExtendWith(MockitoExtension.class)
-public class SessionScopeProxyTest {
+class SessionScopeProxyTest {
 
     @Mock
     Session session;
@@ -55,7 +55,7 @@ public class SessionScopeProxyTest {
     PlexusContainer container;
 
     @Test
-    void testProxiedSessionScopedBean() throws ComponentLookupException {
+    void proxiedSessionScopedBean() throws ComponentLookupException {
         ComponentLookupException e =
                 assertThrows(ComponentLookupException.class, () -> container.lookup(MySingletonBean2.class));
         assertTrue(e.getMessage().matches("[\\s\\S]*: Can not set .* field .* to [\\s\\S]*"));

--- a/impl/maven-core/src/test/java/org/apache/maven/settings/PomConstructionWithSettingsTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/settings/PomConstructionWithSettingsTest.java
@@ -72,7 +72,7 @@ class PomConstructionWithSettingsTest {
     }
 
     @Test
-    void testSettingsNoPom() throws Exception {
+    void settingsNoPom() throws Exception {
         PomTestWrapper pom = buildPom("settings-no-pom");
         assertEquals("local-profile-prop-value", pom.getValue("properties/local-profile-prop"));
     }
@@ -81,7 +81,7 @@ class PomConstructionWithSettingsTest {
      * MNG-4107
      */
     @Test
-    void testPomAndSettingsInterpolation() throws Exception {
+    void pomAndSettingsInterpolation() throws Exception {
         PomTestWrapper pom = buildPom("test-pom-and-settings-interpolation");
         assertEquals("applied", pom.getValue("properties/settingsProfile"));
         assertEquals("applied", pom.getValue("properties/pomProfile"));
@@ -93,7 +93,7 @@ class PomConstructionWithSettingsTest {
      * MNG-4107
      */
     @Test
-    void testRepositories() throws Exception {
+    void repositories() throws Exception {
         PomTestWrapper pom = buildPom("repositories");
         assertEquals("maven-core-it-0", pom.getValue("repositories[1]/id"));
     }

--- a/impl/maven-core/src/test/java/org/apache/maven/settings/SettingsUtilsTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/settings/SettingsUtilsTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class SettingsUtilsTest {
 
     @Test
-    void testShouldAppendRecessivePluginGroupIds() {
+    void shouldAppendRecessivePluginGroupIds() {
         Settings dominant = Settings.newBuilder()
                 .pluginGroups(Arrays.asList("org.apache.maven.plugins", "org.codehaus.modello"))
                 .build();
@@ -62,7 +62,7 @@ class SettingsUtilsTest {
     }
 
     @Test
-    void testRoundTripProfiles() {
+    void roundTripProfiles() {
         Random entropy = new Random();
         ActivationFile af = ActivationFile.newBuilder()
                 .exists("exists" + Long.toHexString(entropy.nextLong()))

--- a/impl/maven-di/src/test/java/org/apache/maven/di/impl/InjectorImplTest.java
+++ b/impl/maven-di/src/test/java/org/apache/maven/di/impl/InjectorImplTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("unused")
-public class InjectorImplTest {
+class InjectorImplTest {
 
     @Test
     void markerQualifierTest() {
@@ -157,7 +157,7 @@ public class InjectorImplTest {
     }
 
     @Test
-    public void bindInterfacesTest() {
+    void bindInterfacesTest() {
         Injector injector = Injector.create().bindImplicit(BindInterfaces.class);
         BindInterfaces.TestInterface<String> inst =
                 injector.getInstance(new Key<BindInterfaces.TestInterface<String>>() {});
@@ -256,7 +256,7 @@ public class InjectorImplTest {
     }
 
     @Test
-    void testSingleton() {
+    void singleton() {
         Injector injector = Injector.create()
                 .bindImplicit(SingletonContainer.Bean1.class)
                 .bindImplicit(SingletonContainer.Bean2.class);
@@ -291,7 +291,7 @@ public class InjectorImplTest {
     }
 
     @Test
-    void testProvides() {
+    void provides() {
         Injector injector = Injector.create().bindImplicit(ProvidesContainer.class);
 
         assertNotNull(injector.getInstance(String.class));
@@ -311,7 +311,7 @@ public class InjectorImplTest {
     }
 
     @Test
-    void testInjectConstructor() {
+    void injectConstructor() {
         Injector injector = Injector.create().bindImplicit(InjectConstructorContainer.class);
 
         assertNotNull(injector.getInstance(InjectConstructorContainer.Bean.class));
@@ -334,7 +334,7 @@ public class InjectorImplTest {
     }
 
     @Test
-    void testNullableOnField() {
+    void nullableOnField() {
         Injector injector = Injector.create().bindImplicit(NullableOnField.class);
         NullableOnField.MyMojo mojo = injector.getInstance(NullableOnField.MyMojo.class);
         assertNotNull(mojo);
@@ -355,7 +355,7 @@ public class InjectorImplTest {
     }
 
     @Test
-    void testNullableOnConstructor() {
+    void nullableOnConstructor() {
         Injector injector = Injector.create().bindImplicit(NullableOnConstructor.class);
         NullableOnConstructor.MyMojo mojo = injector.getInstance(NullableOnConstructor.MyMojo.class);
         assertNotNull(mojo);
@@ -379,12 +379,11 @@ public class InjectorImplTest {
     }
 
     @Test
-    void testCircularPriorityDependency() {
+    void circularPriorityDependency() {
         Injector injector = Injector.create().bindImplicit(CircularPriorityTest.class);
 
-        DIException exception = assertThrows(DIException.class, () -> {
-            injector.getInstance(CircularPriorityTest.MyService.class);
-        });
+        DIException exception =
+                assertThrows(DIException.class, () -> injector.getInstance(CircularPriorityTest.MyService.class));
         assertThat(exception).isInstanceOf(DIException.class).hasMessageContaining("HighPriorityServiceImpl");
         assertThat(exception.getCause())
                 .isInstanceOf(DIException.class)

--- a/impl/maven-di/src/test/java/org/apache/maven/di/impl/TypeUtilsTest.java
+++ b/impl/maven-di/src/test/java/org/apache/maven/di/impl/TypeUtilsTest.java
@@ -32,12 +32,12 @@ import static org.apache.maven.di.impl.Types.simplifyType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class TypeUtilsTest {
+class TypeUtilsTest {
 
     TreeSet<String> aField;
 
     @Test
-    void testGetSuperTypes() {
+    void getSuperTypes() {
         Type type = new Key<TreeSet<String>>() {}.getType();
         Set<Type> types = Types.getAllSuperTypes(type);
         assertNotNull(types);
@@ -62,7 +62,7 @@ public class TypeUtilsTest {
 
     @Test
     @SuppressWarnings("checkstyle:AvoidNestedBlocks")
-    public void testSimplifyType() {
+    void testSimplifyType() {
         {
             Type type = Integer.class;
             assertEquals(type, simplifyType(type));

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -41,7 +41,7 @@ import static org.apache.maven.cling.executor.MavenExecutorTestSupport.mvn4Execu
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ToolboxToolTest {
+class ToolboxToolTest {
     @TempDir
     private static Path userHome;
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
@@ -40,7 +40,7 @@ class DefaultModelXmlFactoryTest {
     }
 
     @Test
-    void testValidNamespaceWithModelVersion400() throws Exception {
+    void validNamespaceWithModelVersion400() throws Exception {
         String xml =
                 """
                 <project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -56,7 +56,7 @@ class DefaultModelXmlFactoryTest {
     }
 
     @Test
-    void testValidNamespaceWithModelVersion410() throws Exception {
+    void validNamespaceWithModelVersion410() throws Exception {
         String xml =
                 """
                 <project xmlns="http://maven.apache.org/POM/4.1.0">
@@ -72,7 +72,7 @@ class DefaultModelXmlFactoryTest {
     }
 
     @Test
-    void testInvalidNamespaceWithModelVersion410() {
+    void invalidNamespaceWithModelVersion410() {
         String xml =
                 """
                 <project xmlns="http://invalid.namespace/4.1.0">
@@ -88,7 +88,7 @@ class DefaultModelXmlFactoryTest {
     }
 
     @Test
-    void testNoNamespaceWithModelVersion400() throws Exception {
+    void noNamespaceWithModelVersion400() throws Exception {
         String xml =
                 """
                 <project>
@@ -104,12 +104,12 @@ class DefaultModelXmlFactoryTest {
     }
 
     @Test
-    void testNullRequest() {
+    void nullRequest() {
         assertThrows(IllegalArgumentException.class, () -> factory.read((XmlReaderRequest) null));
     }
 
     @Test
-    void testMalformedModelVersion() throws Exception {
+    void malformedModelVersion() throws Exception {
         String xml =
                 """
                 <project xmlns="http://maven.apache.org/POM/4.0.0">

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultNodeTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultNodeTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DefaultNodeTest {
 
     @Test
-    void testAsString() {
+    void asString() {
         InternalSession session = Mockito.mock(InternalSession.class);
 
         // Create a basic dependency node

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsBuilderFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsBuilderFactoryTest.java
@@ -54,7 +54,7 @@ class DefaultSettingsBuilderFactoryTest {
     }
 
     @Test
-    void testCompleteWiring() {
+    void completeWiring() {
         SettingsBuilder builder =
                 new DefaultSettingsBuilder(new DefaultSettingsXmlFactory(), new DefaultInterpolator(), Map.of());
         assertNotNull(builder);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsValidatorTest.java
@@ -43,7 +43,7 @@ class DefaultSettingsValidatorTest {
     }
 
     @Test
-    void testValidate() {
+    void validate() {
         Profile prof = Profile.newBuilder().id("xxx").build();
         Settings model = Settings.newBuilder().profiles(List.of(prof)).build();
         ProblemCollector<BuilderProblem> problems = validator.validate(model);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/ModelVersionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/ModelVersionParserTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ModelVersionParserTest {
+class ModelVersionParserTest {
 
     private final DefaultModelVersionParser versionParser = new DefaultModelVersionParser(new GenericVersionScheme());
 
@@ -43,7 +43,7 @@ public class ModelVersionParserTest {
     }
 
     @Test
-    void testEnumeratedVersions() throws VersionParserException {
+    void enumeratedVersions() throws VersionParserException {
         VersionConstraint c = versionParser.parseVersionConstraint("1.0");
         assertEquals("1.0", c.getRecommendedVersion().toString());
         assertTrue(c.contains(versionParser.parseVersion("1.0")));
@@ -84,14 +84,14 @@ public class ModelVersionParserTest {
     }
 
     @Test
-    void testInvalid() {
+    void invalid() {
         parseInvalid("[1,");
         parseInvalid("[1,2],(3,");
         parseInvalid("[1,2],3");
     }
 
     @Test
-    void testSameUpperAndLowerBound() throws VersionParserException {
+    void sameUpperAndLowerBound() throws VersionParserException {
         VersionConstraint c = versionParser.parseVersionConstraint("[1.0]");
         assertEquals("[1.0,1.0]", c.toString());
         VersionConstraint c2 = versionParser.parseVersionConstraint(c.toString());

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/RequestTraceHelperTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/RequestTraceHelperTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 class RequestTraceHelperTest {
 
     @Test
-    void testEnterWithRequestData() {
+    void enterWithRequestData() {
         InternalSession session = mock(InternalSession.class);
         Request<?> request = mock(Request.class);
         org.apache.maven.api.services.RequestTrace existingTrace =
@@ -50,7 +50,7 @@ class RequestTraceHelperTest {
     }
 
     @Test
-    void testInterpretTraceWithArtifactRequest() {
+    void interpretTraceWithArtifactRequest() {
         ArtifactRequest artifactRequest = mock(ArtifactRequest.class);
         RequestTrace trace = RequestTrace.newChild(null, artifactRequest);
 
@@ -60,17 +60,17 @@ class RequestTraceHelperTest {
     }
 
     @Test
-    void testToMavenWithNullTrace() {
+    void toMavenWithNullTrace() {
         assertNull(RequestTraceHelper.toMaven("test", null));
     }
 
     @Test
-    void testToResolverWithNullTrace() {
+    void toResolverWithNullTrace() {
         assertNull(RequestTraceHelper.toResolver(null));
     }
 
     @Test
-    void testExitResetsParentTrace() {
+    void exitResetsParentTrace() {
         InternalSession session = mock(InternalSession.class);
         org.apache.maven.api.services.RequestTrace parentTrace =
                 new org.apache.maven.api.services.RequestTrace(null, "parent");

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/VersionRangeTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/VersionRangeTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class VersionRangeTest {
+class VersionRangeTest {
 
     private ModelVersionParser versionParser = new DefaultModelVersionParser(new GenericVersionScheme());
 
@@ -64,7 +64,7 @@ public class VersionRangeTest {
     }
 
     @Test
-    void testLowerBoundInclusiveUpperBoundInclusive() {
+    void lowerBoundInclusiveUpperBoundInclusive() {
         VersionRange range = parseValid("[1,2]");
         assertContains(range, "1");
         assertContains(range, "1.1-SNAPSHOT");
@@ -73,7 +73,7 @@ public class VersionRangeTest {
     }
 
     @Test
-    void testLowerBoundInclusiveUpperBoundExclusive() {
+    void lowerBoundInclusiveUpperBoundExclusive() {
         VersionRange range = parseValid("[1.2.3.4.5,1.2.3.4.6)");
         assertContains(range, "1.2.3.4.5");
         assertNotContains(range, "1.2.3.4.6");
@@ -81,7 +81,7 @@ public class VersionRangeTest {
     }
 
     @Test
-    void testLowerBoundExclusiveUpperBoundInclusive() {
+    void lowerBoundExclusiveUpperBoundInclusive() {
         VersionRange range = parseValid("(1a,1b]");
         assertNotContains(range, "1a");
         assertContains(range, "1b");
@@ -89,7 +89,7 @@ public class VersionRangeTest {
     }
 
     @Test
-    void testLowerBoundExclusiveUpperBoundExclusive() {
+    void lowerBoundExclusiveUpperBoundExclusive() {
         VersionRange range = parseValid("(1,3)");
         assertNotContains(range, "1");
         assertContains(range, "2-SNAPSHOT");
@@ -98,7 +98,7 @@ public class VersionRangeTest {
     }
 
     @Test
-    void testSingleVersion() {
+    void singleVersion() {
         VersionRange range = parseValid("[1]");
         assertContains(range, "1");
         assertEquals(range, parseValid(range.toString()));
@@ -109,7 +109,7 @@ public class VersionRangeTest {
     }
 
     @Test
-    void testSingleWildcardVersion() {
+    void singleWildcardVersion() {
         VersionRange range = parseValid("[1.2.*]");
         assertContains(range, "1.2-alpha-1");
         assertContains(range, "1.2-SNAPSHOT");
@@ -120,24 +120,24 @@ public class VersionRangeTest {
     }
 
     @Test
-    void testMissingOpenCloseDelimiter() {
+    void missingOpenCloseDelimiter() {
         parseInvalid("1.0");
     }
 
     @Test
-    void testMissingOpenDelimiter() {
+    void missingOpenDelimiter() {
         parseInvalid("1.0]");
         parseInvalid("1.0)");
     }
 
     @Test
-    void testMissingCloseDelimiter() {
+    void missingCloseDelimiter() {
         parseInvalid("[1.0");
         parseInvalid("(1.0");
     }
 
     @Test
-    void testTooManyVersions() {
+    void tooManyVersions() {
         parseInvalid("[1,2,3]");
         parseInvalid("(1,2,3)");
         parseInvalid("[1,2,3)");

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/VersionTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/VersionTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  */
-public class VersionTest extends AbstractVersionTest {
+class VersionTest extends AbstractVersionTest {
     private final ModelVersionParser modelVersionParser = new DefaultModelVersionParser(new GenericVersionScheme());
 
     protected Version newVersion(String version) {
@@ -42,12 +42,12 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testEmptyVersion() {
+    void emptyVersion() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "0", "");
     }
 
     @Test
-    void testNumericOrdering() {
+    void numericOrdering() {
         assertOrder(AbstractVersionTest.X_LT_Y, "2", "10");
         assertOrder(AbstractVersionTest.X_LT_Y, "1.2", "1.10");
         assertOrder(AbstractVersionTest.X_LT_Y, "1.0.2", "1.0.10");
@@ -57,14 +57,14 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testDelimiters() {
+    void delimiters() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0", "1-0");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0", "1_0");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.a", "1a");
     }
 
     @Test
-    void testLeadingZerosAreSemanticallyIrrelevant() {
+    void leadingZerosAreSemanticallyIrrelevant() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1", "01");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.2", "1.002");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.2.3", "1.2.0003");
@@ -72,7 +72,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testTrailingZerosAreSemanticallyIrrelevant() {
+    void trailingZerosAreSemanticallyIrrelevant() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1", "1.0.0.0.0.0.0.0.0.0.0.0.0.0");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1", "1-0-0-0-0-0-0-0-0-0-0-0-0-0");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1", "1.0-0.0-0.0-0.0-0.0-0.0-0.0");
@@ -81,7 +81,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testTrailingZerosBeforeQualifierAreSemanticallyIrrelevant() {
+    void trailingZerosBeforeQualifierAreSemanticallyIrrelevant() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0-ga", "1.0.0-ga");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0.ga", "1.0.0.ga");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0ga", "1.0.0ga");
@@ -99,7 +99,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testTrailingDelimitersAreSemanticallyIrrelevant() {
+    void trailingDelimitersAreSemanticallyIrrelevant() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1", "1.............");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1", "1-------------");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0", "1.............");
@@ -107,7 +107,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testInitialDelimiters() {
+    void initialDelimiters() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "0.1", ".1");
         assertOrder(AbstractVersionTest.X_EQ_Y, "0.0.1", "..1");
         assertOrder(AbstractVersionTest.X_EQ_Y, "0.1", "-1");
@@ -115,7 +115,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testConsecutiveDelimiters() {
+    void consecutiveDelimiters() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0.1", "1..1");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0.0.1", "1...1");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.0.1", "1--1");
@@ -123,18 +123,18 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testUnlimitedNumberOfVersionComponents() {
+    void unlimitedNumberOfVersionComponents() {
         assertOrder(AbstractVersionTest.X_GT_Y, "1.0.1.2.3.4.5.6.7.8.9.0.1.2.10", "1.0.1.2.3.4.5.6.7.8.9.0.1.2.3");
     }
 
     @Test
-    void testUnlimitedNumberOfDigitsInNumericComponent() {
+    void unlimitedNumberOfDigitsInNumericComponent() {
         assertOrder(
                 AbstractVersionTest.X_GT_Y, "1.1234567890123456789012345678901", "1.123456789012345678901234567891");
     }
 
     @Test
-    void testTransitionFromDigitToLetterAndViceVersaIsEquivalentToDelimiter() {
+    void transitionFromDigitToLetterAndViceVersaIsEquivalentToDelimiter() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1alpha10", "1.alpha.10");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1alpha10", "1-alpha-10");
 
@@ -143,7 +143,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testWellKnownQualifierOrdering() {
+    void wellKnownQualifierOrdering() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1-alpha1", "1-a1");
         assertOrder(AbstractVersionTest.X_LT_Y, "1-alpha", "1-beta");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1-beta1", "1-b1");
@@ -171,7 +171,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testWellKnownQualifierVersusUnknownQualifierOrdering() {
+    void wellKnownQualifierVersusUnknownQualifierOrdering() {
         assertOrder(AbstractVersionTest.X_GT_Y, "1-abc", "1-alpha");
         assertOrder(AbstractVersionTest.X_GT_Y, "1-abc", "1-beta");
         assertOrder(AbstractVersionTest.X_GT_Y, "1-abc", "1-milestone");
@@ -182,7 +182,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testWellKnownSingleCharQualifiersOnlyRecognizedIfImmediatelyFollowedByNumber() {
+    void wellKnownSingleCharQualifiersOnlyRecognizedIfImmediatelyFollowedByNumber() {
         assertOrder(AbstractVersionTest.X_GT_Y, "1.0a", "1.0");
         assertOrder(AbstractVersionTest.X_GT_Y, "1.0-a", "1.0");
         assertOrder(AbstractVersionTest.X_GT_Y, "1.0.a", "1.0");
@@ -212,14 +212,14 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testUnknownQualifierOrdering() {
+    void unknownQualifierOrdering() {
         assertOrder(AbstractVersionTest.X_LT_Y, "1-abc", "1-abcd");
         assertOrder(AbstractVersionTest.X_LT_Y, "1-abc", "1-bcd");
         assertOrder(AbstractVersionTest.X_GT_Y, "1-abc", "1-aac");
     }
 
     @Test
-    void testCaseInsensitiveOrderingOfQualifiers() {
+    void caseInsensitiveOrderingOfQualifiers() {
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.alpha", "1.ALPHA");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1.alpha", "1.Alpha");
 
@@ -252,7 +252,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testCaseInsensitiveOrderingOfQualifiersIsLocaleIndependent() {
+    void caseInsensitiveOrderingOfQualifiersIsLocaleIndependent() {
         Locale orig = Locale.getDefault();
         try {
             Locale[] locales = {Locale.ENGLISH, new Locale("tr")};
@@ -266,7 +266,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testQualifierVersusNumberOrdering() {
+    void qualifierVersusNumberOrdering() {
         assertOrder(AbstractVersionTest.X_LT_Y, "1-ga", "1-1");
         assertOrder(AbstractVersionTest.X_LT_Y, "1.ga", "1.1");
         assertOrder(AbstractVersionTest.X_EQ_Y, "1-ga", "1.0");
@@ -286,7 +286,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testVersionEvolution() {
+    void versionEvolution() {
         assertSequence(
                 "0.9.9-SNAPSHOT",
                 "0.9.9",
@@ -322,7 +322,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testMinimumSegment() {
+    void minimumSegment() {
         assertOrder(AbstractVersionTest.X_LT_Y, "1.min", "1.0-alpha-1");
         assertOrder(AbstractVersionTest.X_LT_Y, "1.min", "1.0-SNAPSHOT");
         assertOrder(AbstractVersionTest.X_LT_Y, "1.min", "1.0");
@@ -335,7 +335,7 @@ public class VersionTest extends AbstractVersionTest {
     }
 
     @Test
-    void testMaximumSegment() {
+    void maximumSegment() {
         assertOrder(AbstractVersionTest.X_GT_Y, "1.max", "1.0-alpha-1");
         assertOrder(AbstractVersionTest.X_GT_Y, "1.max", "1.0-SNAPSHOT");
         assertOrder(AbstractVersionTest.X_GT_Y, "1.max", "1.0");
@@ -351,11 +351,11 @@ public class VersionTest extends AbstractVersionTest {
      * UT for <a href="https://issues.apache.org/jira/browse/MRESOLVER-314">MRESOLVER-314</a>.
      *
      * Generates random UUID string based versions and tries to sort them. While this test is not as reliable
-     * as {@link #testCompareUuidVersionStringStream()}, it covers broader range and in case it fails it records
+     * as {@link #compareUuidVersionStringStream()}, it covers broader range and in case it fails it records
      * the failed array, so we can investigate more.
      */
     @Test
-    void testCompareUuidRandom() {
+    void compareUuidRandom() {
         for (int j = 0; j < 32; j++) {
             ArrayList<Version> versions = new ArrayList<>();
             for (int i = 0; i < 64; i++) {
@@ -378,7 +378,7 @@ public class VersionTest extends AbstractVersionTest {
      * Works on known set that failed before fix, provided by {@link #uuidVersionStringStream()}.
      */
     @Test
-    void testCompareUuidVersionStringStream() {
+    void compareUuidVersionStringStream() {
         // this operation below fails with IAEx if comparison is unstable
         uuidVersionStringStream().map(this::newVersion).sorted().toList();
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/cache/SoftIdentityMapTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/cache/SoftIdentityMapTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SoftIdentityMapTest {
     private SoftIdentityMap<Object, String> map;
@@ -144,7 +143,7 @@ class SoftIdentityMapTest {
         String key1 = new String("key");
         String key2 = new String("key");
 
-        assertTrue(key1.equals(key2), "Sanity check: keys should be equal");
+        assertEquals(key1, key2, "Sanity check: keys should be equal");
         assertNotSame(key1, key2, "Sanity check: keys should be distinct objects");
 
         AtomicInteger computeCount = new AtomicInteger(0);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/ComplexActivationTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/ComplexActivationTest.java
@@ -53,7 +53,7 @@ class ComplexActivationTest {
     }
 
     @Test
-    void testAndConditionInActivation() throws Exception {
+    void andConditionInActivation() throws Exception {
         ModelBuilderRequest request = ModelBuilderRequest.builder()
                 .session(session)
                 .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
@@ -68,7 +68,7 @@ class ComplexActivationTest {
     }
 
     @Test
-    public void testConditionExistingAndMissingInActivation() throws Exception {
+    void conditionExistingAndMissingInActivation() throws Exception {
         ModelBuilderRequest request = ModelBuilderRequest.builder()
                 .session(session)
                 .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultDependencyManagementImporterTest {
     @Test
-    void testUpdateWithImportedFromDependencyLocationAndBomLocationAreNullDependencyReturned() {
+    void updateWithImportedFromDependencyLocationAndBomLocationAreNullDependencyReturned() {
         final Dependency dependency = Dependency.newBuilder().build();
         final DependencyManagement depMgmt = DependencyManagement.newBuilder().build();
         final Dependency result = DefaultDependencyManagementImporter.updateWithImportedFrom(dependency, depMgmt);
@@ -37,7 +37,7 @@ class DefaultDependencyManagementImporterTest {
     }
 
     @Test
-    void testUpdateWithImportedFromDependencyManagementAndDependencyHaveSameSourceDependencyImportedFromSameSource() {
+    void updateWithImportedFromDependencyManagementAndDependencyHaveSameSourceDependencyImportedFromSameSource() {
         final InputSource source = new InputSource("SINGLE_SOURCE", "");
         final Dependency dependency = Dependency.newBuilder()
                 .location("", new InputLocation(1, 1, source))
@@ -54,7 +54,7 @@ class DefaultDependencyManagementImporterTest {
     }
 
     @Test
-    public void testUpdateWithImportedFromSingleLevelImportedFromSet() {
+    void updateWithImportedFromSingleLevelImportedFromSet() {
         // Arrange
         final InputSource dependencySource = new InputSource("DEPENDENCY", "DEPENDENCY");
         final InputSource bomSource = new InputSource("BOM", "BOM");
@@ -75,7 +75,7 @@ class DefaultDependencyManagementImporterTest {
     }
 
     @Test
-    public void testUpdateWithImportedFromMultiLevelImportedFromSetChanged() {
+    void updateWithImportedFromMultiLevelImportedFromSetChanged() {
         // Arrange
         final InputSource bomSource = new InputSource("BOM", "BOM");
         final InputSource intermediateSource =
@@ -99,7 +99,7 @@ class DefaultDependencyManagementImporterTest {
     }
 
     @Test
-    public void testUpdateWithImportedFromMultiLevelAlreadyFoundInDifferentSourceImportedFromSetMaintained() {
+    void updateWithImportedFromMultiLevelAlreadyFoundInDifferentSourceImportedFromSetMaintained() {
         // Arrange
         final InputSource bomSource = new InputSource("BOM", "BOM");
         final InputSource intermediateSource =

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInterpolatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInterpolatorTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class DefaultInterpolatorTest {
 
     @Test
-    void testBasicSubstitution() {
+    void basicSubstitution() {
         Map<String, String> props = new HashMap<>();
         props.put("key0", "value0");
         props.put("key1", "${value1}");
@@ -46,7 +46,7 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testBasicSubstitutionWithContext() {
+    void basicSubstitutionWithContext() {
         HashMap<String, String> props = new HashMap<>();
         props.put("key0", "value0");
         props.put("key1", "${value1}");
@@ -58,23 +58,23 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testSubstitutionFailures() {
+    void substitutionFailures() {
         assertEquals("a}", substVars("a}", "b"));
         assertEquals("${a", substVars("${a", "b"));
     }
 
     @Test
-    void testEmptyVariable() {
+    void emptyVariable() {
         assertEquals("", substVars("${}", "b"));
     }
 
     @Test
-    void testInnerSubst() {
+    void innerSubst() {
         assertEquals("c", substVars("${${a}}", "z", Map.of("a", "b", "b", "c")));
     }
 
     @Test
-    void testSubstLoop() {
+    void substLoop() {
         assertThrows(
                 InterpolatorException.class,
                 () -> substVars("${a}", "a"),
@@ -82,17 +82,17 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testLoopEmpty() {
+    void loopEmpty() {
         assertEquals("${a}", substVars("${a}", null, null, null, false));
     }
 
     @Test
-    void testLoopEmpty2() {
+    void loopEmpty2() {
         assertEquals("${a}", substVars("${a}", null, null, null, false));
     }
 
     @Test
-    void testSubstitutionEscape() {
+    void substitutionEscape() {
         assertEquals("${a}", substVars("$\\{a${#}\\}", "b"));
         assertEquals("${a}", substVars("$\\{a\\}${#}", "b"));
         assertEquals("${a}", substVars("$\\{a\\}", "b"));
@@ -100,7 +100,7 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testSubstitutionOrder() {
+    void substitutionOrder() {
         LinkedHashMap<String, String> map1 = new LinkedHashMap<>();
         map1.put("a", "$\\\\{var}");
         map1.put("abc", "${ab}c");
@@ -117,7 +117,7 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testMultipleEscapes() {
+    void multipleEscapes() {
         LinkedHashMap<String, String> map1 = new LinkedHashMap<>();
         map1.put("a", "$\\\\{var}");
         map1.put("abc", "${ab}c");
@@ -130,7 +130,7 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testPreserveUnresolved() {
+    void preserveUnresolved() {
         Map<String, String> props = new HashMap<>();
         props.put("a", "${b}");
         assertEquals("", substVars("${b}", "a", props, null, true));
@@ -145,7 +145,7 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testExpansion() {
+    void expansion() {
         Map<String, String> props = new LinkedHashMap<>();
         props.put("a", "foo");
         props.put("b", "");
@@ -170,7 +170,7 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testTernary() {
+    void ternary() {
         Map<String, String> props;
 
         props = new LinkedHashMap<>();
@@ -216,7 +216,7 @@ class DefaultInterpolatorTest {
     }
 
     @Test
-    void testXdg() {
+    void xdg() {
         Map<String, String> props;
 
         props = new LinkedHashMap<>();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderResultTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderResultTest.java
@@ -57,7 +57,7 @@ class DefaultModelBuilderResultTest {
     }
 
     @Test
-    void testModelLifecycle() {
+    void modelLifecycle() {
         // Test initial state
         assertNull(result.getSource());
         assertNull(result.getFileModel());
@@ -83,7 +83,7 @@ class DefaultModelBuilderResultTest {
     }
 
     @Test
-    void testProblemCollection() {
+    void problemCollection() {
         ModelProblem problem = mock(ModelProblem.class);
         Mockito.when(problem.getSeverity()).thenReturn(BuilderProblem.Severity.ERROR);
         problemCollector.reportProblem(problem);
@@ -93,7 +93,7 @@ class DefaultModelBuilderResultTest {
     }
 
     @Test
-    void testChildrenManagement() {
+    void childrenManagement() {
         DefaultModelBuilderResult child1 = new DefaultModelBuilderResult(request, problemCollector);
         DefaultModelBuilderResult child2 = new DefaultModelBuilderResult(request, problemCollector);
 
@@ -106,7 +106,7 @@ class DefaultModelBuilderResultTest {
     }
 
     @Test
-    void testRequestAssociation() {
+    void requestAssociation() {
         assertSame(request, result.getRequest());
     }
 }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -56,7 +56,7 @@ class DefaultModelBuilderTest {
     }
 
     @Test
-    public void testPropertiesAndProfiles() {
+    void propertiesAndProfiles() {
         ModelBuilderRequest request = ModelBuilderRequest.builder()
                 .session(session)
                 .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
@@ -68,7 +68,7 @@ class DefaultModelBuilderTest {
     }
 
     @Test
-    public void testMergeRepositories() throws Exception {
+    void mergeRepositories() throws Exception {
         // this is here only to trigger mainSession creation; unrelated
         ModelBuilderRequest request = ModelBuilderRequest.builder()
                 .session(session)

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelInterpolatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelInterpolatorTest.java
@@ -71,15 +71,13 @@ class DefaultModelInterpolatorTest {
     AtomicReference<Path> rootDirectory; // used in TestRootLocator below
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         context = new HashMap<>();
         context.put("basedir", "myBasedir");
         context.put("anotherdir", "anotherBasedir");
         context.put("project.baseUri", "myBaseUri");
 
-        session = ApiRunner.createSession(injector -> {
-            injector.bindInstance(DefaultModelInterpolatorTest.class, this);
-        });
+        session = ApiRunner.createSession(injector -> injector.bindInstance(DefaultModelInterpolatorTest.class, this));
         interpolator = session.getService(Lookup.class).lookup(DefaultModelInterpolator.class);
     }
 
@@ -108,7 +106,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testDefaultBuildTimestampFormatShouldFormatTimeIn24HourFormat() {
+    void defaultBuildTimestampFormatShouldFormatTimeIn24HourFormat() {
         Calendar cal = Calendar.getInstance();
         cal.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
         cal.set(Calendar.HOUR, 12);
@@ -140,7 +138,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testDefaultBuildTimestampFormatWithLocalTimeZoneMidnightRollover() {
+    void defaultBuildTimestampFormatWithLocalTimeZoneMidnightRollover() {
         Calendar cal = Calendar.getInstance();
         cal.setTimeZone(TimeZone.getTimeZone("Europe/Berlin"));
 
@@ -164,7 +162,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldNotThrowExceptionOnReferenceToNonExistentValue() throws Exception {
+    void shouldNotThrowExceptionOnReferenceToNonExistentValue() throws Exception {
         Scm scm = Scm.newBuilder().connection("${test}/somepath").build();
         Model model = Model.newBuilder().scm(scm).build();
 
@@ -177,7 +175,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldThrowExceptionOnRecursiveScmConnectionReference() throws Exception {
+    void shouldThrowExceptionOnRecursiveScmConnectionReference() throws Exception {
         Scm scm = Scm.newBuilder()
                 .connection("${project.scm.connection}/somepath")
                 .build();
@@ -190,7 +188,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldNotThrowExceptionOnReferenceToValueContainingNakedExpression() throws Exception {
+    void shouldNotThrowExceptionOnReferenceToValueContainingNakedExpression() throws Exception {
         Scm scm = Scm.newBuilder().connection("${test}/somepath").build();
         Map<String, String> props = new HashMap<>();
         props.put("test", "test");
@@ -221,7 +219,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void shouldInterpolateDependencyVersionToSetSameAsProjectVersion() throws Exception {
+    void shouldInterpolateDependencyVersionToSetSameAsProjectVersion() throws Exception {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .dependencies(Collections.singletonList(
@@ -237,7 +235,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testShouldNotInterpolateDependencyVersionWithInvalidReference() throws Exception {
+    void shouldNotInterpolateDependencyVersionWithInvalidReference() throws Exception {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .dependencies(Collections.singletonList(
@@ -253,7 +251,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testTwoReferences() throws Exception {
+    void twoReferences() throws Exception {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
@@ -271,7 +269,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testProperty() throws Exception {
+    void property() throws Exception {
         Model model = Model.newBuilder()
                 .version("3.8.1")
                 .artifactId("foo")
@@ -294,7 +292,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testBasedirUnx() throws Exception {
+    void basedirUnx() throws Exception {
         FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
         Path projectBasedir = fs.getPath("projectBasedir");
 
@@ -316,7 +314,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testBasedirWin() throws Exception {
+    void basedirWin() throws Exception {
         FileSystem fs = Jimfs.newFileSystem(Configuration.windows());
         Path projectBasedir = fs.getPath("projectBasedir");
 
@@ -338,7 +336,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testBaseUri() throws Exception {
+    void baseUri() throws Exception {
         Path projectBasedir = Paths.get("projectBasedir");
 
         Model model = Model.newBuilder()
@@ -360,7 +358,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    void testRootDirectory() throws Exception {
+    void rootDirectory() throws Exception {
         Path rootDirectory = Paths.get("myRootDirectory");
 
         Model model = Model.newBuilder()
@@ -380,7 +378,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    void testRootDirectoryWithUri() throws Exception {
+    void rootDirectoryWithUri() throws Exception {
         Path rootDirectory = Paths.get("myRootDirectory");
 
         Model model = Model.newBuilder()
@@ -402,7 +400,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    void testRootDirectoryWithNull() throws Exception {
+    void rootDirectoryWithNull() throws Exception {
         Path projectDirectory = Paths.get("myProjectDirectory");
         this.rootDirectory = new AtomicReference<>(null);
 
@@ -427,7 +425,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testEnvars() throws Exception {
+    void envars() throws Exception {
         context.put("env.HOME", "/path/to/home");
 
         Map<String, String> modelProperties = new HashMap<>();
@@ -444,7 +442,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void envarExpressionThatEvaluatesToNullReturnsTheLiteralString() throws Exception {
+    void envarExpressionThatEvaluatesToNullReturnsTheLiteralString() throws Exception {
 
         Map<String, String> modelProperties = new HashMap<>();
         modelProperties.put("outputDirectory", "${env.DOES_NOT_EXIST}");
@@ -460,7 +458,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void expressionThatEvaluatesToNullReturnsTheLiteralString() throws Exception {
+    void expressionThatEvaluatesToNullReturnsTheLiteralString() throws Exception {
         Map<String, String> modelProperties = new HashMap<>();
         modelProperties.put("outputDirectory", "${DOES_NOT_EXIST}");
 
@@ -475,7 +473,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void shouldInterpolateSourceDirectoryReferencedFromResourceDirectoryCorrectly() throws Exception {
+    void shouldInterpolateSourceDirectoryReferencedFromResourceDirectoryCorrectly() throws Exception {
         Model model = Model.newBuilder()
                 .build(Build.newBuilder()
                         .sourceDirectory("correct")
@@ -497,7 +495,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void shouldInterpolateUnprefixedBasedirExpression() throws Exception {
+    void shouldInterpolateUnprefixedBasedirExpression() throws Exception {
         Path basedir = Paths.get("/test/path");
         Model model = Model.newBuilder()
                 .dependencies(Collections.singletonList(Dependency.newBuilder()
@@ -519,7 +517,7 @@ class DefaultModelInterpolatorTest {
     }
 
     @Test
-    public void testRecursiveExpressionCycleNPE() throws Exception {
+    void recursiveExpressionCycleNPE() throws Exception {
         Map<String, String> props = new HashMap<>();
         props.put("aa", "${bb}");
         props.put("bb", "${aa}");
@@ -537,7 +535,7 @@ class DefaultModelInterpolatorTest {
 
     @Disabled("per def cannot be recursive: ${basedir} is immediately going for project.basedir")
     @Test
-    public void testRecursiveExpressionCycleBaseDir() throws Exception {
+    void recursiveExpressionCycleBaseDir() throws Exception {
         Map<String, String> props = new HashMap<>();
         props.put("basedir", "${basedir}");
         ModelBuilderRequest request = createModelBuildingRequest(Map.of()).build();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -104,7 +104,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingModelVersion() throws Exception {
+    void missingModelVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-modelVersion-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -113,7 +113,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadModelVersion() throws Exception {
+    void badModelVersion() throws Exception {
         SimpleProblemCollector result = validateFile("bad-modelVersion.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -122,7 +122,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testModelVersionMessage() throws Exception {
+    void modelVersionMessage() throws Exception {
         SimpleProblemCollector result = validateFile("modelVersion-4_0.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -131,7 +131,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingArtifactId() throws Exception {
+    void missingArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -140,7 +140,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingGroupId() throws Exception {
+    void missingGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-groupId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -149,7 +149,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidCoordinateIds() throws Exception {
+    void invalidCoordinateIds() throws Exception {
         SimpleProblemCollector result = validate("invalid-coordinate-ids-pom.xml");
 
         assertViolations(result, 0, 2, 0);
@@ -164,7 +164,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingType() throws Exception {
+    void missingType() throws Exception {
         SimpleProblemCollector result = validate("missing-type-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -173,7 +173,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingVersion() throws Exception {
+    void missingVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-version-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -182,7 +182,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidAggregatorPackaging() throws Exception {
+    void invalidAggregatorPackaging() throws Exception {
         SimpleProblemCollector result = validate("invalid-aggregator-packaging-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -191,7 +191,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyArtifactId() throws Exception {
+    void missingDependencyArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -204,7 +204,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyGroupId() throws Exception {
+    void missingDependencyGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-groupId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -217,7 +217,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyVersion() throws Exception {
+    void missingDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-version-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -230,7 +230,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyManagementArtifactId() throws Exception {
+    void missingDependencyManagementArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-mgmt-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -243,7 +243,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyManagementGroupId() throws Exception {
+    void missingDependencyManagementGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-mgmt-groupId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -256,7 +256,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingAll() throws Exception {
+    void missingAll() throws Exception {
         SimpleProblemCollector result = validate("missing-1-pom.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -271,7 +271,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginArtifactId() throws Exception {
+    void missingPluginArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-artifactId-pom.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -282,7 +282,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testEmptyPluginVersion() throws Exception {
+    void emptyPluginVersion() throws Exception {
         SimpleProblemCollector result = validate("empty-plugin-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -294,7 +294,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingRepositoryId() throws Exception {
+    void missingRepositoryId() throws Exception {
         SimpleProblemCollector result =
                 validateFile("missing-repository-id-pom.xml", ModelValidator.VALIDATION_LEVEL_STRICT);
 
@@ -317,7 +317,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingResourceDirectory() throws Exception {
+    void missingResourceDirectory() throws Exception {
         SimpleProblemCollector result = validate("missing-resource-directory-pom.xml");
 
         assertViolations(result, 0, 2, 0);
@@ -332,7 +332,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadPluginDependencyScope() throws Exception {
+    void badPluginDependencyScope() throws Exception {
         SimpleProblemCollector result = validate("bad-plugin-dependency-scope.xml");
 
         assertViolations(result, 0, 3, 0);
@@ -345,7 +345,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyScope() throws Exception {
+    void badDependencyScope() throws Exception {
         SimpleProblemCollector result = validate("bad-dependency-scope.xml");
 
         assertViolations(result, 0, 0, 2);
@@ -356,7 +356,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyManagementScope() throws Exception {
+    void badDependencyManagementScope() throws Exception {
         SimpleProblemCollector result = validate("bad-dependency-management-scope.xml");
 
         assertViolations(result, 0, 0, 1);
@@ -365,7 +365,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyVersion() throws Exception {
+    void badDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-dependency-version.xml");
 
         assertViolations(result, 0, 2, 0);
@@ -379,7 +379,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicateModule() throws Exception {
+    void duplicateModule() throws Exception {
         SimpleProblemCollector result = validateFile("duplicate-module.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -388,7 +388,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidProfileId() throws Exception {
+    void invalidProfileId() throws Exception {
         SimpleProblemCollector result = validateFile("invalid-profile-ids.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -400,7 +400,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicateProfileId() throws Exception {
+    void duplicateProfileId() throws Exception {
         SimpleProblemCollector result = validateFile("duplicate-profile-id.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -409,7 +409,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadPluginVersion() throws Exception {
+    void badPluginVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-plugin-version.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -426,7 +426,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDistributionManagementStatus() throws Exception {
+    void distributionManagementStatus() throws Exception {
         SimpleProblemCollector result = validate("distribution-management-status.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -435,7 +435,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testIncompleteParent() throws Exception {
+    void incompleteParent() throws Exception {
         SimpleProblemCollector result = validateRaw("incomplete-parent.xml");
 
         assertViolations(result, 3, 0, 0);
@@ -445,7 +445,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testHardCodedSystemPath() throws Exception {
+    void hardCodedSystemPath() throws Exception {
         SimpleProblemCollector result = validateFile("hard-coded-system-path.xml");
 
         assertViolations(result, 0, 0, 3);
@@ -462,7 +462,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testEmptyModule() throws Exception {
+    void emptyModule() throws Exception {
         SimpleProblemCollector result = validate("empty-module.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -471,7 +471,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicatePlugin() throws Exception {
+    void duplicatePlugin() throws Exception {
         SimpleProblemCollector result = validateFile("duplicate-plugin.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -483,7 +483,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testDuplicatePluginExecution() throws Exception {
+    void duplicatePluginExecution() throws Exception {
         SimpleProblemCollector result = validateFile("duplicate-plugin-execution.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -495,7 +495,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testReservedRepositoryId() throws Exception {
+    void reservedRepositoryId() throws Exception {
         SimpleProblemCollector result = validate("reserved-repository-id.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -507,7 +507,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginDependencyGroupId() throws Exception {
+    void missingPluginDependencyGroupId() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-dependency-groupId.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -516,7 +516,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginDependencyArtifactId() throws Exception {
+    void missingPluginDependencyArtifactId() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-dependency-artifactId.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -525,7 +525,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingPluginDependencyVersion() throws Exception {
+    void missingPluginDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-plugin-dependency-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -534,7 +534,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadPluginDependencyVersion() throws Exception {
+    void badPluginDependencyVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-plugin-dependency-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -543,7 +543,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadVersion() throws Exception {
+    void badVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -552,7 +552,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadSnapshotVersion() throws Exception {
+    void badSnapshotVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-snapshot-version.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -561,7 +561,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadRepositoryId() throws Exception {
+    void badRepositoryId() throws Exception {
         SimpleProblemCollector result = validate("bad-repository-id.xml");
 
         assertViolations(result, 0, 4, 0);
@@ -580,7 +580,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadDependencyExclusionId() throws Exception {
+    void badDependencyExclusionId() throws Exception {
         SimpleProblemCollector result =
                 validateEffective("bad-dependency-exclusion-id.xml", ModelValidator.VALIDATION_LEVEL_MAVEN_2_0);
 
@@ -601,7 +601,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingDependencyExclusionId() throws Exception {
+    void missingDependencyExclusionId() throws Exception {
         SimpleProblemCollector result = validate("missing-dependency-exclusion-id.xml");
 
         assertViolations(result, 0, 0, 2);
@@ -615,7 +615,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadImportScopeType() throws Exception {
+    void badImportScopeType() throws Exception {
         SimpleProblemCollector result = validateFile("bad-import-scope-type.xml");
 
         assertViolations(result, 0, 0, 1);
@@ -626,7 +626,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testBadImportScopeClassifier() throws Exception {
+    void badImportScopeClassifier() throws Exception {
         SimpleProblemCollector result = validateFile("bad-import-scope-classifier.xml");
 
         assertViolations(result, 0, 1, 0);
@@ -637,7 +637,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testSystemPathRefersToProjectBasedir() throws Exception {
+    void systemPathRefersToProjectBasedir() throws Exception {
         SimpleProblemCollector result = validateFile("basedir-system-path.xml");
 
         assertViolations(result, 0, 0, 4);
@@ -657,7 +657,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidVersionInPluginManagement() throws Exception {
+    void invalidVersionInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/missing-plugin-version-pluginManagement.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -668,7 +668,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidGroupIdInPluginManagement() throws Exception {
+    void invalidGroupIdInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/missing-groupId-pluginManagement.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -679,7 +679,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidArtifactIdInPluginManagement() throws Exception {
+    void invalidArtifactIdInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/missing-artifactId-pluginManagement.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -690,7 +690,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testInvalidGroupAndArtifactIdInPluginManagement() throws Exception {
+    void invalidGroupAndArtifactIdInPluginManagement() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/missing-ga-pluginManagement.xml");
 
         assertViolations(result, 2, 0, 0);
@@ -705,14 +705,14 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testMissingReportPluginVersion() throws Exception {
+    void missingReportPluginVersion() throws Exception {
         SimpleProblemCollector result = validate("missing-report-version-pom.xml");
 
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testDeprecatedDependencyMetaversionsLatestAndRelease() throws Exception {
+    void deprecatedDependencyMetaversionsLatestAndRelease() throws Exception {
         SimpleProblemCollector result = validateFile("deprecated-dependency-metaversions-latest-and-release.xml");
 
         assertViolations(result, 0, 0, 2);
@@ -726,7 +726,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testSelfReferencingDependencyInRawModel() throws Exception {
+    void selfReferencingDependencyInRawModel() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/self-referencing.xml");
 
         assertViolations(result, 1, 0, 0);
@@ -737,38 +737,38 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testSelfReferencingDependencyWithClassifierInRawModel() throws Exception {
+    void selfReferencingDependencyWithClassifierInRawModel() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/self-referencing-classifier.xml");
 
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlySha1() throws Exception {
+    void ciFriendlySha1() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-sha1.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyRevision() throws Exception {
+    void ciFriendlyRevision() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-revision.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyChangeList() throws Exception {
+    void ciFriendlyChangeList() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-changelist.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyAllExpressions() throws Exception {
+    void ciFriendlyAllExpressions() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/ok-ci-friendly-all-expressions.xml");
         assertViolations(result, 0, 0, 0);
     }
 
     @Test
-    void testCiFriendlyBad() throws Exception {
+    void ciFriendlyBad() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/bad-ci-friendly.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -777,7 +777,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testCiFriendlyBadSha1Plus() throws Exception {
+    void ciFriendlyBadSha1Plus() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/bad-ci-friendly-sha1plus.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -786,7 +786,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testCiFriendlyBadSha1Plus2() throws Exception {
+    void ciFriendlyBadSha1Plus2() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/bad-ci-friendly-sha1plus2.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -795,7 +795,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testParentVersionLATEST() throws Exception {
+    void parentVersionLATEST() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/bad-parent-version-latest.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(
@@ -804,7 +804,7 @@ class DefaultModelValidatorTest {
     }
 
     @Test
-    void testParentVersionRELEASE() throws Exception {
+    void parentVersionRELEASE() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/bad-parent-version-release.xml");
         assertViolations(result, 0, 0, 1);
         assertEquals(

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenBuildTimestampTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenBuildTimestampTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MavenBuildTimestampTest {
     @Test
-    void testMavenBuildTimestampUsesUTC() {
+    void mavenBuildTimestampUsesUTC() {
         Map<String, String> interpolationProperties = new HashMap<>();
         interpolationProperties.put("maven.build.timestamp.format", "yyyyMMdd'T'HHmm'Z'");
         MavenBuildTimestamp timestamp = new MavenBuildTimestamp(MonotonicClock.now(), interpolationProperties);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
@@ -33,7 +33,7 @@ class MavenModelMergerTest {
 
     // modelVersion is neither inherited nor injected
     @Test
-    void testMergeModelModelVersion() {
+    void mergeModelModelVersion() {
         Model parent = Model.newBuilder().modelVersion("4.0.0").build();
         Model model = Model.newInstance();
         Model.Builder builder = Model.newBuilder(model);
@@ -48,7 +48,7 @@ class MavenModelMergerTest {
 
     // ArtifactId is neither inherited nor injected
     @Test
-    void testMergeModelArtifactId() {
+    void mergeModelArtifactId() {
         Model parent = Model.newBuilder().artifactId("PARENT").build();
         Model model = Model.newInstance();
         Model.Builder builder = Model.newBuilder(model);
@@ -63,7 +63,7 @@ class MavenModelMergerTest {
 
     // Prerequisites are neither inherited nor injected
     @Test
-    void testMergeModelPrerequisites() {
+    void mergeModelPrerequisites() {
         Model parent =
                 Model.newBuilder().prerequisites(Prerequisites.newInstance()).build();
         Model model = Model.newInstance();
@@ -81,7 +81,7 @@ class MavenModelMergerTest {
 
     // Profiles are neither inherited nor injected
     @Test
-    void testMergeModelProfiles() {
+    void mergeModelProfiles() {
         Model parent = Model.newBuilder()
                 .profiles(Collections.singletonList(Profile.newInstance()))
                 .build();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
@@ -71,31 +71,31 @@ class ConditionParserTest {
     }
 
     @Test
-    void testStringLiterals() {
+    void stringLiterals() {
         assertEquals("Hello, World!", parser.parse("'Hello, World!'"));
         assertEquals("Hello, World!", parser.parse("\"Hello, World!\""));
     }
 
     @Test
-    void testStringConcatenation() {
+    void stringConcatenation() {
         assertEquals("HelloWorld", parser.parse("'Hello' + 'World'"));
         assertEquals("Hello123", parser.parse("'Hello' + 123"));
     }
 
     @Test
-    void testLengthFunction() {
+    void lengthFunction() {
         assertEquals(13, parser.parse("length('Hello, World!')"));
         assertEquals(5, parser.parse("length(\"Hello\")"));
     }
 
     @Test
-    void testCaseConversionFunctions() {
+    void caseConversionFunctions() {
         assertEquals("HELLO", parser.parse("upper('hello')"));
         assertEquals("world", parser.parse("lower('WORLD')"));
     }
 
     @Test
-    void testConcatFunction() {
+    void concatFunction() {
         assertEquals("HelloWorld", parser.parse("'Hello' + 'World'"));
         assertEquals("The answer is 42", parser.parse("'The answer is ' + 42"));
         assertEquals("The answer is 42", parser.parse("'The answer is ' + 42.0"));
@@ -118,49 +118,49 @@ class ConditionParserTest {
     }
 
     @Test
-    void testSubstringFunction() {
+    void substringFunction() {
         assertEquals("World", parser.parse("substring('Hello, World!', 7, 12)"));
         assertEquals("World!", parser.parse("substring('Hello, World!', 7)"));
     }
 
     @Test
-    void testIndexOf() {
+    void indexOf() {
         assertEquals(7, parser.parse("indexOf('Hello, World!', 'World')"));
         assertEquals(-1, parser.parse("indexOf('Hello, World!', 'OpenAI')"));
     }
 
     @Test
-    void testInRange() {
+    void inRange() {
         assertTrue((Boolean) parser.parse("inrange('1.8.0_292', '[1.8,2.0)')"));
         assertFalse((Boolean) parser.parse("inrange('1.7.0', '[1.8,2.0)')"));
     }
 
     @Test
-    void testIfFunction() {
+    void ifFunction() {
         assertEquals("long", parser.parse("if(length('test') > 3, 'long', 'short')"));
         assertEquals("short", parser.parse("if(length('hi') > 3, 'long', 'short')"));
     }
 
     @Test
-    void testContainsFunction() {
+    void containsFunction() {
         assertTrue((Boolean) parser.parse("contains('Hello, World!', 'World')"));
         assertFalse((Boolean) parser.parse("contains('Hello, World!', 'OpenAI')"));
     }
 
     @Test
-    void testMatchesFunction() {
+    void matchesFunction() {
         assertTrue((Boolean) parser.parse("matches('test123', '\\w+')"));
         assertFalse((Boolean) parser.parse("matches('test123', '\\d+')"));
     }
 
     @Test
-    void testComplexExpression() {
+    void complexExpression() {
         String expression = "if(contains(lower('HELLO WORLD'), 'hello'), upper('success') + '!', 'failure')";
         assertEquals("SUCCESS!", parser.parse(expression));
     }
 
     @Test
-    void testStringComparison() {
+    void stringComparison() {
         assertTrue((Boolean) parser.parse("'abc' != 'cdf'"));
         assertFalse((Boolean) parser.parse("'abc' != 'abc'"));
         assertTrue((Boolean) parser.parse("'abc' == 'abc'"));
@@ -168,7 +168,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testParenthesesMismatch() {
+    void parenthesesMismatch() {
         functions.put("property", args -> "foo");
         functions.put("inrange", args -> false);
         assertThrows(
@@ -190,7 +190,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testBasicArithmetic() {
+    void basicArithmetic() {
         assertEquals(5.0, parser.parse("2 + 3"));
         assertEquals(10.0, parser.parse("15 - 5"));
         assertEquals(24.0, parser.parse("6 * 4"));
@@ -198,7 +198,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testArithmeticPrecedence() {
+    void arithmeticPrecedence() {
         assertEquals(14.0, parser.parse("2 + 3 * 4"));
         assertEquals(20.0, parser.parse("(2 + 3) * 4"));
         assertEquals(11.0, parser.parse("15 - 6 + 2"));
@@ -206,7 +206,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testFloatingPointArithmetic() {
+    void floatingPointArithmetic() {
         assertEquals(5.5, parser.parse("2.2 + 3.3"));
         assertEquals(0.1, (Double) parser.parse("3.3 - 3.2"), 1e-10);
         assertEquals(6.25, parser.parse("2.5 * 2.5"));
@@ -214,7 +214,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testArithmeticComparisons() {
+    void arithmeticComparisons() {
         assertTrue((Boolean) parser.parse("5 > 3"));
         assertTrue((Boolean) parser.parse("3 < 5"));
         assertTrue((Boolean) parser.parse("5 >= 5"));
@@ -227,7 +227,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testComplexArithmeticExpressions() {
+    void complexArithmeticExpressions() {
         assertFalse((Boolean) parser.parse("(2 + 3 * 4) > (10 + 5)"));
         assertTrue((Boolean) parser.parse("(2 + 3 * 4) < (10 + 5)"));
         assertTrue((Boolean) parser.parse("(10 / 2 + 3) == 8"));
@@ -235,7 +235,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testArithmeticFunctions() {
+    void arithmeticFunctions() {
         assertEquals(5.0, parser.parse("2 + 3"));
         assertEquals(2.0, parser.parse("5 - 3"));
         assertEquals(15.0, parser.parse("3 * 5"));
@@ -243,19 +243,19 @@ class ConditionParserTest {
     }
 
     @Test
-    void testCombinedArithmeticAndLogic() {
+    void combinedArithmeticAndLogic() {
         assertTrue((Boolean) parser.parse("(5 > 3) && (10 / 2 == 5)"));
         assertFalse((Boolean) parser.parse("(5 < 3) || (10 / 2 != 5)"));
         assertTrue((Boolean) parser.parse("2 + 3 == 1 * 5"));
     }
 
     @Test
-    void testDivisionByZero() {
+    void divisionByZero() {
         assertThrows(ArithmeticException.class, () -> parser.parse("5 / 0"));
     }
 
     @Test
-    void testPropertyAlias() {
+    void propertyAlias() {
         assertTrue((Boolean) parser.parse("${os.name} == 'windows'"));
         assertFalse((Boolean) parser.parse("${os.name} == 'linux'"));
         assertTrue((Boolean) parser.parse("${os.arch} == 'amd64' && ${os.name} == 'windows'"));
@@ -263,7 +263,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testNestedPropertyAlias() {
+    void nestedPropertyAlias() {
         functions.put("property", args -> {
             if (args.get(0).equals("project.rootDirectory")) {
                 return "/home/user/project";
@@ -282,7 +282,7 @@ class ConditionParserTest {
     }
 
     @Test
-    void testToInt() {
+    void toInt() {
         assertEquals(123, ConditionParser.toInt(123));
         assertEquals(123, ConditionParser.toInt(123L));
         assertEquals(123, ConditionParser.toInt(123.0));

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionProfileActivatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionProfileActivatorTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<ConditionProfileActivator> {
+class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<ConditionProfileActivator> {
 
     @TempDir
     Path tempDir;
@@ -75,7 +75,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testNullSafe() throws Exception {
+    void nullSafe() throws Exception {
         Profile p = Profile.newInstance();
 
         assertActivation(false, p, newContext(null, null));
@@ -86,7 +86,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testJdkPrefix() throws Exception {
+    void jdkPrefix() throws Exception {
         Profile profile = newProfile("inrange(${java.version}, '[1.4,1.5)')");
 
         assertActivation(true, profile, newContext(null, newJdkProperties("1.4")));
@@ -100,7 +100,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testJdkPrefixNegated() throws Exception {
+    void jdkPrefixNegated() throws Exception {
         Profile profile = newProfile("not(inrange(${java.version}, '[1.4,1.5)'))");
 
         assertActivation(false, profile, newContext(null, newJdkProperties("1.4")));
@@ -114,7 +114,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testJdkVersionRangeInclusiveBounds() throws Exception {
+    void jdkVersionRangeInclusiveBounds() throws Exception {
         Profile profile = newProfile("inrange(${java.version}, '[1.5,1.6.1]')");
 
         assertActivation(false, profile, newContext(null, newJdkProperties("1.4")));
@@ -135,7 +135,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testJdkVersionRangeExclusiveBounds() throws Exception {
+    void jdkVersionRangeExclusiveBounds() throws Exception {
         Profile profile = newProfile("inrange(${java.version}, '[1.3.1,1.6)')");
 
         assertActivation(false, profile, newContext(null, newJdkProperties("1.3")));
@@ -157,7 +157,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testJdkVersionRangeInclusiveLowerBound() throws Exception {
+    void jdkVersionRangeInclusiveLowerBound() throws Exception {
         Profile profile = newProfile("inrange(${java.version}, '[1.5,)')");
 
         assertActivation(false, profile, newContext(null, newJdkProperties("1.4")));
@@ -178,7 +178,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testJdkVersionRangeExclusiveUpperBound() throws Exception {
+    void jdkVersionRangeExclusiveUpperBound() throws Exception {
         Profile profile = newProfile("inrange(${java.version}, '(,1.6)')");
 
         assertActivation(true, profile, newContext(null, newJdkProperties("1.5")));
@@ -195,7 +195,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
 
     @Disabled
     @Test
-    void testJdkRubbishJavaVersion() {
+    void jdkRubbishJavaVersion() {
         Profile profile = newProfile("inrange(${java.version}, '[1.8,)')");
 
         assertActivationWithProblems(profile, newContext(null, newJdkProperties("Pūteketeke")), "invalid JDK version");
@@ -222,7 +222,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testOsVersionStringComparison() throws Exception {
+    void osVersionStringComparison() throws Exception {
         Profile profile = newProfile("inrange(${os.version}, '[6.5.0-1014-aws,6.6)')");
 
         assertActivation(true, profile, newContext(null, newOsProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -232,7 +232,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testOsVersionRegexMatching() throws Exception {
+    void osVersionRegexMatching() throws Exception {
         Profile profile = newProfile("matches(${os.version}, '.*aws')");
 
         assertActivation(true, profile, newContext(null, newOsProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -242,7 +242,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testOsName() {
+    void osName() {
         Profile profile = newProfile("${os.name} == 'windows'");
 
         assertActivation(false, profile, newContext(null, newOsProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -250,7 +250,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testOsNegatedName() {
+    void osNegatedName() {
         Profile profile = newProfile("${os.name} != 'windows'");
 
         assertActivation(true, profile, newContext(null, newOsProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -258,7 +258,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testOsArch() {
+    void osArch() {
         Profile profile = newProfile("${os.arch} == 'amd64'");
 
         assertActivation(true, profile, newContext(null, newOsProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -266,7 +266,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testOsNegatedArch() {
+    void osNegatedArch() {
         Profile profile = newProfile("${os.arch} != 'amd64'");
 
         assertActivation(false, profile, newContext(null, newOsProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -274,7 +274,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testOsAllConditions() {
+    void osAllConditions() {
         Profile profile =
                 newProfile("${os.name} == 'windows' && ${os.arch} != 'amd64' && inrange(${os.version}, '[99,)')");
 
@@ -285,7 +285,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    public void testOsCapitalName() {
+    void osCapitalName() {
         Profile profile = newProfile("lower(${os.name}) == 'mac os x'");
 
         assertActivation(false, profile, newContext(null, newOsProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -299,7 +299,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithNameOnlyUserProperty() throws Exception {
+    void propWithNameOnlyUserProperty() throws Exception {
         Profile profile = newProfile("${prop}");
 
         assertActivation(true, profile, newContext(newPropProperties("prop", "value"), null));
@@ -308,7 +308,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithNameOnlySystemProperty() throws Exception {
+    void propWithNameOnlySystemProperty() throws Exception {
         Profile profile = newProfile("${prop}");
 
         assertActivation(true, profile, newContext(null, newPropProperties("prop", "value")));
@@ -317,7 +317,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithNegatedNameOnlyUserProperty() throws Exception {
+    void propWithNegatedNameOnlyUserProperty() throws Exception {
         Profile profile = newProfile("not(${prop})");
 
         assertActivation(false, profile, newContext(newPropProperties("prop", "value"), null));
@@ -326,7 +326,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithNegatedNameOnlySystemProperty() throws Exception {
+    void propWithNegatedNameOnlySystemProperty() throws Exception {
         Profile profile = newProfile("not(${prop})");
 
         assertActivation(false, profile, newContext(null, newPropProperties("prop", "value")));
@@ -335,7 +335,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithValueUserProperty() throws Exception {
+    void propWithValueUserProperty() throws Exception {
         Profile profile = newProfile("${prop} == 'value'");
 
         assertActivation(true, profile, newContext(newPropProperties("prop", "value"), null));
@@ -344,7 +344,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithValueSystemProperty() throws Exception {
+    void propWithValueSystemProperty() throws Exception {
         Profile profile = newProfile("${prop} == 'value'");
 
         assertActivation(true, profile, newContext(null, newPropProperties("prop", "value")));
@@ -353,7 +353,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithNegatedValueUserProperty() throws Exception {
+    void propWithNegatedValueUserProperty() throws Exception {
         Profile profile = newProfile("${prop} != 'value'");
 
         assertActivation(false, profile, newContext(newPropProperties("prop", "value"), null));
@@ -362,7 +362,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithNegatedValueSystemProperty() throws Exception {
+    void propWithNegatedValueSystemProperty() throws Exception {
         Profile profile = newProfile("${prop} != 'value'");
 
         assertActivation(false, profile, newContext(null, newPropProperties("prop", "value")));
@@ -371,7 +371,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testPropWithValueUserPropertyDominantOverSystemProperty() throws Exception {
+    void propWithValueUserPropertyDominantOverSystemProperty() throws Exception {
         Profile profile = newProfile("${prop} == 'value'");
 
         Map<String, String> props1 = newPropProperties("prop", "value");
@@ -383,7 +383,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
 
     @Test
     @Disabled
-    void testFileRootDirectoryWithNull() {
+    void fileRootDirectoryWithNull() {
         IllegalStateException e = assertThrows(
                 IllegalStateException.class,
                 () -> assertActivation(false, newProfile("exists('${project.rootDirectory}')"), newFileContext(null)));
@@ -391,7 +391,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testFileRootDirectory() {
+    void fileRootDirectory() {
         assertActivation(false, newProfile("exists('${project.rootDirectory}/someFile.txt')"), newFileContext());
         assertActivation(true, newProfile("missing('${project.rootDirectory}/someFile.txt')"), newFileContext());
         assertActivation(true, newProfile("exists('${project.rootDirectory}')"), newFileContext());
@@ -402,7 +402,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
 
     @Test
     @Disabled
-    void testFileWilcards() {
+    void fileWilcards() {
         assertActivation(true, newProfile("exists('${project.rootDirectory}/**/*.xsd')"), newFileContext());
         assertActivation(true, newProfile("exists('${project.basedir}/**/*.xsd')"), newFileContext());
         assertActivation(true, newProfile("exists('${project.basedir}/**/*.xsd')"), newFileContext());
@@ -411,7 +411,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testFileIsActiveNoFileWithShortBasedir() {
+    void fileIsActiveNoFileWithShortBasedir() {
         assertActivation(false, newExistsProfile(null), newFileContext());
         assertActivation(false, newProfile("exists('someFile.txt')"), newFileContext());
         assertActivation(false, newProfile("exists('${basedir}/someFile.txt')"), newFileContext());
@@ -422,7 +422,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testFileIsActiveNoFile() {
+    void fileIsActiveNoFile() {
         assertActivation(false, newExistsProfile(null), newFileContext());
         assertActivation(false, newProfile("exists('someFile.txt')"), newFileContext());
         assertActivation(false, newProfile("exists('${project.basedir}/someFile.txt')"), newFileContext());
@@ -433,7 +433,7 @@ public class ConditionProfileActivatorTest extends AbstractProfileActivatorTest<
     }
 
     @Test
-    void testFileIsActiveExistsFileExists() {
+    void fileIsActiveExistsFileExists() {
         assertActivation(true, newProfile("exists('file.txt')"), newFileContext());
         assertActivation(true, newProfile("exists('${project.basedir}')"), newFileContext());
         assertActivation(true, newProfile("exists('${project.basedir}/file.txt')"), newFileContext());

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/FileProfileActivatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/FileProfileActivatorTest.java
@@ -60,7 +60,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testRootDirectoryWithNull() {
+    void rootDirectoryWithNull() {
         context.setModel(Model.newInstance());
 
         NullPointerException e = assertThrows(
@@ -70,7 +70,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testRootDirectory() {
+    void rootDirectory() {
         assertActivation(false, newExistsProfile("${project.rootDirectory}/someFile.txt"), context);
         assertActivation(true, newMissingProfile("${project.rootDirectory}/someFile.txt"), context);
         assertActivation(true, newExistsProfile("${project.rootDirectory}"), context);
@@ -80,7 +80,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveNoFileWithShortBasedir() {
+    void isActiveNoFileWithShortBasedir() {
         assertActivation(false, newExistsProfile(null), context);
         assertActivation(false, newExistsProfile("someFile.txt"), context);
         assertActivation(false, newExistsProfile("${basedir}/someFile.txt"), context);
@@ -91,7 +91,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveNoFile() {
+    void isActiveNoFile() {
         assertActivation(false, newExistsProfile(null), context);
         assertActivation(false, newExistsProfile("someFile.txt"), context);
         assertActivation(false, newExistsProfile("${project.basedir}/someFile.txt"), context);
@@ -102,7 +102,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveExistsFileExists() {
+    void isActiveExistsFileExists() {
         assertActivation(true, newExistsProfile("file.txt"), context);
         assertActivation(true, newExistsProfile("${project.basedir}"), context);
         assertActivation(true, newExistsProfile("${project.basedir}/" + "file.txt"), context);
@@ -113,7 +113,7 @@ class FileProfileActivatorTest extends AbstractProfileActivatorTest<FileProfileA
     }
 
     @Test
-    void testIsActiveExistsLeavesFileUnchanged() {
+    void isActiveExistsLeavesFileUnchanged() {
         Profile profile = newExistsProfile("file.txt");
         assertEquals("file.txt", profile.getActivation().getFile().getExists());
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/JdkVersionProfileActivatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/JdkVersionProfileActivatorTest.java
@@ -55,7 +55,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testNullSafe() throws Exception {
+    void nullSafe() throws Exception {
         Profile p = Profile.newInstance();
 
         assertActivation(false, p, newContext(null, null));
@@ -66,7 +66,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testPrefix() throws Exception {
+    void prefix() throws Exception {
         Profile profile = newProfile("1.4");
 
         assertActivation(true, profile, newContext(null, newProperties("1.4")));
@@ -80,7 +80,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testPrefixNegated() throws Exception {
+    void prefixNegated() throws Exception {
         Profile profile = newProfile("!1.4");
 
         assertActivation(false, profile, newContext(null, newProperties("1.4")));
@@ -94,7 +94,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeInclusiveBounds() throws Exception {
+    void versionRangeInclusiveBounds() throws Exception {
         Profile profile = newProfile("[1.5,1.6]");
 
         assertActivation(false, profile, newContext(null, newProperties("1.4")));
@@ -115,7 +115,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeExclusiveBounds() throws Exception {
+    void versionRangeExclusiveBounds() throws Exception {
         Profile profile = newProfile("(1.3,1.6)");
 
         assertActivation(false, profile, newContext(null, newProperties("1.3")));
@@ -137,7 +137,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeInclusiveLowerBound() throws Exception {
+    void versionRangeInclusiveLowerBound() throws Exception {
         Profile profile = newProfile("[1.5,)");
 
         assertActivation(false, profile, newContext(null, newProperties("1.4")));
@@ -158,7 +158,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testVersionRangeExclusiveUpperBound() throws Exception {
+    void versionRangeExclusiveUpperBound() throws Exception {
         Profile profile = newProfile("(,1.6)");
 
         assertActivation(true, profile, newContext(null, newProperties("1.5")));
@@ -174,7 +174,7 @@ class JdkVersionProfileActivatorTest extends AbstractProfileActivatorTest<JdkVer
     }
 
     @Test
-    void testRubbishJavaVersion() {
+    void rubbishJavaVersion() {
         Profile profile = newProfile("[1.8,)");
 
         assertActivationWithProblems(profile, newContext(null, newProperties("Pūteketeke")), "invalid JDK version");

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/OperatingSystemProfileActivatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/OperatingSystemProfileActivatorTest.java
@@ -51,7 +51,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testVersionStringComparison() throws Exception {
+    void versionStringComparison() throws Exception {
         Profile profile = newProfile(ActivationOS.newBuilder().version("6.5.0-1014-aws"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -61,7 +61,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testVersionRegexMatching() throws Exception {
+    void versionRegexMatching() throws Exception {
         Profile profile = newProfile(ActivationOS.newBuilder().version("regex:.*aws"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -71,7 +71,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testName() {
+    void name() {
         Profile profile = newProfile(ActivationOS.newBuilder().name("windows"));
 
         assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -79,7 +79,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testNegatedName() {
+    void negatedName() {
         Profile profile = newProfile(ActivationOS.newBuilder().name("!windows"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -87,7 +87,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testArch() {
+    void arch() {
         Profile profile = newProfile(ActivationOS.newBuilder().arch("amd64"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -95,7 +95,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testNegatedArch() {
+    void negatedArch() {
         Profile profile = newProfile(ActivationOS.newBuilder().arch("!amd64"));
 
         assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -103,7 +103,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testFamily() {
+    void family() {
         Profile profile = newProfile(ActivationOS.newBuilder().family("windows"));
 
         assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -111,7 +111,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testNegatedFamily() {
+    void negatedFamily() {
         Profile profile = newProfile(ActivationOS.newBuilder().family("!windows"));
 
         assertActivation(true, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
@@ -119,7 +119,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testAllOsConditions() {
+    void allOsConditions() {
         Profile profile = newProfile(ActivationOS.newBuilder()
                 .family("windows")
                 .name("windows")
@@ -133,7 +133,7 @@ class OperatingSystemProfileActivatorTest extends AbstractProfileActivatorTest<O
     }
 
     @Test
-    void testCapitalOsName() {
+    void capitalOsName() {
         Profile profile = newProfile(ActivationOS.newBuilder()
                 .family("Mac")
                 .name("Mac OS X")

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/PropertyProfileActivatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/PropertyProfileActivatorTest.java
@@ -54,7 +54,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testNullSafe() throws Exception {
+    void nullSafe() throws Exception {
         Profile p = Profile.newInstance();
 
         assertActivation(false, p, newContext(null, null));
@@ -65,7 +65,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNameOnlyUserProperty() throws Exception {
+    void withNameOnlyUserProperty() throws Exception {
         Profile profile = newProfile("prop", null);
 
         assertActivation(true, profile, newContext(newProperties("prop", "value"), null));
@@ -76,7 +76,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNameOnlySystemProperty() throws Exception {
+    void withNameOnlySystemProperty() throws Exception {
         Profile profile = newProfile("prop", null);
 
         assertActivation(true, profile, newContext(null, newProperties("prop", "value")));
@@ -87,7 +87,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedNameOnlyUserProperty() throws Exception {
+    void withNegatedNameOnlyUserProperty() throws Exception {
         Profile profile = newProfile("!prop", null);
 
         assertActivation(false, profile, newContext(newProperties("prop", "value"), null));
@@ -98,7 +98,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedNameOnlySystemProperty() throws Exception {
+    void withNegatedNameOnlySystemProperty() throws Exception {
         Profile profile = newProfile("!prop", null);
 
         assertActivation(false, profile, newContext(null, newProperties("prop", "value")));
@@ -109,7 +109,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithValueUserProperty() throws Exception {
+    void withValueUserProperty() throws Exception {
         Profile profile = newProfile("prop", "value");
 
         assertActivation(true, profile, newContext(newProperties("prop", "value"), null));
@@ -120,7 +120,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithValueSystemProperty() throws Exception {
+    void withValueSystemProperty() throws Exception {
         Profile profile = newProfile("prop", "value");
 
         assertActivation(true, profile, newContext(null, newProperties("prop", "value")));
@@ -131,7 +131,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedValueUserProperty() throws Exception {
+    void withNegatedValueUserProperty() throws Exception {
         Profile profile = newProfile("prop", "!value");
 
         assertActivation(false, profile, newContext(newProperties("prop", "value"), null));
@@ -142,7 +142,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithNegatedValueSystemProperty() throws Exception {
+    void withNegatedValueSystemProperty() throws Exception {
         Profile profile = newProfile("prop", "!value");
 
         assertActivation(false, profile, newContext(null, newProperties("prop", "value")));
@@ -153,7 +153,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     }
 
     @Test
-    void testWithValueUserPropertyDominantOverSystemProperty() throws Exception {
+    void withValueUserPropertyDominantOverSystemProperty() throws Exception {
         Profile profile = newProfile("prop", "value");
 
         Map<String, String> props1 = newProperties("prop", "value");

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractorTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * ReflectionValueExtractorTest class.
  */
-public class ReflectionValueExtractorTest {
+class ReflectionValueExtractorTest {
     private Project project;
 
     /**
@@ -86,7 +86,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    void testValueExtraction() throws Exception {
+    void valueExtraction() throws Exception {
         // ----------------------------------------------------------------------
         // Top level values
         // ----------------------------------------------------------------------
@@ -171,7 +171,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testValueExtractorWithAInvalidExpression() throws Exception {
+    void valueExtractorWithAInvalidExpression() throws Exception {
         assertNull(ReflectionValueExtractor.evaluate("project.foo", project));
         assertNull(ReflectionValueExtractor.evaluate("project.dependencies[10]", project));
         assertNull(ReflectionValueExtractor.evaluate("project.dependencies[0].foo", project));
@@ -183,7 +183,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testMappedDottedKey() throws Exception {
+    void mappedDottedKey() throws Exception {
         Map<String, String> map = new HashMap<String, String>();
         map.put("a.b", "a.b-value");
 
@@ -196,7 +196,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIndexedMapped() throws Exception {
+    void indexedMapped() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("a", "a-value");
         List<Object> list = new ArrayList<Object>();
@@ -211,7 +211,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testMappedIndexed() throws Exception {
+    void mappedIndexed() throws Exception {
         List<Object> list = new ArrayList<Object>();
         list.add("a-value");
         Map<Object, Object> map = new HashMap<Object, Object>();
@@ -225,7 +225,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testMappedMissingDot() throws Exception {
+    void mappedMissingDot() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("a", new ValueHolder("a-value"));
         assertNull(ReflectionValueExtractor.evaluate("h.value(a)value", new ValueHolder(map)));
@@ -237,7 +237,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIndexedMissingDot() throws Exception {
+    void indexedMissingDot() throws Exception {
         List<Object> list = new ArrayList<Object>();
         list.add(new ValueHolder("a-value"));
         assertNull(ReflectionValueExtractor.evaluate("h.value[0]value", new ValueHolder(list)));
@@ -249,7 +249,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testDotDot() throws Exception {
+    void dotDot() throws Exception {
         assertNull(ReflectionValueExtractor.evaluate("h..value", new ValueHolder("value")));
     }
 
@@ -259,7 +259,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testBadIndexedSyntax() throws Exception {
+    void badIndexedSyntax() throws Exception {
         List<Object> list = new ArrayList<Object>();
         list.add("a-value");
         Object value = new ValueHolder(list);
@@ -278,7 +278,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testBadMappedSyntax() throws Exception {
+    void badMappedSyntax() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("a", "a-value");
         Object value = new ValueHolder(map);
@@ -295,7 +295,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIllegalIndexedType() throws Exception {
+    void illegalIndexedType() throws Exception {
         try {
             ReflectionValueExtractor.evaluate("h.value[1]", new ValueHolder("string"));
         } catch (Exception e) {
@@ -309,7 +309,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testIllegalMappedType() throws Exception {
+    void illegalMappedType() throws Exception {
         try {
             ReflectionValueExtractor.evaluate("h.value(key)", new ValueHolder("string"));
         } catch (Exception e) {
@@ -323,7 +323,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testTrimRootToken() throws Exception {
+    void trimRootToken() throws Exception {
         assertNull(ReflectionValueExtractor.evaluate("project", project, true));
     }
 
@@ -333,7 +333,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testArtifactMap() throws Exception {
+    void artifactMap() throws Exception {
         assertEquals(
                 "g0",
                 ((Artifact) ReflectionValueExtractor.evaluate("project.artifactMap(g0:a0:c0)", project)).getGroupId());
@@ -358,7 +358,7 @@ public class ReflectionValueExtractorTest {
 
         private String classifier;
 
-        public Artifact(String groupId, String artifactId, String version, String extension, String classifier) {
+        Artifact(String groupId, String artifactId, String version, String extension, String classifier) {
             this.groupId = groupId;
             this.artifactId = artifactId;
             this.version = version;
@@ -550,7 +550,7 @@ public class ReflectionValueExtractorTest {
     public static class ValueHolder {
         private final Object value;
 
-        public ValueHolder(Object value) {
+        ValueHolder(Object value) {
             this.value = value;
         }
 
@@ -565,7 +565,7 @@ public class ReflectionValueExtractorTest {
      * @throws Exception if any.
      */
     @Test
-    public void testRootPropertyRegression() throws Exception {
+    void rootPropertyRegression() throws Exception {
         Project project = new Project();
         project.setDescription("c:\\\\org\\apache\\test");
         Object evalued = ReflectionValueExtractor.evaluate("description", project);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/resolver/DefaultModelResolverTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/resolver/DefaultModelResolverTest.java
@@ -58,17 +58,14 @@ class DefaultModelResolverTest {
         Path localRepoPath = basedir.resolve("target/local-repo");
         Path remoteRepoPath = basedir.resolve("src/test/remote-repo");
         Session s = ApiRunner.createSession(
-                injector -> {
-                    injector.bindInstance(DefaultModelResolverTest.class, this);
-                },
-                localRepoPath);
+                injector -> injector.bindInstance(DefaultModelResolverTest.class, this), localRepoPath);
         RemoteRepository remoteRepository = s.createRemoteRepository(
                 RemoteRepository.CENTRAL_ID, remoteRepoPath.toUri().toString());
         session = s.withRemoteRepositories(List.of(remoteRepository));
     }
 
     @Test
-    void testResolveParentThrowsModelResolverExceptionWhenNotFound() throws Exception {
+    void resolveParentThrowsModelResolverExceptionWhenNotFound() throws Exception {
         final Parent parent = Parent.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -84,7 +81,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveParentThrowsModelResolverExceptionWhenNoMatchingVersionFound() throws Exception {
+    void resolveParentThrowsModelResolverExceptionWhenNoMatchingVersionFound() throws Exception {
         final Parent parent = Parent.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -99,7 +96,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveParentThrowsModelResolverExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
+    void resolveParentThrowsModelResolverExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
         final Parent parent = Parent.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -114,7 +111,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception {
+    void resolveParentSuccessfullyResolvesExistingParentWithoutRange() throws Exception {
         final Parent parent = Parent.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -126,7 +123,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception {
+    void resolveParentSuccessfullyResolvesExistingParentUsingHighestVersion() throws Exception {
         final Parent parent = Parent.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -139,7 +136,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveDependencyThrowsModelResolverExceptionWhenNotFound() throws Exception {
+    void resolveDependencyThrowsModelResolverExceptionWhenNotFound() throws Exception {
         final Dependency dependency = Dependency.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -155,7 +152,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveDependencyThrowsModelResolverExceptionWhenNoMatchingVersionFound() throws Exception {
+    void resolveDependencyThrowsModelResolverExceptionWhenNoMatchingVersionFound() throws Exception {
         final Dependency dependency = Dependency.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -170,7 +167,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveDependencyThrowsModelResolverExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
+    void resolveDependencyThrowsModelResolverExceptionWhenUsingRangesWithoutUpperBound() throws Exception {
         final Dependency dependency = Dependency.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -185,7 +182,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception {
+    void resolveDependencySuccessfullyResolvesExistingDependencyWithoutRange() throws Exception {
         final Dependency dependency = Dependency.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")
@@ -197,7 +194,7 @@ class DefaultModelResolverTest {
     }
 
     @Test
-    void testResolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception {
+    void resolveDependencySuccessfullyResolvesExistingDependencyUsingHighestVersion() throws Exception {
         final Dependency dependency = Dependency.newBuilder()
                 .groupId("org.apache")
                 .artifactId("apache")

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/DiTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/DiTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class DiTest {
 
     @Test
-    void testGenerics() {
+    void generics() {
         Set<Type> types = Types.getAllSuperTypes(ExtensibleEnumRegistries.DefaultPathScopeRegistry.class);
         assertNotNull(types);
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/RequestTraceTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/RequestTraceTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RequestTraceTest {
 
     @Test
-    void testTraces() {
+    void traces() {
         Session session = ApiRunner.createSession(injector -> {
             injector.bindInstance(RequestTraceTest.class, this);
         });

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/TestApiStandalone.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/TestApiStandalone.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TestApiStandalone {
 
     @Test
-    void testStandalone() {
+    void standalone() {
         Session session = ApiRunner.createSession(injector -> {
             injector.bindInstance(TestApiStandalone.class, this);
         });

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/util/PhasingExecutorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/util/PhasingExecutorTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class PhasingExecutorTest {
 
     @Test
-    void testPhaser() {
+    void phaser() {
         try (PhasingExecutor p = new PhasingExecutor(Executors.newFixedThreadPool(4))) {
             p.execute(() -> waitSomeTime(p, 2));
         }

--- a/impl/maven-support/src/test/java/org/apache/maven/model/v4/MavenStaxReaderTest.java
+++ b/impl/maven-support/src/test/java/org/apache/maven/model/v4/MavenStaxReaderTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MavenStaxReaderTest {
 
     @Test
-    void testNamespaceReporting() throws Exception {
+    void namespaceReporting() throws Exception {
         String xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
                 + "  <modelVersion>4.0.0</modelVersion>\n"
                 + "</project>";
@@ -43,7 +43,7 @@ class MavenStaxReaderTest {
     }
 
     @Test
-    void testEmptyNamespaceReporting() throws Exception {
+    void emptyNamespaceReporting() throws Exception {
         String xml = "<project>\n" + "  <modelVersion>4.0.0</modelVersion>\n" + "</project>";
 
         Model model = fromXml(xml);
@@ -51,7 +51,7 @@ class MavenStaxReaderTest {
     }
 
     @Test
-    void testNamespaceConsistency() throws XMLStreamException {
+    void namespaceConsistency() throws XMLStreamException {
         String xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
                 + "  <build xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
                 + "    <plugins>\n"
@@ -67,7 +67,7 @@ class MavenStaxReaderTest {
     }
 
     @Test
-    void testNamespaceInconsistencyThrows() {
+    void namespaceInconsistencyThrows() {
         String xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
                 + "  <build xmlns=\"http://maven.apache.org/POM/4.1.0\">\n"
                 + "    <plugins>\n"
@@ -85,7 +85,7 @@ class MavenStaxReaderTest {
     }
 
     @Test
-    void testEmptyNamespaceConsistency() throws XMLStreamException {
+    void emptyNamespaceConsistency() throws XMLStreamException {
         String xml = "<project>\n"
                 + "  <build>\n"
                 + "    <plugins>\n"
@@ -101,7 +101,7 @@ class MavenStaxReaderTest {
     }
 
     @Test
-    void testEmptyNamespaceInconsistencyThrows() {
+    void emptyNamespaceInconsistencyThrows() {
         String xml = "<project>\n"
                 + "  <build xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
                 + "    <plugins>\n"
@@ -119,7 +119,7 @@ class MavenStaxReaderTest {
     }
 
     @Test
-    void testPluginConfigurationAllowsOtherNamespaces() throws XMLStreamException {
+    void pluginConfigurationAllowsOtherNamespaces() throws XMLStreamException {
         String xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
                 + "  <build>\n"
                 + "    <plugins>\n"

--- a/impl/maven-testing/src/test/java/org/apache/maven/api/di/testing/SimpleDITest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/api/di/testing/SimpleDITest.java
@@ -30,7 +30,7 @@ import static org.apache.maven.api.di.testing.MavenDIExtension.getBasedir;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @MavenDITest
-public class SimpleDITest {
+class SimpleDITest {
 
     private static final String LOCAL_REPO = getBasedir() + File.separator + "target" + File.separator + "local-repo";
 
@@ -38,7 +38,7 @@ public class SimpleDITest {
     Session session;
 
     @Test
-    void testSession() {
+    void session() {
         assertNotNull(session);
         assertNotNull(session.getLocalRepository());
     }

--- a/impl/maven-testing/src/test/java/org/apache/maven/api/plugin/testing/ExpressionEvaluatorTest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/api/plugin/testing/ExpressionEvaluatorTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.doReturn;
  * @author Edwin Punzalan
  */
 @MojoTest
-public class ExpressionEvaluatorTest {
+class ExpressionEvaluatorTest {
 
     private static final String LOCAL_REPO = "target/local-repo/";
     private static final String GROUP_ID = "test";
@@ -65,7 +65,7 @@ public class ExpressionEvaluatorTest {
 
     @Test
     @InjectMojo(goal = COORDINATES, pom = CONFIG)
-    public void testInjection(ExpressionEvaluatorMojo mojo) {
+    void injection(ExpressionEvaluatorMojo mojo) {
         assertNotNull(mojo.basedir);
         assertNotNull(mojo.workdir);
         assertDoesNotThrow(mojo::execute);
@@ -75,7 +75,7 @@ public class ExpressionEvaluatorTest {
     @InjectMojo(goal = COORDINATES, pom = CONFIG)
     @Basedir("${basedir}/target/test-classes")
     @MojoParameter(name = "param", value = "paramValue")
-    public void testParam(ExpressionEvaluatorMojo mojo) {
+    void param(ExpressionEvaluatorMojo mojo) {
         assertNotNull(mojo.basedir);
         assertNotNull(mojo.workdir);
         assertEquals("paramValue", mojo.param);
@@ -86,7 +86,7 @@ public class ExpressionEvaluatorTest {
     @InjectMojo(goal = COORDINATES, pom = CONFIG)
     @MojoParameter(name = "param", value = "paramValue")
     @MojoParameter(name = "param2", value = "param2Value")
-    public void testParams(ExpressionEvaluatorMojo mojo) {
+    void params(ExpressionEvaluatorMojo mojo) {
         assertNotNull(mojo.basedir);
         assertNotNull(mojo.workdir);
         assertEquals("paramValue", mojo.param);

--- a/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlNodeBuilderTest.java
+++ b/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlNodeBuilderTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class XmlNodeBuilderTest {
 
     @Test
-    void testReadMultiDoc() throws Exception {
+    void readMultiDoc() throws Exception {
         String doc = "<?xml version='1.0'?><doc><child>foo</child></doc>";
         StringReader r = new StringReader(doc + doc) {
             @Override
@@ -47,7 +47,7 @@ class XmlNodeBuilderTest {
     }
 
     @Test
-    void testWithNamespace() throws Exception {
+    void withNamespace() throws Exception {
         String doc = "<?xml version='1.0'?><doc xmlns='foo:bar'/>";
         StringReader r = new StringReader(doc);
         XMLStreamReader xsr = XMLInputFactory.newFactory().createXMLStreamReader(r);

--- a/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlNodeImplTest.java
+++ b/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlNodeImplTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class XmlNodeImplTest {
 
     @Test
-    void testCombineChildrenAppend() throws Exception {
+    void combineChildrenAppend() throws Exception {
         String lhs = "<configuration>\n"
                 + "    <plugins>\n"
                 + "        <plugin>\n"
@@ -152,7 +152,7 @@ class XmlNodeImplTest {
     }
 
     @Test
-    void testAppend() throws Exception {
+    void append() throws Exception {
         String lhs =
                 """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -194,7 +194,7 @@ class XmlNodeImplTest {
      * @throws java.lang.Exception if any.
      */
     @Test
-    void testCombineId() throws Exception {
+    void combineId() throws Exception {
         String lhs = "<props>" + "<property combine.id='LHS-ONLY'><name>LHS-ONLY</name><value>LHS</value></property>"
                 + "<property combine.id='TOOVERWRITE'><name>TOOVERWRITE</name><value>LHS</value></property>"
                 + "</props>";
@@ -240,7 +240,7 @@ class XmlNodeImplTest {
      * @throws java.lang.Exception if any.
      */
     @Test
-    void testCombineKeys() throws Exception {
+    void combineKeys() throws Exception {
         String lhs = "<props combine.keys='key'>"
                 + "<property key=\"LHS-ONLY\"><name>LHS-ONLY</name><value>LHS</value></property>"
                 + "<property combine.keys='name'><name>TOOVERWRITE</name><value>LHS</value></property>" + "</props>";
@@ -281,7 +281,7 @@ class XmlNodeImplTest {
     }
 
     @Test
-    void testPreserveDominantBlankValue() throws XMLStreamException, IOException {
+    void preserveDominantBlankValue() throws XMLStreamException, IOException {
         String lhs = "<parameter xml:space=\"preserve\"> </parameter>";
 
         String rhs = "<parameter>recessive</parameter>";
@@ -294,7 +294,7 @@ class XmlNodeImplTest {
     }
 
     @Test
-    void testPreserveDominantEmptyNode() throws XMLStreamException, IOException {
+    void preserveDominantEmptyNode() throws XMLStreamException, IOException {
         String lhs = "<parameter></parameter>";
 
         String rhs = "<parameter>recessive</parameter>";
@@ -307,7 +307,7 @@ class XmlNodeImplTest {
     }
 
     @Test
-    void testPreserveDominantEmptyNode2() throws XMLStreamException, IOException {
+    void preserveDominantEmptyNode2() throws XMLStreamException, IOException {
         String lhs = "<parameter/>";
 
         String rhs = "<parameter>recessive</parameter>";
@@ -323,7 +323,7 @@ class XmlNodeImplTest {
      * <p>testShouldPerformAppendAtFirstSubElementLevel.</p>
      */
     @Test
-    void testShouldPerformAppendAtFirstSubElementLevel() throws XMLStreamException {
+    void shouldPerformAppendAtFirstSubElementLevel() throws XMLStreamException {
         String lhs =
                 """
                 <top combine.children="append">
@@ -359,7 +359,7 @@ class XmlNodeImplTest {
      * <p>testShouldOverrideAppendAndDeepMerge.</p>
      */
     @Test
-    void testShouldOverrideAppendAndDeepMerge() {
+    void shouldOverrideAppendAndDeepMerge() {
         // create the dominant DOM
         Xpp3Dom t1 = new Xpp3Dom("top");
         t1.setAttribute(Xpp3Dom.CHILDREN_COMBINATION_MODE_ATTRIBUTE, Xpp3Dom.CHILDREN_COMBINATION_APPEND);
@@ -395,7 +395,7 @@ class XmlNodeImplTest {
      * <p>testShouldPerformSelfOverrideAtTopLevel.</p>
      */
     @Test
-    void testShouldPerformSelfOverrideAtTopLevel() {
+    void shouldPerformSelfOverrideAtTopLevel() {
         // create the dominant DOM
         Xpp3Dom t1 = new Xpp3Dom("top");
         t1.setAttribute("attr", "value");
@@ -421,7 +421,7 @@ class XmlNodeImplTest {
      * <p>testShouldMergeValuesAtTopLevelByDefault.</p>
      */
     @Test
-    void testShouldNotMergeValuesAtTopLevelByDefault() {
+    void shouldNotMergeValuesAtTopLevelByDefault() {
         // create the dominant DOM
         Xpp3Dom t1 = new Xpp3Dom("top");
         t1.setAttribute("attr", "value");
@@ -447,7 +447,7 @@ class XmlNodeImplTest {
      * <p>testShouldMergeValuesAtTopLevel.</p>
      */
     @Test
-    void testShouldNotMergeValuesAtTopLevel() {
+    void shouldNotMergeValuesAtTopLevel() {
         // create the dominant DOM
         Xpp3Dom t1 = new Xpp3Dom("top");
         t1.setAttribute("attr", "value");
@@ -470,11 +470,11 @@ class XmlNodeImplTest {
      * <p>testEquals.</p>
      */
     @Test
-    void testEquals() {
+    void equals() {
         XmlNode dom = XmlNode.newInstance("top");
 
         assertEquals(dom, dom);
-        assertNotEquals(dom, null);
+        assertNotEquals(null, dom);
         assertNotEquals(dom, XmlNode.newInstance(""));
     }
 
@@ -482,7 +482,7 @@ class XmlNodeImplTest {
      * <p>testEqualsIsNullSafe.</p>
      */
     @Test
-    void testEqualsIsNullSafe() throws XMLStreamException, IOException {
+    void equalsIsNullSafe() throws XMLStreamException, IOException {
         String testDom = "<configuration><items thing='blah'><item>one</item><item>two</item></items></configuration>";
         XmlNode dom = toXmlNode(testDom);
 
@@ -501,7 +501,7 @@ class XmlNodeImplTest {
      * <p>testShouldOverwritePluginConfigurationSubItemsByDefault.</p>
      */
     @Test
-    void testShouldOverwritePluginConfigurationSubItemsByDefault() throws XMLStreamException, IOException {
+    void shouldOverwritePluginConfigurationSubItemsByDefault() throws XMLStreamException, IOException {
         String parentConfigStr = "<configuration><items><item>one</item><item>two</item></items></configuration>";
         XmlNode parentConfig = toXmlNode(parentConfigStr, new FixedInputLocationBuilder("parent"));
 
@@ -522,7 +522,7 @@ class XmlNodeImplTest {
      * <p>testShouldMergePluginConfigurationSubItemsWithMergeAttributeSet.</p>
      */
     @Test
-    void testShouldMergePluginConfigurationSubItemsWithMergeAttributeSet() throws XMLStreamException, IOException {
+    void shouldMergePluginConfigurationSubItemsWithMergeAttributeSet() throws XMLStreamException, IOException {
         String parentConfigStr = "<configuration><items><item>one</item><item>two</item></items></configuration>";
         XmlNode parentConfig = toXmlNode(parentConfigStr, new FixedInputLocationBuilder("parent"));
 
@@ -551,7 +551,7 @@ class XmlNodeImplTest {
      * @throws java.lang.Exception if any.
      */
     @Test
-    void testShouldNotChangeUponMergeWithItselfWhenFirstOrLastSubItemIsEmpty() throws Exception {
+    void shouldNotChangeUponMergeWithItselfWhenFirstOrLastSubItemIsEmpty() throws Exception {
         String configStr = "<configuration><items><item/><item>test</item><item/></items></configuration>";
         XmlNode dominantConfig = toXmlNode(configStr);
         XmlNode recessiveConfig = toXmlNode(configStr);
@@ -572,7 +572,7 @@ class XmlNodeImplTest {
      * @throws java.lang.Exception if any.
      */
     @Test
-    void testShouldCopyRecessiveChildrenNotPresentInTarget() throws Exception {
+    void shouldCopyRecessiveChildrenNotPresentInTarget() throws Exception {
         String dominantStr = "<configuration><foo>x</foo></configuration>";
         String recessiveStr = "<configuration><bar>y</bar></configuration>";
         Xpp3Dom dominantConfig = build(new StringReader(dominantStr));
@@ -591,7 +591,7 @@ class XmlNodeImplTest {
      * <p>testDupeChildren.</p>
      */
     @Test
-    void testDupeChildren() throws IOException, XMLStreamException {
+    void dupeChildren() throws IOException, XMLStreamException {
         String dupes = "<configuration><foo>x</foo><foo>y</foo></configuration>";
         XmlNode dom = toXmlNode(new StringReader(dupes));
         assertNotNull(dom);
@@ -604,7 +604,7 @@ class XmlNodeImplTest {
      * @throws java.lang.Exception if any.
      */
     @Test
-    void testShouldRemoveEntireElementWithAttributesAndChildren() throws Exception {
+    void shouldRemoveEntireElementWithAttributesAndChildren() throws Exception {
         String dominantStr = "<config><service combine.self=\"remove\"/></config>";
         String recessiveStr = "<config><service><parameter>parameter</parameter></service></config>";
         Xpp3Dom dominantConfig = build(new StringReader(dominantStr));
@@ -622,7 +622,7 @@ class XmlNodeImplTest {
      * @throws java.lang.Exception if any.
      */
     @Test
-    void testShouldRemoveDoNotRemoveTagWhenSwappedInputDOMs() throws Exception {
+    void shouldRemoveDoNotRemoveTagWhenSwappedInputDOMs() throws Exception {
         String dominantStr = "<config><service combine.self=\"remove\"/></config>";
         String recessiveStr = "<config><service><parameter>parameter</parameter></service></config>";
         Xpp3Dom dominantConfig = build(new StringReader(dominantStr));
@@ -635,7 +635,7 @@ class XmlNodeImplTest {
     }
 
     @Test
-    void testMergeCombineChildrenAppendOnRecessive() throws XMLStreamException, IOException {
+    void mergeCombineChildrenAppendOnRecessive() throws XMLStreamException, IOException {
         String dominant = "<relocations>\n" + "  <relocation>\n"
                 + "    <pattern>org.apache.shiro.crypto.CipherService</pattern>\n"
                 + "    <shadedPattern>org.apache.shiro.crypto.cipher.CipherService</shadedPattern>\n"

--- a/its/core-it-suite/src/test/resources/mng-4660-outdated-packaged-artifact/module-b/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-4660-outdated-packaged-artifact/module-b/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 public class TestCase {
     @Test
     public void testCase() {

--- a/its/core-it-suite/src/test/resources/mng-4660-resume-from/module-b/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-4660-resume-from/module-b/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-a/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-a/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-b/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-b/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-c/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-c/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-d/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/module-d/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/module-a/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/module-a/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/module-b/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/module-b/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/module-c/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/module-c/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-independent/module-a/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-independent/module-a/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-independent/module-b/src/test/java/org/apache/maven/it/TestCase.java
+++ b/its/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-independent/module-b/src/test/java/org/apache/maven/it/TestCase.java
@@ -18,27 +18,6 @@
  */
 package org.apache.maven.it;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.fail;
 
 public class TestCase {

--- a/its/core-it-suite/src/test/resources/mng-6071/src/test/java/com/mycompany/app/AppTest.java
+++ b/its/core-it-suite/src/test/resources/mng-6071/src/test/java/com/mycompany/app/AppTest.java
@@ -39,8 +39,6 @@ package com.mycompany.app;
 
 import java.net.URL;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertNotNull;
 
 /**

--- a/its/core-it-suite/src/test/resources/mng-6118-submodule-invocation-full-reactor/app/src/test/java/org/apache/its/mng6118/AppTest.java
+++ b/its/core-it-suite/src/test/resources/mng-6118-submodule-invocation-full-reactor/app/src/test/java/org/apache/its/mng6118/AppTest.java
@@ -18,27 +18,6 @@
  */
 package org.apache.its.mng6118;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertTrue;
 
 public class AppTest {

--- a/its/core-it-suite/src/test/resources/mng-6118-submodule-invocation-full-reactor/lib/src/test/java/org/apache/its/mng6118/HelperTest.java
+++ b/its/core-it-suite/src/test/resources/mng-6118-submodule-invocation-full-reactor/lib/src/test/java/org/apache/its/mng6118/HelperTest.java
@@ -18,27 +18,6 @@
  */
 package org.apache.its.mng6118;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;

--- a/its/core-it-suite/src/test/resources/mng-6720-fail-fast/module-1/src/test/java/mng6720/Module1Test.java
+++ b/its/core-it-suite/src/test/resources/mng-6720-fail-fast/module-1/src/test/java/mng6720/Module1Test.java
@@ -18,8 +18,6 @@
  */
 package mng6720;
 
-import org.junit.Test;
-
 public class Module1Test {
     @Test
     public void test() throws Exception {

--- a/its/core-it-suite/src/test/resources/mng-6720-fail-fast/module-2/src/test/java/mng6720/Module2Test.java
+++ b/its/core-it-suite/src/test/resources/mng-6720-fail-fast/module-2/src/test/java/mng6720/Module2Test.java
@@ -18,8 +18,6 @@
  */
 package mng6720;
 
-import org.junit.Test;
-
 public class Module2Test {
     @Test
     public void test() throws Exception {

--- a/its/core-it-suite/src/test/resources/mng-6720-fail-fast/module-3/src/test/java/mng6720/Module3Test.java
+++ b/its/core-it-suite/src/test/resources/mng-6720-fail-fast/module-3/src/test/java/mng6720/Module3Test.java
@@ -18,8 +18,6 @@
  */
 package mng6720;
 
-import org.junit.Test;
-
 public class Module3Test {
     @Test
     public void test() {

--- a/its/core-it-suite/src/test/resources/mng-6754-version-timestamp-in-multimodule-build/child-a/src/test/java/org/apache/maven/its/mng6754/DelayingTest.java
+++ b/its/core-it-suite/src/test/resources/mng-6754-version-timestamp-in-multimodule-build/child-a/src/test/java/org/apache/maven/its/mng6754/DelayingTest.java
@@ -39,8 +39,6 @@ package org.apache.maven.its.mng6754;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-
 public class DelayingTest {
     @Test
     public void generateSomeDelay() throws InterruptedException {

--- a/its/core-it-suite/src/test/resources/mng-6754-version-timestamp-in-multimodule-build/child-b/src/test/java/org/apache/maven/its/mng6754/DelayingTest.java
+++ b/its/core-it-suite/src/test/resources/mng-6754-version-timestamp-in-multimodule-build/child-b/src/test/java/org/apache/maven/its/mng6754/DelayingTest.java
@@ -39,8 +39,6 @@ package org.apache.maven.its.mng6754;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-
 public class DelayingTest {
     @Test
     public void generateSomeDelay() throws InterruptedException {

--- a/its/core-it-suite/src/test/resources/mng-7587-jsr330/plugin/src/test/MyMojoTest.java
+++ b/its/core-it-suite/src/test/resources/mng-7587-jsr330/plugin/src/test/MyMojoTest.java
@@ -6,7 +6,6 @@ import org.apache.maven.plugin.testing.WithoutMojo;
 
 import org.junit.Rule;
 import static org.junit.Assert.*;
-import org.junit.Test;
 import java.io.File;
 
 public class MyMojoTest

--- a/pom.xml
+++ b/pom.xml
@@ -796,9 +796,68 @@ under the License.</licenseText>
             </excludes>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.openrewrite.maven</groupId>
+          <artifactId>rewrite-maven-plugin</artifactId>
+          <version>6.8.0</version>
+          <configuration>
+            <activeRecipes>
+              <!-- BestPractices -->
+              <!-- <recipe>org.openrewrite.java.recipes.JavaRecipeBestPractices</recipe> -->
+              <!-- <recipe>org.openrewrite.java.recipes.RecipeNullabilityBestPractices</recipe> -->
+              <!-- <recipe>org.openrewrite.java.recipes.RecipeTestingBestPractices</recipe> -->
+              <!-- testing -->
+              <!-- <recipe>org.openrewrite.java.testing.assertj.JUnitToAssertj</recipe> -->
+              <!-- <recipe>org.openrewrite.java.testing.assertj.SimplifyAssertJAssertion</recipe> -->
+              <!-- <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe> -->
+              <!-- staticanalysis -->
+              <!-- <recipe>org.openrewrite.staticanalysis.CodeCleanup</recipe> -->
+              <!-- <recipe>org.openrewrite.staticanalysis.CommonStaticAnalysis</recipe> -->
+              <!-- <recipe>org.openrewrite.staticanalysis.FinalizeMethodArguments</recipe> -->
+              <!-- <recipe>org.openrewrite.staticanalysis.RemoveUnusedLocalVariables</recipe> -->
+              <!-- <recipe>org.openrewrite.staticanalysis.RemoveUnusedPrivateFields</recipe> -->
+              <!-- <recipe>org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods</recipe> -->
+              <recipe>org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration</recipe>
+              <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe>
+            </activeRecipes>
+            <exportDatatables>true</exportDatatables>
+            <failOnDryRunResults>true</failOnDryRunResults>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.openrewrite.recipe</groupId>
+              <artifactId>rewrite-static-analysis</artifactId>
+              <version>2.9.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.openrewrite.recipe</groupId>
+              <artifactId>rewrite-spring</artifactId>
+              <version>6.7.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.openrewrite.recipe</groupId>
+              <artifactId>rewrite-testing-frameworks</artifactId>
+              <version>3.8.0</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>rewrite-maven-plugin</id>
+              <goals>
+                <goal>dryRun</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <!--      undo-->
+      <plugin>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>rewrite-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>io.github.olamy.maven.plugins</groupId>
         <artifactId>jacoco-aggregator-maven-plugin</artifactId>
@@ -1155,6 +1214,20 @@ under the License.</licenseText>
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>rewrite</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.openrewrite.maven</groupId>
+            <artifactId>rewrite-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
[POC] `rewrite-maven-plugin`: Migrate to `JUnit 5` from `JUnit 4`

- https://github.com/apache/maven/pull/2320
- https://github.com/apache/maven/pull/2307
- https://github.com/apache/maven/pull/2322
- https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-from-junit-4-to-junit-5