### PR TITLE
Fix maven.mainClass property missing for external tools

### DIFF
--- a/apache-maven/src/assembly/maven/bin/m2.conf
+++ b/apache-maven/src/assembly/maven/bin/m2.conf
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+set maven.mainClass default org.apache.maven.cling.MavenCling
+
 main is ${maven.mainClass} from plexus.core
 
 set maven.conf default ${maven.home}/conf


### PR DESCRIPTION
Fixes #10996

When external tools like IntelliJ launch Maven directly using the ClassWorlds launcher without setting the `maven.mainClass` system property, Maven fails with:

```
org.codehaus.plexus.classworlds.launcher.ConfigurationException: No such property: maven.mainClass
```

## Root Cause
The m2.conf file was changed to use `${maven.mainClass}` but this property is only set by the Maven launcher scripts (`mvn` and `mvn.cmd`). External tools that launch Maven directly don't set this property.

## Solution
This change adds a default value for `maven.mainClass` in m2.conf:

```
set maven.mainClass default org.apache.maven.cling.MavenCling
```

## How it works
1. When Maven launcher scripts run, they set `-Dmaven.mainClass=org.apache.maven.cling.MavenCling` (or other variants for `--enc`, `--shell`, `--up`)
2. When external tools launch Maven without setting this property, the ClassWorlds configuration now provides a default value
3. The default value `org.apache.maven.cling.MavenCling` is the standard Maven CLI entry point

## Impact
- Maven continues to work normally when launched via `mvn` scripts
- External tools like IntelliJ can now launch Maven without needing to know about the new `maven.mainClass` property
- The fix is minimal and maintains backward compatibility

The solution uses the same ClassWorlds configuration syntax already used elsewhere in the m2.conf file (`set maven.conf default ${maven.home}/conf`).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author