### PR TITLE
[MNG-8728] Update Eclipse Sisu to 0.9.0.M4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: ['17', '21']
+        java: ['17', '21', '24']
     steps:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: ['17', '21']
+        java: ['17', '21', '24']
     steps:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4

--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -128,7 +128,6 @@ under the License.
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
-      <classifier>no_asm</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@ under the License.
     <plexusXmlVersion>4.1.0</plexusXmlVersion>
     <resolverVersion>2.0.9</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
-    <sisuVersion>0.9.0.M3</sisuVersion>
+    <sisuVersion>0.9.0.M4</sisuVersion>
     <slf4jVersion>2.0.17</slf4jVersion>
     <stax2ApiVersion>4.2.2</stax2ApiVersion>
     <wagonVersion>3.5.3</wagonVersion>
@@ -410,12 +410,6 @@ under the License.
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.inject</artifactId>
         <version>${sisuVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.sisu</groupId>
-        <artifactId>org.eclipse.sisu.inject</artifactId>
-        <version>${sisuVersion}</version>
-        <classifier>no_asm</classifier>
       </dependency>
       <dependency>
         <groupId>jakarta.inject</groupId>
@@ -804,6 +798,18 @@ under the License.</licenseText>
               <groupId>net.sourceforge.pmd</groupId>
               <artifactId>pmd-core</artifactId>
               <version>7.12.0</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>sisu-maven-plugin</artifactId>
+          <version>${sisuVersion}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>${asmVersion}</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
This now makes possible to add Java 24 to CI as well.

The PR not only updates to Sisu 0.9.0.M4, but also aligns the `sisu-maven-plugin` version and plugin
ASM with the Maven ASM dependency.

---

https://issues.apache.org/jira/browse/MNG-8728
