### PR TITLE
fix: debounce `while(true)` in `CheckThreadSafetyMojo` PMD-Rule: `EmptyControlStatement`

### DIFF
--- a/its/core-it-support/core-it-plugins/maven-it-plugin-active-collection/src/main/java/org/apache/maven/plugin/coreit/CheckThreadSafetyMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-active-collection/src/main/java/org/apache/maven/plugin/coreit/CheckThreadSafetyMojo.java
@@ -95,7 +95,10 @@ public class CheckThreadSafetyMojo extends AbstractMojo {
                     getLog().info("[MAVEN-CORE-IT-LOG] Thread " + this + " uses " + tccl);
                     Thread.currentThread().setContextClassLoader(tccl);
                     while (go.isEmpty()) {
-                        // wait for start
+                        try {
+                            Thread.sleep(100); // wait for the start
+                        } catch (InterruptedException ignored) {
+                        }
                     }
                     for (int j = 0; j < 10 * 1000; j++) {
                         try {


### PR DESCRIPTION
- https://github.com/apache/maven/pull/2381