### PR TITLE
Uninterpolated repositories from parent POMs during model building (backport)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -510,6 +510,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             Model interpolatedModel = interpolateModel(
                     Model.newBuilder()
                             .pomFile(model.getPomFile())
+                            .properties(model.getProperties())
                             .repositories(model.getRepositories())
                             .build(),
                     request,

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -92,6 +92,7 @@ class DefaultModelBuilderTest {
         assertEquals(1, repositories.size()); // central
 
         Model model = Model.newBuilder()
+                .properties(Map.of("thirdParentRepo", "https://third.repo"))
                 .repositories(Arrays.asList(
                         Repository.newBuilder()
                                 .id("first")
@@ -100,18 +101,25 @@ class DefaultModelBuilderTest {
                         Repository.newBuilder()
                                 .id("second")
                                 .url("${secondParentRepo}")
+                                .build(),
+                        Repository.newBuilder()
+                                .id("third")
+                                .url("${thirdParentRepo}")
                                 .build()))
                 .build();
+
         state.mergeRepositories(model, false);
 
         // after merge
         repositories = (List<RemoteRepository>) repositoriesField.get(state);
-        assertEquals(3, repositories.size());
+        assertEquals(4, repositories.size());
         assertEquals("first", repositories.get(0).getId());
-        assertEquals("https://some.repo", repositories.get(0).getUrl()); // interpolated
+        assertEquals("https://some.repo", repositories.get(0).getUrl()); // interpolated (user properties)
         assertEquals("second", repositories.get(1).getId());
         assertEquals("${secondParentRepo}", repositories.get(1).getUrl()); // un-interpolated (no source)
-        assertEquals("central", repositories.get(2).getId()); // default
+        assertEquals("third", repositories.get(2).getId());
+        assertEquals("https://third.repo", repositories.get(2).getUrl()); // interpolated (own model properties)
+        assertEquals("central", repositories.get(3).getId()); // default
     }
 
     private Path getPom(String name) {


### PR DESCRIPTION
Backport of https://github.com/apache/maven/pull/11037

On parent loading, the repositories were interpolated okay, but there was a problem that parent own properties were not considered in interpolation (of own repositories).

Fixes #11021