### PR TITLE
Mimir updates (#11161)

### DIFF
--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -20,7 +20,7 @@ under the License.
 <extensions>
   <extension>
     <groupId>eu.maveniverse.maven.mimir</groupId>
-    <artifactId>extension</artifactId>
-    <version>0.7.8</version>
+    <artifactId>extension3</artifactId>
+    <version>0.8.1</version>
   </extension>
 </extensions>

--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-# Mimir Daemon properties
+# Mimir Daemon config properties
 
 # Disable JGroups; we don't want/use LAN cache sharing
 mimir.jgroups.enabled=false

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,14 +53,12 @@ jobs:
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
           cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
-      - name: Handle Mimir caches
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      - name: Restore Mimir caches
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: restore-cache
         with:
           path: ~/.mimir/local
-          key: mimir-${{ runner.os }}-initial-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mimir-${{ runner.os }}-initial-
-            mimir-${{ runner.os }}-
+          key: mimir-${{ runner.os }}-initial
 
       - name: Set up Maven
         shell: bash
@@ -73,6 +71,13 @@ jobs:
       - name: List contents of target directory
         shell: bash
         run: ls -la apache-maven/target
+
+      - name: Save Mimir caches
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        if: ${{ github.event_name != 'pull_request' && !cancelled() && !failure() }}
+        with:
+          path: ~/.mimir/local
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       - name: Upload Maven distributions
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -122,14 +127,15 @@ jobs:
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
           cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
-      - name: Handle Mimir caches
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      - name: Restore Mimir caches
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: restore-cache
         with:
           path: ~/.mimir/local
-          key: mimir-${{ runner.os }}-full-${{ hashFiles('**/pom.xml') }}
+          key: mimir-full-${{ matrix.os }}-${{ matrix.java }}
           restore-keys: |
-            mimir-${{ runner.os }}-full-
-            mimir-${{ runner.os }}-
+            mimir-full-${{ matrix.os }}-
+            mimir-full-
 
       - name: Download Maven distribution
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
@@ -170,6 +176,13 @@ jobs:
         shell: bash
         run: mvn site -e -B -V -Preporting
 
+      - name: Save Mimir caches
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        if: ${{ github.event_name != 'pull_request' && !cancelled() && !failure() }}
+        with:
+          path: ~/.mimir/local
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
+
       - name: Upload test artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
@@ -205,14 +218,15 @@ jobs:
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
           cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
-      - name: Handle Mimir caches
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      - name: Restore Mimir caches
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: restore-cache
         with:
           path: ~/.mimir/local
-          key: mimir-${{ runner.os }}-its-${{ hashFiles('**/pom.xml') }}
+          key: mimir-its-${{ matrix.os }}-${{ matrix.java }}
           restore-keys: |
-            mimir-${{ runner.os }}-its-
-            mimir-${{ runner.os }}-
+            mimir-its-${{ matrix.os }}-
+            mimir-its-
 
       - name: Download Maven distribution
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
@@ -248,6 +262,13 @@ jobs:
       - name: Build Maven and ITs and run them
         shell: bash
         run: mvn install -e -B -V -Prun-its,mimir
+
+      - name: Save Mimir caches
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        if: ${{ github.event_name != 'pull_request' && !cancelled() && !failure() }}
+        with:
+          path: ~/.mimir/local
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MimirInfuser.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MimirInfuser.java
@@ -37,7 +37,7 @@ public final class MimirInfuser {
         if (Files.isRegularFile(realUserWideExtensions)) {
             String realUserWideExtensionsString = Files.readString(realUserWideExtensions);
             if (realUserWideExtensionsString.contains("<groupId>eu.maveniverse.maven.mimir</groupId>")
-                    && realUserWideExtensionsString.contains("<artifactId>extension</artifactId>")) {
+                    && realUserWideExtensionsString.contains("<artifactId>extension3</artifactId>")) {
                 Path userWideExtensions = userHome.resolve(".m2").resolve("extensions.xml");
                 // some tests do prepare project and user wide extensions; skip those for now
                 if (!Files.isRegularFile(userWideExtensions)) {

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MimirInfuser.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MimirInfuser.java
@@ -37,7 +37,7 @@ public final class MimirInfuser {
         if (Files.isRegularFile(realUserWideExtensions)) {
             String realUserWideExtensionsString = Files.readString(realUserWideExtensions);
             if (realUserWideExtensionsString.contains("<groupId>eu.maveniverse.maven.mimir</groupId>")
-                    && realUserWideExtensionsString.contains("<artifactId>extension</artifactId>")) {
+                    && realUserWideExtensionsString.contains("<artifactId>extension3</artifactId>")) {
                 Path userWideExtensions = userHome.resolve(".m2").resolve("extensions.xml");
                 // some tests do prepare project and user wide extensions; skip those for now
                 if (!Files.isRegularFile(userWideExtensions)) {


### PR DESCRIPTION
Changes:
* update Mimir to latest 0.8.1 version
* update infusers as well
* cache changes (see below)

Cache strategy changes:
* initial build: it is snowballing one cache when build is not about PR
* full (rebuild itself + site with itself) and its build: it is snowballing cache differentiated by OS/JDK when build is not about PR

Current problems: on unchanged POM (ie. new IT added), the dependencies ITs pull from Central will be cached by Mimir, but due "cache hit" the new cache will not get stored. Hence, Mimir caching was basically lost. Also, there was a mixup of caches from PRs and main branches. Finally, matrix jobs were competing for cache store.
