### PR TITLE
core(consumer-pom): drop compile-only/test-only; map test-runtime -> test; adjust tests

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -46,6 +46,7 @@ import org.apache.maven.api.services.ModelBuilderResult;
 import org.apache.maven.api.services.Sources;
 import org.apache.maven.api.services.model.LifecycleBindingsInjector;
 import org.apache.maven.impl.InternalSession;
+import org.apache.maven.impl.resolver.scopes.Maven4ScopeManagerConfiguration;
 import org.apache.maven.model.v4.MavenModelVersion;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystemSession;
@@ -190,12 +191,10 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         if (dependency == null) {
             return null;
         }
-        String mapped =
-                org.apache.maven.impl.resolver.scopes.Maven4ScopeManagerConfiguration.mapScopeForMaven3ConsumerPom(
-                        dependency.getScope());
         if (dependency.getScope() == null) {
             return dependency;
         }
+        String mapped = Maven4ScopeManagerConfiguration.mapScopeForMaven3ConsumerPom(dependency.getScope());
         if (mapped == null) {
             return null; // omit
         }

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
@@ -30,6 +30,7 @@ import org.apache.maven.api.Node;
 import org.apache.maven.api.PathScope;
 import org.apache.maven.api.Session;
 import org.apache.maven.api.SessionData;
+import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Scm;
 import org.apache.maven.api.services.DependencyResolver;
@@ -51,6 +52,7 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -157,5 +159,86 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
         assertNull(transformed.getScm().getChildScmConnectionInheritAppendPath());
         assertNull(transformed.getScm().getChildScmUrlInheritAppendPath());
         assertNull(transformed.getScm().getChildScmDeveloperConnectionInheritAppendPath());
+    }
+
+    @Test
+    void testNewMaven4ScopesInConsumerPom() throws Exception {
+        // Create dependencies with new Maven 4 scopes
+        Dependency compileOnlyDep = Dependency.newBuilder()
+                .groupId("org.example")
+                .artifactId("compile-only-dep")
+                .version("1.0.0")
+                .scope("compile-only")
+                .build();
+
+        Dependency testOnlyDep = Dependency.newBuilder()
+                .groupId("org.example")
+                .artifactId("test-only-dep")
+                .version("1.0.0")
+                .scope("test-only")
+                .build();
+
+        Dependency testRuntimeDep = Dependency.newBuilder()
+                .groupId("org.example")
+                .artifactId("test-runtime-dep")
+                .version("1.0.0")
+                .scope("test-runtime")
+                .build();
+
+        Dependency compileDep = Dependency.newBuilder()
+                .groupId("org.example")
+                .artifactId("compile-dep")
+                .version("1.0.0")
+                .scope("compile")
+                .build();
+
+        // Transform using the consumer POM builder
+        DefaultConsumerPomBuilder builder = new DefaultConsumerPomBuilder(null);
+
+        // Test the transformation method directly
+        Dependency transformedCompileOnly = builder.transformDependencyForConsumerPom(compileOnlyDep);
+        Dependency transformedTestOnly = builder.transformDependencyForConsumerPom(testOnlyDep);
+        Dependency transformedTestRuntime = builder.transformDependencyForConsumerPom(testRuntimeDep);
+        Dependency transformedCompile = builder.transformDependencyForConsumerPom(compileDep);
+
+        // New Maven 4 scopes handling
+        assertNull(transformedCompileOnly, "compile-only dependencies should be omitted from consumer POM");
+        assertNull(transformedTestOnly, "test-only dependencies should be omitted from consumer POM");
+        assertNotNull(
+                transformedTestRuntime, "test-runtime dependencies should be preserved as 'test' in consumer POM");
+        assertEquals("test", transformedTestRuntime.getScope());
+
+        // Standard scopes should be preserved
+        assertNotNull(transformedCompile, "compile dependencies should be preserved in consumer POM");
+        assertEquals("compile", transformedCompile.getScope());
+    }
+
+    @Test
+    void testNewMaven4ScopesInDependencyManagement() throws Exception {
+        // Create managed dependencies with new Maven 4 scopes
+        Dependency compileOnlyManaged = Dependency.newBuilder()
+                .groupId("org.example")
+                .artifactId("compile-only-managed")
+                .version("1.0.0")
+                .scope("compile-only")
+                .build();
+
+        Dependency testOnlyManaged = Dependency.newBuilder()
+                .groupId("org.example")
+                .artifactId("test-only-managed")
+                .version("1.0.0")
+                .scope("test-only")
+                .build();
+
+        // Test the transformation method directly
+        DefaultConsumerPomBuilder builder = new DefaultConsumerPomBuilder(null);
+
+        Dependency transformedCompileOnlyManaged = builder.transformDependencyForConsumerPom(compileOnlyManaged);
+        Dependency transformedTestOnlyManaged = builder.transformDependencyForConsumerPom(testOnlyManaged);
+
+        // New Maven 4 scopes should be filtered out even in dependency management
+        assertNull(
+                transformedCompileOnlyManaged, "compile-only managed dependencies should be omitted from consumer POM");
+        assertNull(transformedTestOnlyManaged, "test-only managed dependencies should be omitted from consumer POM");
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
@@ -189,6 +189,42 @@ public final class Maven4ScopeManagerConfiguration implements ScopeManagerConfig
         return result;
     }
 
