### PR TITLE
Simplify JUnit dependency management

### DIFF
--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -100,7 +100,7 @@ under the License.
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <!-- NOTE: Use compile scope for transitivity. -->
     </dependency>
     <dependency>

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-class-loader/maven-it-plugin-class-loader/pom.xml
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-class-loader/maven-it-plugin-class-loader/pom.xml
@@ -22,16 +22,15 @@ under the License.
 
   <!-- We can't use the parent which has managed dependencies
     which make the tests using this plugin to fail -->
-  <!--  <parent>-->
-  <!--    <groupId>org.apache.maven.its.plugins</groupId>-->
-  <!--    <artifactId>maven-it-plugins</artifactId>-->
-  <!--    <version>2.1-SNAPSHOT</version>-->
-  <!--    <relativePath>../../pom.xml</relativePath>-->
-  <!--  </parent>-->
+  <parent>
+    <groupId>org.apache.maven.its.plugins</groupId>
+    <artifactId>maven-it-plugins</artifactId>
+    <version>2.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
 
   <groupId>org.apache.maven.its.plugins</groupId>
   <artifactId>maven-it-plugin-class-loader</artifactId>
-  <version>2.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Maven IT Plugin :: Class Loader</name>
@@ -58,8 +57,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>5.13.4</version>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- dedicated IT artifact that is surely not shadowed by the Maven core -->

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-class-loader/maven-it-plugin-class-loader/src/test/java/org/apache/maven/plugin/coreit/ExpressionUtilTest.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-class-loader/maven-it-plugin-class-loader/src/test/java/org/apache/maven/plugin/coreit/ExpressionUtilTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.plugin.coreit;
 
 /*
@@ -34,107 +52,98 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * @author Benjamin Bentmann
  *
  */
