### PR TITLE
Improve source root modification warning message

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1216,15 +1216,27 @@ public class MavenProject implements Cloneable {
                 return;
             }
 
-            LOGGER.warn("Direct modification of " + collectionName + " through " + method
-                    + "() is deprecated and will not work in Maven 4.0.0. "
-                    + "Please use the add/remove methods instead. If you're using a plugin that causes this warning, "
-                    + "please upgrade to the latest version and report an issue if the warning persists. "
+            String specificMethods = getRecommendedMethods(collectionName);
+            LOGGER.warn("Plugin is modifying " + collectionName + " through " + method
+                    + "(), which will not work in Maven 4.0.0. "
+                    + "Use " + specificMethods + " instead. "
+                    + "If using a plugin, please upgrade to the latest version or report the issue to the plugin maintainer. "
                     + "To disable these warnings, set -D" + DISABLE_WARNINGS_PROPERTY + "=true on the command line, "
                     + "in the .mvn/maven.config file, or in project POM properties.");
             // Log a stack trace to help identify the caller
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Stack trace", new Exception("Stack trace"));
+                LOGGER.debug("Stack trace for deprecated source root modification:", new Exception("Stack trace"));
+            }
+        }
+
+        private String getRecommendedMethods(String collectionName) {
+            switch (collectionName) {
+                case "compileSourceRoots":
+                    return "MavenProject.addCompileSourceRoot()/removeCompileSourceRoot() methods";
+                case "testCompileSourceRoots":
+                    return "MavenProject.addTestCompileSourceRoot()/removeTestCompileSourceRoot() methods";
+                default:
+                    return "appropriate MavenProject add/remove methods";
             }
         }
 


### PR DESCRIPTION
## Summary

This PR improves the warning message for deprecated source root collection modifications to address concerns raised in #11089.

## Changes Made

- **More specific method recommendations**: Instead of generic "add/remove methods", now shows exact method names:
  - For `compileSourceRoots`: "Use MavenProject.addCompileSourceRoot()/removeCompileSourceRoot() methods instead"
  - For `testCompileSourceRoots`: "Use MavenProject.addTestCompileSourceRoot()/removeTestCompileSourceRoot() methods instead"

- **Clearer language**: Changed "Direct modification of" to "Plugin is modifying" to make it clearer what's happening

- **More concise messaging**: Removed redundant phrases while keeping essential information

- **Better debugging information**: Improved the debug stack trace message description

- **Ecosystem health**: Encourages reporting issues to plugin maintainers to help prepare the Maven ecosystem for 4.0.0

- **Preserved helpful configuration guidance**: Kept the valuable information about where users can set the disable property

## Before and After

**Before:**
```
[WARNING] Direct modification of testCompileSourceRoots through iterator.remove() 
is deprecated and will not work in Maven 4.0.0. Please use the add/remove methods 
instead. If you're using a plugin that causes this warning, please upgrade to the latest 
version and report an issue if the warning persists. To disable these warnings, set 
-Dmaven.project.sourceRoots.warningsDisabled=true on the command line, in the 
.mvn/maven.config file, or in project POM properties.
```

**After:**
```
[WARNING] Plugin is modifying testCompileSourceRoots through iterator.remove(), 
which will not work in Maven 4.0.0. 
Use MavenProject.addTestCompileSourceRoot()/removeTestCompileSourceRoot() 
methods instead. If using a plugin, please upgrade to the latest version or report the 
issue to the plugin maintainer. To disable these warnings, set 
-Dmaven.project.sourceRoots.warningsDisabled=true on the command line, in the 
.mvn/maven.config file, or in project POM properties.
```

## Addresses Issues Raised in #11089

1. ✅ **Confusion about "add/remove methods"**: Now provides specific method names
2. ✅ **More actionable**: Clearer about what methods to use
3. ✅ **Less confusing**: Removes the contradiction about adding through iterators
4. ✅ **Maintains helpful configuration info**: Keeps the guidance on where to set the disable property
5. ✅ **Better debugging**: Improved stack trace description for developers
6. ✅ **Ecosystem health**: Encourages issue reporting to help Maven 4.0.0 readiness

The changes maintain backward compatibility while making the warning message much more helpful and less confusing for both end users and plugin developers.

Fixes #11089

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author