### PR TITLE
Switch resolver to use rwlock-local locks

### DIFF
--- a/apache-maven/src/assembly/maven/conf/maven.properties
+++ b/apache-maven/src/assembly/maven/conf/maven.properties
@@ -65,3 +65,9 @@ maven.user.extensions         = ${maven.user.conf}/extensions.xml
 # Maven central repository URL.
 #
 maven.repo.central = ${env.MAVEN_REPO_CENTRAL:-https://repo.maven.apache.org/maven2}
+
+#
+# Maven Resolver Configuration
+#
+# Align locking to the same as in Maven 3.9.x
+aether.syncContext.named.factory = rwlock-local


### PR DESCRIPTION
This change configures Maven 4 to use rwlock-local locks
instead of the default file-based locks for the resolver's named locking mechanism.

