### PR TITLE
Fix #11127: enforce non-null keys for InputLocation lookups and document behavior

### DIFF
--- a/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocation.java
+++ b/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocation.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents the location of an element within a model source file.
@@ -95,6 +96,7 @@ public class InputLocation implements Serializable, InputLocationTracker {
 
     @Override
     public InputLocation getLocation(Object key) {
+        Objects.requireNonNull(key, "key");
         return locations != null ? locations.get(key) : null;
     }
 

--- a/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocationTracker.java
+++ b/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocationTracker.java
@@ -18,7 +18,23 @@
  */
 package org.apache.maven.api.model;
 
+/**
+ * Tracks input source locations for model fields.
+ * <p>
+ * Implementations provide a mapping from keys (typically field names or indices) to
+ * {@link InputLocation} instances to support precise error reporting and diagnostics.
+ * Keys must be non-null.
+ *
+ * @since 4.0.0
+ */
 public interface InputLocationTracker {
+    /**
+     * Gets the location of the specified field in the input source.
+     *
+     * @param field the key of the field, must not be {@code null}
+     * @return the location of the field in the input source or {@code null} if unknown
+     * @throws NullPointerException if {@code field} is {@code null}
+     */
     InputLocation getLocation(Object field);
 
     /**

--- a/src/mdo/java/InputLocationTracker.java
+++ b/src/mdo/java/InputLocationTracker.java
@@ -18,6 +18,19 @@
  */
 package ${package};
 
+/**
+ * Tracks input locations for model fields.
+ * <p>
+ * Implementations store a mapping from keys (usually field names or indices) to
+ * the corresponding InputLocation in the source. Keys must be non-null.
+ */
 public interface InputLocationTracker {
+    /**
+     * Gets the location of the specified field in the input source.
+     *
+     * @param field the key of the field, must not be {@code null}
+     * @return the location of the field in the input source or {@code null} if unknown
+     * @throws NullPointerException if {@code field} is {@code null}
+     */
     InputLocation getLocation(Object field);
 }

--- a/src/mdo/model.vm
+++ b/src/mdo/model.vm
@@ -240,8 +240,13 @@ public class ${class.name}
     #if ( $locationTracking && !$class.superClass )
     /**
      * Gets the location of the specified field in the input source.
+     *
+     * @param key the key of the field, must not be {@code null}
+     * @return the location of the field in the input source or {@code null} if unknown
+     * @throws NullPointerException if {@code key} is {@code null}
      */
     public InputLocation getLocation(Object key) {
+        Objects.requireNonNull(key, "key");
         return locations.get(key);
     }
 


### PR DESCRIPTION
- api: InputLocation.getLocation(Object) now requires a non-null key (NPE if null)
- api: Clarify InputLocationTracker Javadoc and add class-level docs
- modello templates: propagate null-check and Javadoc to all generated model classes/interfaces
- Run spotless and verify via full reactor build

Fixes #11127