### PR TITLE
Fix #10939: DefaultModelXmlFactory: make location tracking opt-in—disabled by def…

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Singleton;
+import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.services.xml.ModelXmlFactory;
@@ -121,22 +122,29 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
         Path path = request.getPath();
         OutputStream outputStream = request.getOutputStream();
         Writer writer = request.getWriter();
-        Function<Object, String> inputLocationFormatter = request.getInputLocationFormatter();
+
         if (writer == null && outputStream == null && path == null) {
             throw new IllegalArgumentException("writer, outputStream or path must be non null");
         }
+
         try {
-            MavenStaxWriter w = new MavenStaxWriter();
-            if (inputLocationFormatter != null) {
-                w.setStringFormatter((Function) inputLocationFormatter);
+            final MavenStaxWriter xmlWriter = new MavenStaxWriter();
+            xmlWriter.setAddLocationInformation(false);
+
+            final Function<Object, String> formatter = request.getInputLocationFormatter();
+            if (formatter != null) {
+                xmlWriter.setAddLocationInformation(true);
+                final Function<InputLocation, String> adapter = formatter::apply;
+                xmlWriter.setStringFormatter(adapter);
             }
+
             if (writer != null) {
-                w.write(writer, content);
+                xmlWriter.write(writer, content);
             } else if (outputStream != null) {
-                w.write(outputStream, content);
+                xmlWriter.write(outputStream, content);
             } else {
                 try (OutputStream os = Files.newOutputStream(path)) {
-                    w.write(os, content);
+                    xmlWriter.write(os, content);
                 }
             }
         } catch (Exception e) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -128,13 +128,13 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
         }
 
         try {
-            final MavenStaxWriter xmlWriter = new MavenStaxWriter();
+            MavenStaxWriter xmlWriter = new MavenStaxWriter();
             xmlWriter.setAddLocationInformation(false);
 
-            final Function<Object, String> formatter = request.getInputLocationFormatter();
+            Function<Object, String> formatter = request.getInputLocationFormatter();
             if (formatter != null) {
                 xmlWriter.setAddLocationInformation(true);
-                final Function<InputLocation, String> adapter = formatter::apply;
+                Function<InputLocation, String> adapter = formatter::apply;
                 xmlWriter.setStringFormatter(adapter);
             }
 


### PR DESCRIPTION
…ault, enabled when an InputLocationFormatter is provided.

Adapt formatter to Function<InputLocation,String> and write to the actually opened stream for path output. Fixes #10939.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ X] Your pull request should address just one issue, without pulling in other changes.
- [ X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ X] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ X] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/


====

Supersedes #10940 