### PR TITLE
chore: `DefaultUpdateCheckManager` unused parameter `RepositoryMetadata metadata`

### DIFF
--- a/compat/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManager.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManager.java
@@ -50,8 +50,6 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
 
     private static final String ERROR_KEY_SUFFIX = ".error";
 
-    public DefaultUpdateCheckManager() {}
-
     public DefaultUpdateCheckManager(Logger logger) {
         enableLogging(logger);
     }
@@ -130,13 +128,13 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
             return true;
         }
 
-        Date lastCheckDate = readLastUpdated(metadata, repository, file);
+        Date lastCheckDate = readLastUpdated(repository, file);
 
         return (lastCheckDate == null) || policy.checkOutOfDate(lastCheckDate);
     }
 
-    private Date readLastUpdated(RepositoryMetadata metadata, ArtifactRepository repository, File file) {
-        File touchfile = getTouchfile(metadata, file);
+    private Date readLastUpdated(ArtifactRepository repository, File file) {
+        File touchfile = getTouchfile(file);
 
         String key = getMetadataKey(repository, file);
 
@@ -164,7 +162,7 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
 
     @Override
     public void touch(RepositoryMetadata metadata, ArtifactRepository repository, File file) {
-        File touchfile = getTouchfile(metadata, file);
+        File touchfile = getTouchfile(file);
 
         String key = getMetadataKey(repository, file);
 
@@ -303,7 +301,7 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
                 Properties props = new Properties();
 
                 try (FileInputStream in = new FileInputStream(touchfile)) {
-                    try (FileLock lock = in.getChannel().lock(0, Long.MAX_VALUE, true)) {
+                    try (FileLock ignored = in.getChannel().lock(0, Long.MAX_VALUE, true)) {
                         getLogger().debug("Reading resolution-state from: " + touchfile);
                         props.load(in);
 
@@ -330,7 +328,7 @@ public class DefaultUpdateCheckManager extends AbstractLogEnabled implements Upd
         return new File(artifact.getFile().getParentFile(), sb.toString());
     }
 
-    File getTouchfile(RepositoryMetadata metadata, File file) {
+    File getTouchfile(File file) {
         return new File(file.getParent(), TOUCHFILE_NAME);
     }
 }


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MNG-XXX] SUMMARY`,
       where you replace `MNG-XXX` and `SUMMARY` with the appropriate JIRA issue.
 - [ ] Also format the first line of the commit message like `[MNG-XXX] SUMMARY`.
       Best practice is to use the JIRA issue title in both the pull request title and in the first line of the commit message.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
