### PR TITLE
[maven-4.0.x] Improve mvn usage message (#11211)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
@@ -535,7 +535,7 @@ public class CommonsCliOptions implements Options {
         }
 
         protected String commandLineSyntax(String command) {
-            return command + " [options] [goals]";
+            return command + " [options] [<goal|phase> ...]";
         }
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Improve mvn usage message (#11211)](https://github.com/apache/maven/pull/11211)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)