### PR TITLE
Move project mutation inside project lock

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -304,9 +304,9 @@ public class MojoExecutor {
 
         List<MavenProject> forkedProjects = executeForkedExecutions(mojoExecution, session);
 
-        ensureDependenciesAreResolved(mojoDescriptor, session, dependencyContext);
-
         try (NoExceptionCloseable lock = getProjectLock(session, mojoDescriptor)) {
+            ensureDependenciesAreResolved(mojoDescriptor, session, dependencyContext);
+
             doExecute2(session, mojoExecution);
         } finally {
             for (MavenProject forkedProject : forkedProjects) {


### PR DESCRIPTION
Move method into lock scope as it is mutating MavenProject instance.
This ensures that instance mutation happens by single caller.

Fixes #2455
