### PR TITLE
[maven-4.0.x] model-builder: simplify subproject auto-discovery decision (#11124)

### DIFF
--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -545,4 +545,44 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
         MavenProject parent = p1.getArtifactId().equals("parent") ? p1 : p2;
         assertEquals(List.of("child"), parent.getModel().getDelegate().getSubprojects());
     }
+
+    @Test
+    public void testEmptySubprojectsElementPreventsDiscovery() throws Exception {
+        File pom = getTestFile("src/test/resources/projects/subprojects-empty/pom.xml");
+        ProjectBuildingRequest configuration = newBuildingRequest();
+        InternalSession internalSession = InternalSession.from(configuration.getRepositorySession());
+        InternalMavenSession mavenSession = InternalMavenSession.from(internalSession);
+        mavenSession
+                .getMavenSession()
+                .getRequest()
+                .setRootDirectory(pom.toPath().getParent());
+
+        List<ProjectBuildingResult> results = projectBuilder.build(List.of(pom), true, configuration);
+        // Should only build the parent project, not discover the child
+        assertEquals(1, results.size());
+        MavenProject parent = results.get(0).getProject();
+        assertEquals("parent", parent.getArtifactId());
+        // The subprojects list should be empty since we explicitly defined an empty <subprojects /> element
+        assertTrue(parent.getModel().getDelegate().getSubprojects().isEmpty());
+    }
+
+    @Test
+    public void testEmptyModulesElementPreventsDiscovery() throws Exception {
+        File pom = getTestFile("src/test/resources/projects/modules-empty/pom.xml");
+        ProjectBuildingRequest configuration = newBuildingRequest();
+        InternalSession internalSession = InternalSession.from(configuration.getRepositorySession());
+        InternalMavenSession mavenSession = InternalMavenSession.from(internalSession);
+        mavenSession
+                .getMavenSession()
+                .getRequest()
+                .setRootDirectory(pom.toPath().getParent());
+
+        List<ProjectBuildingResult> results = projectBuilder.build(List.of(pom), true, configuration);
+        // Should only build the parent project, not discover the child
+        assertEquals(1, results.size());
+        MavenProject parent = results.get(0).getProject();
+        assertEquals("parent", parent.getArtifactId());
+        // The modules list should be empty since we explicitly defined an empty <modules /> element
+        assertTrue(parent.getModel().getDelegate().getModules().isEmpty());
+    }
 }

--- a/impl/maven-core/src/test/resources/projects/modules-empty/child/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/modules-empty/child/pom.xml
@@ -1,0 +1,8 @@
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>modules-empty</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+  <artifactId>child</artifactId>
+  <packaging>jar</packaging>
+</project>

--- a/impl/maven-core/src/test/resources/projects/modules-empty/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/modules-empty/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <groupId>modules-empty</groupId>
+  <artifactId>parent</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+  <modules />
+</project>

--- a/impl/maven-core/src/test/resources/projects/subprojects-empty/child/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/subprojects-empty/child/pom.xml
@@ -1,0 +1,8 @@
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>subprojects-empty</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+  <artifactId>child</artifactId>
+  <packaging>jar</packaging>
+</project>

--- a/impl/maven-core/src/test/resources/projects/subprojects-empty/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/subprojects-empty/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <groupId>subprojects-empty</groupId>
+  <artifactId>parent</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+  <subprojects />
+</project>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1366,7 +1366,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 }
 
                 // subprojects discovery
-                if (getSubprojects(model).isEmpty()
+                if (!hasSubprojectsDefined(model)
                         // only discover subprojects if POM > 4.0.0
                         && !MODEL_VERSION_4_0_0.equals(model.getModelVersion())
                         // and if packaging is POM (we check type, but the session is not yet available,
@@ -1900,6 +1900,20 @@ public class DefaultModelBuilder implements ModelBuilder {
             subprojects = activated.getModules();
         }
         return subprojects;
+    }
+
+    /**
+     * Checks if subprojects are explicitly defined in the main model.
+     * This method distinguishes between:
+     * 1. No subprojects/modules element present - returns false (should auto-discover)
+     * 2. Empty subprojects/modules element present - returns true (should NOT auto-discover)
+     * 3. Non-empty subprojects/modules - returns true (should NOT auto-discover)
+     */
+    @SuppressWarnings("deprecation")
+    private static boolean hasSubprojectsDefined(Model model) {
+        // Only consider the main model: profiles do not influence auto-discovery
+        // Inline the check for explicit elements using location tracking
+        return model.getLocation("subprojects") != null || model.getLocation("modules") != null;
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [model-builder: simplify subproject auto-discovery decision (#11124)](https://github.com/apache/maven/pull/11124)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)