### PR TITLE
[maven-4.0.x] Bugfix: fix CLI graceful death (#11239)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -435,8 +435,9 @@ public abstract class BaseParser implements Parser {
         // are most dominant.
         // ----------------------------------------------------------------------
 
-        Map<String, String> userSpecifiedProperties =
-                new HashMap<>(context.options.userProperties().orElse(new HashMap<>()));
+        Map<String, String> userSpecifiedProperties = context.options != null
+                ? new HashMap<>(context.options.userProperties().orElse(new HashMap<>()))
+                : new HashMap<>();
         createInterpolator().interpolate(userSpecifiedProperties, paths::get);
 
         // ----------------------------------------------------------------------


### PR DESCRIPTION
When CLI contains unsupported parameters, the `context.options` may be null, that is violated by `populateUserProperties` method.

Before (master):
```
$ mvn --encrypt-master-password xxxxx
[ERROR] Error executing Maven.
[ERROR] Error parsing program arguments
[ERROR] Caused by: Failed to parse CLI arguments: Unrecognized option: --encrypt-master-password
[ERROR] Error populating user properties
[ERROR] Caused by: Cannot invoke "org.apache.maven.api.cli.Options.userProperties()" because "context.options" is null
[ERROR] Error reading core extensions descriptor
[ERROR] Caused by: null
$
```

With PR:
```
$ mvn --encrypt-master-password 
[ERROR] Error executing Maven.
[ERROR] Error parsing program arguments
[ERROR] Caused by: Failed to parse CLI arguments: Unrecognized option: --encrypt-master-password
$
```

Backport of 7baf2a8921923bb4782490e0adb5d4b0381ae4fc