### PR TITLE
[MNG-8731] Use https for xsi:schemaLocation in generated descriptors

### DIFF
--- a/maven-core/src/main/mdo/extension.mdo
+++ b/maven-core/src/main/mdo/extension.mdo
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd">
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd">
   <id>extension</id>
   <name>ExtensionDescriptor</name>
   <description><![CDATA[

--- a/maven-core/src/main/mdo/toolchains.mdo
+++ b/maven-core/src/main/mdo/toolchains.mdo
@@ -19,10 +19,10 @@
   under the License.
 
 -->
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.0.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.0.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/TOOLCHAINS/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/toolchains-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/toolchains-${version}.xsd">
     <id>toolchains</id>
     <name>MavenToolchains</name>
     <description><![CDATA[

--- a/maven-embedder/src/main/mdo/core-extensions.mdo
+++ b/maven-embedder/src/main/mdo/core-extensions.mdo
@@ -20,10 +20,10 @@
 
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/EXTENSIONS/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/core-extensions-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/core-extensions-${version}.xsd">
 
   <id>core-extensions</id>
   <name>CoreExtensions</name>

--- a/maven-plugin-api/src/main/mdo/lifecycle.mdo
+++ b/maven-plugin-api/src/main/mdo/lifecycle.mdo
@@ -17,10 +17,10 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.0.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.0.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/LIFECYCLE/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/lifecycle-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/lifecycle-${version}.xsd">
   <id>lifecycle-mappings</id>
   <name>LifecycleMappings</name>
   <description><![CDATA[

--- a/maven-plugin-api/src/main/mdo/plugin.mdo
+++ b/maven-plugin-api/src/main/mdo/plugin.mdo
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd">
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd">
   <id>plugin</id>
   <name>PluginDescriptor</name>
   <description><![CDATA[

--- a/maven-repository-metadata/src/main/mdo/metadata.mdo
+++ b/maven-repository-metadata/src/main/mdo/metadata.mdo
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xsd.namespace="http://maven.apache.org/METADATA/${version}"
   xml.schemaLocation="https://maven.apache.org/xsd/repository-metadata-${version}.xsd">
   <id>repository-metadata</id>

--- a/maven-settings/src/main/mdo/settings.mdo
+++ b/maven-settings/src/main/mdo/settings.mdo
@@ -19,10 +19,10 @@
   under the License.
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
   xml.namespace="http://maven.apache.org/SETTINGS/${version}"
-  xml.schemaLocation="http://maven.apache.org/xsd/settings-${version}.xsd">
+  xml.schemaLocation="https://maven.apache.org/xsd/settings-${version}.xsd">
   <id>settings</id>
   <name>Settings</name>
   <description>


### PR DESCRIPTION
Attribute xml.schemaLocation is used by modello to generate documentations

Also update modello descriptor to 2.0.0

