### PR TITLE
Add skipMavenRc to ExecutorRequest and use it in ITs

### DIFF
--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutor.java
@@ -141,6 +141,10 @@ public class ForkedMavenExecutor implements Executor {
         }
         env.remove("MAVEN_ARGS"); // we already used it if configured to do so
 
+        if (executorRequest.skipMavenRc()) {
+            env.put("MAVEN_SKIP_RC", "true");
+        }
+
         try {
             ProcessBuilder pb = new ProcessBuilder()
                     .directory(executorRequest.cwd().toFile())

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -526,6 +526,10 @@ under the License.
             <maven.home>${preparedMavenHome}</maven.home>
             <maven.it.global-settings.dir>${project.build.testOutputDirectory}</maven.it.global-settings.dir>
           </systemPropertyVariables>
+          <excludedEnvironmentVariables>
+            <excludedEnvironmentVariable>MAVEN_ARGS</excludedEnvironmentVariable>
+            <excludedEnvironmentVariable>MAVEN_OPTS</excludedEnvironmentVariable>
+          </excludedEnvironmentVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.maven.cling.executor.ExecutorHelper;
 import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;
@@ -66,10 +67,11 @@ public class TestSuiteOrdering implements ClassOrderer {
             Verifier verifier = new Verifier("");
             String mavenVersion = verifier.getMavenVersion();
             String executable = verifier.getExecutable();
+            ExecutorHelper.Mode defaultMode = verifier.getDefaultMode();
 
             out.println("Running integration tests for Maven " + mavenVersion + System.lineSeparator()
                     + "\tusing Maven executable: " + executable + System.lineSeparator()
-                    + "\twith verifier.forkMode: " + System.getProperty("verifier.forkMode", "not defined == fork"));
+                    + "\twith verifier.forkMode: " + defaultMode);
 
             System.setProperty("maven.version", mavenVersion);
 

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -122,6 +122,8 @@ public class Verifier {
 
     private Path logFile;
 
+    private boolean skipMavenRc = true;
+
     public Verifier(String basedir) throws VerificationException {
         this(basedir, null);
     }
@@ -168,6 +170,10 @@ public class Verifier {
 
     public void setExecutable(String executable) {
         this.executable = requireNonNull(executable);
+    }
+
+    public ExecutorHelper.Mode getDefaultMode() {
+        return executorHelper.getDefaultMode();
     }
 
     public void execute() throws VerificationException {
@@ -221,7 +227,8 @@ public class Verifier {
                     .cwd(basedir)
                     .userHomeDirectory(userHomeDirectory)
                     .jvmArguments(jvmArguments)
-                    .arguments(args);
+                    .arguments(args)
+                    .skipMavenRc(skipMavenRc);
             if (!systemProperties.isEmpty()) {
                 builder.jvmSystemProperties(new HashMap(systemProperties));
             }
@@ -335,6 +342,10 @@ public class Verifier {
 
     public void setForkJvm(boolean forkJvm) {
         this.forkJvm = forkJvm;
+    }
+
+    public void setSkipMavenRc(boolean skipMavenRc) {
+        this.skipMavenRc = skipMavenRc;
     }
 
     public void setHandleLocalRepoTail(boolean handleLocalRepoTail) {


### PR DESCRIPTION
* Add skipMavenRc to ExecutorRequest and use it in ITs

ITs should be isolated from the executing system, so:

- skip mavenrc in forked mode
- exclude MAVEN_ARGS and MAVEN_OPTS from test environments

(cherry picked from commit e2ad3e6abcf9676a996668a721ceb84232d1300e)

- #10925

