### PR TITLE
Add quotes in the command-line arguments formatted by `JavaPathType`.

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Artifact.java
@@ -39,7 +39,7 @@ import org.apache.maven.api.annotations.Nonnull;
 @Immutable
 public interface Artifact {
     /**
-     * {@return a unique identifier for this artifact}
+     * {@return a unique identifier for this artifact}.
      * The identifier is composed of groupId, artifactId, extension, classifier, and version.
      *
      * @see ArtifactCoordinates#getId()
@@ -58,7 +58,7 @@ public interface Artifact {
     }
 
     /**
-     * {@return the group identifier of the artifact}
+     * {@return the group identifier of the artifact}.
      *
      * @see ArtifactCoordinates#getGroupId()
      */
@@ -66,7 +66,7 @@ public interface Artifact {
     String getGroupId();
 
     /**
-     * {@return the identifier of the artifact}
+     * {@return the identifier of the artifact}.
      *
      * @see ArtifactCoordinates#getArtifactId()
      */
@@ -74,7 +74,7 @@ public interface Artifact {
     String getArtifactId();
 
     /**
-     * {@return the version of the artifact}
+     * {@return the version of the artifact}.
      * Contrarily to {@link ArtifactCoordinates},
      * each {@code Artifact} is associated to a specific version instead of a range of versions.
      * If the {@linkplain #getBaseVersion() base version} contains a meta-version such as {@code SNAPSHOT},
@@ -86,7 +86,7 @@ public interface Artifact {
     Version getVersion();
 
     /**
-     * {@return the version or meta-version of the artifact}
+     * {@return the version or meta-version of the artifact}.
      * A meta-version is a version suffixed with the {@code SNAPSHOT} keyword.
      * Meta-versions are represented in a base version by their symbols (e.g., {@code SNAPSHOT}),
      * while they are replaced by, for example, the actual timestamp in the {@linkplain #getVersion() version}.
@@ -122,7 +122,7 @@ public interface Artifact {
     boolean isSnapshot();
 
     /**
-     * {@return coordinates with the same identifiers as this artifact}
+     * {@return coordinates with the same identifiers as this artifact}.
      * This is a shortcut for {@code session.createArtifactCoordinates(artifact)}.
      *
      * @see org.apache.maven.api.Session#createArtifactCoordinates(Artifact)

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
@@ -53,7 +53,7 @@ public interface ArtifactCoordinates {
     String getClassifier();
 
     /**
-     * {@return the specific version, range of versions or meta-version of the artifact}.
+     * {@return the specific version, range of versions, or meta-version of the artifact}.
      * A meta-version is a version suffixed with the {@code SNAPSHOT} keyword.
      */
     @Nonnull
@@ -69,7 +69,7 @@ public interface ArtifactCoordinates {
     String getExtension();
 
     /**
-     * {@return a unique string representation identifying this artifact}.
+     * {@return a unique string identifying this artifact}.
      *
      * The default implementation returns a colon-separated list of group
      * identifier, artifact identifier, extension, classifier and version.

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
@@ -33,13 +33,13 @@ import org.apache.maven.api.annotations.Nonnull;
 @Immutable
 public interface ArtifactCoordinates {
     /**
-     * {@return the group identifier of the artifact}
+     * {@return the group identifier of the artifact}.
      */
     @Nonnull
     String getGroupId();
 
     /**
-     * {@return the identifier of the artifact}
+     * {@return the identifier of the artifact}.
      */
     @Nonnull
     String getArtifactId();
@@ -53,7 +53,7 @@ public interface ArtifactCoordinates {
     String getClassifier();
 
     /**
-     * {@return the specific version, range of versions or meta-version of the artifact}
+     * {@return the specific version, range of versions or meta-version of the artifact}.
      * A meta-version is a version suffixed with the {@code SNAPSHOT} keyword.
      */
     @Nonnull
@@ -69,7 +69,7 @@ public interface ArtifactCoordinates {
     String getExtension();
 
     /**
-     * {@return a unique string representation identifying this artifact}
+     * {@return a unique string representation identifying this artifact}.
      *
      * The default implementation returns a colon-separated list of group
      * identifier, artifact identifier, extension, classifier and version.

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Dependency.java
@@ -36,7 +36,7 @@ import org.apache.maven.api.annotations.Nonnull;
 @Immutable
 public interface Dependency extends Artifact {
     /**
-     * {@return the type of the dependency}
+     * {@return the type of the dependency}.
      * A dependency can be a <abbr>JAR</abbr> file,
      * a modular-<abbr>JAR</abbr> if it is intended to be placed on the module path,
      * a <abbr>JAR</abbr> containing test classes, <i>etc.</i>
@@ -47,7 +47,7 @@ public interface Dependency extends Artifact {
     Type getType();
 
     /**
-     * {@return the time at which the dependency will be used}
+     * {@return the time at which the dependency will be used}.
      * It may be, for example, at compile time only, at run time or at test time.
      *
      * @see DependencyCoordinates#getScope()
@@ -66,7 +66,7 @@ public interface Dependency extends Artifact {
     boolean isOptional();
 
     /**
-     * {@return coordinates with the same identifiers as this dependency}
+     * {@return coordinates with the same identifiers as this dependency}.
      */
     @Nonnull
     @Override

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DownloadedArtifact.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DownloadedArtifact.java
@@ -33,7 +33,7 @@ import org.apache.maven.api.annotations.Immutable;
 public interface DownloadedArtifact extends Artifact {
 
     /**
-     * {@return the actual file that has been downloaded in the file system}.
+     * {@return the a path to the file that has been downloaded to the file system}.
      */
     Path getPath();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DownloadedArtifact.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DownloadedArtifact.java
@@ -33,7 +33,7 @@ import org.apache.maven.api.annotations.Immutable;
 public interface DownloadedArtifact extends Artifact {
 
     /**
-     * {@return the actual file that has been downloaded in the file system}
+     * {@return the actual file that has been downloaded in the file system}.
      */
     Path getPath();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
@@ -263,8 +263,8 @@ public enum JavaPathType implements PathType {
         if (option == null) {
             throw new IllegalStateException("No option is associated to this path type.");
         }
-        String prefix = (moduleName == null) ? "" : (moduleName + '=');
-        StringJoiner joiner = new StringJoiner(File.pathSeparator, prefix, "");
+        String prefix = (moduleName == null) ? "\"" : (moduleName + "=\"");
+        var joiner = new StringJoiner(File.pathSeparator, prefix, "\"");
         joiner.setEmptyValue("");
         for (Path p : paths) {
             joiner.add(p.toString());

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
@@ -264,7 +264,7 @@ public enum JavaPathType implements PathType {
             throw new IllegalStateException("No option is associated to this path type.");
         }
         String prefix = (moduleName == null) ? "\"" : (moduleName + "=\"");
-        var joiner = new StringJoiner(File.pathSeparator, prefix, "\"");
+        StringJoiner joiner = new StringJoiner(File.pathSeparator, prefix, "\"");
         joiner.setEmptyValue("");
         for (Path p : paths) {
             joiner.add(p.toString());

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SourceRoot.java
@@ -68,9 +68,8 @@ public interface SourceRoot {
      * If no syntax is specified, or if its length is 1 character (interpreted as a Windows drive),
      * the default is a Maven-specific variation of the {@code "glob"} pattern.
      *
-     * <p>
-     * The default implementation returns an empty list, which means to apply a language-dependent pattern.
-     * For example, for the Java language, the pattern includes all files with the {@code .java} suffix.
+     * <p>The default implementation returns an empty list, which means to apply a language-dependent pattern.
+     * For example, for the Java language, the pattern includes all files with the {@code .java} suffix.</p>
      *
      * @see java.nio.file.FileSystem#getPathMatcher(String)
      */

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JavaPathTypeTest {
+    /**
+     * {@return dummy paths to use in tests}.
+     */
+    private static List<Path> paths() {
+        return List.of(Path.of("src", "foo.java"), Path.of("src", "bar.java"));
+    }
+
+    /**
+     * Converts paths from Unix style to platform-dependent style.
+     *
+     * @param expected the option value expected by the test
+     * @return the given expected value with separators of the host
+     */
+    private static String toPlatformSpecific(String expected) {
+        return expected.replace("/", File.separator).replace(":", File.pathSeparator);
+    }
+
+    /**
+     * Tests the formatting of an option without module name.
+     */
+    @Test
+    public void testOption() {
+        String[] f = JavaPathType.MODULES.option(paths());
+        assertEquals(2, f.length);
+        assertEquals("--module-path", f[0]);
+        assertEquals(toPlatformSpecific("\"src/foo.java:src/bar.java\""), f[1]);
+    }
+
+    /**
+     * Tests the formatting of an option with a module name.
+     */
+    @Test
+    public void testModularOption() {
+        String[] f = JavaPathType.patchModule("my.module").option(paths());
+        assertEquals(2, f.length);
+        assertEquals("--patch-module", f[0]);
+        assertEquals(toPlatformSpecific("my.module=\"src/foo.java:src/bar.java\""), f[1]);
+    }
+}

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
@@ -38,7 +38,7 @@ public class JavaPathTypeTest {
      * Converts paths from Unix style to platform-dependent style.
      *
      * @param expected the option value expected by the test
-     * @return the given expected value with separators of the host
+     * @return the expected value with separators of the host
      */
     private static String toPlatformSpecific(String expected) {
         return expected.replace("/", File.separator).replace(":", File.pathSeparator);
@@ -49,10 +49,10 @@ public class JavaPathTypeTest {
      */
     @Test
     public void testOption() {
-        String[] f = JavaPathType.MODULES.option(paths());
-        assertEquals(2, f.length);
-        assertEquals("--module-path", f[0]);
-        assertEquals(toPlatformSpecific("\"src/foo.java:src/bar.java\""), f[1]);
+        String[] formatted = JavaPathType.MODULES.option(paths());
+        assertEquals(2, formatted.length);
+        assertEquals("--module-path", formatted[0]);
+        assertEquals(toPlatformSpecific("\"src/foo.java:src/bar.java\""), formatted[1]);
     }
 
     /**
@@ -60,9 +60,9 @@ public class JavaPathTypeTest {
      */
     @Test
     public void testModularOption() {
-        String[] f = JavaPathType.patchModule("my.module").option(paths());
-        assertEquals(2, f.length);
-        assertEquals("--patch-module", f[0]);
-        assertEquals(toPlatformSpecific("my.module=\"src/foo.java:src/bar.java\""), f[1]);
+        String[] formatted = JavaPathType.patchModule("my.module").option(paths());
+        assertEquals(2, formatted.length);
+        assertEquals("--patch-module", formatted[0]);
+        assertEquals(toPlatformSpecific("my.module=\"src/foo.java:src/bar.java\""), formatted[1]);
     }
 }


### PR DESCRIPTION
The main purpose of this pull request is to put the file paths between quotes in the command line. For example instead of:

```
--module-source-path my.module=src/foo:src/bar
```

Format as:

```
--module-source-path my.module="src/foo:src/bar"
```

This pull request also contains opportunistic Javadoc formatting: missing dots at the end of summary sentences, missing closing `</p>` HTML tag.