### PR TITLE
[maven-4.0.x] Fix dependency groupId inference for Maven 4.1.0 model version (#11228)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -580,6 +580,12 @@ public class DefaultModelBuilder implements ModelBuilder {
                     if (newDep != null) {
                         changed = true;
                     }
+                } else if (dep.getGroupId() == null) {
+                    // Handle missing groupId when version is present
+                    newDep = inferDependencyGroupId(model, dep);
+                    if (newDep != null) {
+                        changed = true;
+                    }
                 }
                 newDeps.add(newDep == null ? dep : newDep);
             }
@@ -608,6 +614,22 @@ public class DefaultModelBuilder implements ModelBuilder {
                 }
                 depBuilder.groupId(depGroupId).location("groupId", groupIdLocation);
             }
+            return depBuilder.build();
+        }
+
+        private Dependency inferDependencyGroupId(Model model, Dependency dep) {
+            Model depModel = getRawModel(model.getPomFile(), dep.getGroupId(), dep.getArtifactId());
+            if (depModel == null) {
+                return null;
+            }
+            Dependency.Builder depBuilder = Dependency.newBuilder(dep);
+            String depGroupId = depModel.getGroupId();
+            InputLocation groupIdLocation = depModel.getLocation("groupId");
+            if (depGroupId == null && depModel.getParent() != null) {
+                depGroupId = depModel.getParent().getGroupId();
+                groupIdLocation = depModel.getParent().getLocation("groupId");
+            }
+            depBuilder.groupId(depGroupId).location("groupId", groupIdLocation);
             return depBuilder.build();
         }
 

--- a/impl/maven-impl/src/test/resources/poms/factory/missing-dependency-groupId-41-app.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/missing-dependency-groupId-41-app.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <parent>
+    <groupId>com.example.test</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>app</artifactId>
+  
+  <dependencies>
+    <dependency>
+      <artifactId>service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/missing-dependency-groupId-41-service.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/missing-dependency-groupId-41-service.xml
@@ -1,0 +1,28 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <parent>
+    <groupId>com.example.test</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>service</artifactId>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/missing-dependency-groupId-41.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/missing-dependency-groupId-41.xml
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+  
+  <groupId>com.example.test</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  
+  <modules>
+    <module>service</module>
+    <module>app</module>
+  </modules>
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Fix dependency groupId inference for Maven 4.1.0 model version (#11228)](https://github.com/apache/maven/pull/11228)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)