### PR TITLE
Restore method RepositoryUtils.newArtifactTypeRegistry

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.impl.resolver.artifact.MavenArtifactProperties;
@@ -258,13 +259,15 @@ public class RepositoryUtils {
     }
 
     public static ArtifactType newArtifactType(String id, ArtifactHandler handler) {
-        return new DefaultArtifactType(
-                id,
-                handler.getExtension(),
-                handler.getClassifier(),
-                handler.getLanguage(),
-                handler.isAddedToClasspath(),
-                handler.isIncludesDependencies());
+        return handler != null
+                ? new DefaultArtifactType(
+                        id,
+                        handler.getExtension(),
+                        handler.getClassifier(),
+                        handler.getLanguage(),
+                        handler.isAddedToClasspath(),
+                        handler.isIncludesDependencies())
+                : null;
     }
 
     public static Dependency toDependency(
@@ -304,6 +307,14 @@ public class RepositoryUtils {
 
     private static Exclusion toExclusion(org.apache.maven.model.Exclusion exclusion) {
         return new Exclusion(exclusion.getGroupId(), exclusion.getArtifactId(), "*", "*");
+    }
+
+    /**
+     * @deprecated Use by maven-artifact-transfer.
+     */
+    @Deprecated
+    public static ArtifactTypeRegistry newArtifactTypeRegistry(ArtifactHandlerManager handlerManager) {
+        return typeId -> newArtifactType(typeId, handlerManager.getArtifactHandler(typeId));
     }
 
     public static Collection<Artifact> toArtifacts(Collection<org.apache.maven.artifact.Artifact> artifactsToConvert) {


### PR DESCRIPTION
used by maven-artifact-transfer

discovered in m-dependency-p

```
Caused by: java.lang.NoSuchMethodException: org.apache.maven.RepositoryUtils.newArtifactTypeRegistry(org.apache.maven.artifact.handler.manager.ArtifactHandlerManager)
    at java.lang.Class.getMethod(Class.java:2168)
    at org.apache.maven.shared.transfer.dependencies.resolve.internal.Invoker.invoke(Invoker.java:57)
    at org.apache.maven.shared.transfer.dependencies.resolve.internal.Maven31DependencyResolver.createTypeRegistry(Maven31DependencyResolver.java:122)
    at org.apache.maven.shared.transfer.dependencies.resolve.internal.Maven31DependencyResolver.resolveDependencies(Maven31DependencyResolver.java:111)
    at org.apache.maven.shared.transfer.dependencies.resolve.internal.DefaultDependencyResolver.resolveDependencies(DefaultDependencyResolver.java:76)
    at org.apache.maven.plugins.dependency.GetMojo.execute(GetMojo.java:186)

```

so as `maven-artifact-transfer` is archived and is used by many plugins .... we need restore it.


Used in:
https://github.com/search?q=%22%3CartifactId%3Emaven-artifact-transfer%3C%2FartifactId%3E%22+language%3A%22Maven+POM%22++NOT+is%3Aarchived+NOT+is%3Afork&type=code

introduced in:
 - #10941