### PR TITLE
[master] Fix XmlNode.equals returning false between two different node implementations (#10942)

### DIFF
--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
@@ -493,17 +493,12 @@ public interface XmlNode {
 
             @Override
             public boolean equals(Object o) {
-                if (this == o) {
-                    return true;
-                }
-                if (o == null || getClass() != o.getClass()) {
-                    return false;
-                }
-                Impl that = (Impl) o;
-                return Objects.equals(this.name, that.name)
-                        && Objects.equals(this.value, that.value)
-                        && Objects.equals(this.attributes, that.attributes)
-                        && Objects.equals(this.children, that.children);
+                return this == o
+                        || o instanceof XmlNode that
+                                && Objects.equals(this.name, that.name())
+                                && Objects.equals(this.value, that.value())
+                                && Objects.equals(this.attributes, that.attributes())
+                                && Objects.equals(this.children, that.children());
             }
 
             @Override

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/XmlNodeImpl.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/XmlNodeImpl.java
@@ -279,17 +279,12 @@ public class XmlNodeImpl implements Serializable, XmlNode {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        XmlNodeImpl that = (XmlNodeImpl) o;
-        return Objects.equals(this.name, that.name)
-                && Objects.equals(this.value, that.value)
-                && Objects.equals(this.attributes, that.attributes)
-                && Objects.equals(this.children, that.children);
+        return this == o
+                || o instanceof XmlNode that
+                        && Objects.equals(this.name, that.name())
+                        && Objects.equals(this.value, that.value())
+                        && Objects.equals(this.attributes, that.attributes())
+                        && Objects.equals(this.children, that.children());
     }
 
     @Override

--- a/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlNodeImplTest.java
+++ b/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlNodeImplTest.java
@@ -479,6 +479,18 @@ class XmlNodeImplTest {
     }
 
     /**
+     * <p>testEqualsComplex.</p>
+     */
+    @Test
+    void testEqualsComplex() throws XMLStreamException, XmlPullParserException, IOException {
+        String testDom = "<configuration><items thing='blah'><item>one</item><item>two</item></items></configuration>";
+        XmlNode dom1 = XmlService.read(new StringReader(testDom));
+        XmlNode dom2 = XmlNodeBuilder.build(new StringReader(testDom));
+
+        assertEquals(dom1, dom2);
+    }
+
+    /**
      * <p>testEqualsWithDifferentStructures.</p>
      */
     @Test


### PR DESCRIPTION
# Backport

This will backport the following commits from `maven-4.0.x` to `master`:
 - [Fix XmlNode.equals returning false between two different node implementations (#10942)](https://github.com/apache/maven/pull/10942)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)