### PR TITLE
Resolver 2.0.11 (#11043)

### DIFF
--- a/compat/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/artifact/AbstractArtifactComponentTestCase.java
@@ -69,8 +69,8 @@ import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+import org.eclipse.aether.util.graph.transformer.ConfigurableVersionSelector;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
-import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
 import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
 import org.junit.jupiter.api.BeforeEach;
@@ -323,7 +323,7 @@ public abstract class AbstractArtifactComponentTestCase // extends PlexusTestCas
         ScopeManagerImpl scopeManager = new ScopeManagerImpl(Maven4ScopeManagerConfiguration.INSTANCE);
         session.setScopeManager(scopeManager);
         DependencyGraphTransformer transformer = new ConflictResolver(
-                new NearestVersionSelector(), new ManagedScopeSelector(scopeManager),
+                new ConfigurableVersionSelector(), new ManagedScopeSelector(scopeManager),
                 new SimpleOptionalitySelector(), new ManagedScopeDeriver(scopeManager));
         transformer =
                 new ChainedDependencyGraphTransformer(transformer, new ManagedDependencyContextRefiner(scopeManager));

--- a/compat/maven-embedder/pom.xml
+++ b/compat/maven-embedder/pom.xml
@@ -169,11 +169,6 @@ under the License.
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jansi-core</artifactId>
     </dependency>

--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenSessionBuilderSupplier.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenSessionBuilderSupplier.java
@@ -46,8 +46,8 @@ import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+import org.eclipse.aether.util.graph.transformer.ConfigurableVersionSelector;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
-import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
 import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
 
@@ -109,7 +109,7 @@ public class MavenSessionBuilderSupplier implements Supplier<SessionBuilder> {
     protected DependencyGraphTransformer getDependencyGraphTransformer() {
         return new ChainedDependencyGraphTransformer(
                 new ConflictResolver(
-                        new NearestVersionSelector(), new ManagedScopeSelector(getScopeManager()),
+                        new ConfigurableVersionSelector(), new ManagedScopeSelector(getScopeManager()),
                         new SimpleOptionalitySelector(), new ManagedScopeDeriver(getScopeManager())),
                 new ManagedDependencyContextRefiner(getScopeManager()));
     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenContext.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenContext.java
@@ -22,6 +22,7 @@ import org.apache.maven.Maven;
 import org.apache.maven.api.cli.InvokerRequest;
 import org.apache.maven.api.cli.mvn.MavenOptions;
 import org.apache.maven.cling.invoker.LookupContext;
+import org.apache.maven.cling.transfer.SimplexTransferListener;
 
 @SuppressWarnings("VisibilityModifier")
 public class MavenContext extends LookupContext {
@@ -29,6 +30,7 @@ public class MavenContext extends LookupContext {
         super(invokerRequest, containerCapsuleManaged, mavenOptions);
     }
 
+    public SimplexTransferListener simplexTransferListener;
     public Maven maven;
 
     @Override

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
@@ -360,12 +360,15 @@ public class MavenInvoker extends LookupInvoker<MavenContext> {
         if (quiet || noTransferProgress || quietCI) {
             delegate = new QuietMavenTransferListener();
         } else if (context.interactive && !logFile) {
-            SimplexTransferListener simplex = new SimplexTransferListener(new ConsoleMavenTransferListener(
-                    context.invokerRequest.messageBuilderFactory(),
-                    context.terminal.writer(),
-                    context.invokerRequest.effectiveVerbose()));
-            context.closeables.add(simplex);
-            delegate = simplex;
+            if (context.simplexTransferListener == null) {
+                SimplexTransferListener simplex = new SimplexTransferListener(new ConsoleMavenTransferListener(
+                        context.invokerRequest.messageBuilderFactory(),
+                        context.terminal.writer(),
+                        context.invokerRequest.effectiveVerbose()));
+                context.closeables.add(simplex);
+                context.simplexTransferListener = simplex;
+            }
+            delegate = context.simplexTransferListener;
         } else {
             delegate = new Slf4jMavenTransferListener();
         }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/resident/ResidentMavenInvoker.java
@@ -86,6 +86,7 @@ public class ResidentMavenInvoker extends MavenInvoker {
         shadow.containerCapsule = mavenContext.containerCapsule;
         shadow.lookup = mavenContext.lookup;
         shadow.eventSpyDispatcher = mavenContext.eventSpyDispatcher;
+        shadow.simplexTransferListener = mavenContext.simplexTransferListener;
         shadow.maven = mavenContext.maven;
 
         return shadow;

--- a/impl/maven-core/src/test/java/org/apache/maven/repository/TestRepositoryConnector.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/repository/TestRepositoryConnector.java
@@ -130,11 +130,15 @@ public class TestRepositoryConnector implements RepositoryConnector {
     private String path(Metadata metadata) {
         StringBuilder path = new StringBuilder(128);
 
-        path.append(metadata.getGroupId().replace('.', '/')).append('/');
+        if (!metadata.getGroupId().isBlank()) {
+            path.append(metadata.getGroupId().replace('.', '/')).append('/');
+        }
 
-        path.append(metadata.getArtifactId()).append('/');
+        if (!metadata.getArtifactId().isBlank()) {
+            path.append(metadata.getArtifactId()).append('/');
+        }
 
-        path.append("maven-metadata.xml");
+        path.append(metadata.getType());
 
         return path.toString();
     }

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -43,6 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ToolboxToolTest {
+    private static final String VERSION = "0.7.4";
+
     @TempDir
     private static Path userHome;
 
@@ -69,7 +71,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        Map<String, String> dump = new ToolboxTool(helper).dump(getExecutorRequest(helper));
+        Map<String, String> dump = new ToolboxTool(helper, VERSION).dump(getExecutorRequest(helper));
         assertEquals(System.getProperty("maven3version"), dump.get("maven.version"));
     }
 
@@ -83,7 +85,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        Map<String, String> dump = new ToolboxTool(helper).dump(getExecutorRequest(helper));
+        Map<String, String> dump = new ToolboxTool(helper, VERSION).dump(getExecutorRequest(helper));
         assertEquals(System.getProperty("maven4version"), dump.get("maven.version"));
     }
 
@@ -123,7 +125,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String localRepository = new ToolboxTool(helper).localRepository(getExecutorRequest(helper));
+        String localRepository = new ToolboxTool(helper, VERSION).localRepository(getExecutorRequest(helper));
         Path local = Paths.get(localRepository);
         assertTrue(Files.isDirectory(local));
     }
@@ -139,7 +141,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String localRepository = new ToolboxTool(helper).localRepository(getExecutorRequest(helper));
+        String localRepository = new ToolboxTool(helper, VERSION).localRepository(getExecutorRequest(helper));
         Path local = Paths.get(localRepository);
         assertTrue(Files.isDirectory(local));
     }
@@ -154,7 +156,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper)
+        String path = new ToolboxTool(helper, VERSION)
                 .artifactPath(getExecutorRequest(helper), "aopalliance:aopalliance:1.0", "central");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(
@@ -173,7 +175,7 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper)
+        String path = new ToolboxTool(helper, VERSION)
                 .artifactPath(getExecutorRequest(helper), "aopalliance:aopalliance:1.0", "central");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(
@@ -192,7 +194,8 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
+        String path =
+                new ToolboxTool(helper, VERSION).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
     }
@@ -207,7 +210,8 @@ public class ToolboxToolTest {
                 userHome,
                 MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
                 MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
+        String path =
+                new ToolboxTool(helper, VERSION).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
@@ -258,8 +258,11 @@ public class RepositorySystemSupplier {
     @Provides
     @Named(PrefixesRemoteRepositoryFilterSource.NAME)
     static PrefixesRemoteRepositoryFilterSource newPrefixesRemoteRepositoryFilterSource(
+            MetadataResolver metadataResolver,
+            RemoteRepositoryManager remoteRepositoryManager,
             RepositoryLayoutProvider repositoryLayoutProvider) {
-        return new PrefixesRemoteRepositoryFilterSource(repositoryLayoutProvider);
+        return new PrefixesRemoteRepositoryFilterSource(
+                () -> metadataResolver, () -> remoteRepositoryManager, repositoryLayoutProvider);
     }
 
     @Provides

--- a/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/RepositorySystemSupplier.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/RepositorySystemSupplier.java
@@ -544,7 +544,8 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
                 new GroupIdRemoteRepositoryFilterSource(getRepositorySystemLifecycle()));
         result.put(
                 PrefixesRemoteRepositoryFilterSource.NAME,
-                new PrefixesRemoteRepositoryFilterSource(getRepositoryLayoutProvider()));
+                new PrefixesRemoteRepositoryFilterSource(
+                        this::getMetadataResolver, this::getRemoteRepositoryManager, getRepositoryLayoutProvider()));
         return result;
     }
 

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -80,6 +80,7 @@ under the License.
     <jetty9Version>9.4.57.v20241219</jetty9Version>
 
     <stubPluginVersion>0.1-stub-SNAPSHOT</stubPluginVersion>
+    <version.toolbox>0.7.4</version.toolbox>
   </properties>
 
   <dependencies>
@@ -519,6 +520,7 @@ under the License.
           <useSystemClassLoader>false</useSystemClassLoader>
           <promoteUserPropertiesToSystemProperties>false</promoteUserPropertiesToSystemProperties>
           <systemPropertyVariables>
+            <version.toolbox>${version.toolbox}</version.toolbox>
             <maven.test.user.home>${preparedUserHome}</maven.test.user.home>
             <maven.test.repo.outer>${settings.localRepository}</maven.test.repo.outer>
             <maven.test.repo.local>${preparedUserHome}/.m2/repository</maven.test.repo.local>

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -155,7 +155,7 @@ public class Verifier {
                     this.userHomeDirectory,
                     EMBEDDED_MAVEN_EXECUTOR,
                     FORKED_MAVEN_EXECUTOR);
-            this.executorTool = new ToolboxTool(executorHelper);
+            this.executorTool = new ToolboxTool(executorHelper, System.getProperty("version.toolbox", "0.7.4"));
             this.defaultCliArguments =
                     new ArrayList<>(defaultCliArguments != null ? defaultCliArguments : DEFAULT_CLI_ARGUMENTS);
             this.logFile = this.basedir.resolve(logFileName);

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ under the License.
     <plexusInterpolationVersion>1.28</plexusInterpolationVersion>
     <plexusTestingVersion>1.6.0</plexusTestingVersion>
     <plexusXmlVersion>4.1.0</plexusXmlVersion>
-    <resolverVersion>2.0.10</resolverVersion>
+    <resolverVersion>2.0.11</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
     <sisuVersion>0.9.0.M4</sisuVersion>
     <slf4jVersion>2.0.17</slf4jVersion>


### PR DESCRIPTION
Update to Resolver 2.0.11.

Changes:
* up to Resolver 2.0.11
* port over required changes (ctor changes mostly in suppliers)
* `TestRepositoryConnector` never dealt with metadata properly, now is getting prefix metadata due RRF, fix it.

Unrelated to resolver changes:
* remove slf4j-simple from maven-compat (emits warnings as maven provider is already present)
* maven-cli fix double/unneeded simplex transfer listener creation
* maven-executor and ITs: externalize Toolbox version for simpler maintenance
