### PR TITLE
Make config files use UTF8

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -27,7 +27,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
@@ -19,7 +19,6 @@
 package org.apache.maven.cling.invoker.mvn;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
Maven-Embedder uses system default encoding, making builds non portable. This was "inherited" by maven-cli.

Now all config files are made UTF8.

Fixes https://github.com/apache/maven/issues/11258