### PR TITLE
More accurate help text for options with comma-delimited lists

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -188,7 +188,7 @@ public class CLIManager {
         options.addOption(Option.builder(Character.toString(ACTIVATE_PROFILES))
                 .longOpt("activate-profiles")
                 .desc(
-                        "Comma-delimited list of profiles to activate. Don't use spaces between commas or double quote the full list. Prefixing a profile with ! excludes it, and ? marks it as optional")
+                        "Comma-delimited list of profiles to activate. Don't use spaces between commas or double quote the full list. Prefixing a profile with ! excludes it, and ? marks it as optional.")
                 .hasArg()
                 .build());
         options.addOption(Option.builder(Character.toString(BATCH_MODE))
@@ -271,7 +271,7 @@ public class CLIManager {
         options.addOption(Option.builder(PROJECT_LIST)
                 .longOpt("projects")
                 .desc(
-                        "Comma-delimited list of specified reactor projects to build instead of all projects. Don't use spaces between commas or double quote the full list. A project can be specified by [groupId]:artifactId or by its relative path. Prefixing a project with ! excludes it, and ? marks it as optional")
+                        "Comma-delimited list of specified reactor projects to build instead of all projects. Don't use spaces between commas or double quote the full list. A project can be specified by [groupId]:artifactId or by its relative path. Prefixing a project with ! excludes it, and ? marks it as optional.")
                 .hasArg()
                 .build());
         options.addOption(Option.builder(ALSO_MAKE)

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
@@ -273,7 +273,7 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
             options.addOption(Option.builder(ACTIVATE_PROFILES)
                     .longOpt("activate-profiles")
                     .desc(
-                            "Comma-delimited list of profiles to activate. Don't use spaces between commas or double quote the full list. Prefixing a profile with ! excludes it, and ? marks it as optional")
+                            "Comma-delimited list of profiles to activate. Don't use spaces between commas or double quote the full list. Prefixing a profile with ! excludes it, and ? marks it as optional.")
                     .hasArg()
                     .build());
             options.addOption(Option.builder(SUPPRESS_SNAPSHOT_UPDATES)
@@ -313,7 +313,7 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
             options.addOption(Option.builder(PROJECT_LIST)
                     .longOpt("projects")
                     .desc(
-                            "Comma-delimited list of specified reactor projects to build instead of all projects. Don't use spaces between commas or double quote the full list. A project can be specified by [groupId]:artifactId or by its relative path. Prefixing a project with ! excludes it, and ? marks it as optional")
+                            "Comma-delimited list of specified reactor projects to build instead of all projects. Don't use spaces between commas or double quote the full list. A project can be specified by [groupId]:artifactId or by its relative path. Prefixing a project with ! excludes it, and ? marks it as optional.")
                     .hasArg()
                     .build());
             options.addOption(Option.builder(ALSO_MAKE)


### PR DESCRIPTION
Many tools which parse CSV lines trim spaces between options. In Maven this does not happen (and can't happen as multiple CLI arguments can be passed). This PR adds a note to the help texts of options where comma-delimited lists are possible to prevent users run into issues when they accidentally uses spaces. 