### PR TITLE
Make config files use UTF8 (#11263)

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -27,7 +27,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -384,7 +384,7 @@ public class MavenCli {
             File configFile = new File(cliRequest.multiModuleProjectDirectory, MVN_MAVEN_CONFIG);
 
             if (configFile.isFile()) {
-                try (Stream<String> lines = Files.lines(configFile.toPath(), Charset.defaultCharset())) {
+                try (Stream<String> lines = Files.lines(configFile.toPath(), StandardCharsets.UTF_8)) {
                     String[] args = lines.filter(arg -> !arg.isEmpty() && !arg.startsWith("#"))
                             .toArray(String[]::new);
                     mavenConfig = cliManager.parse(args);

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
@@ -19,7 +19,7 @@
 package org.apache.maven.cling.invoker.mvn;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -64,7 +64,7 @@ public class MavenParser extends BaseParser {
     }
 
     protected MavenOptions parseMavenAtFileOptions(Path atFile) {
-        try (Stream<String> lines = Files.lines(atFile, Charset.defaultCharset())) {
+        try (Stream<String> lines = Files.lines(atFile, StandardCharsets.UTF_8)) {
             List<String> args =
                     lines.filter(arg -> !arg.isEmpty() && !arg.startsWith("#")).toList();
             return parseArgs("atFile", args);
@@ -77,7 +77,7 @@ public class MavenParser extends BaseParser {
     }
 
     protected MavenOptions parseMavenConfigOptions(Path configFile) {
-        try (Stream<String> lines = Files.lines(configFile, Charset.defaultCharset())) {
+        try (Stream<String> lines = Files.lines(configFile, StandardCharsets.UTF_8)) {
             List<String> args =
                     lines.filter(arg -> !arg.isEmpty() && !arg.startsWith("#")).toList();
             MavenOptions options = parseArgs("maven.config", args);


### PR DESCRIPTION
Maven-Embedder uses system default encoding, making builds non portable. This was "inherited" by maven-cli.

Now all config files are made UTF8.

Fixes https://github.com/apache/maven/issues/11258

Backport of 5e9d4f7c975e44ba371a002cf0e7254ceab77187