### PR TITLE
[maven-4.0.x] Maven model 4.1.0 should not allow non-pom packaging for aggregators (#11279)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -857,7 +857,7 @@ public class DefaultModelValidator implements ModelValidator {
 
         validateStringNotEmpty("packaging", problems, Severity.ERROR, Version.BASE, m.getPackaging(), m);
 
-        if (!m.getModules().isEmpty()) {
+        if (!m.getModules().isEmpty() || !m.getSubprojects().isEmpty()) {
             if (!"pom".equals(m.getPackaging())) {
                 addViolation(
                         problems,
@@ -891,6 +891,30 @@ public class DefaultModelValidator implements ModelValidator {
                             null,
                             "has been specified without a path to the project directory.",
                             m.getLocation("modules"));
+                }
+            }
+
+            for (int index = 0, size = m.getSubprojects().size(); index < size; index++) {
+                String subproject = m.getSubprojects().get(index);
+
+                boolean isBlankSubproject = true;
+                if (subproject != null) {
+                    for (int charIndex = 0; charIndex < subproject.length(); charIndex++) {
+                        if (!Character.isWhitespace(subproject.charAt(charIndex))) {
+                            isBlankSubproject = false;
+                        }
+                    }
+                }
+
+                if (isBlankSubproject) {
+                    addViolation(
+                            problems,
+                            Severity.ERROR,
+                            Version.BASE,
+                            "subprojects.subproject[" + index + "]",
+                            null,
+                            "has been specified without a path to the project directory.",
+                            m.getLocation("subprojects"));
                 }
             }
         }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -511,6 +511,24 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testInvalidAggregatorPackagingSubprojects() throws Exception {
+        SimpleProblemCollector result = validate("invalid-aggregator-packaging-subprojects-pom.xml");
+
+        assertViolations(result, 0, 1, 0);
+
+        assertTrue(result.getErrors().get(0).contains("Aggregator projects require 'pom' as packaging."));
+    }
+
+    @Test
+    void testEmptySubproject() throws Exception {
+        SimpleProblemCollector result = validate("empty-subproject.xml");
+
+        assertViolations(result, 0, 1, 0);
+
+        assertTrue(result.getErrors().get(0).contains("'subprojects.subproject[0]' has been specified without a path"));
+    }
+
+    @Test
     void testDuplicatePlugin() throws Exception {
         SimpleProblemCollector result = validateFile("duplicate-plugin.xml");
 

--- a/impl/maven-impl/src/test/resources/poms/validation/empty-subproject.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/empty-subproject.xml
@@ -1,0 +1,30 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.1.0</modelVersion>
+  <artifactId>aid</artifactId>
+  <groupId>gid</groupId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject> </subproject>
+  </subprojects>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/validation/invalid-aggregator-packaging-subprojects-pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/invalid-aggregator-packaging-subprojects-pom.xml
@@ -1,0 +1,30 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.1.0</modelVersion>
+  <artifactId>foo</artifactId>
+  <groupId>foo</groupId>
+  <version>99.44</version>
+  <packaging>jar</packaging>
+
+  <subprojects>
+    <subproject>test-subproject</subproject>
+  </subprojects>
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Maven model 4.1.0 should not allow non-pom packaging for aggregators (#11279)](https://github.com/apache/maven/pull/11279)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)