### PR TITLE
Bug: when raw-streams are used, ensure system streams are set up (#11303)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -323,6 +323,13 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
             context.terminal = MessageUtils.getTerminal();
             context.closeables.add(MessageUtils::systemUninstall);
             MessageUtils.registerShutdownHook(); // safety belt
+
+            // when we use embedded executor AND --raw-streams, we must ENSURE streams are properly set up
+            if (context.invokerRequest.embedded()
+                    && context.options().rawStreams().orElse(false)) {
+                // to trigger FastTerminal; with raw-streams we must do this ASAP (to have system in/out/err set up)
+                context.terminal.getName();
+            }
         } else {
             doConfigureWithTerminal(context, context.terminal);
         }

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
@@ -159,9 +159,11 @@ public class ToolboxTool implements ExecutorTool {
             result = result.replace("\n", "").replace("\r", "");
         }
         // sanity checks: stderr has any OR result is empty string (no method should emit empty string)
-        if (stderr.size() > 0 || result.trim().isEmpty()) {
-            System.err.println(
-                    "Unexpected stdout[" + stdout.size() + "]=" + stdout + "; stderr[" + stderr.size() + "]=" + stderr);
+        if (result.trim().isEmpty()) {
+            // see bug https://github.com/apache/maven/pull/11303 Fail in this case
+            // tl;dr We NEVER expect empty string as output from this tool; so fail here instead to chase ghosts
+            throw new IllegalStateException("Empty output from Toolbox; stdout[" + stdout.size() + "]=" + stdout
+                    + "; stderr[" + stderr.size() + "]=" + stderr);
         }
         return result;
     }


### PR DESCRIPTION
When `--raw-streams` is used (especially when combined with options like `--quiet` and `-DforceStdout`) there is no guarantee that anything touches terminal. Hence, in case of embedded executor it is quite possible that cached/warm code arrives quickly at the place that would do system out **before** the thread with `FastTerminal` finishes system install.

In other words, when `--raw-streams` are used, we cannot guarantee that system streams are already properly set up. This PR changes that, and makes sure (by triggering a dummy call to terminal), at the cost of "jline3 install lag" for CLI invocation. OTOH, this lag in case of embedded executors does not exists (it exists only on first invocation).

My suspicion that this is the cause of IT instability issues, when Verifier used Toolbox output ends up on Surefire stdout and not on "grabbed" output, as simply streams are not yet set up properly. Also, this usually happens "around the second half" of ITs, when cached and warmed up embedded instance is already uber optimized.

Backport of bb94de05501d2b9744d6e7db249318f07b633a5d