### PR TITLE
Parameter 'request' is never used

### DIFF
--- a/compat/maven-settings-builder/src/main/java/org/apache/maven/settings/building/DefaultSettingsBuilder.java
+++ b/compat/maven-settings-builder/src/main/java/org/apache/maven/settings/building/DefaultSettingsBuilder.java
@@ -92,10 +92,10 @@ public class DefaultSettingsBuilder implements SettingsBuilder {
 
         Source globalSettingsSource =
                 getSettingsSource(request.getGlobalSettingsFile(), request.getGlobalSettingsSource());
-        Settings globalSettings = readSettings(globalSettingsSource, request, problems);
+        Settings globalSettings = readSettings(globalSettingsSource, problems);
 
         Source userSettingsSource = getSettingsSource(request.getUserSettingsFile(), request.getUserSettingsSource());
-        Settings userSettings = readSettings(userSettingsSource, request, problems);
+        Settings userSettings = readSettings(userSettingsSource, problems);
 
         settingsMerger.merge(userSettings, globalSettings, TrackableBase.GLOBAL_LEVEL);
 
@@ -140,8 +140,7 @@ public class DefaultSettingsBuilder implements SettingsBuilder {
         return null;
     }
 
-    private Settings readSettings(
-            Source settingsSource, SettingsBuildingRequest request, DefaultSettingsProblemCollector problems) {
+    private Settings readSettings(Source settingsSource, DefaultSettingsProblemCollector problems) {
         if (settingsSource == null) {
             return new Settings();
         }


### PR DESCRIPTION
Parameter 'request' is never used

- https://github.com/apache/maven/pull/2333
- https://github.com/openrewrite/rewrite-static-analysis/pull/560
- https://pmd.github.io/pmd/pmd_rules_java_bestpractices.html#unusedformalparameter
- https://pmd.github.io/pmd/pmd_rules_java_bestpractices.html#unusedassignment
- https://github.com/apache/maven/pull/2322

PMD or rewrite, might even do both.

Spot seems ending up being short:
- https://github.com/apache/maven/pull/2338