### PR TITLE
Enable the search for `module-info.class` file in the `META-INF/versions/` sub-directories of a JAR file.

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolverResult.java
@@ -114,7 +114,12 @@ public class DefaultDependencyResolverResult implements DependencyResolverResult
      */
     public DefaultDependencyResolverResult(
             DependencyResolverRequest request, List<Exception> exceptions, Node root, int count) {
-        this(request, new PathModularizationCache(), exceptions, root, count);
+        this(
+                request,
+                new PathModularizationCache(DefaultDependencyResolver.getTargetVersion(request)),
+                exceptions,
+                root,
+                count);
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
@@ -43,7 +43,7 @@ import org.apache.maven.api.annotations.Nonnull;
  * or module hierarchy, but not module source hierarchy. The latter is excluded because this class
  * is for path elements of compiled codes.
  */
-class PathModularization {
+final class PathModularization {
     /**
      * A unique constant for all non-modular dependencies.
      */
@@ -132,10 +132,11 @@ class PathModularization {
      * Otherwise builds an empty map.
      *
      * @param path directory or JAR file to test
+     * @param target the target Java release for which the project is built
      * @param resolve whether the module names are requested. If false, null values may be used instead
      * @throws IOException if an error occurred while reading the JAR file or the module descriptor
      */
-    PathModularization(Path path, boolean resolve) throws IOException {
+    PathModularization(Path path, Runtime.Version target, boolean resolve) throws IOException {
         filename = path.getFileName().toString();
         if (Files.isDirectory(path)) {
             /*
@@ -192,7 +193,7 @@ class PathModularization {
              * If no descriptor, the "Automatic-Module-Name" manifest attribute is
              * taken as a fallback.
              */
-            try (JarFile jar = new JarFile(path.toFile())) {
+            try (JarFile jar = new JarFile(path.toFile(), false, JarFile.OPEN_READ, target)) {
                 ZipEntry entry = jar.getEntry(MODULE_INFO);
                 if (entry != null) {
                     ModuleDescriptor descriptor = null;


### PR DESCRIPTION
By default, `java.util.jar.JarFile` does not search for resources in `META-INF/versions/` sub-directories. For enabling this feature, we need to specify a version greater than Java 8 to the constructor. The core change of this pull request is this line:

```java
try (JarFile jar = new JarFile(path.toFile(), false, JarFile.OPEN_READ, target)) {
    // ...
}
```

The rest is for answering the question: "which target Java version"? An easy approach would have been to set `target` unconditionally to `Runtime.version()`, i.e. the Java version on which Maven is running. This pull request rather allows configuration, with the intend to set the target version to the value of the `--release` target option. This value can determine whether a dependency will be placed on the class-path or on the module-path. For example, if the `module-info.class` entry of a JAR file exists only in the `META-INF/versions/17/` sub-directory, then the default location of that dependency will be the module-path only if the `--release` option is equal or greater than 17.

This pull request fixes the initial topic of https://github.com/apache/maven-compiler-plugin/issues/966.