### PR TITLE
Backport of "Add PathMatcherFactory.includesAll()"

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/PathMatcherFactory.java
@@ -21,6 +21,7 @@ package org.apache.maven.api.services;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Collection;
+import java.util.Objects;
 
 import org.apache.maven.api.Service;
 import org.apache.maven.api.annotations.Experimental;
@@ -138,4 +139,25 @@ public interface PathMatcherFactory extends Service {
      */
     @Nonnull
     PathMatcher deriveDirectoryMatcher(@Nonnull PathMatcher fileMatcher);
+
+    /**
+     * Returns the path matcher that unconditionally returns {@code true} for all files.
+     * It should be the matcher returned by the other methods of this interface when the
+     * given patterns match all files.
+     *
+     * @return path matcher that unconditionally returns {@code true} for all files
+     */
+    @Nonnull
+    PathMatcher includesAll();
+
+    /**
+     * {@return whether the given matcher includes all files}.
+     * This method may conservatively returns {@code false} if case of doubt.
+     * A return value of {@code true} means that the pattern is certain to match all files.
+     *
+     * @param matcher the matcher to test
+     */
+    default boolean isIncludesAll(@Nonnull PathMatcher matcher) {
+        return Objects.requireNonNull(matcher) == includesAll();
+    }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPathMatcherFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultPathMatcherFactory.java
@@ -52,7 +52,7 @@ public class DefaultPathMatcherFactory implements PathMatcherFactory {
             boolean useDefaultExcludes) {
         requireNonNull(baseDirectory, "baseDirectory cannot be null");
 
-        return new PathSelector(baseDirectory, includes, excludes, useDefaultExcludes);
+        return PathSelector.of(baseDirectory, includes, excludes, useDefaultExcludes);
     }
 
     @Nonnull
@@ -70,6 +70,12 @@ public class DefaultPathMatcherFactory implements PathMatcherFactory {
                 return selector::couldHoldSelected;
             }
         }
