### PR TITLE
[maven-4.0.x] Fix ReactorReader to prefer consumer POMs over build POMs (#11107)

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -330,6 +330,18 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     private File findInProjectLocalRepository(Artifact artifact) {
+        // Prefer the consumer POM when resolving POMs from the project-local repository,
+        // to avoid treating a build POM as a repository (consumer) POM.
+        if ("pom".equals(artifact.getExtension())) {
+            String classifier = artifact.getClassifier();
+            if (classifier == null || classifier.isEmpty()) {
+                Path consumer = getArtifactPath(
+                        artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), "consumer", "pom");
+                if (Files.isRegularFile(consumer)) {
+                    return consumer.toFile();
+                }
+            }
+        }
         Path target = getArtifactPath(artifact);
         return Files.isRegularFile(target) ? target.toFile() : null;
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11084ReactorReaderPreferConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11084ReactorReaderPreferConsumerPomTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for GH-11084.
+ */
+class MavenITgh11084ReactorReaderPreferConsumerPomTest extends AbstractMavenIntegrationTestCase {
+    MavenITgh11084ReactorReaderPreferConsumerPomTest() {
+        super("[4.0.0-rc-2,)");
+    }
+
+    @Test
+    void partialReactorShouldResolveUsingConsumerPom() throws Exception {
+        File testDir = extractResources("/gh-11084-reactorreader-prefer-consumer-pom");
+
+        // First build module a to populate project-local-repo with artifacts including consumer POM
+        Verifier v1 = newVerifier(testDir.getAbsolutePath());
+        v1.addCliArguments("clean", "package", "-X");
+        v1.setLogFileName("log-1.txt");
+        v1.execute();
+        v1.verifyErrorFreeLog();
+
+        // Now build only module b; ReactorReader should pick consumer POM from project-local-repo
+        Verifier v2 = newVerifier(testDir.getAbsolutePath());
+        v2.setLogFileName("log-2.txt");
+        v2.addCliArguments("clean", "compile", "-f", "b", "-X");
+        v2.execute();
+        v2.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -103,6 +103,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITgh11084ReactorReaderPreferConsumerPomTest.class);
         suite.addTestSuite(MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.class);
         suite.addTestSuite(MavenITgh10937QuotedPipesInMavenOptsTest.class);
         suite.addTestSuite(MavenITgh2532DuplicateDependencyEffectiveModelTest.class);

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent />
+
+  <artifactId>a</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>4.0.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/src/main/java/a/A.java
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/a/src/main/java/a/A.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package a;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.codehaus.plexus.util.io.CachingOutputStream;
+
+public class A {
+    public static CachingOutputStream newCachingOutputStream(Path p) throws IOException {
+        return new CachingOutputStream(p);
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/b/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/b/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+
+  <parent />
+
+  <artifactId>b</artifactId>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.gh11084</groupId>
+      <artifactId>a</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/b/src/main/java/b/B.java
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/b/src/main/java/b/B.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package b;
+
+import java.nio.file.Paths;
+
+import a.A;
+import org.codehaus.plexus.util.io.CachingOutputStream;
+
+public class B {
+    public static void v() throws Exception {
+        try (CachingOutputStream is = A.newCachingOutputStream(Paths.get("."))) {}
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11084-reactorreader-prefer-consumer-pom/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.gh11084</groupId>
+  <artifactId>reactor-root</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>a</module>
+    <module>b</module>
+  </modules>
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Fix ReactorReader to prefer consumer POMs over build POMs (#11107)](https://github.com/apache/maven/pull/11107)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)