### PR TITLE
[maven-4.0.x] Fix CI-friendly version processing with profile properties (fix #11196)

### DIFF
--- a/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-profiles.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-profiles.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>ci-friendly-profiles-test</artifactId>
+    <version>${revision}</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <baseVersion>0.2.0</baseVersion>
+        <revision>${baseVersion}+dev</revision>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>releaseBuild</id>
+            <properties>
+                <revision>${baseVersion}</revision>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/directory-properties-profiles.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/directory-properties-profiles.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>directory-properties-profiles-test</artifactId>
+    <version>${revision}</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <baseVersion>1.0.0</baseVersion>
+        <revision>${baseVersion}-SNAPSHOT</revision>
+        <repo.url>http://default.repo.com</repo.url>
+    </properties>
+
+    <profiles>
+        <!-- Profile that uses directory properties in repository URL -->
+        <profile>
+            <id>local-repo</id>
+            <properties>
+                <revision>${baseVersion}-LOCAL</revision>
+                <repo.url>file://${project.basedir}/local-repo</repo.url>
+            </properties>
+        </profile>
+    </profiles>
+
+    <repositories>
+        <repository>
+            <id>test-repo</id>
+            <url>${repo.url}</url>
+        </repository>
+    </repositories>
+
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/repository-url-profiles.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/repository-url-profiles.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>repository-url-profiles-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <repo.base.url>http://default.repo.com</repo.base.url>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>development</id>
+            <properties>
+                <repo.base.url>http://dev.repo.com</repo.base.url>
+            </properties>
+        </profile>
+        
+        <profile>
+            <id>production</id>
+            <properties>
+                <repo.base.url>http://prod.repo.com</repo.base.url>
+            </properties>
+        </profile>
+    </profiles>
+
+    <repositories>
+        <repository>
+            <id>company-repo</id>
+            <url>${repo.base.url}/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+</project>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11196CIFriendlyProfilesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11196CIFriendlyProfilesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/11196">#11196</a>.
+ * It verifies that changes to ${revision} in profiles propagate to the final project version.
+ *
+ * @author Apache Maven Team
+ */
+class MavenITgh11196CIFriendlyProfilesTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh11196CIFriendlyProfilesTest() {
+        super("[4.0.0-rc-4,)");
+    }
+
+    /**
+     * Verify that CI-friendly version resolution works correctly with profile properties.
+     * Without profile activation, the version should be "0.2.0+dev".
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    void testCiFriendlyVersionWithoutProfile() throws Exception {
+        File testDir = extractResources("/gh-11196-ci-friendly-profiles");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/versions.properties");
+        assertEquals("0.2.0+dev", props.getProperty("project.version"));
+        assertEquals("0.2.0+dev", props.getProperty("project.properties.revision"));
+        assertEquals("0.2.0", props.getProperty("project.properties.baseVersion"));
+    }
+
+    /**
+     * Verify that CI-friendly version resolution works correctly with profile properties.
+     * With the releaseBuild profile activated, the version should be "0.2.0" (without +dev).
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    void testCiFriendlyVersionWithReleaseProfile() throws Exception {
+        File testDir = extractResources("/gh-11196-ci-friendly-profiles");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.addCliArgument("-PreleaseBuild");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/release-profile.properties");
+        assertEquals("0.2.0", props.getProperty("project.version"));
+        assertEquals("0.2.0", props.getProperty("project.properties.revision"));
+        assertEquals("0.2.0", props.getProperty("project.properties.baseVersion"));
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11196-ci-friendly-profiles/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11196-ci-friendly-profiles/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng11196</groupId>
+  <artifactId>ci-friendly-profiles-test</artifactId>
+  <version>${revision}</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <baseVersion>0.2.0</baseVersion>
+    <revision>${baseVersion}+dev</revision>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>reportVersions</id>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputFile>target/versions.properties</outputFile>
+              <expressions>
+                <expression>project/version</expression>
+                <expression>project/properties/revision</expression>
+                <expression>project/properties/baseVersion</expression>
+              </expressions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>releaseBuild</id>
+      <properties>
+        <revision>${baseVersion}</revision>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.its.plugins</groupId>
+            <artifactId>maven-it-plugin-expression</artifactId>
+            <version>2.1-SNAPSHOT</version>
+            <executions>
+              <execution>
+                <id>reportReleaseProfile</id>
+                <goals>
+                  <goal>eval</goal>
+                </goals>
+                <phase>validate</phase>
+                <configuration>
+                  <outputFile>target/release-profile.properties</outputFile>
+                  <expressions>
+                    <expression>project/version</expression>
+                    <expression>project/properties/revision</expression>
+                    <expression>project/properties/baseVersion</expression>
+                  </expressions>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Fix CI-friendly version processing with profile properties (fix #11196)](https://github.com/apache/maven/pull/11214)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)