### PR TITLE
[2436] centralize domain init logic `WrapperProperties#init`

### DIFF
--- a/impl/maven-core/src/test/java/org/apache/maven/model/WrapperPropertiesTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/model/WrapperPropertiesTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WrapperPropertiesTest {
+    private Map<String, String> backingStore;
+    private AtomicBoolean getterCalled;
+    private AtomicBoolean setterCalled;
+    private WrapperProperties wrapper;
+
+    @BeforeEach
+    void setUp() {
+        backingStore = new HashMap<>();
+        getterCalled = new AtomicBoolean(false);
+        setterCalled = new AtomicBoolean(false);
+
+        Supplier<Map<String, String>> getter = () -> {
+            getterCalled.set(true);
+            return new HashMap<>(backingStore);
+        };
+
+        Consumer<Properties> setter = props -> {
+            setterCalled.set(true);
+            backingStore.clear();
+            props.forEach((k, v) -> backingStore.put(k.toString(), v.toString()));
+        };
+
+        wrapper = new WrapperProperties(getter, setter);
+    }
+
+    @Test
+    void testInitialization() {
+        wrapper.getProperty("any");
+        assertTrue(getterCalled.get());
+    }
+
+    @Test
+    void testBasicOperations() {
+        // Test set and get
+        wrapper.setProperty("key1", "value1");
+        assertEquals("value1", wrapper.getProperty("key1"));
+        assertEquals("value1", backingStore.get("key1"));
+        assertTrue(setterCalled.get(), "Setter should be called after modification");
+
+        // Test remove
+        wrapper.remove("key1");
+        assertNull(wrapper.getProperty("key1"));
+        assertFalse(backingStore.containsKey("key1"));
+
+        // Test contains
+        wrapper.setProperty("key2", "value2");
+        assertTrue(wrapper.containsKey("key2"));
+        assertTrue(wrapper.containsValue("value2"));
+    }
+
+    @Test
+    void testOrderPreservation() {
+        wrapper.setProperty("a", "1");
+        wrapper.setProperty("b", "2");
+        wrapper.setProperty("c", "3");
+
+        // Check iteration order matches insertion order
+        Set<Object> keys = wrapper.keySet();
+        Object[] keyArray = keys.toArray();
+        assertEquals("a", keyArray[0]);
+        assertEquals("b", keyArray[1]);
+        assertEquals("c", keyArray[2]);
+
+        // Modify existing value and check order remains
+        wrapper.setProperty("b", "22");
+        keyArray = wrapper.keySet().toArray();
+        assertEquals("a", keyArray[0]);
+        assertEquals("b", keyArray[1]);
+        assertEquals("c", keyArray[2]);
+    }
+
+    @Test
+    @Disabled("should not throw NPE but does...")
+    void testBulkOperations() {
+        Properties props = new Properties();
+        props.setProperty("x", "10");
+        props.setProperty("y", "20");
+        props.setProperty("z", "30");
+
+        wrapper.putAll(props);
+        assertEquals("10", wrapper.getProperty("x"));
+        assertEquals("20", wrapper.getProperty("y"));
+        assertEquals("30", wrapper.getProperty("z"));
+
+        wrapper.clear();
+        assertTrue(wrapper.isEmpty());
+    }
+
+    @Test
+    void testStringPropertyNames() {
+        wrapper.setProperty("a", "1");
+        wrapper.setProperty("b", "2");
+
+        Set<String> names = wrapper.stringPropertyNames();
+        assertEquals(2, names.size());
+        assertTrue(names.contains("a"));
+        assertTrue(names.contains("b"));
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        wrapper.setProperty("k1", "v1");
+        wrapper.setProperty("k2", "v2");
+
+        Properties other = new Properties();
+        other.setProperty("k1", "v1");
+        other.setProperty("k2", "v2");
+
+        assertEquals(wrapper, other);
+        assertEquals(wrapper.hashCode(), other.hashCode());
+    }
+
+    @Test
+    void testLoadAndStore() throws IOException {
+        String propsData = "key1=value1\nkey2=value2\n";
+        wrapper.load(new StringReader(propsData));
+
+        assertEquals("value1", wrapper.getProperty("key1"));
+        assertEquals("value2", wrapper.getProperty("key2"));
+
+        StringWriter writer = new StringWriter();
+        wrapper.store(writer, "test");
+        String stored = writer.toString();
+        assertTrue(stored.contains("key1=value1"));
+        assertTrue(stored.contains("key2=value2"));
+    }
+
+    @Test
+    void testLoadFromStream() throws IOException {
+        String propsData = "key3=value3\nkey4=value4\n";
+        wrapper.load(new ByteArrayInputStream(propsData.getBytes()));
+
+        assertEquals("value3", wrapper.getProperty("key3"));
+        assertEquals("value4", wrapper.getProperty("key4"));
+    }
+
+    @Test
+    void testStoreToXML() throws IOException {
+        wrapper.setProperty("xmlkey", "xmlvalue");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wrapper.storeToXML(out, "test");
+
+        String xml = out.toString();
+        assertTrue(xml.contains("<entry key=\"xmlkey\">xmlvalue</entry>"));
+    }
+
+    @Test
+    void testUnsupportedOperations() {
+        assertThrows(UnsupportedOperationException.class, () -> wrapper.list(System.out));
+        assertThrows(UnsupportedOperationException.class, () -> wrapper.loadFromXML(null));
+    }
+
+    @Test
+    void testConcurrentModification() {
+        // Initial setup
+        wrapper.setProperty("initial", "value");
+
+        // Simulate concurrent modification by changing backing store directly
+        backingStore.put("concurrent", "mod");
+
+        // Next access should pick up the concurrent modification
+        assertEquals(null, wrapper.getProperty("concurrent"));
+    }
+
+    @Test
+    void testContainsKey() {
+        wrapper.put("nullkey", "null");
+        assertTrue(wrapper.containsKey("nullkey"));
+        assertNull(wrapper.get("null"));
+    }
+
+    @Test
+    void testComputeOperations() {
+        wrapper.setProperty("compute", "1");
+        wrapper.compute("compute", (k, v) -> v + "1");
+        assertEquals("11", wrapper.getProperty("compute"));
+
+        wrapper.computeIfAbsent("newkey", k -> "newvalue");
+        assertEquals("newvalue", wrapper.getProperty("newkey"));
+
+        wrapper.computeIfPresent("newkey", (k, v) -> "updated");
+        assertEquals("updated", wrapper.getProperty("newkey"));
+    }
+
+    @Test
+    void testMergeOperation() {
+        wrapper.setProperty("merge", "a");
+        wrapper.merge("merge", "b", (oldVal, newVal) -> "" + oldVal + newVal);
+        assertEquals("ab", wrapper.getProperty("merge"));
+
+        wrapper.merge("newmerge", "c", (oldVal, newVal) -> "" + oldVal + newVal);
+        assertEquals("c", wrapper.getProperty("newmerge"));
+    }
+
+    @Test
+    void testReplaceOperations() {
+        wrapper.setProperty("replace", "old");
+        wrapper.replace("replace", "new");
+        assertEquals("new", wrapper.getProperty("replace"));
+
+        wrapper.replace("replace", "new", "newer");
+        assertEquals("newer", wrapper.getProperty("replace"));
+
+        assertFalse(wrapper.replace("nonexistent", "a", "b"));
+    }
+
+    @Test
+    void testEntrySetBehavior() {
+        wrapper.setProperty("entry1", "value1");
+        wrapper.setProperty("entry2", "value2");
+
+        wrapper.entrySet().forEach(entry -> {
+            if ("entry1".equals(entry.getKey())) {
+                entry.setValue("modified");
+            }
+        });
+
+        assertEquals("modified", wrapper.getProperty("entry1"));
+    }
+}

