### PR TITLE
Set Guice class loading to CHILD - avoid using terminally deprecated methods

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -149,6 +149,7 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
         validate(context);
         pushCoreProperties(context);
         pushUserProperties(context);
+        setupGuiceClassLoading(context);
         configureLogging(context);
         createTerminal(context);
         activateLogging(context);
@@ -244,6 +245,16 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
             protoSession.getUserProperties().entrySet().stream()
                     .filter(k -> context.pushedUserProperties.contains(k.getKey()) || !sys.contains(k.getKey()))
                     .forEach(k -> System.setProperty(k.getKey(), k.getValue()));
+        }
+    }
+
+    /**
+     * Sets up Guice class loading mode to CHILD, if not already set.
+     * Default Guice class loading mode uses a terminally deprecated JDK memory-access classes.
+     */
+    protected void setupGuiceClassLoading(C context) {
+        if (System.getProperty("guice_custom_class_loading", "").isBlank()) {
+            System.setProperty("guice_custom_class_loading", "CHILD");
         }
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/10312">GH-10312</a>.
+ */
+class MavenITgh10312TerminallyDeprecatedMethodInGuiceTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh10312TerminallyDeprecatedMethodInGuiceTest() {
+        super(ALL_MAVEN_VERSIONS);
+    }
+
+    @Test
+    void worryingShouldNotBePrinted() throws Exception {
+        requiresJavaVersion("[24,)");
+        File testDir = extractResources("/gh-10312-terminally-deprecated-method-in-guice");
+
+        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        verifier.setForkJvm(true);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+
+        assertTrue(verifier.getStdout().isEmpty(), "Expected no output on stdout, but got: " + verifier.getStdout());
+
+        assertFalse(
+                verifier.getStderr()
+                        .contains(
+                                "WARNING: sun.misc.Unsafe::staticFieldBase has been called by com.google.inject.internal.aop.HiddenClassDefiner"),
+                "Expected no warning about sun.misc.Unsafe::staticFieldBase, but got: " + verifier.getStderr());
+    }
+
+    @Test
+    void allowOverwriteByUser() throws Exception {
+        requiresJavaVersion("[24,26)");
+        File testDir = extractResources("/gh-10312-terminally-deprecated-method-in-guice");
+
+        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        verifier.setForkJvm(true);
+        verifier.addCliArgument("validate");
+        verifier.addCliArgument("-Dguice_custom_class_loading=BRIDGE");
+        verifier.execute();
+
+        assertTrue(verifier.getStdout().isEmpty(), "Expected no output on stdout, but got: " + verifier.getStdout());
+
+        assertTrue(
+                verifier.getStderr()
+                        .contains(
+                                "WARNING: sun.misc.Unsafe::staticFieldBase has been called by com.google.inject.internal.aop.HiddenClassDefiner"),
+                "Expected warning about sun.misc.Unsafe::staticFieldBase, but got: " + verifier.getStderr());
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -103,6 +103,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.class);
         suite.addTestSuite(MavenITgh10937QuotedPipesInMavenOptsTest.class);
         suite.addTestSuite(MavenITgh2532DuplicateDependencyEffectiveModelTest.class);
         suite.addTestSuite(MavenITmng8736ConcurrentFileActivationTest.class);

--- a/its/core-it-suite/src/test/resources/gh-10312-terminally-deprecated-method-in-guice/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-10312-terminally-deprecated-method-in-guice/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh2532</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+</project>

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -124,6 +124,10 @@ public class Verifier {
 
     private boolean skipMavenRc = true;
 
+    private ByteArrayOutputStream stdout;
+
+    private ByteArrayOutputStream stderr;
+
     public Verifier(String basedir) throws VerificationException {
         this(basedir, null);
     }
@@ -240,8 +244,8 @@ public class Verifier {
             if (forkJvm) {
                 mode = ExecutorHelper.Mode.FORKED;
             }
-            ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-            ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+            stdout = new ByteArrayOutputStream();
+            stderr = new ByteArrayOutputStream();
             ExecutorRequest request = builder.stdOut(stdout).stdErr(stderr).build();
             int ret = executorHelper.execute(mode, request);
             if (ret > 0) {
@@ -470,6 +474,14 @@ public class Verifier {
         if (!result) {
             throw new VerificationException("Text not found in log: " + text);
         }
+    }
+
+    public String getStdout() {
+        return stdout != null ? stdout.toString(StandardCharsets.UTF_8) : "";
+    }
+
+    public String getStderr() {
+        return stderr != null ? stderr.toString(StandardCharsets.UTF_8) : "";
     }
 
     public static String stripAnsi(String msg) {


### PR DESCRIPTION

Default Guice class loading uses a terminally deprecated JDK memory-access classes.

Fix #10312

(cherry picked from commit 335baf58fb499ee4e14cd1fe0c3cc2c1c9ed4ffe)

