### PR TITLE
[maven-4.0.x] chore: remove unused managed dependency (#2570)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,11 +407,6 @@ under the License.
         <version>${sisuVersion}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.inject</groupId>
-        <artifactId>jakarta.inject-api</artifactId>
-        <version>${jakartaInjectApiVersion}</version>
-      </dependency>
-      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>${asmVersion}</version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [chore: remove unused managed dependency (#2570)](https://github.com/apache/maven/pull/2570)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)