### PR TITLE
Improve configuration for dependabot in 3.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,16 +22,25 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: maven
+  - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
     target-branch: "maven-3.9.x"
     labels:
       - "mvn3"
+      - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "maven-3.9.x"
+    labels:
+      - "mvn3"
+      - "dependencies"


### PR DESCRIPTION
- add 'dependencies' label
- check GitHub Action in 3.x

