### PR TITLE
Deprecate old project builder API in favor of new API

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultDependencyResolutionRequest.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultDependencyResolutionRequest.java
@@ -22,7 +22,9 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.graph.DependencyFilter;
 
 /**
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public class DefaultDependencyResolutionRequest implements DependencyResolutionRequest {
 
     private MavenProject project;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultDependencyResolutionResult.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultDependencyResolutionResult.java
@@ -28,7 +28,9 @@ import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 
 /**
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 class DefaultDependencyResolutionResult implements DependencyResolutionResult {
 
     private DependencyNode root;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -105,7 +105,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * DefaultProjectBuilder
+ *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 @Named
 @Singleton
 public class DefaultProjectBuilder implements ProjectBuilder {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingRequest.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingRequest.java
@@ -33,7 +33,10 @@ import org.eclipse.aether.RepositorySystemSession;
 
 /**
  * DefaultProjectBuildingRequest
+ *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public class DefaultProjectBuildingRequest implements ProjectBuildingRequest {
 
     private RepositorySystemSession repositorySession;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingResult.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingResult.java
@@ -27,7 +27,9 @@ import org.apache.maven.model.building.ModelProblem;
 /**
  * Collects the output of the project builder.
  *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 class DefaultProjectBuildingResult implements ProjectBuildingResult {
 
     private final String projectId;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -53,7 +53,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 @Named
 @Singleton
 public class DefaultProjectDependenciesResolver implements ProjectDependenciesResolver {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DependencyResolutionException.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DependencyResolutionException.java
@@ -23,7 +23,9 @@ import java.util.List;
 import org.eclipse.aether.graph.Dependency;
 
 /**
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public class DependencyResolutionException extends Exception {
 
     private final transient DependencyResolutionResult result;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DependencyResolutionRequest.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DependencyResolutionRequest.java
@@ -24,7 +24,9 @@ import org.eclipse.aether.graph.DependencyFilter;
 /**
  * A request to resolve the dependencies of a project.
  *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public interface DependencyResolutionRequest {
 
     /**

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DependencyResolutionResult.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DependencyResolutionResult.java
@@ -26,7 +26,9 @@ import org.eclipse.aether.graph.DependencyNode;
 /**
  * The result of a project dependency resolution.
  *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public interface DependencyResolutionResult {
 
     /**

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuilder.java
@@ -26,7 +26,10 @@ import org.apache.maven.model.building.ModelSource;
 
 /**
  * Builds in-memory descriptions of projects.
+ *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public interface ProjectBuilder {
 
     /**

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
@@ -22,7 +22,9 @@ import java.io.File;
 import java.util.List;
 
 /**
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public class ProjectBuildingException extends Exception {
     private final String projectId;
 

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingRequest.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingRequest.java
@@ -29,7 +29,10 @@ import org.eclipse.aether.RepositorySystemSession;
 
 /**
  * ProjectBuildingRequest
+ *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public interface ProjectBuildingRequest {
 
     ProjectBuildingRequest setLocalRepository(ArtifactRepository localRepository);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingResult.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingResult.java
@@ -26,7 +26,9 @@ import org.apache.maven.model.building.ModelProblem;
 /**
  * Collects the output of the project builder.
  *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public interface ProjectBuildingResult {
 
     /**

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectDependenciesResolver.java
@@ -21,7 +21,9 @@ package org.apache.maven.project;
 /**
  * Resolves the transitive dependencies of a project.
  *
+ * @deprecated use {@code org.apache.maven.api.services.ProjectBuilder} instead
  */
+@Deprecated(since = "4.0.0")
 public interface ProjectDependenciesResolver {
 
     /**


### PR DESCRIPTION
## Description

Deprecates the old project builder API in favor of the new `org.apache.maven.api.services.ProjectBuilder` API, following the same pattern used for the model builder API deprecation.

## Background

This addresses the issue mentioned in #10984 where `ProjectBuildingResult` exposes `ModelProblem` from the deprecated model builder API, creating an inconsistency since `ModelProblem` is deprecated but `ProjectBuildingResult` was not.

## Changes Made

- Added `@Deprecated(since = "4.0.0")` annotations to all project builder related classes and interfaces
- Added deprecation messages pointing users to `org.apache.maven.api.services.ProjectBuilder`
- Follows the exact same deprecation pattern used for the model builder API

### Deprecated Classes:

**Core Project Builder API:**
- `ProjectBuilder` - Main interface
- `ProjectBuildingRequest` - Request interface  
- `ProjectBuildingResult` - Result interface
- `ProjectBuildingException` - Exception class

**Default Implementations:**
- `DefaultProjectBuilder` - Default implementation
- `DefaultProjectBuildingRequest` - Default request implementation
- `DefaultProjectBuildingResult` - Default result implementation

**Dependency Resolution API:**
- `DependencyResolutionRequest` - Request interface
- `DependencyResolutionResult` - Result interface
- `DependencyResolutionException` - Exception class
- `ProjectDependenciesResolver` - Resolver interface
- `DefaultDependencyResolutionRequest` - Default request implementation
- `DefaultDependencyResolutionResult` - Default result implementation
- `DefaultProjectDependenciesResolver` - Default resolver implementation

## Testing

- ✅ Full build passes with Maven 4.0.0-rc-4 and JDK 21
- ✅ All compilation and tests continue to work
- ✅ Deprecation warnings are properly displayed when using the old API
- ✅ No breaking changes - purely additive deprecation annotations

## Migration Path

All deprecated classes now clearly point developers to use `org.apache.maven.api.services.ProjectBuilder` instead, providing a clear migration path to the new API.

## Consistency Achieved

This resolves the inconsistency where `ProjectBuildingResult` was exposing the deprecated `ModelProblem` class but wasn't itself deprecated. Now there's complete consistency between the deprecation status of the old model builder API and the old project builder API.

Fixes #10984

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author