### PR TITLE
[maven-4.0.x] Allow repository URL interpolation with improved validation (#11140)

### DIFF
--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -336,7 +336,7 @@ class DefaultModelValidatorTest {
     @Test
     void testMissingRepositoryId() throws Exception {
         SimpleProblemCollector result =
-                validateFile("missing-repository-id-pom.xml", ModelValidator.VALIDATION_LEVEL_STRICT);
+                validateRaw("missing-repository-id-pom.xml", ModelValidator.VALIDATION_LEVEL_STRICT);
 
         assertViolations(result, 0, 4, 0);
 
@@ -855,16 +855,23 @@ class DefaultModelValidatorTest {
     @Test
     void repositoryWithExpression() throws Exception {
         SimpleProblemCollector result = validateFile("raw-model/repository-with-expression.xml");
-        assertViolations(result, 0, 1, 0);
-        assertEquals(
-                "'repositories.repository.[repo].url' contains an unsupported expression (only expressions starting with 'project.basedir' or 'project.rootDirectory' are supported).",
-                result.getErrors().get(0));
+        // Interpolation in repository URLs is allowed; unresolved placeholders will fail later during resolution
+        assertViolations(result, 0, 0, 0);
     }
 
     @Test
     void repositoryWithBasedirExpression() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/repository-with-basedir-expression.xml");
-        assertViolations(result, 0, 0, 0);
+        // This test runs on raw model without interpolation, so all expressions appear uninterpolated
+        // In the real flow, supported expressions would be interpolated before validation
+        assertViolations(result, 0, 3, 0);
+    }
+
+    @Test
+    void repositoryWithUnsupportedExpression() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/repository-with-unsupported-expression.xml");
+        // Unsupported expressions should cause validation errors
+        assertViolations(result, 0, 1, 0);
     }
 
     @Test

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/repository-with-unsupported-expression.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/repository-with-unsupported-expression.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng0000</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: Test</name>
+  <description>Test unsupported repository URL expressions that should cause validation errors.</description>
+
+  <repositories>
+    <repository>
+      <id>repo-unsupported</id>
+      <url>${project.baseUri}/sdk/maven/repo</url>
+    </repository>
+  </repositories>
+
+</project>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11140RepoDmUnresolvedTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11140RepoDmUnresolvedTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * IT to assert unresolved placeholders cause failure when used.
+ */
+class MavenITgh11140RepoDmUnresolvedTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh11140RepoDmUnresolvedTest() {
+        super("(4.0.0-rc-3,)");
+    }
+
+    @Test
+    void testFailsOnUnresolvedPlaceholders() throws Exception {
+        File testDir = extractResources("/gh-11140-repo-dm-unresolved");
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+
+        try {
+            verifier.addCliArgument("validate");
+            verifier.execute();
+        } catch (VerificationException expected) {
+            // Expected to fail due to unresolved placeholders during model validation
+        }
+        // We expect error mentioning uninterpolated expression
+        verifier.verifyTextInLog("contains an uninterpolated expression");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11140RepoInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11140RepoInterpolationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ITs for repository/distributionManagement URL interpolation.
+ */
+class MavenITgh11140RepoInterpolationTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh11140RepoInterpolationTest() {
+        super("(4.0.0-rc-3,)");
+    }
+
+    @Test
+    void testInterpolationFromEnvAndProps() throws Exception {
+        File testDir = extractResources("/gh-11140-repo-interpolation");
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+
+        // Provide env vars consumed by POM via ${env.*}
+        Path base = testDir.toPath().toAbsolutePath();
+        String baseUri = getBaseUri(base);
+        verifier.setEnvironmentVariable("IT_REPO_BASE", baseUri);
+        verifier.setEnvironmentVariable("IT_DM_BASE", baseUri);
+
+        // Use a cheap goal that prints effective POM
+        verifier.addCliArgument("help:effective-pom");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        List<String> lines = verifier.loadLogLines();
+        // Expect resolved file:// URLs, not placeholders
+        assertTrue(lines.stream().anyMatch(s -> s.contains("<id>envRepo</id>")), "envRepo present");
+        assertTrue(lines.stream().anyMatch(s -> s.contains("<url>" + baseUri + "/repo</url>")), "envRepo url resolved");
+        assertTrue(lines.stream().anyMatch(s -> s.contains("<id>propRepo</id>")), "propRepo present");
+        assertTrue(
+                lines.stream().anyMatch(s -> s.contains("<url>" + baseUri + "/custom</url>")),
+                "propRepo url resolved via property");
+        assertTrue(lines.stream().anyMatch(s -> s.contains("<id>distRepo</id>")), "distRepo present");
+        assertTrue(
+                lines.stream().anyMatch(s -> s.contains("<url>" + baseUri + "/dist</url>")), "distRepo url resolved");
+    }
+
+    private static String getBaseUri(Path base) {
+        String baseUri = base.toUri().toString();
+        if (baseUri.endsWith("/")) {
+            baseUri = baseUri.substring(0, baseUri.length() - 1);
+        }
+        return baseUri;
+    }
+
+    @Test
+    void testUnresolvedPlaceholderFailsResolution() throws Exception {
+        File testDir = extractResources("/gh-11140-repo-interpolation");
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+
+        // Do NOT set env vars, so placeholders stay
+        verifier.addCliArgument("validate");
+        try {
+            verifier.execute();
+        } catch (VerificationException expected) {
+            // Expected to fail due to unresolved placeholders during model validation
+        }
+        // We expect error mentioning uninterpolated expression
+        verifier.verifyTextInLog("contains an uninterpolated expression");
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11140-repo-dm-unresolved/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11140-repo-dm-unresolved/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.repointerp</groupId>
+  <artifactId>repo-dm-unresolved</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: Unresolved placeholders must fail</name>
+  <description>Verify that unresolved placeholders in repository/distributionManagement cause failure when used.</description>
+
+  <distributionManagement>
+    <repository>
+      <id>badDist</id>
+      <url>${env.MISSING_VAR}/dist</url>
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>badRepo</id>
+      <url>${env.MISSING_VAR}/repo</url>
+    </repository>
+  </repositories>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11140-repo-interpolation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11140-repo-interpolation/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.repointerp</groupId>
+  <artifactId>repo-interpolation</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: Repository and DistributionManagement URL interpolation</name>
+  <description>Verify that repository and distributionManagement URLs are interpolated from env and project properties.</description>
+
+  <distributionManagement>
+    <repository>
+      <id>distRepo</id>
+      <url>${env.IT_DM_BASE}/dist</url>
+    </repository>
+  </distributionManagement>
+
+  <properties>
+    <!-- Property sourced from env via model interpolation in test class -->
+    <customRepoUrl>${env.IT_REPO_BASE}/custom</customRepoUrl>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>envRepo</id>
+      <url>${env.IT_REPO_BASE}/repo</url>
+    </repository>
+    <repository>
+      <id>propRepo</id>
+      <url>${customRepoUrl}</url>
+    </repository>
+  </repositories>
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Allow repository URL interpolation with improved validation (#11140)](https://github.com/apache/maven/pull/11140)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)