### PR TITLE
Simplify “**” handling using brace expansion (fixes #11110)

### DIFF
--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
@@ -86,8 +86,77 @@ public class PathSelectorTest {
         List<String> excludes = List.of("baz/**");
         PathMatcher matcher = PathSelector.of(directory, includes, excludes, true);
         String s = matcher.toString();
-        assertTrue(s.contains("glob:**/*.java"));
+        assertTrue(s.contains("glob:**/*.java") || s.contains("glob:{**/,}*.java"));
         assertFalse(s.contains("project.pj")); // Unnecessary exclusion should have been omitted.
         assertFalse(s.contains(".DS_Store"));
+    }
+
+    /**
+     * Test to verify the current behavior of ** patterns before implementing brace expansion improvement.
+     * This test documents the expected behavior that must be preserved after the optimization.
+     */
+    @Test
+    public void testDoubleAsteriskPatterns(final @TempDir Path directory) throws IOException {
+        // Create a nested directory structure to test ** behavior
+        Path src = Files.createDirectory(directory.resolve("src"));
+        Path main = Files.createDirectory(src.resolve("main"));
+        Path java = Files.createDirectory(main.resolve("java"));
+        Path test = Files.createDirectory(src.resolve("test"));
+        Path testJava = Files.createDirectory(test.resolve("java"));
+
+        // Create files at different levels
+        Files.createFile(directory.resolve("root.java"));
+        Files.createFile(src.resolve("src.java"));
+        Files.createFile(main.resolve("main.java"));
+        Files.createFile(java.resolve("deep.java"));
+        Files.createFile(test.resolve("test.java"));
+        Files.createFile(testJava.resolve("testdeep.java"));
+
+        // Test that ** matches zero or more directories (POSIX behavior)
+        PathMatcher matcher = PathSelector.of(directory, List.of("src/**/test/**/*.java"), null, false);
+
+        // Should match files in src/test/java/ (** matches zero dirs before test, zero dirs after test)
+        assertTrue(matcher.matches(testJava.resolve("testdeep.java")));
+
+        // Should also match files directly in src/test/ (** matches zero dirs after test)
+        assertTrue(matcher.matches(test.resolve("test.java")));
+
+        // Should NOT match files in other paths
+        assertFalse(matcher.matches(directory.resolve("root.java")));
+        assertFalse(matcher.matches(src.resolve("src.java")));
+        assertFalse(matcher.matches(main.resolve("main.java")));
+        assertFalse(matcher.matches(java.resolve("deep.java")));
+    }
+
+    @Test
+    public void testLiteralBracesAreEscapedInMavenSyntax(@TempDir Path directory) throws IOException {
+        // Create a file with literal braces in the name
+        Files.createDirectories(directory.resolve("dir"));
+        Path file = directory.resolve("dir/foo{bar}.txt");
+        Files.createFile(file);
+
+        // In Maven syntax (no explicit glob:), user-provided braces must be treated literally
+        PathMatcher matcher = PathSelector.of(directory, List.of("**/foo{bar}.txt"), null, false);
+
+        assertTrue(matcher.matches(file));
+    }
+
+    @Test
+    public void testBraceAlternationOnlyWithExplicitGlob(@TempDir Path directory) throws IOException {
+        // Create src/main/java and src/test/java with files
+        Path mainJava = Files.createDirectories(directory.resolve("src/main/java"));
+        Path testJava = Files.createDirectories(directory.resolve("src/test/java"));
+        Path mainFile = Files.createFile(mainJava.resolve("Main.java"));
+        Path testFile = Files.createFile(testJava.resolve("Test.java"));
+
+        // Without explicit glob:, braces from user input are escaped and treated literally -> no matches
+        PathMatcher mavenSyntax = PathSelector.of(directory, List.of("src/{main,test}/**/*.java"), null, false);
+        assertFalse(mavenSyntax.matches(mainFile));
+        assertFalse(mavenSyntax.matches(testFile));
+
+        // With explicit glob:, braces should act as alternation and match both
+        PathMatcher explicitGlob = PathSelector.of(directory, List.of("glob:src/{main,test}/**/*.java"), null, false);
+        assertTrue(explicitGlob.matches(mainFile));
+        assertTrue(explicitGlob.matches(testFile));
     }
 }


### PR DESCRIPTION
This PR simplifies support for the ** wildcard and clarifies brace handling.

What changes
- Convert `**/` to `{**/,}` after escaping special characters (including braces)
- Escape user-provided `{` and `}` in Maven-style patterns so braces are treated literally
- Keep brace alternation available when the user explicitly opts into `glob:` syntax
- Add focused tests for literal braces and explicit `glob:` alternation

Why
- Provides clear, POSIX-like behavior for `**` (“zero or more directories”) without custom logic
- Aligns implementation with the documented rule that `[ ]` and `{ }` are escaped in Maven-style patterns
- Ensures only the injected braces participate in expansion; user braces remain literals unless `glob:` is used

Behavior notes
- `**` continues to mean “0+ directories”; `**/` is normalized to `{**/,}` so both the current directory and subdirectories match
- Users who relied on unescaped braces acting as alternation in Maven-style patterns may see a behavior change; this corrects behavior to match the documentation
- With `glob:` prefix, brace alternation remains supported per NIO glob rules

Tests
- `testLiteralBracesAreEscapedInMavenSyntax`: verifies that files with literal braces match with Maven-style patterns
- `testBraceAlternationOnlyWithExplicitGlob`: verifies alternation works only with `glob:`

Fixes #11110