### PR TITLE
[maven-4.0.x] Tidy up executor UTs (#11249)

### DIFF
--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -218,10 +218,11 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
         Map<String, String> logs = invoke(
                 cwd,
                 userHome,
-                List.of("eu.maveniverse.maven.plugins:toolbox:0.7.4:help"),
+                List.of("eu.maveniverse.maven.plugins:toolbox:" + System.getProperty("version.toolbox") + ":help"),
                 List.of("--force-interactive"));
 
-        String log = logs.get("eu.maveniverse.maven.plugins:toolbox:0.7.4:help");
+        String log =
+                logs.get("eu.maveniverse.maven.plugins:toolbox:" + System.getProperty("version.toolbox") + ":help");
         assertTrue(log.contains("https://repo1.maven.org/maven2"), log);
         assertFalse(log.contains("https://repo.maven.apache.org/maven2"), log);
     }

--- a/impl/maven-executor/pom.xml
+++ b/impl/maven-executor/pom.xml
@@ -32,8 +32,9 @@ under the License.
   <description>Maven 4 Executor, for executing Maven 3/4.</description>
 
   <properties>
-    <maven3version>3.9.9</maven3version>
+    <maven3version>3.9.11</maven3version>
     <maven4version>${project.version}</maven4version>
+    <testTmpDir>${project.build.directory}/tmp</testTmpDir>
   </properties>
 
   <dependencies>
@@ -112,6 +113,24 @@ under the License.
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-tmp-dir</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${testTmpDir}" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <promoteUserPropertiesToSystemProperties>false</promoteUserPropertiesToSystemProperties>
@@ -122,6 +141,7 @@ under the License.
             <maven4home>${project.build.directory}/dependency/apache-maven-${maven4version}</maven4home>
             <localRepository>${settings.localRepository}</localRepository>
           </systemPropertyVariables>
