### PR TITLE
Fix ArtifactTypeRegistry implementations

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.impl.resolver.artifact.MavenArtifactProperties;
@@ -305,25 +304,6 @@ public class RepositoryUtils {
 
     private static Exclusion toExclusion(org.apache.maven.model.Exclusion exclusion) {
         return new Exclusion(exclusion.getGroupId(), exclusion.getArtifactId(), "*", "*");
-    }
-
-    public static ArtifactTypeRegistry newArtifactTypeRegistry(ArtifactHandlerManager handlerManager) {
-        return new MavenArtifactTypeRegistry(handlerManager);
-    }
-
-    static class MavenArtifactTypeRegistry implements ArtifactTypeRegistry {
-
-        private final ArtifactHandlerManager handlerManager;
-
-        MavenArtifactTypeRegistry(ArtifactHandlerManager handlerManager) {
-            this.handlerManager = handlerManager;
-        }
-
-        @Override
-        public ArtifactType get(String stereotypeId) {
-            ArtifactHandler handler = handlerManager.getArtifactHandler(stereotypeId);
-            return newArtifactType(stereotypeId, handler);
-        }
     }
 
     public static Collection<Artifact> toArtifacts(Collection<org.apache.maven.artifact.Artifact> artifactsToConvert) {

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/aether/TypeRegistryAdapter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/aether/TypeRegistryAdapter.java
@@ -40,15 +40,12 @@ class TypeRegistryAdapter implements ArtifactTypeRegistry {
         if (type instanceof ArtifactType artifactType) {
             return artifactType;
         }
-        if (type != null) {
-            return new DefaultType(
-                    type.id(),
-                    type.getLanguage(),
-                    type.getExtension(),
-                    type.getClassifier(),
-                    type.isIncludesDependencies(),
-                    type.getPathTypes().toArray(new PathType[0]));
-        }
-        return null;
+        return new DefaultType(
+                type.id(),
+                type.getLanguage(),
+                type.getExtension(),
+                type.getClassifier(),
+                type.isIncludesDependencies(),
+                type.getPathTypes().toArray(new PathType[0]));
     }
 }


### PR DESCRIPTION
There are two implementations of ArtifactTypeRegistry, one of them is unused, the other one needs to be cleaned up a bit to not be misleading about non null return values.