### PR TITLE
Enable prevent branch protection rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,6 +21,8 @@ github:
     maven-4.0.x: {}
     maven-3.9.x: {}
     maven-3.8.x: {}
+    maven-3.0.x: {}
+    pre-reset-master: {}
   features:
     issues: true
 notifications:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,10 +16,14 @@ github:
     - MNG
   pull_requests:
     del_branch_on_merge: true
+  protected_branches:
+    master: {}
+    maven-4.0.x: {}
+    maven-3.9.x: {}
+    maven-3.8.x: {}
   features:
     issues: true
 notifications:
   commits: commits@maven.apache.org
   issues: issues@maven.apache.org
   pullrequests: issues@maven.apache.org
-  jira_options: link label


### PR DESCRIPTION
we have many branches .... but I don't see for 3.6.x ,3.5.x ... and so on