-public class ExpressionUtilTest
-{
+public class ExpressionUtilTest {
 
     @Test
-    public void testEvaluate()
-    {
-        Object array = new String[]{ "one", "two", "three" };
-        Object list = Arrays.asList( "0", "-1", "-2" );
-        Object map = Collections.singletonMap( "some.key", "value" );
+    public void testEvaluate() {
+        Object array = new String[] {"one", "two", "three"};
+        Object list = Arrays.asList("0", "-1", "-2");
+        Object map = Collections.singletonMap("some.key", "value");
         Object bean = new BeanTwo();
 
         Map<String, Object> contexts = new HashMap<>();
-        contexts.put( "array", array );
-        contexts.put( "list", list );
-        contexts.put( "map", map );
-        contexts.put( "bean", bean );
+        contexts.put("array", array);
+        contexts.put("list", list);
+        contexts.put("map", map);
+        contexts.put("bean", bean);
 
-        assertSame( array, evaluate( "array", contexts ) );
-        assertSame( array, ExpressionUtil.evaluate( "array/", contexts ).get( "array" ) );
-        assertSame( list, evaluate( "list", contexts ) );
-        assertSame( map, evaluate( "map", contexts ) );
-        assertSame( bean, evaluate( "bean", contexts ) );
-        assertNull( evaluate( "no-root", contexts ) );
+        assertSame(array, evaluate("array", contexts));
+        assertSame(array, ExpressionUtil.evaluate("array/", contexts).get("array"));
+        assertSame(list, evaluate("list", contexts));
+        assertSame(map, evaluate("map", contexts));
+        assertSame(bean, evaluate("bean", contexts));
+        assertNull(evaluate("no-root", contexts));
 
-        assertEquals( 3, evaluate( "array/length", contexts ) );
-        assertEquals( "three", evaluate( "array/2", contexts ) );
-        assertEquals( 5, evaluate( "array/2/length", contexts ) );
-        assertNull( evaluate( "array/invalid", contexts ) );
-        assertNull( evaluate( "array/-1", contexts ) );
-        assertNull( evaluate( "array/999", contexts ) );
-        assertEquals( 3, ExpressionUtil.evaluate( "array/*", contexts ).size() );
-        assertEquals( "one", ExpressionUtil.evaluate( "array/*", contexts ).get( "array/0" ) );
-        assertEquals( "two", ExpressionUtil.evaluate( "array/*", contexts ).get( "array/1" ) );
-        assertEquals( "three", ExpressionUtil.evaluate( "array/*", contexts ).get( "array/2" ) );
+        assertEquals(3, evaluate("array/length", contexts));
+        assertEquals("three", evaluate("array/2", contexts));
+        assertEquals(5, evaluate("array/2/length", contexts));
+        assertNull(evaluate("array/invalid", contexts));
+        assertNull(evaluate("array/-1", contexts));
+        assertNull(evaluate("array/999", contexts));
+        assertEquals(3, ExpressionUtil.evaluate("array/*", contexts).size());
+        assertEquals("one", ExpressionUtil.evaluate("array/*", contexts).get("array/0"));
+        assertEquals("two", ExpressionUtil.evaluate("array/*", contexts).get("array/1"));
+        assertEquals("three", ExpressionUtil.evaluate("array/*", contexts).get("array/2"));
 
-        assertEquals( 3, evaluate( "list/size", contexts ) );
-        assertEquals( "-2", evaluate( "list/2", contexts ) );
-        assertNull( evaluate( "list/invalid", contexts ) );
-        assertNull( evaluate( "list/-1", contexts ) );
-        assertNull( evaluate( "list/999", contexts ) );
-        assertEquals( 3, ExpressionUtil.evaluate( "list/*", contexts ).size() );
-        assertEquals( "0", ExpressionUtil.evaluate( "list/*", contexts ).get( "list/0" ) );
-        assertEquals( "-1", ExpressionUtil.evaluate( "list/*", contexts ).get( "list/1" ) );
-        assertEquals( "-2", ExpressionUtil.evaluate( "list/*", contexts ).get( "list/2" ) );
+        assertEquals(3, evaluate("list/size", contexts));
+        assertEquals("-2", evaluate("list/2", contexts));
+        assertNull(evaluate("list/invalid", contexts));
+        assertNull(evaluate("list/-1", contexts));
+        assertNull(evaluate("list/999", contexts));
+        assertEquals(3, ExpressionUtil.evaluate("list/*", contexts).size());
+        assertEquals("0", ExpressionUtil.evaluate("list/*", contexts).get("list/0"));
+        assertEquals("-1", ExpressionUtil.evaluate("list/*", contexts).get("list/1"));
+        assertEquals("-2", ExpressionUtil.evaluate("list/*", contexts).get("list/2"));
 
-        assertEquals( 1, evaluate( "map/size", contexts ) );
-        assertEquals( "value", evaluate( "map/some.key", contexts ) );
-        assertNull( evaluate( "map/invalid", contexts ) );
+        assertEquals(1, evaluate("map/size", contexts));
+        assertEquals("value", evaluate("map/some.key", contexts));
+        assertNull(evaluate("map/invalid", contexts));
 
-        assertEquals( "field", evaluate( "bean/field", contexts ) );
-        assertNull( evaluate( "bean/invalid", contexts ) );
-        assertEquals( "prop", evaluate( "bean/bean/prop", contexts ) );
-        assertEquals( "flag", evaluate( "bean/bean/flag", contexts ) );
-        assertEquals( "arg", evaluate( "bean/bean/arg", contexts ) );
+        assertEquals("field", evaluate("bean/field", contexts));
+        assertNull(evaluate("bean/invalid", contexts));
+        assertEquals("prop", evaluate("bean/bean/prop", contexts));
+        assertEquals("flag", evaluate("bean/bean/flag", contexts));
+        assertEquals("arg", evaluate("bean/bean/arg", contexts));
     }
 
-    private static Object evaluate( String expression, Object context )
-    {
-        return ExpressionUtil.evaluate( expression, context ).get( expression );
+    private static Object evaluate(String expression, Object context) {
+        return ExpressionUtil.evaluate(expression, context).get(expression);
     }
 
     @Test
-    public void testGetProperty()
-    {
+    public void testGetProperty() {
         BeanOne bean1 = new BeanOne();
         BeanTwo bean2 = new BeanTwo();
 
-        assertEquals( bean1.isFlag(), ExpressionUtil.getProperty( bean1, "flag" ) );
-        assertEquals( bean1.getProp(), ExpressionUtil.getProperty( bean1, "prop" ) );
-        assertEquals( bean1.get( "get" ), ExpressionUtil.getProperty( bean1, "get" ) );
+        assertEquals(bean1.isFlag(), ExpressionUtil.getProperty(bean1, "flag"));
+        assertEquals(bean1.getProp(), ExpressionUtil.getProperty(bean1, "prop"));
+        assertEquals(bean1.get("get"), ExpressionUtil.getProperty(bean1, "get"));
 
-        assertNull( ExpressionUtil.getProperty( bean2, "invalid" ) );
-        assertEquals( bean2.field, ExpressionUtil.getProperty( bean2, "field" ) );
-        assertSame( bean2.bean, ExpressionUtil.getProperty( bean2, "bean" ) );
+        assertNull(ExpressionUtil.getProperty(bean2, "invalid"));
+        assertEquals(bean2.field, ExpressionUtil.getProperty(bean2, "field"));
+        assertSame(bean2.bean, ExpressionUtil.getProperty(bean2, "bean"));
 
-        assertEquals( 0, ExpressionUtil.getProperty( new String[0], "length" ) );
+        assertEquals(0, ExpressionUtil.getProperty(new String[0], "length"));
     }
 
-    public static class BeanOne
-    {
-        public String isFlag()
-        {
+    public static class BeanOne {
+        public String isFlag() {
             return "flag";
         }
 
-        public String getProp()
-        {
+        public String getProp() {
             return "prop";
         }
 
-        public String get( String arg )
-        {
+        public String get(String arg) {
             return arg;
         }
     }
 
-    public static class BeanTwo
-    {
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class BeanTwo {
         public String field = "field";
 
         public BeanOne bean = new BeanOne();
-
     }
 }

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-class-loader/pom.xml
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-class-loader/pom.xml
@@ -37,29 +37,4 @@ under the License.
     <module>dep-b</module>
     <module>dep-c</module>
   </modules>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <configuration>
-            <java>
-              <includes>
-                <include>src/main/java/**/*.java</include>
-                <include>maven-it-plugin-class-loader/src/main/java/**/*.java</include>
-              </includes>
-            </java>
-            <pom>
-              <includes>
-                <include>pom.xml</include>
-                <include>maven-it-plugin-class-loader/pom.xml</include>
-              </includes>
-            </pom>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-expression/pom.xml
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-expression/pom.xml
@@ -47,7 +47,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/its/core-it-support/maven-it-helper/pom.xml
+++ b/its/core-it-support/maven-it-helper/pom.xml
@@ -49,7 +49,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -253,11 +253,6 @@ under the License.
         <version>2.0.0-M1</version>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>5.13.4</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-tools-java</artifactId>
         <version>${maven-plugin-tools-version}</version>


### PR DESCRIPTION
* Use a single version for junit 
* Always depend on `junit-jupiter-api`

#11191 and #11189 can then be turned into a single upgrade