### PR TITLE
Improvements in ITs executing - provide default local repo

### DIFF
--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -532,7 +532,8 @@ under the License.
           <promoteUserPropertiesToSystemProperties>false</promoteUserPropertiesToSystemProperties>
           <systemPropertyVariables>
             <maven.test.user.home>${preparedUserHome}</maven.test.user.home>
-            <maven.test.repo.local>${settings.localRepository}</maven.test.repo.local>
+            <maven.test.repo.outer>${settings.localRepository}</maven.test.repo.outer>
+            <maven.test.repo.local>${preparedUserHome}/.m2/repository</maven.test.repo.local>
             <maven.test.tmpdir>${project.build.testOutputDirectory}</maven.test.tmpdir>
             <maven.version>${maven.version}</maven.version>
             <maven.home>${preparedMavenHome}</maven.home>

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -144,7 +144,7 @@ public class Verifier {
             this.tempBasedir = Files.createTempDirectory("verifier");
             this.userHomeDirectory = Paths.get(System.getProperty("maven.test.user.home", "user.home"));
             Files.createDirectories(this.userHomeDirectory);
-            this.outerLocalRepository = Paths.get(System.getProperty("maven.test.repo.local", ".m2/repository"));
+            this.outerLocalRepository = Paths.get(System.getProperty("maven.test.repo.outer", ".m2/repository"));
             this.executorHelper = new HelperImpl(
                     VERIFIER_FORK_MODE,
                     Paths.get(System.getProperty("maven.home")),
@@ -357,10 +357,7 @@ public class Verifier {
     }
 
     public String getLocalRepositoryWithSettings(String settingsXml) {
-        String outerHead = System.getProperty("maven.repo.local", "").trim();
-        if (!outerHead.isEmpty()) {
-            return outerHead;
-        } else if (settingsXml != null) {
+        if (settingsXml != null) {
             // when invoked with settings.xml, the file must be resolved from basedir (as Maven does)
             // but we should not use basedir, as it may contain extensions.xml or a project, that Maven will eagerly
             // load, and may fail, as it would need more (like CI friendly versioning, etc).
@@ -376,8 +373,13 @@ public class Verifier {
                     .argument("-s")
                     .argument(settingsFile.toString()));
         } else {
-            return executorTool.localRepository(
-                    executorHelper.executorRequest().cwd(tempBasedir).userHomeDirectory(userHomeDirectory));
+            String outerHead = System.getProperty("maven.test.repo.local", "").trim();
+            if (!outerHead.isEmpty()) {
+                return outerHead;
+            } else {
+                return executorTool.localRepository(
+                        executorHelper.executorRequest().cwd(tempBasedir).userHomeDirectory(userHomeDirectory));
+            }
         }
     }
 


### PR DESCRIPTION
When local repo is not provided, method getLocalRepository executes external mojo from toolbox, 
it will be more effective to provide it statically and avoid external mojo even in embedded mode

