### PR TITLE
Deprecate org.apache.maven.repository.RepositorySystem in 3.9.x

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/repository/RepositorySystem.java
+++ b/maven-core/src/main/java/org/apache/maven/repository/RepositorySystem.java
@@ -38,7 +38,10 @@ import org.eclipse.aether.RepositorySystemSession;
 /**
  * @author Jason van Zyl
  * @since 3.0-alpha
+ *
+ * @deprecated Use maven-resolver and new DefaultArtifact(...) directly instead.
  */
+@Deprecated
 public interface RepositorySystem {
     String DEFAULT_LOCAL_REPO_ID = "local";
 


### PR DESCRIPTION
As we have only legacy implementation and use many other staff that is already deprecated.

