### PR TITLE
[maven-4.0.x] [#11048]  Fix race condition in MessageUtils (#11049)

### DIFF
--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
@@ -94,6 +94,10 @@ public class MessageUtils {
 
     private static void doSystemUninstall() {
         try {
+            if (terminal instanceof FastTerminal fastTerminal) {
+                // wait for the asynchronous systemInstall call before we uninstall to ensure a consistent state
+                fastTerminal.getTerminal();
+            }
             AnsiConsole.systemUninstall();
         } finally {
             terminal = null;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [[#11048]  Fix race condition in MessageUtils (#11049)](https://github.com/apache/maven/pull/11049)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)