### PR TITLE
[POC-FIX-PMD] `maven-pmd-plugin`: reactivate `PMD` - minimumPriority 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .vscode/
 repo/
 /*.svg
+/**/.cache

--- a/pom.xml
+++ b/pom.xml
@@ -799,6 +799,12 @@ under the License.</licenseText>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
+          <configuration>
+            <analysisCache>true</analysisCache>
+            <analysisCacheLocation>${project.basedir}/.pmd/.cache</analysisCacheLocation>
+            <minimumPriority>1</minimumPriority>
+            <printFailingErrors>true</printFailingErrors>
+          </configuration>
           <dependencies>
             <dependency>
               <groupId>net.sourceforge.pmd</groupId>
@@ -806,10 +812,24 @@ under the License.</licenseText>
               <version>7.12.0</version>
             </dependency>
           </dependencies>
+          <executions>
+            <execution>
+              <id>maven-pmd-plugin</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <!-- why profile not working? -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>io.github.olamy.maven.plugins</groupId>
         <artifactId>jacoco-aggregator-maven-plugin</artifactId>
@@ -1166,6 +1186,20 @@ under the License.</licenseText>
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>pmd</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
enabler:
- https://github.com/apache/maven/pull/2331

PMD Failure:
- [WARNING] PMD Failure: org.apache.maven.api.JavaPathType:262 Rule:UnnecessaryModifier Priority:3 Unnecessary modifier 'final' on method 'format': the method is already in a final class.
- [WARNING] PMD Failure: org.apache.maven.internal.xml.DefaultXmlService:396 Rule:UnusedPrivateMethod Priority:3 Avoid unused private methods such as 'findNodeById(List<XmlNode>, String)'..
- [WARNING] PMD Failure: org.apache.maven.internal.xml.DefaultXmlService:404 Rule:UnusedPrivateMethod Priority:3 Avoid unused private methods such as 'findNodeByKeys(List<XmlNode>, XmlNode, String[])'..
- [WARNING] PMD Failure: org.apache.maven.di.impl.Types:360 Rule:JumbledIncrementer Priority:3 Avoid modifying an outer loop incrementer in an inner loop for update expression.



<img width="1841" alt="image" src="https://github.com/user-attachments/assets/06405bee-d052-4e2b-ac6d-f92144f9cddc" />