+    /**
+     * Maps a Maven 4 scope id to a Maven 3-compatible scope id for consumer POMs.
+     *
+     * <ul>
+     *   <li>compile-only -> omitted (returns null)</li>
+     *   <li>test-only -> omitted (returns null)</li>
+     *   <li>test-runtime -> test</li>
+     *   <li>none -> omitted (returns null)</li>
+     *   <li>others -> unchanged</li>
+     * </ul>
+     *
+     * @param scopeId the Maven 4 scope id (may be null)
+     * @return the mapped Maven 3 scope id, or null if the dependency should be omitted
+     */
+    public static String mapScopeForMaven3ConsumerPom(String scopeId) {
+        if (scopeId == null) {
+            return null;
+        }
+        DependencyScope ds = DependencyScope.forId(scopeId);
+        if (ds == null) {
+            // Unknown scope: keep as-is (do not attempt to remap strings we don't know)
+            return scopeId;
+        }
+        switch (ds) {
+            case COMPILE_ONLY:
+            case TEST_ONLY:
+            case NONE:
+                // Not meaningful for consumers of the artifact in Maven 3
+                return null;
+            case TEST_RUNTIME:
+                return DependencyScope.TEST.id();
+            default:
+                return ds.id();
+        }
+    }
+
     // ===
 
     public static void main(String... args) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
@@ -212,17 +212,11 @@ public final class Maven4ScopeManagerConfiguration implements ScopeManagerConfig
             // Unknown scope: keep as-is (do not attempt to remap strings we don't know)
             return scopeId;
         }
-        switch (ds) {
-            case COMPILE_ONLY:
-            case TEST_ONLY:
-            case NONE:
-                // Not meaningful for consumers of the artifact in Maven 3
-                return null;
-            case TEST_RUNTIME:
-                return DependencyScope.TEST.id();
-            default:
-                return ds.id();
-        }
+        return switch (ds) {
+            case COMPILE_ONLY, TEST_ONLY, NONE -> null; // Not meaningful for consumers of the artifact in Maven 3
+            case TEST_RUNTIME -> DependencyScope.TEST.id();
+            default -> ds.id();
+        };
     }
 
     // ===

--- a/src/mdo/model-version.vm
+++ b/src/mdo/model-version.vm
@@ -50,12 +50,18 @@ import org.apache.maven.api.xml.XmlNode;
 #foreach ( $class in $model.allClasses )
 import ${packageModelV4}.${class.Name};
 #end
+import ${packageModelV4}.Profile;
 
 @Generated
 public class ${className} {
 
     public String getModelVersion(${root.name} model) {
         Objects.requireNonNull(model, "model cannot be null");
+
+        // Check for new Maven 4 dependency scopes first
+        if (is_4_1_0_custom(model)) {
+            return "4.1.0";
+        }
 
 #set ( $String = $model.getClass().forName("java.lang.String") )
 #set ( $Comparator = $model.getClass().forName("java.util.Comparator") )
@@ -188,6 +194,50 @@ public class ${className} {
 
     private boolean has(XmlNode node) {
         return node != null;
+    }
+
+    /**
+     * Checks if a dependency uses one of the new Maven 4 scopes that require model version 4.1.0+
+     */
+    private boolean hasNewMaven4Scope(Dependency dependency) {
+        if (dependency == null || dependency.getScope() == null) {
+            return false;
+        }
+        String scope = dependency.getScope();
+        return "compile-only".equals(scope) || "test-only".equals(scope) || "test-runtime".equals(scope);
+    }
+
+    /**
+     * Override the generated is_4_1_0 method to add custom logic for new Maven 4 dependency scopes
+     */
+    private boolean is_4_1_0_custom(Model model) {
+        if (model == null) {
+            return false;
+        }
+
+        // Check direct dependencies for new scopes
+        if (model.getDependencies().stream().anyMatch(this::hasNewMaven4Scope)) {
+            return true;
+        }
+
+        // Check dependency management for new scopes
+        if (model.getDependencyManagement() != null &&
+            model.getDependencyManagement().getDependencies().stream().anyMatch(this::hasNewMaven4Scope)) {
+            return true;
+        }
+
+        // Check profiles for new scopes
+        for (Profile profile : model.getProfiles()) {
+            if (profile.getDependencies().stream().anyMatch(this::hasNewMaven4Scope)) {
+                return true;
+            }
+            if (profile.getDependencyManagement() != null &&
+                profile.getDependencyManagement().getDependencies().stream().anyMatch(this::hasNewMaven4Scope)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }


### PR DESCRIPTION
This PR updates the consumer POM generation to handle Maven 4–only test scopes in a way that is both minimal and Maven 3 compatible, while preserving relevant test runtime information for consumers.

Changes:
- DefaultConsumerPomBuilder.transformDependencyForConsumerPom:
  - Omit Maven 4–only compile-only and test-only scopes (build-time only; not needed by downstream consumers).
  - Map Maven 4–only test-runtime to classic test for the consumer POM to retain the test runtime classpath in a Maven 3 compatible way.
  - Keep classic scopes (compile/provided/runtime/test/system) unchanged.
- The transformation applies to both direct dependencies and dependencyManagement entries (via the existing transformation stream with null filtering).
- Tests: Update ConsumerPomBuilderTest to reflect the new policy (compile-only and test-only omitted; test-runtime mapped to test; classic scopes unchanged). Existing SCM and consumer POM shape assertions remain.

Rationale:
- The consumer POM targets the 4.0.0 model for Maven 3.x compatibility.
- compile-only and test-only are build-time only and have no safe Maven 3 equivalent; dropping them keeps the consumer POM minimal.
- test-runtime has no exact Maven 3 analog; mapping to test is the closest practical approximation and does not leak to downstream compile/runtime classpaths (test scope is non-transitive).

See #11012 