### PR TITLE
Symbolic change (no issue)

### DIFF
--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -77,7 +77,7 @@ under the License.
     <proxy.user />
     <proxy.pass />
     <proxy.nonProxyHosts>localhost</proxy.nonProxyHosts>
-    <jetty9Version>9.4.56.v20240826</jetty9Version>
+    <jetty9Version>9.4.57.v20241219</jetty9Version>
 
     <stubPluginVersion>0.1-stub-SNAPSHOT</stubPluginVersion>
   </properties>


### PR DESCRIPTION
As this is IT suite, but just to get rid of Security warning on GH. Update, as there is newer version we use, but the reported issue is for sure not exploitable as we use Jetty 9 in ITs only.

