### PR TITLE
Add missing equals and hashCode methods in modular Java path type

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
@@ -377,6 +377,25 @@ public enum JavaPathType implements PathType {
         }
 
         /**
+         * {@return a hash code value based on the raw type and module name}.
+         */
+        @Override
+        public int hashCode() {
+            return rawType().hashCode() + 17 * moduleName.hashCode();
+        }
+
+        /**
+         * {@return whether the given object represents the same type of path as this object}.
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof Modular m) {
+                return rawType() == m.rawType() && moduleName.equals(m.moduleName);
+            }
+            return false;
+        }
+
+        /**
          * Returns the programmatic name of this path type, including the module to patch.
          * For example, if this type was created by {@code JavaPathType.patchModule("foo.bar")},
          * then this method returns {@code "PathType[PATCH_MODULE:foo.bar]")}.

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class JavaPathTypeTest {
     /**
@@ -64,5 +65,19 @@ public class JavaPathTypeTest {
         assertEquals(2, formatted.length);
         assertEquals("--patch-module", formatted[0]);
         assertEquals(toPlatformSpecific("my.module=\"src/foo.java:src/bar.java\""), formatted[1]);
+    }
+
+    /**
+     * Tests the {@code equals} and {@code hashCode} methods of options.
+     */
+    @Test
+    public void testEqualsHashCode() {
+        JavaPathType.Modular foo1 = JavaPathType.patchModule("foo");
+        JavaPathType.Modular foo2 = JavaPathType.patchModule("foo");
+        JavaPathType.Modular bar = JavaPathType.patchModule("bar");
+        assertEquals(foo1, foo2);
+        assertEquals(foo1.hashCode(), foo2.hashCode());
+        assertNotEquals(foo1, bar);
+        assertNotEquals(foo1.hashCode(), bar.hashCode());
     }
 }


### PR DESCRIPTION
Those methods are necessary for the Java Compiler Plugin, which uses those objects as keys in a `HashMap`. It impacts only the `--patch-module` option however.