### PR TITLE
[maven-4.0.x] Add phase upgrade support for Maven 4.1.0 model upgrades

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ModelUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ModelUpgradeStrategy.java
@@ -19,11 +19,13 @@
 package org.apache.maven.cling.invoker.mvnup.goals;
 
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.maven.api.Lifecycle;
 import org.apache.maven.api.cli.mvnup.UpgradeOptions;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Priority;
@@ -42,8 +44,15 @@ import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.Namesp
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlAttributes.SCHEMA_LOCATION;
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlAttributes.XSI_NAMESPACE_PREFIX;
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlAttributes.XSI_NAMESPACE_URI;
+import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.BUILD;
+import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.EXECUTION;
+import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.EXECUTIONS;
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.MODULE;
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.MODULES;
+import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.PHASE;
+import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.PLUGIN;
+import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.PLUGINS;
+import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.PLUGIN_MANAGEMENT;
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.PROFILE;
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.PROFILES;
 import static org.apache.maven.cling.invoker.mvnup.goals.UpgradeConstants.XmlElements.SUBPROJECT;
@@ -141,6 +150,7 @@ public class ModelUpgradeStrategy extends AbstractUpgradeStrategy {
         // Convert modules to subprojects (for 4.1.0 and higher)
         if (ModelVersionUtils.isVersionGreaterOrEqual(targetModelVersion, MODEL_VERSION_4_1_0)) {
             convertModulesToSubprojects(pomDocument, context);
+            upgradeDeprecatedPhases(pomDocument, context);
         }
 
         // Update modelVersion to target version (perhaps removed later during inference step)
@@ -251,5 +261,117 @@ public class ModelUpgradeStrategy extends AbstractUpgradeStrategy {
         } else {
             return MAVEN_4_0_0_NAMESPACE;
         }
+    }
+
+    /**
+     * Upgrades deprecated Maven 3 phase names to Maven 4 equivalents.
+     * This replaces pre-/post- phases with before:/after: phases.
+     */
+    private void upgradeDeprecatedPhases(Document pomDocument, UpgradeContext context) {
+        // Create mapping of deprecated phases to their Maven 4 equivalents
+        Map<String, String> phaseUpgrades = createPhaseUpgradeMap();
+
+        Element root = pomDocument.getRootElement();
+        Namespace namespace = root.getNamespace();
+
+        int totalUpgrades = 0;
+
+        // Upgrade phases in main build section
+        totalUpgrades += upgradePhaseElements(root.getChild(BUILD, namespace), namespace, phaseUpgrades, context);
+
+        // Upgrade phases in profiles
+        Element profilesElement = root.getChild(PROFILES, namespace);
+        if (profilesElement != null) {
+            List<Element> profileElements = profilesElement.getChildren(PROFILE, namespace);
+            for (Element profileElement : profileElements) {
+                Element profileBuildElement = profileElement.getChild(BUILD, namespace);
+                totalUpgrades += upgradePhaseElements(profileBuildElement, namespace, phaseUpgrades, context);
+            }
+        }
+
+        if (totalUpgrades > 0) {
+            context.detail("Upgraded " + totalUpgrades + " deprecated phase name(s) to Maven 4 equivalents");
+        }
+    }
+
+    /**
+     * Creates the mapping of deprecated phase names to their Maven 4 equivalents.
+     * Uses Maven API constants to ensure consistency with the lifecycle definitions.
+     */
+    private Map<String, String> createPhaseUpgradeMap() {
+        Map<String, String> phaseUpgrades = new HashMap<>();
+
+        // Clean lifecycle aliases
+        phaseUpgrades.put("pre-clean", Lifecycle.BEFORE + Lifecycle.Phase.CLEAN);
+        phaseUpgrades.put("post-clean", Lifecycle.AFTER + Lifecycle.Phase.CLEAN);
+
+        // Default lifecycle aliases
+        phaseUpgrades.put("pre-integration-test", Lifecycle.BEFORE + Lifecycle.Phase.INTEGRATION_TEST);
+        phaseUpgrades.put("post-integration-test", Lifecycle.AFTER + Lifecycle.Phase.INTEGRATION_TEST);
+
+        // Site lifecycle aliases
+        phaseUpgrades.put("pre-site", Lifecycle.BEFORE + Lifecycle.SITE);
+        phaseUpgrades.put("post-site", Lifecycle.AFTER + Lifecycle.SITE);
+
+        return phaseUpgrades;
+    }
+
+    /**
+     * Upgrades phase elements within a build section.
+     */
+    private int upgradePhaseElements(
+            Element buildElement, Namespace namespace, Map<String, String> phaseUpgrades, UpgradeContext context) {
+        if (buildElement == null) {
+            return 0;
+        }
+
+        int upgrades = 0;
+
+        // Check plugins section
+        Element pluginsElement = buildElement.getChild(PLUGINS, namespace);
+        if (pluginsElement != null) {
+            upgrades += upgradePhaseElementsInPlugins(pluginsElement, namespace, phaseUpgrades, context);
+        }
+
+        // Check pluginManagement section
+        Element pluginManagementElement = buildElement.getChild(PLUGIN_MANAGEMENT, namespace);
+        if (pluginManagementElement != null) {
+            Element managedPluginsElement = pluginManagementElement.getChild(PLUGINS, namespace);
+            if (managedPluginsElement != null) {
+                upgrades += upgradePhaseElementsInPlugins(managedPluginsElement, namespace, phaseUpgrades, context);
+            }
+        }
+
+        return upgrades;
+    }
+
+    /**
+     * Upgrades phase elements within a plugins section.
+     */
+    private int upgradePhaseElementsInPlugins(
+            Element pluginsElement, Namespace namespace, Map<String, String> phaseUpgrades, UpgradeContext context) {
+        int upgrades = 0;
+
+        List<Element> pluginElements = pluginsElement.getChildren(PLUGIN, namespace);
+        for (Element pluginElement : pluginElements) {
+            Element executionsElement = pluginElement.getChild(EXECUTIONS, namespace);
+            if (executionsElement != null) {
+                List<Element> executionElements = executionsElement.getChildren(EXECUTION, namespace);
+                for (Element executionElement : executionElements) {
+                    Element phaseElement = executionElement.getChild(PHASE, namespace);
+                    if (phaseElement != null) {
+                        String currentPhase = phaseElement.getTextTrim();
+                        String newPhase = phaseUpgrades.get(currentPhase);
+                        if (newPhase != null) {
+                            phaseElement.setText(newPhase);
+                            context.detail("Upgraded phase: " + currentPhase + " → " + newPhase);
+                            upgrades++;
+                        }
+                    }
+                }
+            }
+        }
+
+        return upgrades;
     }
 }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/UpgradeConstants.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/UpgradeConstants.java
@@ -74,9 +74,11 @@ public final class UpgradeConstants {
         public static final String TEST_OUTPUT_DIRECTORY = "testOutputDirectory";
         public static final String EXTENSIONS = "extensions";
         public static final String EXECUTIONS = "executions";
+        public static final String EXECUTION = "execution";
         public static final String GOALS = "goals";
         public static final String INHERITED = "inherited";
         public static final String CONFIGURATION = "configuration";
+        public static final String PHASE = "phase";
 
         // Module elements
         public static final String MODULES = "modules";


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Add phase upgrade support for Maven 4.1.0 model upgrades](https://github.com/apache/maven/pull/11215)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)