### PR TITLE
Improvements in ITs executing - use forkCount for surefire

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Build Maven and ITs and run them
         shell: bash
-        run: mvn install -e -B -V -Prun-its,mimir -Dits.forkCount=0.75C
+        run: mvn install -e -B -V -Prun-its,mimir
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -93,7 +93,7 @@ under the License.
     <!-- Support artifacts version - kept separate from Maven version -->
     <core-it-support-version>2.1-SNAPSHOT</core-it-support-version>
 
-    <its.forkCount>1</its.forkCount>
+    <its.forkCount>0.75C</its.forkCount>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Instead of using multiple threads for surefire, we can fork many JVM for parallel tests execution

It should be safer as tests are executed sequentially in one JVM

