### PR TITLE
remove beta schema location

### DIFF
--- a/its/core-it-suite/src/test/resources/mng-8331-versioned-and-unversioned-deps/module-a/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8331-versioned-and-unversioned-deps/module-a/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0-beta-4.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0">
   <parent>
     <groupId>org.apache.maven.its</groupId>
     <artifactId>mng8331</artifactId>

--- a/its/core-it-suite/src/test/resources/mng-8331-versioned-and-unversioned-deps/module-b/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8331-versioned-and-unversioned-deps/module-b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0-beta-4.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0">
   <parent>
     <groupId>org.apache.maven.its</groupId>
     <artifactId>mng8331</artifactId>

--- a/its/core-it-suite/src/test/resources/mng-8331-versioned-and-unversioned-deps/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8331-versioned-and-unversioned-deps/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0-beta-4.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0">
   <groupId>org.apache.maven.its</groupId>
   <artifactId>mng8331</artifactId>
   <version>1-SNAPSHOT</version>

--- a/its/core-it-suite/src/test/resources/mng-8341-deadlock/child1/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8341-deadlock/child1/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0-beta-4.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0">
   <parent>
     <groupId>org.apache.maven.its.mng8341</groupId>
     <artifactId>parent</artifactId>

--- a/its/core-it-suite/src/test/resources/mng-8341-deadlock/child2/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8341-deadlock/child2/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0-beta-4.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0">
   <parent>
     <groupId>org.apache.maven.its.mng8341</groupId>
     <artifactId>parent</artifactId>

--- a/its/core-it-suite/src/test/resources/mng-8341-deadlock/parent/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8341-deadlock/parent/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0-beta-4.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0">
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>

--- a/its/core-it-suite/src/test/resources/mng-8341-deadlock/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8341-deadlock/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" root="true" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0-beta-4.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
   <parent>
     <groupId>org.apache.maven.its.mng8341</groupId>
     <artifactId>parent</artifactId>


### PR DESCRIPTION
I just removed these completely. schemaLocation attributes aren't actually consulted in almost all cases, and definitely not in integration tests.

fixes #10957

