### PR TITLE
Missed parts for Mimir update (#11312)

### DIFF
--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -19,5 +19,6 @@
 
 # Pre-seed itself
 mimir.daemon.preSeedItself=true
-mimir.file.exclusiveAccess=true
-mimir.file.cachePurge=ON_BEGIN
+# OFF for now; Windows issues
+# mimir.file.exclusiveAccess=true
+# mimir.file.cachePurge=ON_BEGIN

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
@@ -60,8 +60,6 @@ public abstract class MavenExecutorTestSupport {
         userHome = tempDir.resolve(testInfo.getTestMethod().orElseThrow().getName())
                 .resolve("home");
         Files.createDirectories(userHome);
-        MimirInfuser.infuseUW(userHome);
-        MimirInfuser.preseedItselfIntoInnerUserHome(userHome);
 
         System.out.println("=== " + testInfo.getTestMethod().orElseThrow().getName());
     }


### PR DESCRIPTION
Fix build when mimir is not used. Disable cache purge for now; still Windows issues

backport of ec8d98cdf7924dd580f8420c35b5656c440ad3f2
