### PR TITLE
Bug: bad cache isolation between two sessions

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -111,6 +111,7 @@ import org.codehaus.plexus.interpolation.StringSearchInterpolator;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.DefaultRepositoryCache;
 import org.eclipse.aether.transfer.TransferListener;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
@@ -911,6 +912,7 @@ public class MavenCli {
 
     private int execute(CliRequest cliRequest) throws MavenExecutionRequestPopulationException {
         MavenExecutionRequest request = executionRequestPopulator.populateDefaults(cliRequest.request);
+        request.setRepositoryCache(new DefaultRepositoryCache()); // reset caches
 
         eventSpyDispatcher.onEvent(request);
 


### PR DESCRIPTION
The "early" session used to load extension will populate cache in MavenExecutionRequest and same cache is later reused in "normal" session as well.

This is wrong, as if project uses same parent POM as any of loaded extnsions, data loss in form of lost input locations occurs.

Fixes #11081