### PR TITLE
[maven-4.0.x] bug: fix duplicate dependency in effective model (fixes #2532) (#2554)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1169,9 +1169,6 @@ public class DefaultModelBuilder implements ModelBuilder {
 
             Model model = inheritanceAssembler.assembleModelInheritance(inputModel, parentModel, request, this);
 
-            // model normalization
-            model = modelNormalizer.mergeDuplicates(model, request, this);
-
             // profile activation
             profileActivationContext.setModel(model);
 
@@ -1185,6 +1182,9 @@ public class DefaultModelBuilder implements ModelBuilder {
             // model interpolation
             Model resultModel = model;
             resultModel = interpolateModel(resultModel, request, this);
+
+            // model normalization
+            resultModel = modelNormalizer.mergeDuplicates(resultModel, request, this);
 
             // url normalization
             resultModel = modelUrlNormalizer.normalize(resultModel, request);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh2532DuplicateDependencyEffectiveModelTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh2532DuplicateDependencyEffectiveModelTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/2532">GH-2532</a>.
+ * <p>
+ * The issue occurs when a project has duplicate dependencies in the effective model due to
+ * property placeholders in dependency coordinates. Before the fix, deduplication was performed
+ * before interpolation, causing dependencies like {@code scalatest_${scala.binary.version}} and
+ * {@code scalatest_2.13} to be seen as different dependencies. After interpolation, they become
+ * the same dependency, leading to a "duplicate dependency" error during the build.
+ * <p>
+ * The fix moves the deduplication step to after interpolation, ensuring that dependencies with
+ * property placeholders are properly deduplicated after their values are resolved.
+ */
+class MavenITgh2532DuplicateDependencyEffectiveModelTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh2532DuplicateDependencyEffectiveModelTest() {
+        super("[4.0.0-rc-3,)");
+    }
+
+    /**
+     * Tests that a project with dependencies using property placeholders in artifact coordinates
+     * can be built successfully without "duplicate dependency" errors when the same dependency
+     * appears in multiple places in the effective model.
+     * <p>
+     * This test reproduces the scenario where:
+     * <ul>
+     * <li>A dependency is defined with a property placeholder in the artifactId (e.g., scalatest_${scala.binary.version})</li>
+     * <li>The same dependency appears in parent and child modules</li>
+     * <li>The maven-shade-plugin is used, which triggers the duplicate dependency check</li>
+     * </ul>
+     * Before the fix, deduplication happened before interpolation, so scalatest_${scala.binary.version}
+     * and scalatest_2.13 were seen as different dependencies. After interpolation, they become the same,
+     * causing a "duplicate dependency" error during the shade goal.
+     * <p>
+     * The fix moves deduplication to after interpolation, ensuring proper deduplication.
+     */
+    @Test
+    void testDuplicateDependencyWithPropertyPlaceholders() throws Exception {
+        File testDir = extractResources("/gh-2532-duplicate-dependency-effective-model");
+
+        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        verifier.setLogFileName("testDuplicateDependencyWithPropertyPlaceholders.txt");
+        verifier.addCliArgument("package");
+        verifier.execute();
+
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -101,6 +101,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITgh2532DuplicateDependencyEffectiveModelTest.class);
         suite.addTestSuite(MavenITmng8736ConcurrentFileActivationTest.class);
         suite.addTestSuite(MavenITmng8744CIFriendlyTest.class);
         suite.addTestSuite(MavenITmng8572DITypeHandlerTest.class);

--- a/its/core-it-suite/src/test/resources/gh-2532-duplicate-dependency-effective-model/module-a/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-2532-duplicate-dependency-effective-model/module-a/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh2532</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module-a</artifactId>
+
+  <dependencies>
+    <!-- This dependency also uses the same artifact with property placeholder -->
+    <!-- This creates a scenario where the same dependency appears multiple times -->
+    <!-- in the effective model before interpolation but should be deduplicated after -->
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <version>${scalatest.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-2532-duplicate-dependency-effective-model/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-2532-duplicate-dependency-effective-model/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh2532</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module-a</module>
+  </modules>
+
+  <properties>
+    <scala.binary.version>2.13</scala.binary.version>
+    <scalatest.version>3.2.19</scalatest.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- This dependency uses property placeholder in artifactId -->
+      <dependency>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest_${scala.binary.version}</artifactId>
+        <version>${scalatest.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- This dependency inherits version from dependencyManagement -->
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <shadedArtifactAttached>false</shadedArtifactAttached>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [bug: fix duplicate dependency in effective model (fixes #2532) (#2554)](https://github.com/apache/maven/pull/2554)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)