### PR TITLE
[maven-4.0.x] Fix maven.mainClass property missing for external tools (#10998)

### DIFF
--- a/apache-maven/src/assembly/maven/bin/m2.conf
+++ b/apache-maven/src/assembly/maven/bin/m2.conf
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+set maven.mainClass default org.apache.maven.cling.MavenCling
+
 main is ${maven.mainClass} from plexus.core
 
 set maven.conf default ${maven.home}/conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Fix maven.mainClass property missing for external tools (#10998)](https://github.com/apache/maven/pull/10998)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)