### PR TITLE
[maven-4.0.x] Refactor setupContainer to validate ExtensionContext, test class and instance, and throw clear IllegalStateExceptions (#10901, fixes #10428)

### DIFF
--- a/impl/maven-testing/src/main/java/org/apache/maven/api/di/testing/MavenDIExtension.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/di/testing/MavenDIExtension.java
@@ -84,18 +84,34 @@ public class MavenDIExtension implements BeforeEachCallback, AfterEachCallback {
      * Creates and configures the DI container for test execution.
      * Performs component discovery and sets up basic bindings.
      *
-     * @throws IllegalArgumentException if container setup fails
+     * @throws IllegalStateException if the ExtensionContext is null, the required test class is unavailable,
+     *         the required test instance is unavailable, or if container setup fails
      */
-    @SuppressWarnings("unchecked")
     protected void setupContainer() {
+        if (context == null) {
+            throw new IllegalStateException("ExtensionContext must not be null");
+        }
+        final Class<?> testClass = context.getRequiredTestClass();
+        if (testClass == null) {
+            throw new IllegalStateException("Required test class is not available in ExtensionContext");
+        }
+        final Object testInstance = context.getRequiredTestInstance();
+        if (testInstance == null) {
+            throw new IllegalStateException("Required test instance is not available in ExtensionContext");
+        }
+
         try {
             injector = Injector.create();
             injector.bindInstance(ExtensionContext.class, context);
-            injector.discover(context.getRequiredTestClass().getClassLoader());
+            injector.discover(testClass.getClassLoader());
             injector.bindInstance(Injector.class, injector);
-            injector.bindInstance((Class) context.getRequiredTestClass(), context.getRequiredTestInstance());
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to create DI injector.", e);
+            injector.bindInstance(testClass.asSubclass(Object.class), (Object) testInstance); // Safe generics handling
+        } catch (final Exception e) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Failed to set up DI injector for test class '%s': %s",
+                            testClass.getName(), e.getMessage()),
+                    e);
         }
     }
 

--- a/impl/maven-testing/src/test/java/org/apache/maven/api/di/testing/SimpleDITest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/api/di/testing/SimpleDITest.java
@@ -25,9 +25,13 @@ import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.plugin.testing.stubs.SessionMock;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static org.apache.maven.api.di.testing.MavenDIExtension.getBasedir;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @MavenDITest
 public class SimpleDITest {
@@ -47,4 +51,26 @@ public class SimpleDITest {
     Session createSession() {
         return SessionMock.getMockSession(LOCAL_REPO);
     }
+
+    @Test
+    void testSetupContainerWithNullContext() {
+        MavenDIExtension extension = new MavenDIExtension();
+        MavenDIExtension.context = null;
+        assertThrows(IllegalStateException.class, extension::setupContainer);
+    }
+
+    @Test
+    void testSetupContainerWithNullTestClass() {
+        final MavenDIExtension extension = new MavenDIExtension();
+        final ExtensionContext context = mock(ExtensionContext.class);
+        when(context.getRequiredTestClass()).thenReturn(null); // Mock null test class
+        when(context.getRequiredTestInstance()).thenReturn(new TestClass()); // Valid instance
+        MavenDIExtension.context = context;
+        assertThrows(
+                IllegalStateException.class,
+                extension::setupContainer,
+                "Should throw IllegalStateException for null test class");
+    }
+
+    static class TestClass {}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Refactor setupContainer to validate ExtensionContext, test class and instance, and throw clear IllegalStateExceptions (#10901, fixes #10428)](https://github.com/apache/maven/pull/10901)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)