+          <argLine>-Xmx256m @{jacocoArgLine} -Djava.io.tmpdir=${testTmpDir}</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
@@ -47,11 +47,11 @@ public class ToolboxTool implements ExecutorTool {
     private final ExecutorHelper.Mode forceMode;
 
     /**
-     * @deprecated Better specify required version yourself. This one is "cemented" to 0.7.4
+     * @deprecated Better specify required version yourself. This one is "cemented" to 0.13.7
      */
     @Deprecated
     public ToolboxTool(ExecutorHelper helper) {
-        this(helper, "0.7.4");
+        this(helper, "0.13.7");
     }
 
     public ToolboxTool(ExecutorHelper helper, String toolboxVersion) {

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutorTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutorTest.java
@@ -28,6 +28,6 @@ public class EmbeddedMavenExecutorTest extends MavenExecutorTestSupport {
 
     @Override
     protected Executor doSelectExecutor() {
-        return EMBEDDED_MAVEN_EXECUTOR;
+        return new EmbeddedMavenExecutor();
     }
 }

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutorTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutorTest.java
@@ -28,6 +28,6 @@ public class ForkedMavenExecutorTest extends MavenExecutorTestSupport {
 
     @Override
     protected Executor doSelectExecutor() {
-        return FORKED_MAVEN_EXECUTOR;
+        return new ForkedMavenExecutor();
     }
 }

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -25,32 +25,43 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 import eu.maveniverse.maven.mimir.testing.MimirInfuser;
+import org.apache.maven.api.cli.Executor;
 import org.apache.maven.api.cli.ExecutorRequest;
 import org.apache.maven.cling.executor.ExecutorHelper;
-import org.apache.maven.cling.executor.MavenExecutorTestSupport;
+import org.apache.maven.cling.executor.embedded.EmbeddedMavenExecutor;
+import org.apache.maven.cling.executor.forked.ForkedMavenExecutor;
 import org.apache.maven.cling.executor.internal.HelperImpl;
 import org.apache.maven.cling.executor.internal.ToolboxTool;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import static org.apache.maven.cling.executor.MavenExecutorTestSupport.mvn3ExecutorRequestBuilder;
-import static org.apache.maven.cling.executor.MavenExecutorTestSupport.mvn4ExecutorRequestBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Timeout(15)
 public class ToolboxToolTest {
-    private static final String VERSION = "0.7.4";
+    private static final Executor EMBEDDED_MAVEN_EXECUTOR = new EmbeddedMavenExecutor();
+    private static final Executor FORKED_MAVEN_EXECUTOR = new ForkedMavenExecutor();
 
-    @TempDir
-    private static Path userHome;
+    public static final String TOOLBOX_VERSION = System.getProperty("version.toolbox");
 
-    @BeforeAll
-    static void beforeAll() throws Exception {
+    @TempDir(cleanup = CleanupMode.NEVER)
+    private static Path tempDir;
+
+    private Path userHome;
+
+    @BeforeEach
+    void beforeEach(TestInfo testInfo) throws Exception {
+        userHome = tempDir.resolve(testInfo.getTestMethod().orElseThrow().getName());
+        Files.createDirectories(userHome);
         MimirInfuser.infuseUW(userHome);
+
+        System.out.println("=== " + testInfo.getTestMethod().orElseThrow().getName());
     }
 
     private ExecutorRequest.Builder getExecutorRequest(ExecutorHelper helper) {
@@ -61,103 +72,74 @@ public class ToolboxToolTest {
         return builder;
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void dump3(ExecutorHelper.Mode mode) throws Exception {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        Map<String, String> dump = new ToolboxTool(helper, VERSION).dump(getExecutorRequest(helper));
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn3Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        Map<String, String> dump = new ToolboxTool(helper, TOOLBOX_VERSION).dump(getExecutorRequest(helper));
+        System.out.println(mode.name() + ": " + dump.toString());
         assertEquals(System.getProperty("maven3version"), dump.get("maven.version"));
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void dump4(ExecutorHelper.Mode mode) throws Exception {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        Map<String, String> dump = new ToolboxTool(helper, VERSION).dump(getExecutorRequest(helper));
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn4Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        Map<String, String> dump = new ToolboxTool(helper, TOOLBOX_VERSION).dump(getExecutorRequest(helper));
+        System.out.println(mode.name() + ": " + dump.toString());
         assertEquals(System.getProperty("maven4version"), dump.get("maven.version"));
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void version3(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn3Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        System.out.println(mode.name() + ": " + helper.mavenVersion());
         assertEquals(System.getProperty("maven3version"), helper.mavenVersion());
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void version4(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn4Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        System.out.println(mode.name() + ": " + helper.mavenVersion());
         assertEquals(System.getProperty("maven4version"), helper.mavenVersion());
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void localRepository3(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String localRepository = new ToolboxTool(helper, VERSION).localRepository(getExecutorRequest(helper));
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn3Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        String localRepository = new ToolboxTool(helper, TOOLBOX_VERSION).localRepository(getExecutorRequest(helper));
+        System.out.println(mode.name() + ": " + localRepository);
         Path local = Paths.get(localRepository);
         assertTrue(Files.isDirectory(local));
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
-    @Disabled("disable temporarily so that we can get the debug statement")
     void localRepository4(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String localRepository = new ToolboxTool(helper, VERSION).localRepository(getExecutorRequest(helper));
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn4Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        String localRepository = new ToolboxTool(helper, TOOLBOX_VERSION).localRepository(getExecutorRequest(helper));
+        System.out.println(mode.name() + ": " + localRepository);
         Path local = Paths.get(localRepository);
         assertTrue(Files.isDirectory(local));
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void artifactPath3(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper, VERSION)
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn3Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        String path = new ToolboxTool(helper, TOOLBOX_VERSION)
                 .artifactPath(getExecutorRequest(helper), "aopalliance:aopalliance:1.0", "central");
+        System.out.println(mode.name() + ": " + path);
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(
                 path.endsWith("aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
@@ -165,18 +147,14 @@ public class ToolboxToolTest {
                 "path=" + path);
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void artifactPath4(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path = new ToolboxTool(helper, VERSION)
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn4Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        String path = new ToolboxTool(helper, TOOLBOX_VERSION)
                 .artifactPath(getExecutorRequest(helper), "aopalliance:aopalliance:1.0", "central");
+        System.out.println(mode.name() + ": " + path);
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(
                 path.endsWith("aopalliance" + File.separator + "aopalliance" + File.separator + "1.0" + File.separator
@@ -184,35 +162,35 @@ public class ToolboxToolTest {
                 "path=" + path);
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void metadataPath3(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn3ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path =
-                new ToolboxTool(helper, VERSION).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn4Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        String path = new ToolboxTool(helper, TOOLBOX_VERSION)
+                .metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
+        System.out.println(mode.name() + ": " + path);
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
     }
 
-    @Timeout(15)
     @ParameterizedTest
     @EnumSource(ExecutorHelper.Mode.class)
     void metadataPath4(ExecutorHelper.Mode mode) {
-        ExecutorHelper helper = new HelperImpl(
-                mode,
-                mvn4ExecutorRequestBuilder().build().installationDirectory(),
-                userHome,
-                MavenExecutorTestSupport.EMBEDDED_MAVEN_EXECUTOR,
-                MavenExecutorTestSupport.FORKED_MAVEN_EXECUTOR);
-        String path =
-                new ToolboxTool(helper, VERSION).metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
+        ExecutorHelper helper =
+                new HelperImpl(mode, mvn4Home(), userHome, EMBEDDED_MAVEN_EXECUTOR, FORKED_MAVEN_EXECUTOR);
+        String path = new ToolboxTool(helper, TOOLBOX_VERSION)
+                .metadataPath(getExecutorRequest(helper), "aopalliance", "someremote");
+        System.out.println(mode.name() + ": " + path);
         // split repository: assert "ends with" as split may introduce prefixes
         assertTrue(path.endsWith("aopalliance" + File.separator + "maven-metadata-someremote.xml"), "path=" + path);
+    }
+
+    public Path mvn3Home() {
+        return Paths.get(System.getProperty("maven3home"));
+    }
+
+    public Path mvn4Home() {
+        return Paths.get(System.getProperty("maven4home"));
     }
 }

--- a/impl/maven-impl/pom.xml
+++ b/impl/maven-impl/pom.xml
@@ -188,9 +188,9 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemProperties>
+          <systemPropertyVariables>
             <localRepository>${settings.localRepository}</localRepository>
-          </systemProperties>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -80,7 +80,6 @@ under the License.
     <jetty9Version>9.4.57.v20241219</jetty9Version>
 
     <stubPluginVersion>0.1-stub-SNAPSHOT</stubPluginVersion>
-    <version.toolbox>0.7.4</version.toolbox>
   </properties>
 
   <dependencies>
@@ -520,7 +519,6 @@ under the License.
           <useSystemClassLoader>false</useSystemClassLoader>
           <promoteUserPropertiesToSystemProperties>false</promoteUserPropertiesToSystemProperties>
           <systemPropertyVariables>
-            <version.toolbox>${version.toolbox}</version.toolbox>
             <maven.test.user.home>${preparedUserHome}</maven.test.user.home>
             <maven.test.repo.outer>${settings.localRepository}</maven.test.repo.outer>
             <maven.test.repo.local>${preparedUserHome}/.m2/repository</maven.test.repo.local>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -57,7 +57,7 @@ class MavenITmng8400CanonicalMavenHomeTest extends AbstractMavenIntegrationTestC
         Verifier verifier = newVerifier(basedir.toString(), null);
         verifier.addCliArgument("-DasProperties");
         verifier.addCliArgument("-DtoFile=dump.properties");
-        verifier.addCliArgument("eu.maveniverse.maven.plugins:toolbox:0.7.4:gav-dump");
+        verifier.addCliArgument("eu.maveniverse.maven.plugins:toolbox:" + verifier.getToolboxVersion() + ":gav-dump");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -108,6 +108,9 @@ public class Verifier {
 
     private final List<String> jvmArguments = new ArrayList<>();
 
+    // TestSuiteOrdering creates Verifier in non-forked JVM as well, and there no prop set is set (so use default)
+    private final String toolboxVersion = System.getProperty("version.toolbox", "0.14.0");
+
     private Path userHomeDirectory; // the user home
 
     private String executable = ExecutorRequest.MVN;
@@ -155,7 +158,7 @@ public class Verifier {
                     this.userHomeDirectory,
                     EMBEDDED_MAVEN_EXECUTOR,
                     FORKED_MAVEN_EXECUTOR);
-            this.executorTool = new ToolboxTool(executorHelper, System.getProperty("version.toolbox", "0.7.4"));
+            this.executorTool = new ToolboxTool(executorHelper, toolboxVersion);
             this.defaultCliArguments =
                     new ArrayList<>(defaultCliArguments != null ? defaultCliArguments : DEFAULT_CLI_ARGUMENTS);
             this.logFile = this.basedir.resolve(logFileName);
@@ -166,6 +169,10 @@ public class Verifier {
 
     public void setUserHomeDirectory(Path userHomeDirectory) {
         this.userHomeDirectory = requireNonNull(userHomeDirectory, "userHomeDirectory");
+    }
+
+    public String getToolboxVersion() {
+        return toolboxVersion;
     }
 
     public String getExecutable() {

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,9 @@ under the License.
     <woodstoxVersion>7.1.1</woodstoxVersion>
     <xmlunitVersion>2.10.4</xmlunitVersion>
     <jacocoArgLine />
+
+    <!-- Set as system property in surefire/failsafe to propagate to tests and IT Verifier -->
+    <toolboxVersion>0.14.0</toolboxVersion>
   </properties>
 
   <!--bootstrap-start-comment-->
@@ -717,6 +720,20 @@ under the License.
           <configuration>
             <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
             <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <systemPropertyVariables combine.children="append">
+              <version.toolbox>${toolboxVersion}</version.toolbox>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <systemPropertyVariables combine.children="append">
+              <version.toolbox>${toolboxVersion}</version.toolbox>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
         <!-- enforce backwards compatibility -->


### PR DESCRIPTION
Tidy up executor UTs as they are problematic. Output as much as possible as Maven in this case is used in quiet mode.

Also update Toolbox version and centralize it (one exception: tool deprecated and unused ctor).

Backport of 059731ab302e858e506b30dc2fe3d439a4a33944