### PR TITLE
[POC-FIX-PMD] maven-pmd-plugin: reactivate PMD - Error Prone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .vscode/
 repo/
 /*.svg
+/**/.cache

--- a/.pmd/obsoletes.xml
+++ b/.pmd/obsoletes.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<ruleset name="obsoletes"
+		 xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+	<description>Rules that detect unnecessary code constructs across all categories</description>
+	<!--	<rule ref="category/java/bestpractices.xml/UnnecessaryCaseChange" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnnecessaryConversionTemporary" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnnecessaryFinalModifier" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnnecessaryTernary" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnusedAssignment" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnusedImports" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />-->
+	<!--	<rule ref="category/java/bestpractices.xml/UnusedPrivateField" />-->
+	<rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryBoxing" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryCast" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryConstructor" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryImport" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryModifier" />
+		<rule ref="category/java/codestyle.xml/UnnecessaryReturn" />
+		<rule ref="category/java/codestyle.xml/UnnecessarySemicolon" />
+		<!-- liberty, tolerate -->
+		<!-- <rule ref="category/java/codestyle.xml/UselessParentheses" /> -->
+		<rule ref="category/java/codestyle.xml/UselessQualifiedThis" />
+		<rule ref="category/java/design.xml/UnnecessaryAbstractClass" />
+		<rule ref="category/java/design.xml/UnnecessaryInterfaceModifier" />
+</ruleset>

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t01/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t01/ProjectInheritanceTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t02/ProjectInheritanceTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t03/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t03/ProjectInheritanceTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t04/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t04/ProjectInheritanceTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t05/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t05/ProjectInheritanceTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t06/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t06/ProjectInheritanceTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t07/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t07/ProjectInheritanceTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t08/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t08/ProjectInheritanceTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t09/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t09/ProjectInheritanceTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t10/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t10/ProjectInheritanceTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t11/ProjectInheritanceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * @see <a href="https://issues.apache.org/jira/browse/MNG-2919">MNG-2919</a>
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12/ProjectInheritanceTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/project/inheritance/t12/ProjectInheritanceTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * inherit == false are not inherited to the child POM.
  */
 @Deprecated
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class ProjectInheritanceTest extends AbstractProjectInheritanceTestCase {
     // ----------------------------------------------------------------------
     //

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/resolver/DefaultArtifactCollectorTest.java
@@ -293,7 +293,7 @@ class DefaultArtifactCollectorTest {
     }
 
     @Test
-    @SuppressWarnings("checkstyle:UnusedLocalVariable")
+    @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
     void testResolveRangeWithManagedVersion() throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");
         ArtifactSpec b = a.addDependency("b", "[1.0,3.0]");
@@ -676,7 +676,7 @@ class DefaultArtifactCollectorTest {
 
     @Test
     @Disabled("that one does not work")
-    @SuppressWarnings("checkstyle:UnusedLocalVariable")
+    @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
     void testOverConstrainedVersionException()
             throws ArtifactResolutionException, InvalidVersionSpecificationException {
         ArtifactSpec a = createArtifactSpec("a", "1.0");

--- a/impl/maven-core/src/test/java/org/apache/maven/artifact/handler/ArtifactHandlerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/artifact/handler/ArtifactHandlerTest.java
@@ -38,7 +38,7 @@ class ArtifactHandlerTest {
     PlexusContainer container;
 
     @Test
-    @SuppressWarnings("checkstyle:UnusedLocalVariable")
+    @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
     void testAptConsistency() throws Exception {
         File apt = getTestFile("src/site/apt/artifact-handlers.apt");
 

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
@@ -121,7 +121,7 @@ class BuildPlanCreatorTest {
                 String.format("Expected '%s' to be a successor of '%s'", successor.toString(), predecessor.toString()));
     }
 
-    @SuppressWarnings("checkstyle:UnusedLocalVariable")
+    @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
     private BuildPlan calculateLifecycleMappings(Map<MavenProject, List<MavenProject>> projects, String phase) {
         DefaultLifecycleRegistry lifecycles = new DefaultLifecycleRegistry(Collections.emptyList());
         BuildPlanExecutor builder = new BuildPlanExecutor(null, null, null, null, null, null, null, null, lifecycles);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2690MojoLoadingErrorsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2690MojoLoadingErrorsTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author jdcasey
  */
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class MavenITmng2690MojoLoadingErrorsTest extends AbstractMavenIntegrationTestCase {
 
     MavenITmng2690MojoLoadingErrorsTest() {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3023ReactorDependencyResolutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3023ReactorDependencyResolutionTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author jdcasey
  *
  */
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 public class MavenITmng3023ReactorDependencyResolutionTest extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng3023ReactorDependencyResolutionTest() {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3652UserAgentHeaderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3652UserAgentHeaderTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-3652">MNG-3652</a>.
  */
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class MavenITmng3652UserAgentHeaderTest extends AbstractMavenIntegrationTestCase {
     private Server server;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5640LifecycleParticipantAfterSessionEnd.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5640LifecycleParticipantAfterSessionEnd.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * IT that verifies that lifecycle participant
  * methods are invoked even with various build failures/errors.
  */
-@SuppressWarnings("checkstyle:UnusedLocalVariable")
+@SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
 class MavenITmng5640LifecycleParticipantAfterSessionEnd extends AbstractMavenIntegrationTestCase {
     MavenITmng5640LifecycleParticipantAfterSessionEnd() {
         super("[3.2.2,)");

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-active-collection/src/main/java/org/apache/maven/plugin/coreit/CheckThreadSafetyMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-active-collection/src/main/java/org/apache/maven/plugin/coreit/CheckThreadSafetyMojo.java
@@ -95,7 +95,13 @@ public class CheckThreadSafetyMojo extends AbstractMojo {
                     getLog().info("[MAVEN-CORE-IT-LOG] Thread " + this + " uses " + tccl);
                     Thread.currentThread().setContextClassLoader(tccl);
                     while (go.isEmpty()) {
-                        // wait for start
+                        // [WARNING] PMD Failure: Rule:EmptyControlStatement Priority:3 Empty while statement.
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        // wait for the start
                     }
                     for (int j = 0; j < 10 * 1000; j++) {
                         try {

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-configuration/src/main/java/org/apache/maven/plugin/coreit/PropertiesUtil.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-configuration/src/main/java/org/apache/maven/plugin/coreit/PropertiesUtil.java
@@ -104,7 +104,7 @@ class PropertiesUtil {
         } else if (value instanceof Map) {
             Map map = (Map) value;
             props.setProperty(key, Integer.toString(map.size()));
-            @SuppressWarnings("checkstyle:UnusedLocalVariable")
+            @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
             int i = 0;
             for (Iterator it = map.keySet().iterator(); it.hasNext(); i++) {
                 Object k = it.next();

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/AbstractDependencyMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/AbstractDependencyMojo.java
@@ -222,11 +222,8 @@ public abstract class AbstractDependencyMojo extends AbstractMojo {
         MessageDigest digester = MessageDigest.getInstance("SHA-1");
 
         try (FileInputStream is = new FileInputStream(jarFile)) {
-            DigestInputStream dis = new DigestInputStream(is, digester);
-
-            for (byte[] buffer = new byte[1024 * 4]; dis.read(buffer) >= 0; ) {
-                // just read it
-            }
+            // [WARNING] PMD Failure: Rule:EmptyControlStatement Priority:3 Empty for statement.
+            new DigestInputStream(is, digester).read(new byte[1024 * 4]);
         }
 
         byte[] digest = digester.digest();

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-expression/src/main/java/org/apache/maven/plugin/coreit/PropertyUtil.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-expression/src/main/java/org/apache/maven/plugin/coreit/PropertyUtil.java
@@ -87,7 +87,7 @@ class PropertyUtil {
             } else if (obj instanceof Map) {
                 Map map = (Map) obj;
                 props.put(key, Integer.toString(map.size()));
-                @SuppressWarnings("checkstyle:UnusedLocalVariable")
+                @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
                 int index = 0;
                 for (Iterator it = map.entrySet().iterator(); it.hasNext(); index++) {
                     Map.Entry entry = (Map.Entry) it.next();

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-uses-wagon/src/main/java/org/apache/maven/plugin/coreit/UsesWagonMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-uses-wagon/src/main/java/org/apache/maven/plugin/coreit/UsesWagonMojo.java
@@ -47,7 +47,7 @@ public class UsesWagonMojo extends AbstractMojo {
             throw new MojoExecutionException(e.getMessage(), e);
         }
         try {
-            @SuppressWarnings("checkstyle:UnusedLocalVariable")
+            @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
             FileWagon theWagon = (FileWagon) fileWagon;
         } catch (ClassCastException e) {
             getLog().error("", e);
@@ -65,7 +65,7 @@ public class UsesWagonMojo extends AbstractMojo {
             throw new MojoExecutionException(e.getMessage(), e);
         }
         try {
-            @SuppressWarnings("checkstyle:UnusedLocalVariable")
+            @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
             ScpWagon theWagon = (ScpWagon) scpWagon;
         } catch (ClassCastException e) {
             getLog().error("", e);

--- a/its/core-it-support/core-it-plugins/mng7529-plugin/src/main/java/org/apache/maven/its/mng7529/plugin/ResolveMojo.java
+++ b/its/core-it-support/core-it-plugins/mng7529-plugin/src/main/java/org/apache/maven/its/mng7529/plugin/ResolveMojo.java
@@ -58,7 +58,7 @@ public class ResolveMojo extends AbstractMojo {
             request.setMavenProject(project);
             request.setRepositorySession(buildingRequest.getRepositorySession());
 
-            @SuppressWarnings("checkstyle:UnusedLocalVariable")
+            @SuppressWarnings({"checkstyle:UnusedLocalVariable", "PMD.UnusedLocalVariable"})
             DependencyResolutionResult result = dependencyResolver.resolve(request);
 
             getLog().info("Resolution successful, resolved ok");

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -665,24 +665,6 @@ public class Verifier {
                 + executorTool.artifactPath(executorHelper.executorRequest(), gav, null);
     }
 
-    private String getSupportArtifactPath(String artifact) {
-        StringTokenizer tok = new StringTokenizer(artifact, ":");
-        if (tok.countTokens() != 4) {
-            throw new IllegalArgumentException("Artifact must have 4 tokens: '" + artifact + "'");
-        }
-
-        String[] a = new String[4];
-        for (int i = 0; i < 4; i++) {
-            a[i] = tok.nextToken();
-        }
-
-        String groupId = a[0];
-        String artifactId = a[1];
-        String version = a[2];
-        String ext = a[3];
-        return getSupportArtifactPath(groupId, artifactId, version, ext);
-    }
-
     public String getSupportArtifactPath(String groupId, String artifactId, String version, String ext) {
         return getSupportArtifactPath(groupId, artifactId, version, ext, null);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -799,6 +799,17 @@ under the License.</licenseText>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
+          <configuration>
+            <analysisCache>true</analysisCache>
+            <excludeFromFailureFile>.pmd/exclude.properties</excludeFromFailureFile>
+            <printFailingErrors>true</printFailingErrors>
+            <minimumPriority>3</minimumPriority>
+            <rulesets>
+<!--              <ruleset>category/java/errorprone.xml</ruleset>-->
+<!--              <ruleset>category/java/bestpractices.xml</ruleset>-->
+<!--              <ruleset>${project.basedir}.pmd/obsoletes.xml</ruleset>-->
+            </rulesets>
+          </configuration>
           <dependencies>
             <dependency>
               <groupId>net.sourceforge.pmd</groupId>
@@ -806,10 +817,23 @@ under the License.</licenseText>
               <version>7.12.0</version>
             </dependency>
           </dependencies>
+          <executions>
+            <execution>
+              <id>pmd</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>io.github.olamy.maven.plugins</groupId>
         <artifactId>jacoco-aggregator-maven-plugin</artifactId>
@@ -847,6 +871,7 @@ under the License.</licenseText>
                 <exclude>**/*.odg</exclude>
                 <exclude>**/*.svg</exclude>
                 <exclude>.asf.yaml</exclude>
+                <exclude>.pmd/exclude.properties</exclude>
                 <exclude>.mvn/**</exclude>
                 <exclude>.jbang/**</exclude>
                 <!--
@@ -1166,6 +1191,20 @@ under the License.</licenseText>
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>pmd</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
[Error prone](https://pmd.github.io/pmd/pmd_rules_jsp_errorprone.html), which is default, only exposes 3 issues, which seem to have real impact.
[Best practices](https://pmd.github.io/pmd/pmd_rules_java_bestpractices.html) impacts on code shape.


- https://github.com/apache/maven/pull/2331