### PR TITLE
Use local repository in tests

### DIFF
--- a/impl/maven-executor/pom.xml
+++ b/impl/maven-executor/pom.xml
@@ -121,6 +121,7 @@ under the License.
             <maven4version>${maven4version}</maven4version>
             <maven3home>${project.build.directory}/dependency/apache-maven-${maven3version}</maven3home>
             <maven4home>${project.build.directory}/dependency/apache-maven-${maven4version}</maven4home>
+            <localRepository>${settings.localRepository}</localRepository>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
+import org.apache.maven.api.cli.ExecutorRequest;
 import org.apache.maven.cling.executor.ExecutorHelper;
 import org.apache.maven.cling.executor.MavenExecutorTestSupport;
 import org.apache.maven.cling.executor.MimirInfuser;
@@ -50,6 +51,14 @@ public class ToolboxToolTest {
         MimirInfuser.infuse(userHome);
     }
 
+    private ExecutorRequest.Builder getExecutorRequest(ExecutorHelper helper) {
+        ExecutorRequest.Builder builder = helper.executorRequest();
+        if (System.getProperty("localRepository") != null) {
+            builder.argument("-Dmaven.repo.local.tail=" + System.getProperty("localRepository"));
+        }
+        return builder;
+    }
+
     @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
@@ -60,7 +69,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        Map<String, String> dump = new ToolboxTool(helper).dump(helper.executorRequest());
+        Map<String, String> dump = new ToolboxTool(helper).dump(getExecutorRequest(helper));
         assertEquals(System.getProperty("maven3version"), dump.get("maven.version"));
     }
 
@@ -74,7 +83,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        Map<String, String> dump = new ToolboxTool(helper).dump(helper.executorRequest());
+        Map<String, String> dump = new ToolboxTool(helper).dump(getExecutorRequest(helper));
         assertEquals(System.getProperty("maven4version"), dump.get("maven.version"));
     }
 
@@ -114,7 +123,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String localRepository = new ToolboxTool(helper).localRepository(helper.executorRequest());
+        String localRepository = new ToolboxTool(helper).localRepository(getExecutorRequest(helper));
         Path local = Paths.get(localRepository);
         assertTrue(Files.isDirectory(local));
     }
@@ -130,7 +139,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String localRepository = new ToolboxTool(helper).localRepository(helper.executorRequest());
+        String localRepository = new ToolboxTool(helper).localRepository(getExecutorRequest(helper));
         Path local = Paths.get(localRepository);
         assertTrue(Files.isDirectory(local));
     }
@@ -146,7 +155,7 @@ public class ToolboxToolTest {
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
         String path = new ToolboxTool(helper)
-                .artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
+                .artifactPath(getExecutorRequest(helper), "aopalliance:aopalliance:1.0", "central");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(
                 path.endsWith("aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
@@ -165,7 +174,7 @@ public class ToolboxToolTest {
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
         String path = new ToolboxTool(helper)
-                .artifactPath(helper.executorRequest(), "aopalliance:aopalliance:1.0", "central");
+                .artifactPath(getExecutorRequest(helper), "aopalliance:aopalliance:1.0", "central");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(
                 path.endsWith("aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
@@ -183,7 +192,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper).metadataPath(helper.executorRequest(), "aopalliance", "someremote");
+        String path = new ToolboxTool(helper).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
     }
@@ -198,7 +207,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper).metadataPath(helper.executorRequest(), "aopalliance", "someremote");
+        String path = new ToolboxTool(helper).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
     }

--- a/impl/maven-impl/pom.xml
+++ b/impl/maven-impl/pom.xml
@@ -172,4 +172,17 @@ under the License.
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <localRepository>${settings.localRepository}</localRepository>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/RequestTraceTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/RequestTraceTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.impl.standalone;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -56,9 +57,13 @@ class RequestTraceTest {
 
     @Test
     void testTraces() {
-        Session session = ApiRunner.createSession(injector -> {
-            injector.bindInstance(RequestTraceTest.class, this);
-        });
+        Path localRepo =
+                System.getProperty("localRepository") != null ? Path.of(System.getProperty("localRepository")) : null;
+        Session session = ApiRunner.createSession(
+                injector -> {
+                    injector.bindInstance(RequestTraceTest.class, this);
+                },
+                localRepo);
 
         ModelBuilder builder = session.getService(ModelBuilder.class);
         ModelBuilderResult result = builder.newSession()

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/TestApiStandalone.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/standalone/TestApiStandalone.java
@@ -19,6 +19,7 @@
 package org.apache.maven.impl.standalone;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.maven.api.ArtifactCoordinates;
@@ -46,9 +47,14 @@ class TestApiStandalone {
 
     @Test
     void testStandalone() {
-        Session session = ApiRunner.createSession(injector -> {
-            injector.bindInstance(TestApiStandalone.class, this);
-        });
+        Path localRepo =
+                System.getProperty("localRepository") != null ? Path.of(System.getProperty("localRepository")) : null;
+
+        Session session = ApiRunner.createSession(
+                injector -> {
+                    injector.bindInstance(TestApiStandalone.class, this);
+                },
+                localRepo);
 
         ModelBuilder builder = session.getService(ModelBuilder.class);
         ModelBuilderResult result = builder.newSession()


### PR DESCRIPTION
Those tests need to resolve the current project
when we want to use e.g., next parent snapshot version that does not exist in remote repositories test will fail

