### PR TITLE
Fix #11000: fix help default text

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/CommonsCliUpgradeOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/CommonsCliUpgradeOptions.java
@@ -126,7 +126,7 @@ public class CommonsCliUpgradeOptions extends CommonsCliOptions implements Upgra
         printStream.accept(
                 "  -a, --all             Apply all upgrades (equivalent to --model-version 4.1.0 --infer --model --plugins)");
         printStream.accept("");
-        printStream.accept("Default behavior: --model and --plugins are applied if no other options are specified");
+        printStream.accept("Default behavior: --model --plugins --infer are applied if no other options are specified");
         printStream.accept("");
     }
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/PluginUpgradeCliTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/PluginUpgradeCliTest.java
@@ -18,8 +18,13 @@
  */
 package org.apache.maven.cling.invoker.mvnup;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.cli.ParseException;
 import org.apache.maven.api.cli.mvnup.UpgradeOptions;
+import org.apache.maven.cling.MavenUpCling;
+import org.codehaus.plexus.classworlds.ClassWorld;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -189,5 +194,26 @@ class PluginUpgradeCliTest {
 
         assertTrue(interpolated.plugins().isPresent(), "Interpolated options should preserve --plugins");
         assertTrue(interpolated.plugins().get(), "Interpolated --plugins should be true");
+    }
+
+    @Test
+    void helpMentionsInferInDefault() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = MavenUpCling.main(
+                new String[] {"--help"},
+                new ClassWorld("plexus.core", Thread.currentThread().getContextClassLoader()),
+                null,
+                out,
+                err);
+
+        String help = out.toString(StandardCharsets.UTF_8);
+        assertEquals(0, exit, "mvnup --help should exit 0");
+        assertTrue(
+                help.contains("Default behavior: --model --plugins --infer"),
+                "Help footer should advertise --infer as part of the defaults");
+        assertFalse(
+                help.contains("Default behavior: --model and --plugins"), "Old/incorrect default text must be gone");
     }
 }


### PR DESCRIPTION
Include --infer alongside --model and --plugins in help footer. Align CLI help with runtime defaults.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X ] Your pull request should address just one issue, without pulling in other changes.
- [X ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ X] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [X ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/

Fix #11000 