### PR TITLE
Bug: bad cache isolation between two sessions

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -964,6 +964,7 @@ public class MavenCli {
 
     private int execute(CliRequest cliRequest) throws MavenExecutionRequestPopulationException {
         MavenExecutionRequest request = executionRequestPopulator.populateDefaults(cliRequest.request);
+        request.setRepositoryCache(new DefaultRepositoryCache()); // reset caches
 
         if (cliRequest.request.getRepositoryCache() == null) {
             cliRequest.request.setRepositoryCache(new DefaultRepositoryCache());


### PR DESCRIPTION
Port of Maven 3 bugfix to Maven 4 (deprecated) `maven-embedder` module. Maven 4 by default is **not affected**, but this PR aligns Maven 3 and deprecated `maven-embedder` module in Maven 4.

The "early" session used to load extension will populate cache in MavenExecutionRequest and same cache is later reused in "normal" session as well.

This is wrong, as if project uses same parent POM as any of loaded extnsions, data loss in form of lost input locations occurs.

Fixes #11081