### PR TITLE
Update branch name for release-drafter in maven-4.0.x

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - maven-4.0.x
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We should execute release drafter for branch in which we want to generate draft of release.

