### PR TITLE
ReactorReader: prefer consumer POM from project-local repo when resolving POMs

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -330,6 +330,18 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     private File findInProjectLocalRepository(Artifact artifact) {
+        // Prefer the consumer POM when resolving POMs from the project-local repository,
+        // to avoid treating a build POM as a repository (consumer) POM.
+        if ("pom".equals(artifact.getExtension())) {
+            String classifier = artifact.getClassifier();
+            if (classifier == null || classifier.isEmpty()) {
+                Path consumer = getArtifactPath(
+                        artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), "consumer", "pom");
+                if (Files.isRegularFile(consumer)) {
+                    return consumer.toFile();
+                }
+            }
+        }
         Path target = getArtifactPath(artifact);
         return Files.isRegularFile(target) ? target.toFile() : null;
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11084ReactorReaderPreferConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11084ReactorReaderPreferConsumerPomTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * This is a test set for GH-11084.
+ */
+class MavenITgh11084ReactorReaderPreferConsumerPomTest extends AbstractMavenIntegrationTestCase {
+    MavenITgh11084ReactorReaderPreferConsumerPomTest() {
+        super("[4.0.0-rc-2,)");
+    }
+
+    @Test
+    void partialReactorShouldResolveUsingConsumerPom() throws Exception {
+        File testDir = extractResources("/gh-11084-reactorreader-prefer-consumer-pom");
+
+        // First build module a to populate project-local-repo with artifacts including consumer POM
+        Verifier v1 = newVerifier(testDir.getAbsolutePath());
+        v1.setAutoclean(false);
+        v1.addCliArguments("compile");
+        v1.execute();
+        v1.verifyErrorFreeLog();
+
+        // Now build only module b; ReactorReader should pick consumer POM from project-local-repo
+        Verifier v2 = newVerifier(testDir.getAbsolutePath());
+        v2.setAutoclean(false);
+        v2.addCliArguments("-f", "b", "compile");
+        v2.execute();
+        v2.verifyErrorFreeLog();
+        String log = v2.loadLogContent();
+        assertFalse(log.contains("The POM for org.apache.maven.its.gh11084:a:jar:1.0.0-SNAPSHOT is invalid"), log);
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -103,6 +103,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITgh11084ReactorReaderPreferConsumerPomTest.class);
         suite.addTestSuite(MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.class);
         suite.addTestSuite(MavenITgh10937QuotedPipesInMavenOptsTest.class);
         suite.addTestSuite(MavenITgh2532DuplicateDependencyEffectiveModelTest.class);

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent />
+
+  <artifactId>a</artifactId>
+  <packaging>jar</packaging>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/src/main/java/p/A.java
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/src/main/java/p/A.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package p;
+
+public class A {
+    public static String v() {
+        return "A";
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/b/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/b/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+
+  <parent />
+
+  <artifactId>b</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.gh11084</groupId>
+      <artifactId>a</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.gh11084</groupId>
+  <artifactId>reactor-root</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>a</module>
+    <module>b</module>
+  </modules>
+</project>


### PR DESCRIPTION
When only part of a reactor is built, ReactorReader mirrors artifacts into a project-local repo. If a module depends on another reactor module not in the current session, POM resolution may hit that repo. Today, the main POM path contains the build POM, which can include Maven-4 build-time constructs and be invalid as a repository POM (e.g., missing parent.*). As a result, dependency resolution can fail with fatal model errors.

Teach ReactorReader to prefer the consumer POM (classifier=consumer) for POM artifacts when present in the project-local repo, falling back to the main POM otherwise. This avoids consuming a build POM from the project-local repo without changing the repo contents or layout.
