### PR TITLE
[maven-4.0.x] Add backward compatibility dependencies to maven-compat (#11301)

### DIFF
--- a/compat/maven-compat/pom.xml
+++ b/compat/maven-compat/pom.xml
@@ -150,12 +150,21 @@ under the License.
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
-      <scope>provided</scope>
+      <!-- only for backward compatibility otherwhise would be provided -->
+      <scope>compile</scope>
     </dependency>
+    <dependency>
+      <!-- only for backward compatibility -->
+      <groupId>aopalliance</groupId>
+      <artifactId>aopalliance</artifactId>
+      <version>1.0</version>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
-      <scope>provided</scope>
+      <!-- only for backward compatibility otherwhise would be provided -->
+      <scope>compile</scope>
     </dependency>
     <!-- ONLY version here; nothing else use or should use this dependency -->
     <dependency>
@@ -166,7 +175,8 @@ under the License.
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <scope>provided</scope>
+      <!-- only for backward compatibility otherwhise would be provided -->
+      <scope>compile</scope>
     </dependency>
 
     <dependency>
@@ -183,7 +193,8 @@ under the License.
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <classifier>classes</classifier>
-      <scope>test</scope>
+      <!-- only for backward compatibility otherwhise would be test-->
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/graph/ReactorGraph.java
+++ b/src/graph/ReactorGraph.java
@@ -44,7 +44,7 @@ public class ReactorGraph {
         CLUSTER_PATTERNS.put("Maven Resolver", Pattern.compile("^org\\.apache\\.maven\\.resolver:.*"));
         CLUSTER_PATTERNS.put("Maven Implementation", Pattern.compile("^org\\.apache\\.maven:maven-(support|impl|di|core|cli|xml|jline|logging|executor|testing):.*"));
         CLUSTER_PATTERNS.put("Maven Compatibility", Pattern.compile("^org\\.apache\\.maven:maven-(artifact|builder-support|compat|embedder|model|model-builder|plugin-api|repository-metadata|resolver-provider|settings|settings-builder|toolchain-builder|toolchain-model):.*"));
-        CLUSTER_PATTERNS.put("Sisu", Pattern.compile("(^org\\.eclipse\\.sisu:.*)|(.*:guice:.*)|(.*:javax.inject:.*)|(.*:javax.annotation-api:.*)"));
+        CLUSTER_PATTERNS.put("Sisu", Pattern.compile("(^org\\.eclipse\\.sisu:.*)|(.*:guice:.*)|(.*:javax.inject:.*)|(.*:javax.annotation-api:.*)|(.*:aopalliance:.*)"));
         CLUSTER_PATTERNS.put("Plexus", Pattern.compile("^org\\.codehaus\\.plexus:.*"));
         CLUSTER_PATTERNS.put("XML Parsing", Pattern.compile("(.*:woodstox-core:.*)|(.*:stax2-api:.*)"));
         CLUSTER_PATTERNS.put("Wagon", Pattern.compile("^org\\.apache\\.maven\\.wagon:.*"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Add backward compatibility dependencies to maven-compat (#11301)](https://github.com/apache/maven/pull/11301)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)