--- a/src/mdo/java/WrapperProperties.java
+++ b/src/mdo/java/WrapperProperties.java
@@ -48,44 +48,45 @@ import java.util.function.Supplier;
 
 class WrapperProperties extends Properties {
 
-    final Supplier<Map<String, String>> getter;
-    final Consumer<Properties> setter;
     private final OrderedProperties orderedProps = new OrderedProperties();
-    private boolean initialized;
+    private final Supplier<Map<String, String>> getter;
+    private final Consumer<Properties> setter;
 
     WrapperProperties(Supplier<Map<String, String>> getter, Consumer<Properties> setter) {
         this.getter = getter;
         this.setter = setter;
+        orderedProps.putAll(getter.get());
+//        init();
     }
 
-    private synchronized void ensureInitialized() {
-        if (!initialized) {
-            orderedProps.putAll(getter.get());
-            initialized = true;
-        }
-    }
+//    /**
+//     * Initializes the ordered properties by populating it with values retrieved
+//     * from the getter. The retrieved map from the getter is merged into the
+//     * existing `orderedProps` map using the `putAll` method.
+//     *
+//     * This method ensures thread-safe initialization by synchronizing its operation.
+//     */
+//    private synchronized void init() {
+//        orderedProps.putAll(getter.get());
+//    }
 
     @Override
     public String getProperty(String key) {
-        ensureInitialized();
         return orderedProps.getProperty(key);
     }
 
     @Override
     public String getProperty(String key, String defaultValue) {
-        ensureInitialized();
         return orderedProps.getProperty(key, defaultValue);
     }
 
     @Override
     public Enumeration<?> propertyNames() {
-        ensureInitialized();
         return orderedProps.propertyNames();
     }
 
     @Override
     public Set<String> stringPropertyNames() {
-        ensureInitialized();
         return orderedProps.stringPropertyNames();
     }
 
@@ -101,81 +102,67 @@ class WrapperProperties extends Properties {
 
     @Override
     public int size() {
-        ensureInitialized();
         return orderedProps.size();
     }
 
     @Override
     public boolean isEmpty() {
-        ensureInitialized();
         return orderedProps.isEmpty();
     }
 
     @Override
     public Enumeration<Object> keys() {
-        ensureInitialized();
         return orderedProps.keys();
     }
 
     @Override
     public Enumeration<Object> elements() {
-        ensureInitialized();
         return orderedProps.elements();
     }
 
     @Override
     public boolean contains(Object value) {
-        ensureInitialized();
         return orderedProps.contains(value);
     }
 
     @Override
     public boolean containsValue(Object value) {
-        ensureInitialized();
         return orderedProps.containsValue(value);
     }
 
     @Override
     public boolean containsKey(Object key) {
-        ensureInitialized();
         return orderedProps.containsKey(key);
     }
 
     @Override
     public Object get(Object key) {
-        ensureInitialized();
         return orderedProps.get(key);
     }
 
     @Override
     public synchronized String toString() {
-        ensureInitialized();
         return orderedProps.toString();
     }
 
     @Override
     public Set<Object> keySet() {
-        ensureInitialized();
         return orderedProps.keySet();
     }
 
     @Override
     public Collection<Object> values() {
-        ensureInitialized();
         return orderedProps.values();
     }
 
     @Override
     public Set<Map.Entry<Object, Object>> entrySet() {
-        ensureInitialized();
         return orderedProps.entrySet();
     }
 
     @Override
     public synchronized boolean equals(Object o) {
-        ensureInitialized();
         if (o instanceof WrapperProperties wrapperProperties) {
-            wrapperProperties.ensureInitialized();
             return orderedProps.equals(wrapperProperties.orderedProps);
         }
         return orderedProps.equals(o);
@@ -183,19 +170,16 @@ class WrapperProperties extends Properties {
 
     @Override
     public synchronized int hashCode() {
-        ensureInitialized();
         return orderedProps.hashCode();
     }
 
     @Override
     public Object getOrDefault(Object key, Object defaultValue) {
-        ensureInitialized();
         return orderedProps.getOrDefault(key, defaultValue);
     }
 
     @Override
     public synchronized void forEach(BiConsumer<? super Object, ? super Object> action) {
-        ensureInitialized();
         orderedProps.forEach(action);
     }
 
@@ -208,16 +192,19 @@ class WrapperProperties extends Properties {
     }
 
     private <T> T writeOperation(WriteOp<T> runner) {
-        ensureInitialized();
         T ret = runner.perform(orderedProps);
-        setter.accept(orderedProps);
+        accept();
         return ret;
     }
 
     private void writeOperationVoid(WriteOpVoid runner) {
-        ensureInitialized();
         runner.perform(orderedProps);
+        accept();
+    }
+
+    private void accept() {
         setter.accept(orderedProps);
+//        init();
     }
 
     @Override


### PR DESCRIPTION
follow up:

 - https://github.com/apache/maven/pull/2404

its just calling some `getter.get()`, right? no need for de`bounce` or de`lay`?

evolve duplicate to centrale.