### PR TITLE
[#10939] Enable addLocationInformation in DefaultModelXmlFactory base on InputLocationFormatter presence

### DIFF
--- a/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
+++ b/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
@@ -44,8 +44,7 @@ public class MavenXpp3Writer {
     // - Methods -/
     // -----------/
 
-    public MavenXpp3Writer() {
-    }
+    public MavenXpp3Writer() {}
 
     protected MavenXpp3Writer(Function<org.apache.maven.api.model.InputLocation, String> formatter) {
         delegate.setStringFormatter(formatter);

--- a/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
+++ b/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
@@ -45,7 +45,6 @@ public class MavenXpp3Writer {
     // -----------/
 
     public MavenXpp3Writer() {
-        this((inputLocation) -> inputLocation.toString());
     }
 
     protected MavenXpp3Writer(Function<org.apache.maven.api.model.InputLocation, String> formatter) {

--- a/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
+++ b/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
@@ -23,13 +23,14 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
+import java.util.function.Function;
 
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.v4.MavenStaxWriter;
 
 /**
- * @deprecated Use MavenStaxWriter instead
+ * @deprecated Use {@link MavenStaxWriter} instead
  */
 @Deprecated
 public class MavenXpp3Writer {
@@ -44,11 +45,11 @@ public class MavenXpp3Writer {
     // -----------/
 
     public MavenXpp3Writer() {
-        this(false);
+        this((inputLocation) -> inputLocation.toString());
     }
 
-    protected MavenXpp3Writer(boolean addLocationInformation) {
-        delegate.setAddLocationInformation(addLocationInformation);
+    protected MavenXpp3Writer(Function<org.apache.maven.api.model.InputLocation, String> formatter) {
+        delegate.setStringFormatter(formatter);
     }
 
     /**

--- a/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3WriterEx.java
+++ b/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3WriterEx.java
@@ -24,9 +24,10 @@ import java.io.Writer;
 
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.v4.MavenStaxWriter;
 
 /**
- * @deprecated Use MavenStaxWriter instead
+ * @deprecated Use {@link MavenStaxWriter} instead
  */
 @Deprecated
 public class MavenXpp3WriterEx extends MavenXpp3Writer {
@@ -36,7 +37,7 @@ public class MavenXpp3WriterEx extends MavenXpp3Writer {
     // -----------/
 
     public MavenXpp3WriterEx() {
-        super(true);
+        super((inputLocation) -> inputLocation.toString());
     }
 
     /**

--- a/compat/maven-model/src/test/java/org/apache/maven/model/v4/ModelXmlTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/v4/ModelXmlTest.java
@@ -89,7 +89,6 @@ class ModelXmlTest {
     String toXml(Model model) throws IOException, XMLStreamException {
         StringWriter sw = new StringWriter();
         MavenStaxWriter writer = new MavenStaxWriter();
-        writer.setAddLocationInformation(false);
         writer.write(sw, model);
         return sw.toString();
     }

--- a/compat/maven-settings/src/main/java/org/apache/maven/settings/io/xpp3/SettingsXpp3Writer.java
+++ b/compat/maven-settings/src/main/java/org/apache/maven/settings/io/xpp3/SettingsXpp3Writer.java
@@ -38,7 +38,6 @@ public class SettingsXpp3Writer {
 
     public SettingsXpp3Writer() {
         delegate = new SettingsStaxWriter();
-        delegate.setAddLocationInformation(false);
     }
     /**
      * Method setFileComment.

--- a/compat/maven-toolchain-model/src/main/java/org/apache/maven/toolchain/model/io/xpp3/MavenToolchainsXpp3Writer.java
+++ b/compat/maven-toolchain-model/src/main/java/org/apache/maven/toolchain/model/io/xpp3/MavenToolchainsXpp3Writer.java
@@ -41,7 +41,6 @@ public class MavenToolchainsXpp3Writer {
 
     public MavenToolchainsXpp3Writer() {
         delegate = new MavenToolchainsStaxWriter();
-        delegate.setAddLocationInformation(false);
     }
 
     /**

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/TransformerSupport.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/TransformerSupport.java
@@ -80,7 +80,6 @@ abstract class TransformerSupport implements PomArtifactTransformer {
             MavenStaxWriter writer = new MavenStaxWriter();
             writer.setNamespace(String.format(NAMESPACE_FORMAT, version));
             writer.setSchemaLocation(String.format(SCHEMA_LOCATION_FORMAT, version));
-            writer.setAddLocationInformation(false);
             writer.write(w, model);
         }
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -127,7 +127,9 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
         }
         try {
             MavenStaxWriter w = new MavenStaxWriter();
+            w.setAddLocationInformation(false);
             if (inputLocationFormatter != null) {
+                w.setAddLocationInformation(true);
                 w.setStringFormatter((Function) inputLocationFormatter);
             }
             if (writer != null) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -127,9 +127,7 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
         }
         try {
             MavenStaxWriter w = new MavenStaxWriter();
-            w.setAddLocationInformation(false);
             if (inputLocationFormatter != null) {
-                w.setAddLocationInformation(true);
                 w.setStringFormatter((Function) inputLocationFormatter);
             }
             if (writer != null) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
@@ -29,7 +29,6 @@ import org.apache.maven.api.services.xml.XmlWriterRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -167,7 +166,7 @@ class DefaultModelXmlFactoryTest {
         factory.write(request);
 
         final String processedPomAsString = writer.toString();
-        assertThat(processedPomAsString).isEqualTo(expected);
+        assertEquals(expected, processedPomAsString);
     }
 
     @Test
@@ -211,6 +210,6 @@ class DefaultModelXmlFactoryTest {
         factory.write(request);
 
         final String processedPomAsString = writer.toString();
-        assertThat(processedPomAsString).isEqualTo(expected);
+        assertEquals(expected, processedPomAsString);
     }
 }

--- a/its/run-its.bat
+++ b/its/run-its.bat
@@ -22,9 +22,9 @@
 @REM In rare occasions, some ITs may depend on latest maven snapshots.
 @REM In such cases you need to:
 @REM  - build maven using `mvn install -PversionlessMavenDist -Dmaven.repo.local=[my-repo-local]`
-@REM  - run ITs using `mvn clean install -Prun-its,embedded -Dmaven.repo.local=[my-repo-local] -DmavenDistro=[maven-source-tree]/apache-maven/target/maven-bin.zip`
+@REM  - run ITs using `mvn clean install -Prun-its -Dmaven.repo.local=[my-repo-local] -DmavenDistro=[maven-source-tree]/apache-maven/target/maven-bin.zip`
 
-mvn clean install -U -Prun-its,embedded -Dmaven.repo.local=%cd%\repo
+mvn clean install -U -Prun-its -Dmaven.repo.local=%cd%\repo
 
 @REM If behind a proxy try this..
-@REM mvn clean install -Prun-its,embedded -Dmaven.repo.local=%cd%\repo -Dproxy.host=<host> -Dproxy.port=<port> -Dproxy.user= -Dproxy.pass= -Dproxy.nonProxyHosts=<hosts>
+@REM mvn clean install -Prun-its -Dmaven.repo.local=%cd%\repo -Dproxy.host=<host> -Dproxy.port=<port> -Dproxy.user= -Dproxy.pass= -Dproxy.nonProxyHosts=<hosts>

--- a/its/run-its.sh
+++ b/its/run-its.sh
@@ -25,10 +25,10 @@
 # In rare occasions, some ITs may depend on latest maven snapshots.
 # In such cases you need to:
 #  - build maven using `mvn install -PversionlessMavenDist -Dmaven.repo.local=[my-repo-local]`
-#  - run ITs using `mvn clean install -Prun-its,embedded -Dmaven.repo.local=[my-repo-local] -DmavenDistro=[maven-source-tree]/apache-maven/target/maven-bin.zip`
+#  - run ITs using `mvn clean install -Prun-its -Dmaven.repo.local=[my-repo-local] -DmavenDistro=[maven-source-tree]/apache-maven/target/maven-bin.zip`
 
-mvn clean install -Prun-its,embedded -Dmaven.repo.local=`pwd`/repo
+mvn clean install -Prun-its -Dmaven.repo.local=`pwd`/repo
 
 # If behind a proxy try this
 
-# mvn clean install -Prun-its,embedded -Dmaven.repo.local=`pwd`/repo -Dproxy.host=<host> -Dproxy.port=<port> -Dproxy.user= -Dproxy.pass= -Dproxy.nonProxyHosts=<hosts>
+# mvn clean install -Prun-its -Dmaven.repo.local=`pwd`/repo -Dproxy.host=<host> -Dproxy.port=<port> -Dproxy.user= -Dproxy.pass= -Dproxy.nonProxyHosts=<hosts>

--- a/src/mdo/writer-stax.vm
+++ b/src/mdo/writer-stax.vm
@@ -109,8 +109,6 @@ public class ${className} {
     private String fileComment = null;
 
 #if ( $locationTracking )
-    private boolean addLocationInformation = true;
-
     /**
      * Field stringFormatter.
      */
@@ -149,13 +147,6 @@ public class ${className} {
     } //-- void setFileComment(String)
 
 #if ( $locationTracking )
-    /**
-     * Method setAddLocationInformation.
-     */
-    public void setAddLocationInformation(boolean addLocationInformation) {
-        this.addLocationInformation = addLocationInformation;
-    } //-- void setAddLocationInformation(String)
-
     /**
      * Method setStringFormatter.
      *
@@ -383,7 +374,7 @@ public class ${className} {
             }
             serializer.writeEndElement();
 #if ( $locationTracking )
-            if (addLocationInformation && dom.inputLocation() instanceof InputLocation inputLocation && dom.children().isEmpty()) {
+            if (stringFormatter != null && dom.inputLocation() instanceof InputLocation inputLocation && dom.children().isEmpty()) {
                 serializer.writeComment(toString(inputLocation));
             }
 #end
@@ -421,7 +412,7 @@ public class ${className} {
      * @throws IOException
      */
     protected void writeLocationTracking(InputLocationTracker locationTracker, Object key, XMLStreamWriter serializer) throws IOException, XMLStreamException {
-        if (addLocationInformation) {
+        if (stringFormatter != null) {
             InputLocation location = (locationTracker == null) ? null : locationTracker.getLocation(key);
             if (location != null) {
                 serializer.writeComment(toString(location));


### PR DESCRIPTION
Show example for [#10939] 

Set addLocationInformation to false by default in DefaultModelXmlFactory.
If the XmlWriterRequest specifies an InputLocationFormatter, set addLocationInformation to true and apply the formatter.

---
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
