### PR TITLE
[maven-4.0.x] Remove use of toRealPath (#11250)

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1723,11 +1723,7 @@ public class MavenCli {
     }
 
     private static Path getCanonicalPath(Path path) {
-        try {
-            return path.toRealPath();
-        } catch (IOException e) {
-            return getCanonicalPath(path.getParent()).resolve(path.getFileName());
-        }
+        return path.toAbsolutePath().normalize();
     }
 
     static class ExitException extends Exception {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CliUtils.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CliUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.cling.invoker;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,11 +59,7 @@ public final class CliUtils {
     @Nonnull
     public static Path getCanonicalPath(Path path) {
         requireNonNull(path, "path");
-        try {
-            return path.toRealPath();
-        } catch (IOException e) {
-            return getCanonicalPath(path.getParent()).resolve(path.getFileName());
-        }
+        return path.toAbsolutePath().normalize();
     }
 
     @Nonnull

--- a/impl/maven-executor/src/main/java/org/apache/maven/api/cli/ExecutorRequest.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/api/cli/ExecutorRequest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.api.cli;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
@@ -401,9 +400,13 @@ public interface ExecutorRequest {
                 this.cwd = getCanonicalPath(requireNonNull(cwd));
                 this.installationDirectory = getCanonicalPath(requireNonNull(installationDirectory));
                 this.userHomeDirectory = getCanonicalPath(requireNonNull(userHomeDirectory));
-                this.jvmSystemProperties = jvmSystemProperties != null ? Map.copyOf(jvmSystemProperties) : null;
-                this.environmentVariables = environmentVariables != null ? Map.copyOf(environmentVariables) : null;
-                this.jvmArguments = jvmArguments != null ? List.copyOf(jvmArguments) : null;
+                this.jvmSystemProperties = jvmSystemProperties != null && !jvmSystemProperties.isEmpty()
+                        ? Map.copyOf(jvmSystemProperties)
+                        : null;
+                this.environmentVariables = environmentVariables != null && !environmentVariables.isEmpty()
+                        ? Map.copyOf(environmentVariables)
+                        : null;
+                this.jvmArguments = jvmArguments != null && !jvmArguments.isEmpty() ? List.copyOf(jvmArguments) : null;
                 this.stdIn = stdIn;
                 this.stdOut = stdOut;
                 this.stdErr = stdErr;
@@ -510,10 +513,6 @@ public interface ExecutorRequest {
     @Nonnull
     static Path getCanonicalPath(Path path) {
         requireNonNull(path, "path");
-        try {
-            return path.toRealPath();
-        } catch (IOException e) {
-            return getCanonicalPath(path.getParent()).resolve(path.getFileName());
-        }
+        return path.toAbsolutePath().normalize();
     }
 }

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
@@ -208,10 +208,12 @@ public class EmbeddedMavenExecutor implements Executor {
                     getClass().getSimpleName() + " does not support command " + executorRequest.command());
         }
         if (executorRequest.environmentVariables().isPresent()) {
-            throw new IllegalArgumentException(getClass().getSimpleName() + " does not support environment variables");
+            throw new IllegalArgumentException(getClass().getSimpleName() + " does not support environment variables: "
+                    + executorRequest.environmentVariables().get());
         }
         if (executorRequest.jvmArguments().isPresent()) {
-            throw new IllegalArgumentException(getClass().getSimpleName() + " does not support jvmArguments");
+            throw new IllegalArgumentException(getClass().getSimpleName() + " does not support jvmArguments: "
+                    + executorRequest.jvmArguments().get());
         }
         Path boot = mavenHome.resolve("boot");
         Path m2conf = mavenHome.resolve("bin/m2.conf");

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
@@ -19,7 +19,6 @@
 package org.apache.maven.cling.executor.internal;
 
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -94,8 +93,7 @@ public class HelperImpl implements ExecutorHelper {
     }
 
     private Executor getExecutorByRequest(ExecutorRequest request) {
-        if (request.environmentVariables().orElse(Collections.emptyMap()).isEmpty()
-                && request.jvmArguments().orElse(Collections.emptyList()).isEmpty()) {
+        if (request.environmentVariables().isEmpty() && request.jvmArguments().isEmpty()) {
             return getExecutor(Mode.EMBEDDED, request);
         } else {
             return getExecutor(Mode.FORKED, request);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/rootlocator/DefaultRootLocator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/rootlocator/DefaultRootLocator.java
@@ -98,10 +98,6 @@ public class DefaultRootLocator implements RootLocator {
     }
 
     protected Path getCanonicalPath(Path path) {
-        try {
-            return path.toRealPath();
-        } catch (IOException e) {
-            return getCanonicalPath(path.getParent()).resolve(path.getFileName());
-        }
+        return path.toAbsolutePath().normalize();
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8181CentralRepoTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8181CentralRepoTest.java
@@ -47,10 +47,15 @@ public class MavenITmng8181CentralRepoTest extends AbstractMavenIntegrationTestC
         verifier.addCliArgument("--settings=settings.xml");
         verifier.addCliArgument("-Dmaven.repo.local=" + testDir.toPath().resolve("target/local-repo"));
         verifier.addCliArgument("-Dmaven.repo.local.tail=target/null");
-        verifier.addCliArgument("-Dmaven.repo.central=http://repo1.maven.org/");
+        // note: intentionally bad URL, we just want tu ensure that this bad URL is used
+        verifier.addCliArgument("-Dmaven.repo.central=https://repo1.maven.org");
         verifier.addCliArgument("validate");
-        verifier.setHandleLocalRepoTail(false); // we want isolation to have Maven fail due non-HTTPS repo
+        verifier.setHandleLocalRepoTail(false); // we want isolation to have Maven fail due bad URL
         assertThrows(VerificationException.class, verifier::execute);
-        verifier.verifyTextInLog("central (http://repo1.maven.org/, default, releases)");
+        // error is
+        // PluginResolutionException: Plugin eu.maveniverse.maven.mimir:extension3:XXX or one of its dependencies could
+        // not be resolved:
+        //	 Could not find artifact eu.maveniverse.maven.mimir:extension3:jar:XXX in central (https://repo1.maven.org)
+        verifier.verifyTextInLog("central (https://repo1.maven.org)");
     }
 }


### PR DESCRIPTION
As this makes us "escape" from paths that are symbolic links, and also causes inconsistencies among paths (like maven home, and system settings and system toolchains).

Backport of 92d53cb7075d4ff62fff0a05c7bc6b1d51566db8
