### PR TITLE
Add PathMatcherFactory.includesAll()

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
@@ -138,4 +138,19 @@ public interface PathMatcherFactory extends Service {
      */
     @Nonnull
     PathMatcher deriveDirectoryMatcher(@Nonnull PathMatcher fileMatcher);
+
+    /**
+     * Returns the patch matcher that unconditionally returns {@code true} for all files.
+     * It should be the matcher returned by the other methods of this interface when the
+     * given patterns match all files. Therefore, the following idiom can be used:
+     *
+     * {@snippet lang="java" :
+     * PathMatcher fileMatcher = factory.createPathMatcher(dir, includes, excludes);
+     * boolean selectedAllFiles = (fileMatcher == factory.includesAll);
+     * }
+     *
+     * @return patch matcher that unconditionally returns {@code true} for all files
+     */
+    @Nonnull
+    PathMatcher includesAll();
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
@@ -157,7 +157,7 @@ public interface PathMatcherFactory extends Service {
      *
      * @param matcher the matcher to test
      */
-    default boolean isIncludesAll(PathMatcher matcher) {
+    default boolean isIncludesAll(@Nonnull PathMatcher matcher) {
         return Objects.requireNonNull(matcher) == includesAll();
     }
 }

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
@@ -140,14 +140,14 @@ public interface PathMatcherFactory extends Service {
     PathMatcher deriveDirectoryMatcher(@Nonnull PathMatcher fileMatcher);
 
     /**
-     * Returns the patch matcher that unconditionally returns {@code true} for all files.
+     * Returns the path matcher that unconditionally returns {@code true} for all files.
      * It should be the matcher returned by the other methods of this interface when the
      * given patterns match all files. Therefore, the following idiom can be used:
      *
      * <pre>PathMatcher fileMatcher = factory.createPathMatcher(dir, includes, excludes);
      * boolean selectedAllFiles = fileMatcher == factory.includesAll();</pre>
      *
-     * @return patch matcher that unconditionally returns {@code true} for all files
+     * @return path matcher that unconditionally returns {@code true} for all files
      */
     @Nonnull
     PathMatcher includesAll();

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
@@ -145,7 +145,7 @@ public interface PathMatcherFactory extends Service {
      * given patterns match all files. Therefore, the following idiom can be used:
      *
      * <pre>PathMatcher fileMatcher = factory.createPathMatcher(dir, includes, excludes);
-     * boolean selectedAllFiles = (fileMatcher == factory.includesAll);</pre>
+     * boolean selectedAllFiles = fileMatcher == factory.includesAll();</pre>
      *
      * @return patch matcher that unconditionally returns {@code true} for all files
      */

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
@@ -144,10 +144,8 @@ public interface PathMatcherFactory extends Service {
      * It should be the matcher returned by the other methods of this interface when the
      * given patterns match all files. Therefore, the following idiom can be used:
      *
-     * {@snippet lang="java" :
-     * PathMatcher fileMatcher = factory.createPathMatcher(dir, includes, excludes);
-     * boolean selectedAllFiles = (fileMatcher == factory.includesAll);
-     * }
+     * <pre>PathMatcher fileMatcher = factory.createPathMatcher(dir, includes, excludes);
+     * boolean selectedAllFiles = (fileMatcher == factory.includesAll);</pre>
      *
      * @return patch matcher that unconditionally returns {@code true} for all files
      */

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
@@ -21,6 +21,7 @@ package org.apache.maven.api.services;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Collection;
+import java.util.Objects;
 
 import org.apache.maven.api.Service;
 import org.apache.maven.api.annotations.Experimental;
@@ -142,13 +143,21 @@ public interface PathMatcherFactory extends Service {
     /**
      * Returns the path matcher that unconditionally returns {@code true} for all files.
      * It should be the matcher returned by the other methods of this interface when the
-     * given patterns match all files. Therefore, the following idiom can be used:
-     *
-     * <pre>PathMatcher fileMatcher = factory.createPathMatcher(dir, includes, excludes);
-     * boolean selectedAllFiles = fileMatcher == factory.includesAll();</pre>
+     * given patterns match all files.
      *
      * @return path matcher that unconditionally returns {@code true} for all files
      */
     @Nonnull
     PathMatcher includesAll();
+
+    /**
+     * {@return whether the given matcher includes all files}.
+     * This method may conservatively returns {@code false} if case of doubt.
+     * A return value of {@code true} means that the pattern is certain to match all files.
+     *
+     * @param matcher the matcher to test
+     */
+    default boolean isIncludesAll(PathMatcher matcher) {
+        return Objects.requireNonNull(matcher) == includesAll();
+    }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPathMatcherFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPathMatcherFactory.java
@@ -52,7 +52,7 @@ public class DefaultPathMatcherFactory implements PathMatcherFactory {
             boolean useDefaultExcludes) {
         requireNonNull(baseDirectory, "baseDirectory cannot be null");
 
-        return new PathSelector(baseDirectory, includes, excludes, useDefaultExcludes).simplify();
+        return PathSelector.of(baseDirectory, includes, excludes, useDefaultExcludes);
     }
 
     @Nonnull

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPathMatcherFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPathMatcherFactory.java
@@ -52,7 +52,7 @@ public class DefaultPathMatcherFactory implements PathMatcherFactory {
             boolean useDefaultExcludes) {
         requireNonNull(baseDirectory, "baseDirectory cannot be null");
 
-        return new PathSelector(baseDirectory, includes, excludes, useDefaultExcludes);
+        return new PathSelector(baseDirectory, includes, excludes, useDefaultExcludes).simplify();
     }
 
     @Nonnull
@@ -70,6 +70,12 @@ public class DefaultPathMatcherFactory implements PathMatcherFactory {
                 return selector::couldHoldSelected;
             }
         }
+        return PathSelector.INCLUDES_ALL;
+    }
+
+    @Nonnull
+    @Override
+    public PathMatcher includesAll() {
         return PathSelector.INCLUDES_ALL;
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -219,7 +219,7 @@ public final class DefaultSourceRoot implements SourceRoot {
         if (actual == null || actual.isEmpty()) {
             actual = defaultIncludes;
         }
-        return new PathSelector(directory(), actual, excludes(), useDefaultExcludes).simplify();
+        return PathSelector.of(directory(), actual, excludes(), useDefaultExcludes);
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
@@ -61,7 +61,7 @@ import org.apache.maven.api.annotations.Nonnull;
  *
  * @see java.nio.file.FileSystem#getPathMatcher(String)
  */
-public class PathSelector implements PathMatcher {
+final class PathSelector implements PathMatcher {
     /**
      * Patterns which should be excluded by default, like <abbr>SCM</abbr> files.
      *
@@ -232,7 +232,7 @@ public class PathSelector implements PathMatcher {
      * @param useDefaultExcludes whether to augment the excludes with a default set of <abbr>SCM</abbr> patterns
      * @throws NullPointerException if directory is null
      */
-    public PathSelector(
+    private PathSelector(
             @Nonnull Path directory,
             Collection<String> includes,
             Collection<String> excludes,
@@ -564,18 +564,28 @@ public class PathSelector implements PathMatcher {
     }
 
     /**
-     * {@return whether there are no include or exclude filters}.
-     * In such case, this {@code PathSelector} instance should be ignored.
+     * Creates a new matcher from the given includes and excludes.
+     *
+     * @param directory the base directory of the files to filter
+     * @param includes the patterns of the files to include, or null or empty for including all files
+     * @param excludes the patterns of the files to exclude, or null or empty for no exclusion
+     * @param useDefaultExcludes whether to augment the excludes with a default set of <abbr>SCM</abbr> patterns
+     * @throws NullPointerException if directory is null
+     * @return a path matcher for the given includes and excludes
      */
-    public boolean isEmpty() {
-        return includes.length == 0 && excludes.length == 0;
+    public static PathMatcher of(
+            @Nonnull Path directory,
+            Collection<String> includes,
+            Collection<String> excludes,
+            boolean useDefaultExcludes) {
+        return new PathSelector(directory, includes, excludes, useDefaultExcludes).simplify();
     }
 
     /**
      * {@return a potentially simpler matcher equivalent to this matcher}.
      */
     @SuppressWarnings("checkstyle:MissingSwitchDefault")
-    public PathMatcher simplify() {
+    private PathMatcher simplify() {
         if (!needRelativize && excludes.length == 0) {
             switch (includes.length) {
                 case 0:

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
@@ -249,6 +249,24 @@ final class PathSelector implements PathMatcher {
     }
 
     /**
+     * Creates a new matcher from the given includes and excludes.
+     *
+     * @param directory the base directory of the files to filter
+     * @param includes the patterns of the files to include, or null or empty for including all files
+     * @param excludes the patterns of the files to exclude, or null or empty for no exclusion
+     * @param useDefaultExcludes whether to augment the excludes with a default set of <abbr>SCM</abbr> patterns
+     * @throws NullPointerException if directory is null
+     * @return a path matcher for the given includes and excludes
+     */
+    public static PathMatcher of(
+            @Nonnull Path directory,
+            Collection<String> includes,
+            Collection<String> excludes,
+            boolean useDefaultExcludes) {
+        return new PathSelector(directory, includes, excludes, useDefaultExcludes).simplify();
+    }
+
+    /**
      * Returns the given array of excludes, optionally expanded with a default set of excludes,
      * then with unnecessary excludes omitted. An unnecessary exclude is an exclude which will never
      * match a file because there are no include which would accept a file that could match the exclude.
@@ -561,24 +579,6 @@ final class PathSelector implements PathMatcher {
             matchers[i] = fs.getPathMatcher(patterns[i]);
         }
         return matchers;
-    }
-
-    /**
-     * Creates a new matcher from the given includes and excludes.
-     *
-     * @param directory the base directory of the files to filter
-     * @param includes the patterns of the files to include, or null or empty for including all files
-     * @param excludes the patterns of the files to exclude, or null or empty for no exclusion
-     * @param useDefaultExcludes whether to augment the excludes with a default set of <abbr>SCM</abbr> patterns
-     * @throws NullPointerException if directory is null
-     * @return a path matcher for the given includes and excludes
-     */
-    public static PathMatcher of(
-            @Nonnull Path directory,
-            Collection<String> includes,
-            Collection<String> excludes,
-            boolean useDefaultExcludes) {
-        return new PathSelector(directory, includes, excludes, useDefaultExcludes).simplify();
     }
 
     /**

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
@@ -185,7 +185,7 @@ public class DefaultPathMatcherFactoryTest {
 
         // Test that PathSelector constructor also throws NPE for null directory
         assertThrows(
-                NullPointerException.class, () -> new PathSelector(null, List.of("*.txt"), List.of("*.tmp"), false));
+                NullPointerException.class, () -> PathSelector.of(null, List.of("*.txt"), List.of("*.tmp"), false));
 
         // Test that deriveDirectoryMatcher throws NPE for null fileMatcher
         assertThrows(NullPointerException.class, () -> factory.deriveDirectoryMatcher(null));

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -134,11 +135,12 @@ public class DefaultPathMatcherFactoryTest {
     }
 
     @Test
-    public void testPathMatcherReturnsPathSelector(@TempDir Path tempDir) {
+    public void testIncludesAll(@TempDir Path tempDir) {
         PathMatcher matcher = factory.createPathMatcher(tempDir, null, null, false);
 
-        // Verify that the returned matcher is actually a PathSelector
-        assertTrue(matcher instanceof PathSelector);
+        // Because no pattern has been specified, simplify to includes all.
+        // IT must be the same instance, by method contract.
+        assertSame(factory.includesAll(), matcher);
     }
 
     /**

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.impl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,9 +61,9 @@ public class PathSelectorTest {
      */
     private static void assertFilteredFilesContains(final Path directory, final String syntax, final String... expected)
             throws IOException {
-        var includes = List.of(syntax + "**/*.txt");
-        var excludes = List.of(syntax + "baz/**");
-        var matcher = new PathSelector(directory, includes, excludes, false);
+        List<String> includes = List.of(syntax + "**/*.txt");
+        List<String> excludes = List.of(syntax + "baz/**");
+        PathMatcher matcher = PathSelector.of(directory, includes, excludes, false);
         Set<Path> filtered =
                 new HashSet<>(Files.walk(directory).filter(matcher::matches).toList());
         for (String path : expected) {
@@ -81,9 +82,9 @@ public class PathSelectorTest {
     @Test
     public void testExcludeOmission() {
         Path directory = Path.of("dummy");
-        var includes = List.of("**/*.java");
-        var excludes = List.of("baz/**");
-        var matcher = new PathSelector(directory, includes, excludes, true);
+        List<String> includes = List.of("**/*.java");
+        List<String> excludes = List.of("baz/**");
+        PathMatcher matcher = PathSelector.of(directory, includes, excludes, true);
         String s = matcher.toString();
         assertTrue(s.contains("glob:**/*.java"));
         assertFalse(s.contains("project.pj")); // Unnecessary exclusion should have been omitted.


### PR DESCRIPTION
Minor modifications to the `PathMatcherFactory` service:

* Simplify the patch matcher when possible.
* Add a `PathMatcherFactory.includesAll()` method.

The two changes, combined together, allows the caller to know when a matcher includes all files. The Maven Clean Plugin needs this information for deciding if it can delete the files in a background thread.