### PR TITLE
Update to Mimir 0.9.4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ concurrency:
 permissions: {}
 
 env:
-  MIMIR_VERSION: 0.9.3
+  MIMIR_VERSION: 0.9.4
   MIMIR_BASEDIR: ~/.mimir
   MIMIR_LOCAL: ~/.mimir/local
 

--- a/pom.xml
+++ b/pom.xml
@@ -671,7 +671,7 @@ under the License.
       <dependency>
         <groupId>eu.maveniverse.maven.mimir</groupId>
         <artifactId>testing</artifactId>
-        <version>0.9.3</version>
+        <version>0.9.4</version>
       </dependency>
     </dependencies>
     <!--bootstrap-start-comment-->


### PR DESCRIPTION
That makes Mimir "load early" in ITs that is needed for some ITs that use build extensions.

Note: despite what it looks, the POM change does not to be in 'lockstep" with Mimir version defined in workflow, is just "nice to do it".