### PR TITLE
Revert "use `try-with-resources` statement in `CatchMojo`"

### DIFF
--- a/its/core-it-support/core-it-plugins/maven-it-plugin-context-passing/src/main/java/org/apache/maven/plugin/coreit/CatchMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-context-passing/src/main/java/org/apache/maven/plugin/coreit/CatchMojo.java
@@ -58,10 +58,23 @@ public class CatchMojo extends AbstractMojo {
 
         File outfile = new File(outDir, value);
 
-        try (Writer writer = new FileWriter(outfile)) {
+        Writer writer = null;
+        try {
+            writer = new FileWriter(outfile);
+
             writer.write(value);
+
+            writer.flush();
         } catch (IOException e) {
             throw new MojoExecutionException("Cannot write output file: " + outfile, e);
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Reverts apache/maven#2424

lets undo, as nobody cares.

It seems @slachiewicz wants to promote silly boilerplate.