### PR TITLE
Revert "use `try-with-resources` statement in `LookupWagonMojo`"

### DIFF
--- a/its/core-it-support/core-it-plugins/maven-it-plugin-uses-wagon/src/main/java/org/apache/maven/plugin/coreit/LookupWagonMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-uses-wagon/src/main/java/org/apache/maven/plugin/coreit/LookupWagonMojo.java
@@ -92,11 +92,21 @@ public class LookupWagonMojo extends AbstractMojo {
 
         getLog().info("[MAVEN-CORE-IT-LOG] Creating output file " + outputFile);
 
-        outputFile.getParentFile().mkdirs();
-        try (OutputStream out = new FileOutputStream(outputFile)) {
+        OutputStream out = null;
+        try {
+            outputFile.getParentFile().mkdirs();
+            out = new FileOutputStream(outputFile);
             loaderProperties.store(out, "MAVEN-CORE-IT-LOG");
         } catch (IOException e) {
-            throw new MojoExecutionException(e);
+            throw new MojoExecutionException("Output file could not be created: " + outputFile, e);
+        } finally {
+            if (out != null) {
+                try {
+                    out.close();
+                } catch (IOException e) {
+                    // just ignore
+                }
+            }
         }
 
         getLog().info("[MAVEN-CORE-IT-LOG] Created output file " + outputFile);


### PR DESCRIPTION
Reverts apache/maven#2426

lets undo, as nobody cares.

It seems @slachiewicz wants to promote silly boilerplate.