### PR TITLE
[MNG-8449] - Add Filtering Support to ProblemCollector

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
@@ -201,7 +201,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
      */
     @Nonnull
     static <P extends BuilderProblem> ProblemCollector<P> create(
-            final int maxCountLimit, final Predicate<? super P> filter) {
+            int maxCountLimit, Predicate<? super P> filter) {
         return new Impl<>(maxCountLimit, filter);
     }
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Constants;
@@ -181,11 +182,27 @@ public interface ProblemCollector<P extends BuilderProblem> {
     static <P extends BuilderProblem> ProblemCollector<P> create(@Nullable ProtoSession protoSession) {
         if (protoSession != null
                 && protoSession.getUserProperties().containsKey(Constants.MAVEN_BUILDER_MAX_PROBLEMS)) {
-            return new Impl<>(
-                    Integer.parseInt(protoSession.getUserProperties().get(Constants.MAVEN_BUILDER_MAX_PROBLEMS)));
+            final int limit =
+                    Integer.parseInt(protoSession.getUserProperties().get(Constants.MAVEN_BUILDER_MAX_PROBLEMS));
+            return create(limit, p -> true);
         } else {
             return create(100);
         }
+    }
+
+    /**
+     * Creates new instance of problem collector with the specified maximum problem count limit,
+     * but only preserves problems that match the given filter.
+     *
+     * @param <P>           the type of problem
+     * @param maxCountLimit the maximum number of problems to preserve
+     * @param filter        predicate to decide which problems to record
+     * @return a new filtered problem collector instance
+     */
+    @Nonnull
+    static <P extends BuilderProblem> ProblemCollector<P> create(
+            final int maxCountLimit, final Predicate<? super P> filter) {
+        return new Impl<>(maxCountLimit, filter);
     }
 
     /**
@@ -198,7 +215,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
      */
     @Nonnull
     static <P extends BuilderProblem> ProblemCollector<P> create(int maxCountLimit) {
-        return new Impl<>(maxCountLimit);
+        return create(maxCountLimit, p -> true);
     }
 
     /**
@@ -212,13 +229,14 @@ public interface ProblemCollector<P extends BuilderProblem> {
         private final AtomicInteger totalCount;
         private final ConcurrentMap<BuilderProblem.Severity, LongAdder> counters;
         private final ConcurrentMap<BuilderProblem.Severity, List<P>> problems;
+        private final Predicate<? super P> filter;
 
         private static final List<BuilderProblem.Severity> REVERSED_ORDER = Arrays.stream(
                         BuilderProblem.Severity.values())
                 .sorted(Comparator.reverseOrder())
                 .toList();
 
-        private Impl(int maxCountLimit) {
+        private Impl(int maxCountLimit, final Predicate<? super P> filter) {
             if (maxCountLimit < 0) {
                 throw new IllegalArgumentException("maxCountLimit must be non-negative");
             }
@@ -226,6 +244,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
             this.totalCount = new AtomicInteger();
             this.counters = new ConcurrentHashMap<>();
             this.problems = new ConcurrentHashMap<>();
+            this.filter = requireNonNull(filter, "filter");
         }
 
         @Override
@@ -245,6 +264,11 @@ public interface ProblemCollector<P extends BuilderProblem> {
         @Override
         public boolean reportProblem(P problem) {
             requireNonNull(problem, "problem");
+            // first apply filter
+            if (!filter.test(problem)) {
+                // drop without counting towards preserved problems
+                return false;
+            }
             int currentCount = totalCount.incrementAndGet();
             getCounter(problem.getSeverity()).increment();
             if (currentCount <= maxCountLimit || dropProblemWithLowerSeverity(problem.getSeverity())) {

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
@@ -182,8 +182,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
     static <P extends BuilderProblem> ProblemCollector<P> create(@Nullable ProtoSession protoSession) {
         if (protoSession != null
                 && protoSession.getUserProperties().containsKey(Constants.MAVEN_BUILDER_MAX_PROBLEMS)) {
-            int limit =
-                    Integer.parseInt(protoSession.getUserProperties().get(Constants.MAVEN_BUILDER_MAX_PROBLEMS));
+            int limit = Integer.parseInt(protoSession.getUserProperties().get(Constants.MAVEN_BUILDER_MAX_PROBLEMS));
             return create(limit, p -> true);
         } else {
             return create(100);
@@ -200,8 +199,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
      * @return a new filtered problem collector instance
      */
     @Nonnull
-    static <P extends BuilderProblem> ProblemCollector<P> create(
-            int maxCountLimit, Predicate<? super P> filter) {
+    static <P extends BuilderProblem> ProblemCollector<P> create(int maxCountLimit, Predicate<? super P> filter) {
         return new Impl<>(maxCountLimit, filter);
     }
 

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
@@ -236,7 +236,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
                 .sorted(Comparator.reverseOrder())
                 .toList();
 
-        private Impl(int maxCountLimit, final Predicate<? super P> filter) {
+        private Impl(int maxCountLimit, Predicate<? super P> filter) {
             if (maxCountLimit < 0) {
                 throw new IllegalArgumentException("maxCountLimit must be non-negative");
             }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ProblemCollector.java
@@ -182,7 +182,7 @@ public interface ProblemCollector<P extends BuilderProblem> {
     static <P extends BuilderProblem> ProblemCollector<P> create(@Nullable ProtoSession protoSession) {
         if (protoSession != null
                 && protoSession.getUserProperties().containsKey(Constants.MAVEN_BUILDER_MAX_PROBLEMS)) {
-            final int limit =
+            int limit =
                     Integer.parseInt(protoSession.getUserProperties().get(Constants.MAVEN_BUILDER_MAX_PROBLEMS));
             return create(limit, p -> true);
         } else {

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.building;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,5 +38,85 @@ class ProblemCollectorFactoryTest {
         assertNotSame(collector1, collector2);
         assertEquals(0, collector1.getProblems().size());
         assertEquals(1, collector2.getProblems().size());
+    }
+
+    private static class TestProblem implements Problem {
+        private final String message;
+        private final Problem.Severity severity;
+        private final String source;
+        private final int lineNumber;
+        private final int columnNumber;
+        private final Exception cause;
+
+        TestProblem(
+                final String message,
+                final Problem.Severity severity,
+                final String source,
+                final int lineNumber,
+                final int columnNumber,
+                final Exception cause) {
+            this.message = message;
+            this.severity = severity;
+            this.source = source != null ? source : "";
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.cause = cause;
+        }
+
+        @Override
+        public String getSource() {
+            return source;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return lineNumber;
+        }
+
+        @Override
+        public int getColumnNumber() {
+            return columnNumber;
+        }
+
+        @Override
+        public String getLocation() {
+            final StringBuilder loc = new StringBuilder(source);
+            if (lineNumber > 0) {
+                loc.append(":").append(lineNumber);
+                if (columnNumber > 0) {
+                    loc.append(":").append(columnNumber);
+                }
+            }
+            return loc.toString();
+        }
+
+        @Override
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public Exception getException() {
+            return cause;
+        }
+
+        @Override
+        public Problem.Severity getSeverity() {
+            return severity;
+        }
+    }
+
+    @Test
+    void testAddProblem() {
+        final ProblemCollector collector = ProblemCollectorFactory.newInstance(null);
+        collector.setSource("pom.xml");
+        collector.add(Problem.Severity.ERROR, "Error message", 10, 5, null);
+        collector.add(Problem.Severity.WARNING, "Warning message", 15, 3, null);
+
+        final List<Problem> problems = collector.getProblems();
+        assertEquals(2, problems.size(), "Should collect both problems");
+        assertEquals(Problem.Severity.ERROR, problems.get(0).getSeverity(), "First problem should be ERROR");
+        assertEquals("Error message", problems.get(0).getMessage(), "First problem should have correct message");
+        assertEquals(Problem.Severity.WARNING, problems.get(1).getSeverity(), "Second problem should be WARNING");
     }
 }

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
@@ -108,7 +108,7 @@ class ProblemCollectorFactoryTest {
 
     @Test
     void testAddProblem() {
-        final ProblemCollector collector = ProblemCollectorFactory.newInstance(null);
+        ProblemCollector collector = ProblemCollectorFactory.newInstance(null);
         collector.setSource("pom.xml");
         collector.add(Problem.Severity.ERROR, "Error message", 10, 5, null);
         collector.add(Problem.Severity.WARNING, "Warning message", 15, 3, null);

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
@@ -49,12 +49,12 @@ class ProblemCollectorFactoryTest {
         private final Exception cause;
 
         TestProblem(
-                final String message,
-                final Problem.Severity severity,
-                final String source,
-                final int lineNumber,
-                final int columnNumber,
-                final Exception cause) {
+                String message,
+                Problem.Severity severity,
+                String source,
+                int lineNumber,
+                int columnNumber,
+                Exception cause) {
             this.message = message;
             this.severity = severity;
             this.source = source != null ? source : "";

--- a/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
+++ b/compat/maven-builder-support/src/test/java/org/apache/maven/building/ProblemCollectorFactoryTest.java
@@ -113,7 +113,7 @@ class ProblemCollectorFactoryTest {
         collector.add(Problem.Severity.ERROR, "Error message", 10, 5, null);
         collector.add(Problem.Severity.WARNING, "Warning message", 15, 3, null);
 
-        final List<Problem> problems = collector.getProblems();
+        List<Problem> problems = collector.getProblems();
         assertEquals(2, problems.size(), "Should collect both problems");
         assertEquals(Problem.Severity.ERROR, problems.get(0).getSeverity(), "First problem should be ERROR");
         assertEquals("Error message", problems.get(0).getMessage(), "First problem should have correct message");


### PR DESCRIPTION
…n.api.services to address [MNG-8449], enabling selective problem collection via Predicate, with thread-safe handling and integration with existing lossy behavior, tested thoroughly to ensure robust severity and message-based filtering.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X ] Your pull request should address just one issue, without pulling in other changes.
- [ X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [X ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ X] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [X ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/


This PR implements filtering for `ProblemCollector` in `org.apache.maven.api.services` to resolve [[MNG-8449](This PR implements filtering for ProblemCollector in org.apache.maven.api.services to resolve [MNG-8449], allowing selective problem collection using a Predicate. The solution ensures thread-safe filtering, integrates with existing lossy behavior, and includes comprehensive tests for severity and message-based filtering.)], allowing selective problem collection using a Predicate. The solution ensures thread-safe filtering, integrates with existing lossy behavior, and includes comprehensive tests for severity and message-based filtering.