+        return PathSelector.INCLUDES_ALL;
+    }
+
+    @Nonnull
+    @Override
+    public PathMatcher includesAll() {
         return PathSelector.INCLUDES_ALL;
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -219,7 +219,7 @@ public final class DefaultSourceRoot implements SourceRoot {
         if (actual == null || actual.isEmpty()) {
             actual = defaultIncludes;
         }
-        return new PathSelector(directory(), actual, excludes(), useDefaultExcludes).simplify();
+        return PathSelector.of(directory(), actual, excludes(), useDefaultExcludes);
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
@@ -61,7 +61,7 @@ import org.apache.maven.api.annotations.Nonnull;
  *
  * @see java.nio.file.FileSystem#getPathMatcher(String)
  */
-public class PathSelector implements PathMatcher {
+final class PathSelector implements PathMatcher {
     /**
      * Patterns which should be excluded by default, like <abbr>SCM</abbr> files.
      *
@@ -232,7 +232,7 @@ public class PathSelector implements PathMatcher {
      * @param useDefaultExcludes whether to augment the excludes with a default set of <abbr>SCM</abbr> patterns
      * @throws NullPointerException if directory is null
      */
-    public PathSelector(
+    private PathSelector(
             @Nonnull Path directory,
             Collection<String> includes,
             Collection<String> excludes,
@@ -246,6 +246,24 @@ public class PathSelector implements PathMatcher {
         dirIncludes = matchers(fileSystem, directoryPatterns(includePatterns, false));
         dirExcludes = matchers(fileSystem, directoryPatterns(excludePatterns, true));
         needRelativize = needRelativize(includePatterns) || needRelativize(excludePatterns);
+    }
+
+    /**
+     * Creates a new matcher from the given includes and excludes.
+     *
+     * @param directory the base directory of the files to filter
+     * @param includes the patterns of the files to include, or null or empty for including all files
+     * @param excludes the patterns of the files to exclude, or null or empty for no exclusion
+     * @param useDefaultExcludes whether to augment the excludes with a default set of <abbr>SCM</abbr> patterns
+     * @throws NullPointerException if directory is null
+     * @return a path matcher for the given includes and excludes
+     */
+    public static PathMatcher of(
+            @Nonnull Path directory,
+            Collection<String> includes,
+            Collection<String> excludes,
+            boolean useDefaultExcludes) {
+        return new PathSelector(directory, includes, excludes, useDefaultExcludes).simplify();
     }
 
     /**
@@ -564,18 +582,10 @@ public class PathSelector implements PathMatcher {
     }
 
     /**
-     * {@return whether there are no include or exclude filters}.
-     * In such case, this {@code PathSelector} instance should be ignored.
-     */
-    public boolean isEmpty() {
-        return includes.length == 0 && excludes.length == 0;
-    }
-
-    /**
      * {@return a potentially simpler matcher equivalent to this matcher}.
      */
     @SuppressWarnings("checkstyle:MissingSwitchDefault")
-    public PathMatcher simplify() {
+    private PathMatcher simplify() {
         if (!needRelativize && excludes.length == 0) {
             switch (includes.length) {
                 case 0:

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -134,11 +135,12 @@ public class DefaultPathMatcherFactoryTest {
     }
 
     @Test
-    public void testPathMatcherReturnsPathSelector(@TempDir Path tempDir) {
+    public void testIncludesAll(@TempDir Path tempDir) {
         PathMatcher matcher = factory.createPathMatcher(tempDir, null, null, false);
 
-        // Verify that the returned matcher is actually a PathSelector
-        assertTrue(matcher instanceof PathSelector);
+        // Because no pattern has been specified, simplify to includes all.
+        // IT must be the same instance, by method contract.
+        assertSame(factory.includesAll(), matcher);
     }
 
     /**
@@ -183,7 +185,7 @@ public class DefaultPathMatcherFactoryTest {
 
         // Test that PathSelector constructor also throws NPE for null directory
         assertThrows(
-                NullPointerException.class, () -> new PathSelector(null, List.of("*.txt"), List.of("*.tmp"), false));
+                NullPointerException.class, () -> PathSelector.of(null, List.of("*.txt"), List.of("*.tmp"), false));
 
         // Test that deriveDirectoryMatcher throws NPE for null fileMatcher
         assertThrows(NullPointerException.class, () -> factory.deriveDirectoryMatcher(null));

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.impl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,9 +61,9 @@ public class PathSelectorTest {
      */
     private static void assertFilteredFilesContains(final Path directory, final String syntax, final String... expected)
             throws IOException {
-        var includes = List.of(syntax + "**/*.txt");
-        var excludes = List.of(syntax + "baz/**");
-        var matcher = new PathSelector(directory, includes, excludes, false);
+        List<String> includes = List.of(syntax + "**/*.txt");
+        List<String> excludes = List.of(syntax + "baz/**");
+        PathMatcher matcher = PathSelector.of(directory, includes, excludes, false);
         Set<Path> filtered =
                 new HashSet<>(Files.walk(directory).filter(matcher::matches).toList());
         for (String path : expected) {
@@ -81,9 +82,9 @@ public class PathSelectorTest {
     @Test
     public void testExcludeOmission() {
         Path directory = Path.of("dummy");
-        var includes = List.of("**/*.java");
-        var excludes = List.of("baz/**");
-        var matcher = new PathSelector(directory, includes, excludes, true);
+        List<String> includes = List.of("**/*.java");
+        List<String> excludes = List.of("baz/**");
+        PathMatcher matcher = PathSelector.of(directory, includes, excludes, true);
         String s = matcher.toString();
         assertTrue(s.contains("glob:**/*.java"));
         assertFalse(s.contains("project.pj")); // Unnecessary exclusion should have been omitted.


### PR DESCRIPTION
This is a backport of #10964. The following is copied from the original pull request:

Minor modifications to the `PathMatcherFactor` service:
    
* Make package-private.
* Ensure that `simplify()` is always invoked.
* Add `PathMatcherFactory.includesAll()` and `isIncludesAll(PathMatcher)` methods.
    
The Maven Clean Plugin needs this information for checking if it can run in a background thread.