### PR TITLE
[MNG-8764] Sort injected lists by @Priority annotation

### DIFF
--- a/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
+++ b/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
@@ -220,7 +220,13 @@ public class InjectorImpl implements Injector {
         if (key.getRawType() == List.class) {
             Set<Binding<Object>> res2 = getBindings(key.getTypeParameter(0));
             if (res2 != null) {
-                List<Supplier<Object>> list = res2.stream().map(this::compile).collect(Collectors.toList());
+                // Sort bindings by priority (highest first) for deterministic ordering
+                List<Binding<Object>> sortedBindings = new ArrayList<>(res2);
+                Comparator<Binding<Object>> comparing = Comparator.comparing(Binding::getPriority);
+                sortedBindings.sort(comparing.reversed());
+
+                List<Supplier<Object>> list =
+                        sortedBindings.stream().map(this::compile).collect(Collectors.toList());
                 //noinspection unchecked
                 return () -> (Q) list(list, Supplier::get);
             }


### PR DESCRIPTION
When injecting List<T> dependencies, the DI container now sorts the
bindings by their @Priority annotation value in descending order
(highest priority first) to ensure deterministic ordering.

This change ensures that components with higher priority values
appear first in injected lists, providing predictable behavior
for dependency injection scenarios where order matters.

- Modified InjectorImpl.doGetCompiledBinding() to sort bindings
  by priority before creating supplier lists
- Added comprehensive tests for priority-based list ordering
- Includes tests for mixed priorities and default priority handling

JIRA issue: [MNG-8764](https://issues.apache.org/jira/browse/MNG-8764)

