### PR TITLE
Ban "plain" Guice

### DIFF
--- a/compat/maven-compat/pom.xml
+++ b/compat/maven-compat/pom.xml
@@ -182,6 +182,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/compat/maven-embedder/pom.xml
+++ b/compat/maven-embedder/pom.xml
@@ -196,6 +196,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>provided</scope>
     </dependency>
 

--- a/compat/maven-resolver-provider/pom.xml
+++ b/compat/maven-resolver-provider/pom.xml
@@ -136,6 +136,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>provided</scope>
     </dependency>
 

--- a/impl/maven-cli/pom.xml
+++ b/impl/maven-cli/pom.xml
@@ -182,6 +182,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>provided</scope>
     </dependency>
 

--- a/impl/maven-core/pom.xml
+++ b/impl/maven-core/pom.xml
@@ -173,6 +173,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>provided</scope>
     </dependency>
 

--- a/impl/maven-testing/pom.xml
+++ b/impl/maven-testing/pom.xml
@@ -89,6 +89,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -352,11 +352,6 @@ under the License.
         <classifier>classes</classifier>
       </dependency>
       <dependency>
-        <groupId>com.google.inject</groupId>
-        <artifactId>guice</artifactId>
-        <version>${guiceVersion}</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guavaVersion}</version>
@@ -647,6 +642,12 @@ under the License.
         <artifactId>plexus-testing</artifactId>
         <version>${plexusTestingVersion}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
@@ -885,9 +886,15 @@ under the License.</licenseText>
               <rules>
                 <bannedDependencies>
                   <excludes>
+                    <!-- we use com.google.inject:classes:guice -->
+                    <exclude>com.google.inject:guice:*</exclude>
+                    <!-- we use org.codehaus.plexus:* -->
                     <exclude>org.sonatype.plexus:plexus-sec-dispatcher</exclude>
                     <exclude>org.sonatype.plexus:plexus-cipher</exclude>
                   </excludes>
+                  <includes>
+                    <include>com.google.inject:guice:*:jar:*:classes</include>
+                  </includes>
                   <message>ensure no more org.sonatype.plexus:plexus-cipher and org.sonatype.plexus:plexus-sec-dispatcher.</message>
                 </bannedDependencies>
               </rules>


### PR DESCRIPTION
We use the one with "classes" classifier. Clean up dependencies as well as we had both, plus we had
popping up via some test deps as well.

Ban the "plain" JAR as well, to make sure we have
only the proper ASM-less one here.