### PR TITLE
[maven-4.0.x] perf: optimize CompositeBeanHelper with reflection caching

### DIFF
--- a/impl/maven-core/pom.xml
+++ b/impl/maven-core/pom.xml
@@ -240,6 +240,16 @@ under the License.
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Used in TestApi -->
     <dependency>

--- a/impl/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelper.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelper.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.configuration.internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import com.google.inject.TypeLiteral;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.ConfigurationConverter;
+import org.codehaus.plexus.component.configurator.converters.ParameterizedConfigurationConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.eclipse.sisu.bean.DeclaredMembers;
+import org.eclipse.sisu.bean.DeclaredMembers.View;
+import org.eclipse.sisu.plexus.TypeArguments;
+
+/**
+ * Optimized version of CompositeBeanHelper with caching for improved performance.
+ * This implementation caches method and field lookups to avoid repeated reflection operations.
+ */
+public final class EnhancedCompositeBeanHelper {
+
+    // Cache for method lookups: Class -> PropertyName -> MethodInfo
+    private static final ConcurrentMap<Class<?>, Map<String, MethodInfo>> METHOD_CACHE = new ConcurrentHashMap<>();
+
+    // Cache for field lookups: Class -> FieldName -> Field
+    private static final ConcurrentMap<Class<?>, Map<String, Field>> FIELD_CACHE = new ConcurrentHashMap<>();
+
+    // Cache for accessible fields to avoid repeated setAccessible calls
+    private static final ConcurrentMap<Field, Boolean> ACCESSIBLE_FIELD_CACHE = new ConcurrentHashMap<>();
+
+    private final ConverterLookup lookup;
+    private final ClassLoader loader;
+    private final ExpressionEvaluator evaluator;
+    private final ConfigurationListener listener;
+
+    /**
+     * Holds information about a method including its parameter type.
+     */
+    private record MethodInfo(Method method, Type parameterType) {}
+
+    public EnhancedCompositeBeanHelper(
+            ConverterLookup lookup, ClassLoader loader, ExpressionEvaluator evaluator, ConfigurationListener listener) {
+        this.lookup = lookup;
+        this.loader = loader;
+        this.evaluator = evaluator;
+        this.listener = listener;
+    }
+
+    /**
+     * Calls the default "set" method on the bean; re-converts the configuration if necessary.
+     */
+    public void setDefault(Object bean, Object defaultValue, PlexusConfiguration configuration)
+            throws ComponentConfigurationException {
+
+        Class<?> beanType = bean.getClass();
+
+        // Find the default "set" method
+        MethodInfo setterInfo = findCachedMethod(beanType, "", null);
+        if (setterInfo == null) {
+            // Look for any method named "set" with one parameter
+            Map<String, MethodInfo> classMethodCache = METHOD_CACHE.computeIfAbsent(beanType, this::buildMethodCache);
+            setterInfo = classMethodCache.get("set");
+        }
+
+        if (setterInfo == null) {
+            throw new ComponentConfigurationException(configuration, "Cannot find default setter in " + beanType);
+        }
+
+        Object value = defaultValue;
+        TypeLiteral<?> paramType = TypeLiteral.get(setterInfo.parameterType);
+
+        if (!paramType.getRawType().isInstance(value)) {
+            if (configuration.getChildCount() > 0) {
+                throw new ComponentConfigurationException(
+                        "Basic element '" + configuration.getName() + "' must not contain child elements");
+            }
+            value = convertProperty(beanType, paramType.getRawType(), paramType.getType(), configuration);
+        }
+
+        if (value != null) {
+            try {
+                if (listener != null) {
+                    listener.notifyFieldChangeUsingSetter("", value, bean);
+                }
+                setterInfo.method.invoke(bean, value);
+            } catch (IllegalAccessException | InvocationTargetException | LinkageError e) {
+                throw new ComponentConfigurationException(configuration, "Cannot set default", e);
+            }
+        }
+    }
+
+    /**
+     * Sets a property in the bean using cached lookups for improved performance.
+     */
+    public void setProperty(Object bean, String propertyName, Class<?> valueType, PlexusConfiguration configuration)
+            throws ComponentConfigurationException {
+
+        Class<?> beanType = bean.getClass();
+
+        // Try setter/adder methods first
+        MethodInfo methodInfo = findCachedMethod(beanType, propertyName, valueType);
+        if (methodInfo != null) {
+            try {
+                Object value = convertPropertyForMethod(beanType, methodInfo, valueType, configuration);
+                if (value != null) {
+                    if (listener != null) {
+                        listener.notifyFieldChangeUsingSetter(propertyName, value, bean);
+                    }
+                    methodInfo.method.invoke(bean, value);
+                    return;
+                }
+            } catch (IllegalAccessException | InvocationTargetException | LinkageError e) {
+                // Fall through to field access
+            }
+        }
+
+        // Try field access
+        Field field = findCachedField(beanType, propertyName);
+        if (field != null) {
+            try {
+                Object value = convertPropertyForField(beanType, field, valueType, configuration);
+                if (value != null) {
+                    if (listener != null) {
+                        listener.notifyFieldChangeUsingReflection(propertyName, value, bean);
+                    }
+                    setFieldValue(bean, field, value);
+                    return;
+                }
+            } catch (IllegalAccessException | LinkageError e) {
+                // Continue to error handling
+            }
+        }
+
+        // If we get here, we couldn't set the property
+        if (methodInfo == null && field == null) {
+            throw new ComponentConfigurationException(
+                    configuration, "Cannot find '" + propertyName + "' in " + beanType);
+        }
+    }
+
+    /**
+     * Find method using cache for improved performance.
+     */
+    private MethodInfo findCachedMethod(Class<?> beanType, String propertyName, Class<?> valueType) {
+        Map<String, MethodInfo> classMethodCache = METHOD_CACHE.computeIfAbsent(beanType, this::buildMethodCache);
+
+        String title = Character.toTitleCase(propertyName.charAt(0)) + propertyName.substring(1);
+
+        // Try setter first
+        MethodInfo setter = classMethodCache.get("set" + title);
+        if (setter != null && isMethodCompatible(setter.method, valueType)) {
+            return setter;
+        }
+
+        // Try adder
+        MethodInfo adder = classMethodCache.get("add" + title);
+        if (adder != null && isMethodCompatible(adder.method, valueType)) {
+            return adder;
+        }
+
+        // Return first found for backward compatibility
+        return setter != null ? setter : adder;
+    }
+
+    /**
+     * Build method cache for a class.
+     */
+    private Map<String, MethodInfo> buildMethodCache(Class<?> beanType) {
+        Map<String, MethodInfo> methodMap = new HashMap<>();
+
+        for (Method method : beanType.getMethods()) {
+            if (!Modifier.isStatic(method.getModifiers()) && method.getParameterCount() == 1) {
+                Type[] paramTypes = method.getGenericParameterTypes();
+                methodMap.putIfAbsent(method.getName(), new MethodInfo(method, paramTypes[0]));
+            }
+        }
+
+        return methodMap;
+    }
+
+    /**
+     * Check if method is compatible with value type.
+     */
+    private boolean isMethodCompatible(Method method, Class<?> valueType) {
+        if (valueType == null) {
+            return true;
+        }
+        return method.getParameterTypes()[0].isAssignableFrom(valueType);
+    }
+
+    /**
+     * Find field using cache for improved performance.
+     */
+    private Field findCachedField(Class<?> beanType, String fieldName) {
+        Map<String, Field> classFieldCache = FIELD_CACHE.computeIfAbsent(beanType, this::buildFieldCache);
+        return classFieldCache.get(fieldName);
+    }
+
+    /**
+     * Build field cache for a class.
+     */
+    private Map<String, Field> buildFieldCache(Class<?> beanType) {
+        Map<String, Field> fieldMap = new HashMap<>();
+
+        for (Object member : new DeclaredMembers(beanType, View.FIELDS)) {
+            Field field = (Field) member;
+            if (!Modifier.isStatic(field.getModifiers())) {
+                fieldMap.put(field.getName(), field);
+            }
+        }
+
+        return fieldMap;
+    }
+
+    /**
+     * Convert property value for method parameter.
+     */
+    private Object convertPropertyForMethod(
+            Class<?> beanType, MethodInfo methodInfo, Class<?> valueType, PlexusConfiguration configuration)
+            throws ComponentConfigurationException {
+
+        TypeLiteral<?> paramType = TypeLiteral.get(methodInfo.parameterType);
+        return convertProperty(beanType, valueType, configuration, paramType);
+    }
+
+    /**
+     * Convert property value for field.
+     */
+    private Object convertPropertyForField(
+            Class<?> beanType, Field field, Class<?> valueType, PlexusConfiguration configuration)
+            throws ComponentConfigurationException {
+
+        TypeLiteral<?> fieldType = TypeLiteral.get(field.getGenericType());
+        return convertProperty(beanType, valueType, configuration, fieldType);
+    }
+
+    private Object convertProperty(
+            Class<?> beanType, Class<?> valueType, PlexusConfiguration configuration, TypeLiteral<?> paramType)
+            throws ComponentConfigurationException {
+        Class<?> rawPropertyType = paramType.getRawType();
+
+        if (valueType != null && rawPropertyType.isAssignableFrom(valueType)) {
+            rawPropertyType = valueType; // pick more specific type
+        }
+
+        return convertProperty(beanType, rawPropertyType, paramType.getType(), configuration);
+    }
+
+    /**
+     * Convert property using appropriate converter.
+     */
+    private Object convertProperty(
+            Class<?> beanType, Class<?> rawPropertyType, Type genericPropertyType, PlexusConfiguration configuration)
+            throws ComponentConfigurationException {
+
+        ConfigurationConverter converter = lookup.lookupConverterForType(rawPropertyType);
+
+        if (!(genericPropertyType instanceof Class) && converter instanceof ParameterizedConfigurationConverter) {
+            Type[] propertyTypeArgs = TypeArguments.get(genericPropertyType);
+            return ((ParameterizedConfigurationConverter) converter)
+                    .fromConfiguration(
+                            lookup,
+                            configuration,
+                            rawPropertyType,
+                            propertyTypeArgs,
+                            beanType,
+                            loader,
+                            evaluator,
+                            listener);
+        }
+
+        return converter.fromConfiguration(
+                lookup, configuration, rawPropertyType, beanType, loader, evaluator, listener);
+    }
+
+    /**
+     * Set field value with cached accessibility.
+     */
+    private void setFieldValue(Object bean, Field field, Object value) throws IllegalAccessException {
+        Boolean isAccessible = ACCESSIBLE_FIELD_CACHE.get(field);
+        if (isAccessible == null) {
+            isAccessible = field.canAccess(bean);
+            if (!isAccessible) {
+                field.setAccessible(true);
+                isAccessible = true;
+            }
+            ACCESSIBLE_FIELD_CACHE.put(field, isAccessible);
+        } else if (!isAccessible) {
+            field.setAccessible(true);
+            ACCESSIBLE_FIELD_CACHE.put(field, true);
+        }
+
+        field.set(bean, value);
+    }
+
+    /**
+     * Clear all caches. Useful for testing or memory management.
+     */
+    public static void clearCaches() {
+        METHOD_CACHE.clear();
+        FIELD_CACHE.clear();
+        ACCESSIBLE_FIELD_CACHE.clear();
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedConfigurationConverter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedConfigurationConverter.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.configuration.internal;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.composite.ObjectWithFieldsConverter;
@@ -26,13 +29,16 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluatio
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.component.configurator.expression.TypeAwareExpressionEvaluator;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
-import org.eclipse.sisu.plexus.CompositeBeanHelper;
 
 /**
  * An enhanced {@link ObjectWithFieldsConverter} leveraging the {@link TypeAwareExpressionEvaluator}
  * interface.
  */
 class EnhancedConfigurationConverter extends ObjectWithFieldsConverter {
+
+    // Cache for expression evaluation results to avoid repeated evaluations
+    private static final ConcurrentMap<String, Object> EXPRESSION_CACHE = new ConcurrentHashMap<>();
+
     protected Object fromExpression(
             final PlexusConfiguration configuration, final ExpressionEvaluator evaluator, final Class<?> type)
             throws ComponentConfigurationException {
@@ -89,7 +95,9 @@ class EnhancedConfigurationConverter extends ObjectWithFieldsConverter {
             if (null == value) {
                 processConfiguration(lookup, bean, loader, configuration, evaluator, listener);
             } else {
-                new CompositeBeanHelper(lookup, loader, evaluator, listener).setDefault(bean, value, configuration);
+                // Use optimized helper for better performance
+                new EnhancedCompositeBeanHelper(lookup, loader, evaluator, listener)
+                        .setDefault(bean, value, configuration);
             }
             return bean;
         } catch (final ComponentConfigurationException e) {
@@ -98,5 +106,35 @@ class EnhancedConfigurationConverter extends ObjectWithFieldsConverter {
             }
             throw e;
         }
+    }
+
+    public void processConfiguration(
+            final ConverterLookup lookup,
+            final Object bean,
+            final ClassLoader loader,
+            final PlexusConfiguration configuration,
+            final ExpressionEvaluator evaluator,
+            final ConfigurationListener listener)
+            throws ComponentConfigurationException {
+        final EnhancedCompositeBeanHelper helper = new EnhancedCompositeBeanHelper(lookup, loader, evaluator, listener);
+        for (int i = 0, size = configuration.getChildCount(); i < size; i++) {
+            final PlexusConfiguration element = configuration.getChild(i);
+            final String propertyName = fromXML(element.getName());
+            Class<?> valueType;
+            try {
+                valueType = getClassForImplementationHint(null, element, loader);
+            } catch (final ComponentConfigurationException e) {
+                valueType = null;
+            }
+            helper.setProperty(bean, propertyName, valueType, element);
+        }
+    }
+
+    /**
+     * Clear all caches. Useful for testing or memory management.
+     */
+    public static void clearCaches() {
+        EXPRESSION_CACHE.clear();
+        EnhancedCompositeBeanHelper.clearCaches();
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/configuration/internal/CompositeBeanHelperPerformanceTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/configuration/internal/CompositeBeanHelperPerformanceTest.java
@@ -1,0 +1,439 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.configuration.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.eclipse.sisu.plexus.CompositeBeanHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Performance comparison test between original CompositeBeanHelper and OptimizedCompositeBeanHelper.
+ * This test uses JMH (Java Microbenchmark Harness) for accurate performance measurement.
+ *
+ * To run this benchmark:
+ * mvn test -Dtest=CompositeBeanHelperPerformanceTest -pl impl/maven-core
+ *
+ * The main method will execute the JMH benchmarks with the configured parameters.
+ *
+ * IMPORTANT: Caches are only cleared between trials (10-second periods), not between individual
+ * iterations, to properly test the cache benefits within each measurement period.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 10)
+@Fork(1)
+@State(Scope.Benchmark)
+public class CompositeBeanHelperPerformanceTest {
+
+    private ConverterLookup converterLookup;
+    private ExpressionEvaluator evaluator;
+    private ConfigurationListener listener;
+    private CompositeBeanHelper originalHelper;
+    private EnhancedCompositeBeanHelper optimizedHelper;
+
+    @Setup(Level.Trial)
+    @BeforeEach
+    public void setUp() throws ExpressionEvaluationException {
+        converterLookup = new DefaultConverterLookup();
+        evaluator = mock(ExpressionEvaluator.class);
+        listener = mock(ConfigurationListener.class);
+
+        when(evaluator.evaluate(anyString())).thenReturn("testValue");
+        for (int i = 0; i < 10; i++) {
+            when(evaluator.evaluate(Integer.toString(i))).thenReturn(i);
+        }
+        when(evaluator.evaluate("123")).thenReturn(123);
+        when(evaluator.evaluate("456")).thenReturn(456);
+        when(evaluator.evaluate("true")).thenReturn(true);
+
+        originalHelper = new CompositeBeanHelper(converterLookup, getClass().getClassLoader(), evaluator, listener);
+        optimizedHelper =
+                new EnhancedCompositeBeanHelper(converterLookup, getClass().getClassLoader(), evaluator, listener);
+    }
+
+    @TearDown(Level.Trial)
+    @AfterEach
+    public void tearDown() {
+        // Clear caches between trials (10-second periods) to allow cache benefits within each trial
+        EnhancedCompositeBeanHelper.clearCaches();
+    }
+
+    @Benchmark
+    public void benchmarkOriginalHelper() throws Exception {
+        RealisticTestBean bean = new RealisticTestBean();
+
+        // Set multiple properties to simulate real mojo configuration
+        // Use direct method calls instead of reflection for fair comparison
+        PlexusConfiguration nameConfig = new XmlPlexusConfiguration("name");
+        nameConfig.setValue("testValue");
+        originalHelper.setProperty(bean, "name", String.class, nameConfig);
+
+        PlexusConfiguration countConfig = new XmlPlexusConfiguration("count");
+        countConfig.setValue("123");
+        originalHelper.setProperty(bean, "count", Integer.class, countConfig);
+
+        PlexusConfiguration enabledConfig = new XmlPlexusConfiguration("enabled");
+        enabledConfig.setValue("true");
+        originalHelper.setProperty(bean, "enabled", Boolean.class, enabledConfig);
+
+        PlexusConfiguration descConfig = new XmlPlexusConfiguration("description");
+        descConfig.setValue("testValue");
+        originalHelper.setProperty(bean, "description", String.class, descConfig);
+
+        PlexusConfiguration timeoutConfig = new XmlPlexusConfiguration("timeout");
+        timeoutConfig.setValue("123");
+        originalHelper.setProperty(bean, "timeout", Long.class, timeoutConfig);
+    }
+
+    @Benchmark
+    public void benchmarkOptimizedHelper() throws Exception {
+        RealisticTestBean bean = new RealisticTestBean();
+
+        // Set multiple properties to simulate real mojo configuration
+        PlexusConfiguration nameConfig = new XmlPlexusConfiguration("name");
+        nameConfig.setValue("testValue");
+        optimizedHelper.setProperty(bean, "name", String.class, nameConfig);
+
+        PlexusConfiguration countConfig = new XmlPlexusConfiguration("count");
+        countConfig.setValue("123");
+        optimizedHelper.setProperty(bean, "count", Integer.class, countConfig);
+
+        PlexusConfiguration enabledConfig = new XmlPlexusConfiguration("enabled");
+        enabledConfig.setValue("true");
+        optimizedHelper.setProperty(bean, "enabled", Boolean.class, enabledConfig);
+
+        PlexusConfiguration descConfig = new XmlPlexusConfiguration("description");
+        descConfig.setValue("testValue");
+        optimizedHelper.setProperty(bean, "description", String.class, descConfig);
+
+        PlexusConfiguration timeoutConfig = new XmlPlexusConfiguration("timeout");
+        timeoutConfig.setValue("123");
+        optimizedHelper.setProperty(bean, "timeout", Long.class, timeoutConfig);
+    }
+
+    /**
+     * Benchmark that tests multiple property configurations in a single operation.
+     * This simulates a more realistic scenario where multiple properties are set on a bean.
+     */
+    @Benchmark
+    public void benchmarkOriginalHelperMultipleProperties() throws Exception {
+        RealisticTestBean bean = new RealisticTestBean();
+
+        // Set multiple properties in one benchmark iteration
+        PlexusConfiguration config6 = new XmlPlexusConfiguration("name");
+        config6.setValue("testValue");
+        originalHelper.setProperty(bean, "name", String.class, config6);
+        PlexusConfiguration config5 = new XmlPlexusConfiguration("count");
+        config5.setValue("123");
+        originalHelper.setProperty(bean, "count", Integer.class, config5);
+        PlexusConfiguration config4 = new XmlPlexusConfiguration("enabled");
+        config4.setValue("true");
+        originalHelper.setProperty(bean, "enabled", Boolean.class, config4);
+        PlexusConfiguration config3 = new XmlPlexusConfiguration("description");
+        config3.setValue("testValue");
+        originalHelper.setProperty(bean, "description", String.class, config3);
+        PlexusConfiguration config2 = new XmlPlexusConfiguration("timeout");
+        config2.setValue("123");
+        originalHelper.setProperty(bean, "timeout", Long.class, config2);
+        // Repeat to test caching
+        PlexusConfiguration config1 = new XmlPlexusConfiguration("name");
+        config1.setValue("testValue2");
+        originalHelper.setProperty(bean, "name", String.class, config1);
+        PlexusConfiguration config = new XmlPlexusConfiguration("count");
+        config.setValue("456");
+        originalHelper.setProperty(bean, "count", Integer.class, config);
+    }
+
+    @Benchmark
+    public void benchmarkOptimizedHelperMultipleProperties() throws Exception {
+        RealisticTestBean bean = new RealisticTestBean();
+
+        // Set multiple properties in one benchmark iteration
+        PlexusConfiguration nameConfig = new XmlPlexusConfiguration("name");
+        nameConfig.setValue("testValue");
+        optimizedHelper.setProperty(bean, "name", String.class, nameConfig);
+
+        PlexusConfiguration countConfig = new XmlPlexusConfiguration("count");
+        countConfig.setValue("123");
+        optimizedHelper.setProperty(bean, "count", Integer.class, countConfig);
+
+        PlexusConfiguration enabledConfig = new XmlPlexusConfiguration("enabled");
+        enabledConfig.setValue("true");
+        optimizedHelper.setProperty(bean, "enabled", Boolean.class, enabledConfig);
+
+        PlexusConfiguration descConfig = new XmlPlexusConfiguration("description");
+        descConfig.setValue("testValue");
+        optimizedHelper.setProperty(bean, "description", String.class, descConfig);
+
+        PlexusConfiguration timeoutConfig = new XmlPlexusConfiguration("timeout");
+        timeoutConfig.setValue("123");
+        optimizedHelper.setProperty(bean, "timeout", Long.class, timeoutConfig);
+
+        // Repeat to test caching benefits
+        nameConfig.setValue("testValue2");
+        optimizedHelper.setProperty(bean, "name", String.class, nameConfig);
+        countConfig.setValue("456");
+        optimizedHelper.setProperty(bean, "count", Integer.class, countConfig);
+    }
+
+    /**
+     * Benchmark that tests cache benefits by repeatedly setting properties on the same class.
+     * This better demonstrates the caching improvements.
+     */
+    @Benchmark
+    public void benchmarkOriginalHelperRepeatedOperations() throws Exception {
+        // Test cache benefits by using same class multiple times
+        for (int i = 0; i < 10; i++) {
+            RealisticTestBean bean = new RealisticTestBean();
+
+            PlexusConfiguration nameConfig = new XmlPlexusConfiguration("name");
+            nameConfig.setValue("testValue" + i);
+            originalHelper.setProperty(bean, "name", String.class, nameConfig);
+
+            PlexusConfiguration countConfig = new XmlPlexusConfiguration("count");
+            countConfig.setValue(String.valueOf(i));
+            originalHelper.setProperty(bean, "count", Integer.class, countConfig);
+        }
+    }
+
+    @Benchmark
+    @Test
+    public void benchmarkOptimizedHelperRepeatedOperations() throws Exception {
+        // Test cache benefits by using same class multiple times
+        for (int i = 0; i < 10; i++) {
+            RealisticTestBean bean = new RealisticTestBean();
+
+            PlexusConfiguration nameConfig = new XmlPlexusConfiguration("name");
+            nameConfig.setValue("testValue" + i);
+            optimizedHelper.setProperty(bean, "name", String.class, nameConfig);
+
+            PlexusConfiguration countConfig = new XmlPlexusConfiguration("count");
+            countConfig.setValue(String.valueOf(i));
+            optimizedHelper.setProperty(bean, "count", Integer.class, countConfig);
+        }
+    }
+
+    /**
+     * Benchmark with multiple different bean types to test method cache effectiveness.
+     */
+    @Benchmark
+    public void benchmarkOriginalHelperMultipleTypes() throws Exception {
+        // Test with different bean types
+        RealisticTestBean bean1 = new RealisticTestBean();
+        TestBean bean2 = new TestBean();
+
+        PlexusConfiguration config1 = new XmlPlexusConfiguration("name");
+        config1.setValue("testValue");
+        originalHelper.setProperty(bean1, "name", String.class, config1);
+        originalHelper.setProperty(bean2, "name", String.class, config1);
+
+        PlexusConfiguration config2 = new XmlPlexusConfiguration("count");
+        config2.setValue("123");
+        originalHelper.setProperty(bean1, "count", Integer.class, config2);
+        originalHelper.setProperty(bean2, "count", Integer.class, config2);
+    }
+
+    @Benchmark
+    public void benchmarkOptimizedHelperMultipleTypes() throws Exception {
+        // Test with different bean types
+        RealisticTestBean bean1 = new RealisticTestBean();
+        TestBean bean2 = new TestBean();
+
+        PlexusConfiguration config1 = new XmlPlexusConfiguration("name");
+        config1.setValue("testValue");
+        optimizedHelper.setProperty(bean1, "name", String.class, config1);
+        optimizedHelper.setProperty(bean2, "name", String.class, config1);
+
+        PlexusConfiguration config2 = new XmlPlexusConfiguration("count");
+        config2.setValue("123");
+        optimizedHelper.setProperty(bean1, "count", Integer.class, config2);
+        optimizedHelper.setProperty(bean2, "count", Integer.class, config2);
+    }
+
+    /**
+     * Main method to run the JMH benchmark.
+     *
+     * @param args command line arguments
+     * @throws RunnerException if the benchmark fails to run
+     */
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(CompositeBeanHelperPerformanceTest.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(3)
+                .measurementIterations(5)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    /**
+     * Test bean class for performance testing.
+     */
+    public static class TestBean {
+        private String name;
+        private String description;
+        private int count;
+        private List<String> items = new ArrayList<>();
+        private boolean enabled;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(int count) {
+            this.count = count;
+        }
+
+        public List<String> getItems() {
+            return items;
+        }
+
+        public void addItem(String item) {
+            this.items.add(item);
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
+    /**
+     * A more realistic test bean that simulates typical mojo parameters
+     */
+    public static class RealisticTestBean {
+        private String name;
+        private int count;
+        private boolean enabled;
+        private String description;
+        private long timeout;
+        private List<String> items;
+        private Map<String, String> properties;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setCount(int count) {
+            this.count = count;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setTimeout(long timeout) {
+            this.timeout = timeout;
+        }
+
+        public long getTimeout() {
+            return timeout;
+        }
+
+        public void setItems(List<String> items) {
+            this.items = items;
+        }
+
+        public List<String> getItems() {
+            return items;
+        }
+
+        public void setProperties(Map<String, String> properties) {
+            this.properties = properties;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+    }
+}

--- a/impl/maven-core/src/test/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelperTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelperTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.configuration.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for EnhancedCompositeBeanHelper to ensure it works correctly and provides performance benefits.
+ */
+class EnhancedCompositeBeanHelperTest {
+
+    private EnhancedCompositeBeanHelper helper;
+    private ConverterLookup converterLookup;
+    private ExpressionEvaluator evaluator;
+    private ConfigurationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        converterLookup = new DefaultConverterLookup();
+        evaluator = mock(ExpressionEvaluator.class);
+        listener = mock(ConfigurationListener.class);
+        helper = new EnhancedCompositeBeanHelper(converterLookup, getClass().getClassLoader(), evaluator, listener);
+    }
+
+    @AfterEach
+    void tearDown() {
+        EnhancedCompositeBeanHelper.clearCaches();
+    }
+
+    @Test
+    void testSetPropertyWithSetter() throws Exception {
+        TestBean bean = new TestBean();
+        PlexusConfiguration config = new XmlPlexusConfiguration("test");
+        config.setValue("testValue");
+
+        when(evaluator.evaluate("testValue")).thenReturn("testValue");
+
+        helper.setProperty(bean, "name", String.class, config);
+
+        assertEquals("testValue", bean.getName());
+        verify(listener).notifyFieldChangeUsingSetter("name", "testValue", bean);
+    }
+
+    @Test
+    void testSetPropertyWithField() throws Exception {
+        TestBean bean = new TestBean();
+        PlexusConfiguration config = new XmlPlexusConfiguration("test");
+        config.setValue("fieldValue");
+
+        when(evaluator.evaluate("fieldValue")).thenReturn("fieldValue");
+
+        helper.setProperty(bean, "directField", String.class, config);
+
+        assertEquals("fieldValue", bean.getDirectField());
+        verify(listener).notifyFieldChangeUsingReflection("directField", "fieldValue", bean);
+    }
+
+    @Test
+    void testSetPropertyWithAdder() throws Exception {
+        TestBean bean = new TestBean();
+        PlexusConfiguration config = new XmlPlexusConfiguration("test");
+        config.setValue("item1");
+
+        when(evaluator.evaluate("item1")).thenReturn("item1");
+
+        helper.setProperty(bean, "item", String.class, config);
+
+        assertEquals(1, bean.getItems().size());
+        assertEquals("item1", bean.getItems().get(0));
+    }
+
+    @Test
+    void testPerformanceWithRepeatedCalls() throws Exception {
+        TestBean bean1 = new TestBean();
+        TestBean bean2 = new TestBean();
+        PlexusConfiguration config = new XmlPlexusConfiguration("test");
+        config.setValue("testValue");
+
+        when(evaluator.evaluate("testValue")).thenReturn("testValue");
+
+        // First call - should populate cache
+        helper.setProperty(bean1, "name", String.class, config);
+
+        // Second call - should use cache
+        long start2 = System.nanoTime();
+        helper.setProperty(bean2, "name", String.class, config);
+        long time2 = System.nanoTime() - start2;
+
+        assertEquals("testValue", bean1.getName());
+        assertEquals("testValue", bean2.getName());
+
+        // Second call should be faster (though this is not guaranteed in all environments)
+        // We mainly verify that both calls work correctly
+        assertTrue(time2 >= 0); // Just verify it completed
+    }
+
+    @Test
+    void testCacheClearance() throws Exception {
+        TestBean bean = new TestBean();
+        PlexusConfiguration config = new XmlPlexusConfiguration("test");
+        config.setValue("testValue");
+
+        when(evaluator.evaluate("testValue")).thenReturn("testValue");
+
+        helper.setProperty(bean, "name", String.class, config);
+        assertEquals("testValue", bean.getName());
+
+        // Clear caches and verify it still works
+        EnhancedCompositeBeanHelper.clearCaches();
+
+        TestBean bean2 = new TestBean();
+        helper.setProperty(bean2, "name", String.class, config);
+        assertEquals("testValue", bean2.getName());
+    }
+
+    /**
+     * Test bean class for testing property setting.
+     */
+    public static class TestBean {
+        private String name;
+        private String directField;
+        private List<String> items = new ArrayList<>();
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDirectField() {
+            return directField;
+        }
+
+        public List<String> getItems() {
+            return items;
+        }
+
+        public void addItem(String item) {
+            this.items.add(item);
+        }
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [perf: optimize CompositeBeanHelper with reflection caching](https://github.com/apache/maven/pull/2526)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)