### PR TITLE
[MNG-8731] Use https for xsi:schemaLocation in generated descriptors

### DIFF
--- a/api/maven-api-cli/src/main/mdo/core-extensions.mdo
+++ b/api/maven-api-cli/src/main/mdo/core-extensions.mdo
@@ -23,7 +23,7 @@
 <model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/EXTENSIONS/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/core-extensions-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/core-extensions-${version}.xsd">
 
   <id>core-extensions</id>
   <name>CoreExtensions</name>

--- a/api/maven-api-plugin/src/main/mdo/lifecycle.mdo
+++ b/api/maven-api-plugin/src/main/mdo/lifecycle.mdo
@@ -20,7 +20,7 @@ under the License.
 <model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/LIFECYCLE/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/lifecycle-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/lifecycle-${version}.xsd">
   <id>lifecycle</id>
   <name>Lifecycle</name>
   <description>

--- a/api/maven-api-settings/src/main/mdo/settings.mdo
+++ b/api/maven-api-settings/src/main/mdo/settings.mdo
@@ -22,7 +22,7 @@
 <model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/SETTINGS/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/settings-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/settings-${version}.xsd">
   <id>settings</id>
   <name>Settings</name>
   <description>

--- a/api/maven-api-toolchain/src/main/mdo/toolchains.mdo
+++ b/api/maven-api-toolchain/src/main/mdo/toolchains.mdo
@@ -22,7 +22,7 @@
 <model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/TOOLCHAINS/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/toolchains-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/toolchains-${version}.xsd">
   <id>toolchains</id>
   <name>MavenToolchains</name>
   <description><![CDATA[


### PR DESCRIPTION
Attribute xml.schemaLocation is used by modello to generate documentations

We have mixed http/https, so it should be fixed to use everywhere https

