### PR TITLE
[MNG-5913] Allow defining aliases for existing server configurations in settings.xml 

### DIFF
--- a/maven-settings-builder/pom.xml
+++ b/maven-settings-builder/pom.xml
@@ -63,6 +63,13 @@ under the License.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.27.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/maven-settings-builder/src/test/java/org/apache/maven/settings/building/DefaultSettingsBuilderFactoryTest.java
+++ b/maven-settings-builder/src/test/java/org/apache/maven/settings/building/DefaultSettingsBuilderFactoryTest.java
@@ -19,28 +19,105 @@
 package org.apache.maven.settings.building;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
 
-import junit.framework.TestCase;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Benjamin Bentmann
  */
-public class DefaultSettingsBuilderFactoryTest extends TestCase {
+public class DefaultSettingsBuilderFactoryTest {
 
     private File getSettings(String name) {
         return new File("src/test/resources/settings/factory/" + name + ".xml").getAbsoluteFile();
     }
 
-    public void testCompleteWiring() throws Exception {
+    private SettingsBuildingResult execute(String settingsName) throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("user.home", "/home/user");
+
         SettingsBuilder builder = new DefaultSettingsBuilderFactory().newInstance();
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
 
         DefaultSettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
-        request.setSystemProperties(System.getProperties());
-        request.setUserSettingsFile(getSettings("simple"));
+        request.setSystemProperties(properties);
+        request.setUserSettingsFile(getSettings(settingsName));
 
         SettingsBuildingResult result = builder.build(request);
-        assertNotNull(result);
-        assertNotNull(result.getEffectiveSettings());
+        return assertThat(result).isNotNull().actual();
+    }
+
+    @Test
+    public void testCompleteWiring() throws Exception {
+        Settings settings = assertThat(execute("simple"))
+                .extracting(SettingsBuildingResult::getEffectiveSettings)
+                .actual();
+
+        assertThat(settings.getLocalRepository())
+                .satisfiesAnyOf(
+                        repo -> assertThat(repo).isEqualTo("/home/user/.m2/repository"),
+                        repo -> assertThat(repo).endsWith("\\home\\user\\.m2\\repository"));
+    }
+
+    @Test
+    public void testSettingsWithServers() throws Exception {
+        Settings settings = assertThat(execute("settings-servers-1"))
+                .extracting(SettingsBuildingResult::getEffectiveSettings)
+                .actual();
+
+        assertThat(settings.getServers())
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        aServer("server-1", "username1", "password1"), aServer("server-2", "username2", "password2"));
+    }
+
+    @Test
+    public void testSettingsWithServersAndAliases() throws Exception {
+        Settings settings = assertThat(execute("settings-servers-2"))
+                .extracting(SettingsBuildingResult::getEffectiveSettings)
+                .actual();
+
+        assertThat(settings.getServers())
+                .hasSize(6)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        aServer("server-1", "username1", "password1", Arrays.asList("server-11", "server-12")),
+                        aServer("server-11", "username1", "password1"),
+                        aServer("server-12", "username1", "password1"),
+                        aServer("server-2", "username2", "password2", Collections.singletonList("server-21")),
+                        aServer("server-21", "username2", "password2"),
+                        aServer("server-3", "username3", "password3"));
+    }
+
+    private Server aServer(String id, String username, String password) {
+        Server server = new Server();
+        server.setId(id);
+        server.setUsername(username);
+        server.setPassword(password);
+        return server;
+    }
+
+    private Server aServer(String id, String username, String password, List<String> ids) {
+        Server server = aServer(id, username, password);
+        server.setIds(ids);
+        return server;
+    }
+
+    @Test
+    public void testSettingsWithDuplicateServersIds() throws Exception {
+        SettingsBuildingResult result = execute("settings-servers-3");
+
+        assertThat(result.getProblems())
+                .hasSize(1)
+                .extracting(SettingsProblem::getMessage)
+                .containsExactly("'servers.server.id' must be unique but found duplicate server with id server-2");
     }
 }

--- a/maven-settings-builder/src/test/resources/settings/factory/settings-servers-1.xml
+++ b/maven-settings-builder/src/test/resources/settings/factory/settings-servers-1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <localRepository>${user.home}/.m2/repository</localRepository>
+  <servers>
+    <server>
+      <id>server-1</id>
+      <username>username1</username>
+      <password>password1</password>
+    </server>
+    <server>
+      <id>server-2</id>
+      <username>username2</username>
+      <password>password2</password>
+    </server>
+  </servers>
+
+</settings>

--- a/maven-settings-builder/src/test/resources/settings/factory/settings-servers-2.xml
+++ b/maven-settings-builder/src/test/resources/settings/factory/settings-servers-2.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <localRepository>${user.home}/.m2/repository</localRepository>
+  <servers>
+    <server>
+      <id>server-1</id>
+      <ids>
+        <id>server-11</id>
+        <id>server-12</id>
+      </ids>
+      <username>username1</username>
+      <password>password1</password>
+    </server>
+    <server>
+      <id>server-2</id>
+      <ids>
+        <id>server-21</id>
+      </ids>
+      <username>username2</username>
+      <password>password2</password>
+    </server>
+    <server>
+      <id>server-3</id>
+      <username>username3</username>
+      <password>password3</password>
+    </server>
+  </servers>
+
+</settings>

--- a/maven-settings-builder/src/test/resources/settings/factory/settings-servers-3.xml
+++ b/maven-settings-builder/src/test/resources/settings/factory/settings-servers-3.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <localRepository>${user.home}/.m2/repository</localRepository>
+  <servers>
+    <server>
+      <id>server-1</id>
+      <ids>
+        <id>server-2</id>
+      </ids>
+      <username>username1</username>
+      <password>password1</password>
+    </server>
+    <server>
+      <id>server-2</id>
+      <username>username2</username>
+      <password>password2</password>
+    </server>
+  </servers>
+
+</settings>

--- a/maven-settings/pom.xml
+++ b/maven-settings/pom.xml
@@ -44,7 +44,7 @@ under the License.
         <groupId>org.codehaus.modello</groupId>
         <artifactId>modello-maven-plugin</artifactId>
         <configuration>
-          <version>1.2.0</version>
+          <version>1.3.0</version>
           <models>
             <model>src/main/mdo/settings.mdo</model>
           </models>

--- a/maven-settings/src/main/mdo/settings.mdo
+++ b/maven-settings/src/main/mdo/settings.mdo
@@ -581,7 +581,18 @@
             ]]>
           </description>
         </field>
-      </fields>
+        <field>
+          <name>ids</name>
+          <version>1.3.0+</version>
+          <description>
+            List of additional ids for server.
+          </description>
+          <association>
+            <type>String</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
+    </fields>
     </class>
     <class>
       <name>Mirror</name>


### PR DESCRIPTION

Add the next tag ids to the server in settings.xml

Additional server will be created in memory by SettingsBuilder, so the generated configuration should be transparent to other as Settings#getServers() will return complete list.

https://issues.apache.org/jira/browse/MNG-5913