### PR TITLE
Mimir 0.10.3 (#11291)

### DIFF
--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -19,3 +19,5 @@
 
 # Pre-seed itself
 mimir.daemon.preSeedItself=true
+mimir.file.exclusiveAccess=true
+mimir.file.cachePurge=ON_BEGIN

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ concurrency:
 permissions: {}
 
 env:
-  MIMIR_VERSION: 0.10.0
+  MIMIR_VERSION: 0.10.3
   MIMIR_BASEDIR: ~/.mimir
   MIMIR_LOCAL: ~/.mimir/local
 
@@ -99,6 +99,15 @@ jobs:
           path: |
             apache-maven/target/apache-maven*.zip
             apache-maven/target/apache-maven*.tar.gz
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: failure() || cancelled()
+        with:
+          name: ${{ github.run_number }}-initial
+          path: |
+            **/target/surefire-reports/*
+            **/target/java_heapdump.hprof
 
   full-build:
     needs: initial-build

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/Environment.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/Environment.java
@@ -22,6 +22,4 @@ public final class Environment {
     private Environment() {}
 
     public static final String TOOLBOX_VERSION = System.getProperty("version.toolbox", "UNSET version.toolbox");
-
-    public static final String MIMIR_VERSION = System.getProperty("version.mimir", "UNSET version.mimir");
 }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTest.java
@@ -222,10 +222,10 @@ public class MavenInvokerTest extends MavenInvokerTestSupport {
         Map<String, String> logs = invoke(
                 cwd,
                 userHome,
-                List.of("eu.maveniverse.maven.plugins:toolbox:" + Environment.TOOLBOX_VERSION + ":help"),
+                List.of("eu.maveniverse.maven.plugins:toolbox:" + Environment.TOOLBOX_VERSION + ":dump"),
                 List.of("--force-interactive"));
 
-        String log = logs.get("eu.maveniverse.maven.plugins:toolbox:" + Environment.TOOLBOX_VERSION + ":help");
+        String log = logs.get("eu.maveniverse.maven.plugins:toolbox:" + Environment.TOOLBOX_VERSION + ":dump");
         assertTrue(log.contains("https://repo1.maven.org/maven2"), log);
         assertFalse(log.contains("https://repo.maven.apache.org/maven2"), log);
     }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenInvokerTestSupport.java
@@ -99,7 +99,8 @@ public abstract class MavenInvokerTestSupport {
         Files.writeString(appJava, APP_JAVA_STRING);
 
         if (MimirInfuser.isMimirPresentUW()) {
-            MimirInfuser.doInfuseUW(Environment.MIMIR_VERSION, userHome);
+            MimirInfuser.doInfuseUW(userHome);
+            MimirInfuser.preseedItselfIntoInnerUserHome(userHome);
         }
 
         HashMap<String, String> logs = new HashMap<>();

--- a/impl/maven-executor/src/main/java/org/apache/maven/api/cli/Executor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/api/cli/Executor.java
@@ -71,5 +71,5 @@ public interface Executor extends AutoCloseable {
      * @throws ExecutorException if an error occurs while closing the {@link Executor}
      */
     @Override
-    default void close() throws ExecutorException {}
+    void close() throws ExecutorException;
 }

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
@@ -183,10 +183,10 @@ public class EmbeddedMavenExecutor implements Executor {
     @Override
     public String mavenVersion(ExecutorRequest executorRequest) throws ExecutorException {
         requireNonNull(executorRequest);
-        validate(executorRequest);
         if (closed.get()) {
             throw new ExecutorException("Executor is closed");
         }
+        validate(executorRequest);
         return mayCreate(executorRequest).version;
     }
 

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/Environment.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/Environment.java
@@ -22,6 +22,4 @@ public final class Environment {
     private Environment() {}
 
     public static final String TOOLBOX_VERSION = System.getProperty("version.toolbox", "UNSET version.toolbox");
-
-    public static final String MIMIR_VERSION = System.getProperty("version.mimir", "UNSET version.mimir");
 }

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
@@ -61,6 +61,7 @@ public abstract class MavenExecutorTestSupport {
                 .resolve("home");
         Files.createDirectories(userHome);
         MimirInfuser.infuseUW(userHome);
+        MimirInfuser.preseedItselfIntoInnerUserHome(userHome);
 
         System.out.println("=== " + testInfo.getTestMethod().orElseThrow().getName());
     }
@@ -338,10 +339,11 @@ public abstract class MavenExecutorTestSupport {
         for (ExecutorRequest request : requests) {
             if (MimirInfuser.isMimirPresentUW()) {
                 if (maven3Home().equals(request.installationDirectory())) {
-                    MimirInfuser.doInfusePW(Environment.MIMIR_VERSION, request.cwd(), request.userHomeDirectory());
+                    MimirInfuser.doInfusePW(request.cwd(), request.userHomeDirectory());
                 } else if (maven4Home().equals(request.installationDirectory())) {
-                    MimirInfuser.doInfuseUW(Environment.MIMIR_VERSION, request.userHomeDirectory());
+                    MimirInfuser.doInfuseUW(request.userHomeDirectory());
                 }
+                MimirInfuser.preseedItselfIntoInnerUserHome(request.userHomeDirectory());
             }
             int exitCode = invoker.execute(request);
             if (exitCode != 0) {

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -64,10 +64,11 @@ public class ToolboxToolTest {
 
         if (MimirInfuser.isMimirPresentUW()) {
             if (testName.contains("3")) {
-                MimirInfuser.doInfusePW(Environment.MIMIR_VERSION, cwd, userHome);
+                MimirInfuser.doInfusePW(cwd, userHome);
             } else {
-                MimirInfuser.doInfuseUW(Environment.MIMIR_VERSION, userHome);
+                MimirInfuser.doInfuseUW(userHome);
             }
+            MimirInfuser.preseedItselfIntoInnerUserHome(userHome);
         }
 
         System.out.println("=== " + testInfo.getTestMethod().orElseThrow().getName());

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -109,7 +109,7 @@ public class Verifier {
     private final List<String> jvmArguments = new ArrayList<>();
 
     // TestSuiteOrdering creates Verifier in non-forked JVM as well, and there no prop set is set (so use default)
-    private final String toolboxVersion = System.getProperty("version.toolbox", "0.14.0");
+    private final String toolboxVersion = System.getProperty("version.toolbox", "0.14.1");
 
     private Path userHomeDirectory; // the user home
 

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@ under the License.
     <version.palantirJavaFormat>2.80.0</version.palantirJavaFormat>
 
     <!-- Set as system property in surefire/failsafe to propagate to tests and IT Verifier -->
-    <toolboxVersion>0.14.0</toolboxVersion>
+    <toolboxVersion>0.14.1</toolboxVersion>
   </properties>
 
   <!--bootstrap-start-comment-->
@@ -693,7 +693,7 @@ under the License.
       <dependency>
         <groupId>eu.maveniverse.maven.mimir</groupId>
         <artifactId>testing</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.3</version>
       </dependency>
     </dependencies>
     <!--bootstrap-start-comment-->
@@ -725,7 +725,6 @@ under the License.
             <argLine>-Xmx256m @{jacocoArgLine}</argLine>
             <systemPropertyVariables combine.children="append">
               <version.toolbox>${toolboxVersion}</version.toolbox>
-              <version.mimir>${env.MIMIR_VERSION}</version.mimir>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -737,7 +736,6 @@ under the License.
             <argLine>-Xmx256m @{jacocoArgLine}</argLine>
             <systemPropertyVariables combine.children="append">
               <version.toolbox>${toolboxVersion}</version.toolbox>
-              <version.mimir>${env.MIMIR_VERSION}</version.mimir>
             </systemPropertyVariables>
           </configuration>
         </plugin>


### PR DESCRIPTION
Changes:
* update to Mimir 0.10.3 (that allows combining cache-purge and pre-seed features)
* uses pre-seed local reposes
* cache purge enabled on outer build

Bacport of 448a6d756351d2b567e498d4087b9637ea69cb0e