### PR TITLE
Fix #11127: enforce non-null keys for InputLocation lookups and document behavior (master)

### DIFF
--- a/src/mdo/java/InputLocation.java
+++ b/src/mdo/java/InputLocation.java
@@ -99,6 +99,7 @@ public class InputLocation implements Serializable, InputLocationTracker {
 
     @Override
     public InputLocation getLocation(Object key) {
+        Objects.requireNonNull(key, "key");
         return locations != null ? locations.get(key) : null;
     }
 

--- a/src/mdo/java/InputLocationTracker.java
+++ b/src/mdo/java/InputLocationTracker.java
@@ -18,7 +18,23 @@
  */
 package ${package};
 
+/**
+ * Tracks input source locations for model fields.
+ * <p>
+ * Implementations provide a mapping from keys (typically field names or indices) to
+ * {@link InputLocation} instances to support precise error reporting and diagnostics.
+ * Keys must be non-null.
+ *
+ * @since 4.0.0
+ */
 public interface InputLocationTracker {
+    /**
+     * Gets the location of the specified field in the input source.
+     *
+     * @param field the key of the field, must not be {@code null}
+     * @return the location of the field in the input source or {@code null} if unknown
+     * @throws NullPointerException if {@code field} is {@code null}
+     */
     InputLocation getLocation(Object field);
 
     /**

--- a/src/mdo/model.vm
+++ b/src/mdo/model.vm
@@ -240,8 +240,13 @@ public class ${class.name}
     #if ( $locationTracking && !$class.superClass )
     /**
      * Gets the location of the specified field in the input source.
+     *
+     * @param key the key of the field, must not be {@code null}
+     * @return the location of the field in the input source or {@code null} if unknown
+     * @throws NullPointerException if {@code key} is {@code null}
      */
     public InputLocation getLocation(Object key) {
+        Objects.requireNonNull(key, "key");
         return locations.get(key);
     }
 


### PR DESCRIPTION
This ports #11128 to master.

- modello templates: add Objects.requireNonNull(key, "key") in InputLocation.getLocation(Object)
- modello templates: document non-null key requirement in InputLocationTracker and method Javadoc
- ensure generated model code across modules reflects the contract

Formatting via Spotless; verified local generation and targeted module build. Full CI will validate the entire reactor.

After merge, we can consider back/forward-port alignment as needed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author