### PR TITLE
[maven-4.0.x] Fix exception caused by duplicate dependencies in consumer pom (#11283)

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -1353,11 +1353,12 @@
     private volatile String managementKey;
 
     /**
-     * @return the management key as {@code groupId:artifactId:type}
+     * @return the management key as {@code groupId:artifactId:type[:classifier]}
      */
     public String getManagementKey() {
         if (managementKey == null) {
-            managementKey = (getGroupId() + ":" + getArtifactId() + ":" + getType() + (getClassifier() != null ? ":" + getClassifier() : "")).intern();
+            managementKey = (getGroupId() + ":" + getArtifactId() + ":" + getType()
+                    + (getClassifier() != null && !getClassifier().isEmpty() ? ":" + getClassifier() : "")).intern();
         }
         return managementKey;
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -2286,7 +2286,7 @@ public class DefaultModelValidator implements ModelValidator {
             return () -> {
                 String hint;
                 if (dependency.getClassifier() == null
-                        || dependency.getClassifier().isBlank()) {
+                        || dependency.getClassifier().isEmpty()) {
                     hint = "groupId=" + valueToValueString(dependency.getGroupId())
                             + ", artifactId=" + valueToValueString(dependency.getArtifactId())
                             + ", type=" + valueToValueString(dependency.getType());

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11280DuplicateDependencyConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11280DuplicateDependencyConsumerPomTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/11280">GH-11280</a>.
+ * <p>
+ * The issue occurs when a BOM (Bill of Materials) defines dependencies with both null and empty string
+ * classifiers for the same artifact. Before the fix, the consumer POM generation would treat these as
+ * different dependencies, but during the merge process they would be considered duplicates because both
+ * null and empty string classifiers resolve to the same management key.
+ * <p>
+ * This was specifically seen with the Apache Arrow BOM which defines:
+ * <ul>
+ * <li>A dependency without a classifier (null)</li>
+ * <li>A dependency with an empty string classifier from a property: {@code <classifier>${arrow.vector.classifier}</classifier>}</li>
+ * </ul>
+ * <p>
+ * The fix ensures that both null and empty string classifiers are treated consistently in the
+ * dependency management key generation, preventing the "Duplicate dependency" error during
+ * consumer POM building.
+ */
+class MavenITgh11280DuplicateDependencyConsumerPomTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh11280DuplicateDependencyConsumerPomTest() {
+        super("[4.0.0-rc-4,)");
+    }
+
+    /**
+     * Tests that a project using a BOM with dependencies that have both null and empty string
+     * classifiers can be built successfully without "Duplicate dependency" errors during
+     * consumer POM generation.
+     * <p>
+     * This test reproduces the scenario where:
+     * <ul>
+     * <li>A BOM defines the same dependency twice: once without classifier and once with an empty string classifier</li>
+     * <li>A project imports this BOM and uses one of the dependencies</li>
+     * <li>The maven-install-plugin is executed, which triggers consumer POM generation</li>
+     * </ul>
+     * Before the fix, this would fail with "Duplicate dependency: groupId:artifactId:type:" during
+     * the consumer POM building process.
+     * <p>
+     * The fix ensures that the dependency management key treats null and empty string classifiers
+     * as equivalent, preventing the duplicate dependency error.
+     */
+    @Test
+    void testDuplicateDependencyWithNullAndEmptyClassifier() throws Exception {
+        File testDir = extractResources("/gh-11280-duplicate-dependency-consumer-pom");
+
+        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        verifier.addCliArgument("install");
+        verifier.execute();
+
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -103,6 +103,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITgh11280DuplicateDependencyConsumerPomTest.class);
         suite.addTestSuite(MavenITgh11162ConsumerPomScopesTest.class);
         suite.addTestSuite(MavenITgh11181CoreExtensionsMetaVersionsTest.class);
         suite.addTestSuite(MavenITgh11055DIServiceInjectionTest.class);

--- a/its/core-it-suite/src/test/resources/gh-11280-duplicate-dependency-consumer-pom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11280-duplicate-dependency-consumer-pom/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh11280</groupId>
+  <artifactId>test-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Import the Apache Arrow BOM that has duplicate dependencies with null and empty classifiers -->
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-bom</artifactId>
+        <version>18.3.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Use one of the dependencies from the BOM -->
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>3.1.4</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11280-duplicate-dependency-consumer-pom/src/main/java/org/apache/maven/its/gh11280/TestApp.java
+++ b/its/core-it-suite/src/test/resources/gh-11280-duplicate-dependency-consumer-pom/src/main/java/org/apache/maven/its/gh11280/TestApp.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.gh11280;
+
+/**
+ * Simple test application for GH-11280 integration test.
+ * This class demonstrates that the project can be compiled and packaged
+ * without encountering duplicate dependency errors during consumer POM generation.
+ */
+public class TestApp {
+
+    public static void main(String[] args) {
+        System.out.println("GH-11280 test application - no duplicate dependency errors!");
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Fix exception caused by duplicate dependencies in consumer pom (#11283)](https://github.com/apache/maven/pull/11283)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)