### PR TITLE
[MNG-8696] Hide the cache from DefaultDependencyResolverResult constructor

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultProjectBuilder.java
@@ -189,8 +189,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 public Optional<DependencyResolverResult> getDependencyResolverResult() {
                     return Optional.ofNullable(res.getDependencyResolutionResult())
                             .map(r -> new DefaultDependencyResolverResult(
-                                    // TODO: this should not be null
-                                    null, null, r.getCollectionErrors(), session.getNode(r.getDependencyGraph()), 0));
+                                    null, r.getCollectionErrors(), session.getNode(r.getDependencyGraph()), 0));
                 }
             };
         } catch (ProjectBuildingException e) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
@@ -67,14 +67,15 @@ import static org.apache.maven.impl.ImplUtils.nonNull;
 @Named
 @Singleton
 public class DefaultDependencyResolver implements DependencyResolver {
+
     /**
      * Cache of information about the modules contained in a path element.
      * This cache is created when first needed. It may be never created.
      *
      * <p><b>TODO:</b> This field should not be in this class, because the cache should be global to the session.
-     * This field exists here only temporarily, until we clarified where to store session-wide caches.</p>
+     * This field exists here only temporarily, until clarified where to store session-wide caches.</p>
      *
-     * @see moduleCache()
+     * @see #moduleCache()
      */
     private PathModularizationCache moduleCache;
 
@@ -245,7 +246,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
      * {@return the cache of information about the modules contained in a path element}.
      *
      * <p><b>TODO:</b> This method should not be in this class, because the cache should be global to the session.
-     * This method exists here only temporarily, until we clarified where to store session-wide caches.</p>
+     * This method exists here only temporarily, until clarified where to store session-wide caches.</p>
      */
     private PathModularizationCache moduleCache() {
         if (moduleCache == null) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
@@ -370,7 +370,7 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
 
     @Override
     public List<Exception> getExceptions() {
-        return exceptions;
+        return Collections.unmodifiableList(exceptions);
     }
 
     @Override
@@ -380,22 +380,22 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
 
     @Override
     public List<Node> getNodes() {
-        return nodes;
+        return Collections.unmodifiableList(nodes);
     }
 
     @Override
     public List<Path> getPaths() {
-        return paths;
+        return Collections.unmodifiableList(paths);
     }
 
     @Override
     public Map<PathType, List<Path>> getDispatchedPaths() {
-        return dispatchedPaths;
+        return Collections.unmodifiableMap(dispatchedPaths);
     }
 
     @Override
     public Map<Dependency, Path> getDependencies() {
-        return dependencies;
+        return Collections.unmodifiableMap(dependencies);
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -56,6 +57,7 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
      * The corresponding request.
      */
     private final DependencyResolverRequest request;
+
     /**
      * The exceptions that occurred while building the dependency graph.
      */
@@ -98,6 +100,24 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
     private final PathModularizationCache cache;
 
     /**
+     * Creates an initially empty result with a temporary cache.
+     * Callers should add path elements by calls to {@link #addDependency(Node, Dependency, Predicate, Path)}.
+     *
+     * <p><b>WARNING: this constructor may be removed in a future Maven release.</b>
+     * The reason is because {@code DefaultDependencyResolverResult} needs a cache, which should
+     * preferably by session-wide. But we have not yet clarified how such caches should be managed.</p>
+     *
+     * @param request the corresponding request
+     * @param exceptions the exceptions that occurred while building the dependency graph
+     * @param root the root node of the dependency graph
+     * @param count estimated number of dependencies
+     */
+    public DefaultDependencyResolverResult(
+            DependencyResolverRequest request, List<Exception> exceptions, Node root, int count) {
+        this(request, new PathModularizationCache(), exceptions, root, count);
+    }
+
+    /**
      * Creates an initially empty result. Callers should add path elements by calls
      * to {@link #addDependency(Node, Dependency, Predicate, Path)}.
      *
@@ -107,14 +127,14 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
      * @param root the root node of the dependency graph
      * @param count estimated number of dependencies
      */
-    public DefaultDependencyResolverResult(
+    DefaultDependencyResolverResult(
             DependencyResolverRequest request,
             PathModularizationCache cache,
             List<Exception> exceptions,
             Node root,
             int count) {
         this.request = request;
-        this.cache = cache;
+        this.cache = Objects.requireNonNull(cache);
         this.exceptions = exceptions;
         this.root = root;
         nodes = new ArrayList<>(count);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
@@ -105,7 +105,7 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
      *
      * <p><b>WARNING: this constructor may be removed in a future Maven release.</b>
      * The reason is because {@code DefaultDependencyResolverResult} needs a cache, which should
-     * preferably by session-wide. But we have not yet clarified how such caches should be managed.</p>
+     * preferably be session-wide. How to manage such caches has not yet been clarified.</p>
      *
      * @param request the corresponding request
      * @param exceptions the exceptions that occurred while building the dependency graph


### PR DESCRIPTION
This is an alternative to pull request #2219 resolving the same issue, but with more emphasis that `PathModularizationCache` should not be created in the `DefaultDependencyResolverResult` constructor, and that doing so is a temporary hack that may be removed in a future version. More specifically:

* Make package-private the `DefaultDependencyResolverResult` constructor having a `PathModularizationCache` argument, because the latter is package-private.
* Add a public constructor without the cache argument for codes in other packages that need to instantiate `DefaultDependencyResolverResult`  directly.
  * Put a warning in the javadoc saying that this constructor may be removed in a future version.
* Add `PathModularizationCache` private field in `DefaultDependencyResolver`. This is partially for performance reasons (see below), but also for expressing the intend that the cache has a longer lifetime than `DependencyResolverResult`.

## Rational
Initializing `PathModularizationCache` inside the `DependencyResolverResult` constructor is close to useless, because a cache is useful only when the cached values are reused. The way that the `DependencyResolverResult` is coded, the same result instance is unlikely to ask the same cached value twice. The cache become useful only when many `DependencyResolverResult` are instantiated while reusing the same cache.

The "useless" approach is nevertheless used by `DependencyResolverResult`, but this is only because I do not yet know how to manage a session-wide cache. The current way to create the cache was intended to be temporary.

I'm not sure if it happens often that the same `DependencyResolverResultBuilder` is reused for creating more than one `DependencyResolverResult`. If not, moving the cache inside `DependencyResolverResultBuilder`, as done in this commit, may not bring real performance improvement. However, it makes clearer that `PathModularizationCache` is expected to have a longer lifetime than `DependencyResolverResult`. The discussion in #2219 gives the impression that such clarification is worth to do.