### PR TITLE
[maven-4.0.x] Maven Upgrade Tool: remove unused --force and --yes options (Fixes #11001) (#11066)

### DIFF
--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvnup/UpgradeOptions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvnup/UpgradeOptions.java
@@ -34,20 +34,6 @@ import org.apache.maven.api.cli.Options;
 @Experimental
 public interface UpgradeOptions extends Options {
     /**
-     * Should the operation be forced (ie overwrite existing files, if any).
-     *
-     * @return an {@link Optional} containing the boolean value {@code true} if specified, or empty
-     */
-    Optional<Boolean> force();
-
-    /**
-     * Should imply "yes" to all questions.
-     *
-     * @return an {@link Optional} containing the boolean value {@code true} if specified, or empty
-     */
-    Optional<Boolean> yes();
-
-    /**
      * Returns the list of upgrade goals to be executed.
      * These goals can include operations like "check", "dependencies", "plugins", etc.
      *

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/CommonsCliUpgradeOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/CommonsCliUpgradeOptions.java
@@ -46,24 +46,6 @@ public class CommonsCliUpgradeOptions extends CommonsCliOptions implements Upgra
 
     @Override
     @Nonnull
-    public Optional<Boolean> force() {
-        if (commandLine.hasOption(CLIManager.FORCE)) {
-            return Optional.of(Boolean.TRUE);
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    @Nonnull
-    public Optional<Boolean> yes() {
-        if (commandLine.hasOption(CLIManager.YES)) {
-            return Optional.of(Boolean.TRUE);
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    @Nonnull
     public Optional<List<String>> goals() {
         if (!commandLine.getArgList().isEmpty()) {
             return Optional.of(commandLine.getArgList());
@@ -143,8 +125,6 @@ public class CommonsCliUpgradeOptions extends CommonsCliOptions implements Upgra
         printStream.accept("      --plugins         Upgrade plugins known to fail with Maven 4");
         printStream.accept(
                 "  -a, --all             Apply all upgrades (equivalent to --model-version 4.1.0 --infer --model --plugins)");
-        printStream.accept("  -f, --force           Overwrite files without asking for confirmation");
-        printStream.accept("  -y, --yes             Answer \"yes\" to all prompts automatically");
         printStream.accept("");
         printStream.accept("Default behavior: --model and --plugins are applied if no other options are specified");
         printStream.accept("");
@@ -157,8 +137,6 @@ public class CommonsCliUpgradeOptions extends CommonsCliOptions implements Upgra
     }
 
     protected static class CLIManager extends CommonsCliOptions.CLIManager {
-        public static final String FORCE = "f";
-        public static final String YES = "y";
         public static final String MODEL_VERSION = "m";
         public static final String DIRECTORY = "d";
         public static final String INFER = "i";
@@ -169,14 +147,6 @@ public class CommonsCliUpgradeOptions extends CommonsCliOptions implements Upgra
         @Override
         protected void prepareOptions(org.apache.commons.cli.Options options) {
             super.prepareOptions(options);
-            options.addOption(Option.builder(FORCE)
-                    .longOpt("force")
-                    .desc("Should overwrite without asking any configuration?")
-                    .build());
-            options.addOption(Option.builder(YES)
-                    .longOpt("yes")
-                    .desc("Should imply user answered \"yes\" to all incoming questions?")
-                    .build());
             options.addOption(Option.builder(MODEL_VERSION)
                     .longOpt("model-version")
                     .hasArg()

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/Help.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/Help.java
@@ -54,8 +54,6 @@ public class Help implements Goal {
         context.info("    --plugins         Upgrade plugins known to fail with Maven 4");
         context.info(
                 "-a, --all             Apply all upgrades (equivalent to --model-version 4.1.0 --infer --model --plugins)");
-        context.info("-f, --force           Overwrite files without asking for confirmation");
-        context.info("-y, --yes             Answer \"yes\" to all prompts automatically");
         context.unindent();
         context.println();
         context.info("Default behavior: --model and --plugins are applied if no other options are specified");

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/HelpTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/HelpTest.java
@@ -103,15 +103,4 @@ class HelpTest {
         Mockito.verify(context.logger)
                 .info("Default behavior: --model and --plugins are applied if no other options are specified");
     }
-
-    @Test
-    void testHelpIncludesForceAndYesOptions() throws Exception {
-        UpgradeContext context = createMockContext();
-
-        help.execute(context);
-
-        // Verify that --force and --yes options are included
-        Mockito.verify(context.logger).info("  -f, --force           Overwrite files without asking for confirmation");
-        Mockito.verify(context.logger).info("  -y, --yes             Answer \"yes\" to all prompts automatically");
-    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Maven Upgrade Tool: remove unused --force and --yes options (Fixes #11001) (#11066)](https://github.com/apache/maven/pull/11066)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)