### PR TITLE
Allow single build per branch or pull request

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,6 +23,11 @@ on:
   pull_request:
     branches: [ maven-4.0.x ]
 
+# allow single build per branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # clear all permissions for GITHUB_TOKEN
 permissions: {}
 


### PR DESCRIPTION
As build takes a long time when a new commit is pushed, 
we should cancel previous build and build only the last one.

(cherry picked from commit c4cbc3828f8056d7249c1443cb14635fe9c3137e)

