### PR TITLE
Fix repository ID interpolation in Maven 4

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1529,6 +1529,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                     ? null
                     : repository
                             .with()
+                            .id(interpolator.interpolate(repository.getId(), callback))
                             .url(interpolator.interpolate(repository.getUrl(), callback))
                             .build();
         }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1587,8 +1587,21 @@ public class DefaultModelValidator implements ModelValidator {
         if (repository == null) {
             return;
         }
-        validateStringNotEmpty(
-                prefix, prefix2, "id", problems, Severity.ERROR, Version.V20, repository.getId(), null, repository);
+        if (validateStringNotEmpty(
+                prefix, prefix2, "id", problems, Severity.ERROR, Version.V20, repository.getId(), null, repository)) {
+            // Check for uninterpolated expressions in ID - these should have been interpolated by now
+            Matcher matcher = EXPRESSION_NAME_PATTERN.matcher(repository.getId());
+            if (matcher.find()) {
+                addViolation(
+                        problems,
+                        Severity.ERROR,
+                        Version.V40,
+                        prefix + prefix2 + "[" + repository.getId() + "].id",
+                        null,
+                        "contains an uninterpolated expression.",
+                        repository);
+            }
+        }
 
         if (!allowEmptyUrl
                 && validateStringNotEmpty(
@@ -1601,7 +1614,7 @@ public class DefaultModelValidator implements ModelValidator {
                         repository.getUrl(),
                         null,
                         repository)) {
-            // Check for uninterpolated expressions - these should have been interpolated by now
+            // Check for uninterpolated expressions in URL - these should have been interpolated by now
             Matcher matcher = EXPRESSION_NAME_PATTERN.matcher(repository.getUrl());
             if (matcher.find()) {
                 addViolation(

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -908,6 +908,24 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void repositoryWithUninterpolatedId() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/repository-with-uninterpolated-id.xml");
+        // Uninterpolated expressions in repository IDs should cause validation errors
+        assertViolations(result, 0, 3, 0);
+
+        // Check that all three repository ID validation errors are present
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains("repositories.repository.[${repository.id}].id")
+                        && error.contains("contains an uninterpolated expression")));
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains("pluginRepositories.pluginRepository.[${plugin.repository.id}].id")
+                        && error.contains("contains an uninterpolated expression")));
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains("distributionManagement.repository.[${staging.repository.id}].id")
+                        && error.contains("contains an uninterpolated expression")));
+    }
+
+    @Test
     void profileActivationWithAllowedExpression() throws Exception {
         SimpleProblemCollector result = validateRaw(
                 "raw-model/profile-activation-file-with-allowed-expressions.xml",

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/repository-with-uninterpolated-id.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/repository-with-uninterpolated-id.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.validation</groupId>
+  <artifactId>project</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <repositories>
+    <repository>
+      <id>${repository.id}</id>
+      <url>https://nexus.acme.com</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>${plugin.repository.id}</id>
+      <url>https://nexus.acme.com</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <distributionManagement>
+    <repository>
+      <id>${staging.repository.id}</id>
+      <url>https://staging.nexus.acme.com</url>
+    </repository>
+  </distributionManagement>
+
+</project>


### PR DESCRIPTION
Repository IDs were not being interpolated while URLs were, causing issues when using expressions like repository.id in repository configurations.

This commit adds ID interpolation alongside URL interpolation and includes validation for uninterpolated expressions in repository IDs.

Fixes #11076
