### PR TITLE
[maven-4.0.x] Restore compatibility in maven-embedder (#11320)

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -140,7 +140,41 @@ import static org.apache.maven.api.Constants.MAVEN_INSTALLATION_CONF;
 @Deprecated
 public class MavenCli {
 
+    /**
+     * @deprecated Use {@link org.apache.maven.api.Constants#MAVEN_REPO_LOCAL} instead
+     */
+    public static final String LOCAL_REPO_PROPERTY = "maven.repo.local";
+
+    /**
+     * @deprecated Use {@link org.apache.maven.api.Session#getRootDirectory()} instead
+     */
     public static final String MULTIMODULE_PROJECT_DIRECTORY = "maven.multiModuleProjectDirectory";
+
+    /**
+     * @deprecated Use {@link System#getProperty(String)} with "user.home" instead
+     */
+    public static final String USER_HOME = System.getProperty("user.home");
+
+    /**
+     * @deprecated Use {@link org.apache.maven.api.Constants#MAVEN_USER_CONF} instead
+     */
+    public static final File USER_MAVEN_CONFIGURATION_HOME = new File(USER_HOME, ".m2");
+
+    /**
+     * @deprecated Use {@link org.apache.maven.api.Constants#MAVEN_USER_TOOLCHAINS} instead
+     */
+    public static final File DEFAULT_USER_TOOLCHAINS_FILE = new File(USER_MAVEN_CONFIGURATION_HOME, "toolchains.xml");
+
+    /**
+     * @deprecated Use {@link org.apache.maven.api.Constants#MAVEN_INSTALLATION_TOOLCHAINS} instead
+     */
+    public static final File DEFAULT_GLOBAL_TOOLCHAINS_FILE =
+            new File(System.getProperty("maven.conf"), "toolchains.xml");
+
+    /**
+     * @deprecated Use {@link org.apache.maven.api.Constants#MAVEN_STYLE_COLOR_PROPERTY} instead
+     */
+    public static final String STYLE_COLOR_PROPERTY = "style.color";
 
     private static final String MVN_MAVEN_CONFIG = ".mvn/maven.config";
 

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/ExtensionResolutionException.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/ExtensionResolutionException.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.cli.internal;
 
-import org.apache.maven.api.cli.extensions.CoreExtension;
+import org.apache.maven.cli.internal.extension.model.CoreExtension;
 
 /**
  * Exception occurring trying to resolve a plugin.
@@ -35,6 +35,28 @@ public class ExtensionResolutionException extends Exception {
                         + cause.getMessage(),
                 cause);
         this.extension = extension;
+    }
+
+    /**
+     * Constructor accepting the new API type for internal use.
+     *
+     * @param extension the new API extension
+     * @param cause the cause
+     */
+    public ExtensionResolutionException(org.apache.maven.api.cli.extensions.CoreExtension extension, Throwable cause) {
+        super(
+                "Extension " + extension.getId() + " or one of its dependencies could not be resolved: "
+                        + cause.getMessage(),
+                cause);
+        // Convert to old type
+        CoreExtension oldExtension = new CoreExtension();
+        oldExtension.setGroupId(extension.getGroupId());
+        oldExtension.setArtifactId(extension.getArtifactId());
+        oldExtension.setVersion(extension.getVersion());
+        if (extension.getClassLoadingStrategy() != null) {
+            oldExtension.setClassLoadingStrategy(extension.getClassLoadingStrategy());
+        }
+        this.extension = oldExtension;
     }
 
     public CoreExtension getExtension() {

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/CoreExtension.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/CoreExtension.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.internal.extension.model;
+
+/**
+ * Describes a build extension to utilise.
+ *
+ * @deprecated Use {@link org.apache.maven.api.cli.extensions.CoreExtension} instead
+ */
+@Deprecated
+@SuppressWarnings("all")
+public class CoreExtension implements java.io.Serializable {
+
+    // --------------------------/
+    // - Class/Member Variables -/
+    // --------------------------/
+
+    /**
+     * The group ID of the extension's artifact.
+     */
+    private String groupId;
+
+    /**
+     * The artifact ID of the extension.
+     */
+    private String artifactId;
+
+    /**
+     * The version of the extension.
+     */
+    private String version;
+
+    /**
+     * The class loading strategy: 'self-first' (the default),
+     * 'parent-first' (loads classes from the parent, then from the
+     * extension) or 'plugin' (follows the rules from extensions
+     * defined as plugins).
+     */
+    private String classLoadingStrategy = "self-first";
+
+    // -----------/
+    // - Methods -/
+    // -----------/
+
+    /**
+     * Get the artifact ID of the extension.
+     *
+     * @return String
+     */
+    public String getArtifactId() {
+        return this.artifactId;
+    } // -- String getArtifactId()
+
+    /**
+     * Get the class loading strategy: 'self-first' (the default),
+     * 'parent-first' (loads classes from the parent, then from the
+     * extension) or 'plugin' (follows the rules from extensions
+     * defined as plugins).
+     *
+     * @return String
+     */
+    public String getClassLoadingStrategy() {
+        return this.classLoadingStrategy;
+    } // -- String getClassLoadingStrategy()
+
+    /**
+     * Get the group ID of the extension's artifact.
+     *
+     * @return String
+     */
+    public String getGroupId() {
+        return this.groupId;
+    } // -- String getGroupId()
+
+    /**
+     * Get the version of the extension.
+     *
+     * @return String
+     */
+    public String getVersion() {
+        return this.version;
+    } // -- String getVersion()
+
+    /**
+     * Set the artifact ID of the extension.
+     *
+     * @param artifactId a artifactId object.
+     */
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    } // -- void setArtifactId( String )
+
+    /**
+     * Set the class loading strategy: 'self-first' (the default),
+     * 'parent-first' (loads classes from the parent, then from the
+     * extension) or 'plugin' (follows the rules from extensions
+     * defined as plugins).
+     *
+     * @param classLoadingStrategy a classLoadingStrategy object.
+     */
+    public void setClassLoadingStrategy(String classLoadingStrategy) {
+        this.classLoadingStrategy = classLoadingStrategy;
+    } // -- void setClassLoadingStrategy( String )
+
+    /**
+     * Set the group ID of the extension's artifact.
+     *
+     * @param groupId a groupId object.
+     */
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    } // -- void setGroupId( String )
+
+    /**
+     * Set the version of the extension.
+     *
+     * @param version a version object.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    } // -- void setVersion( String )
+
+    /**
+     * Gets the identifier of the extension.
+     *
+     * @return The extension id in the form {@code <groupId>:<artifactId>:<version>}, never {@code null}.
+     */
+    public String getId() {
+        StringBuilder id = new StringBuilder(128);
+
+        id.append((getGroupId() == null) ? "[unknown-group-id]" : getGroupId());
+        id.append(":");
+        id.append((getArtifactId() == null) ? "[unknown-artifact-id]" : getArtifactId());
+        id.append(":");
+        id.append((getVersion() == null) ? "[unknown-version]" : getVersion());
+
+        return id.toString();
+    }
+}

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/CoreExtensions.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/CoreExtensions.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.internal.extension.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Extensions to load.
+ *
+ * @deprecated Use {@link org.apache.maven.api.cli.extensions.CoreExtension} instead
+ */
+@Deprecated
+@SuppressWarnings("all")
+public class CoreExtensions implements Serializable {
+
+    // --------------------------/
+    // - Class/Member Variables -/
+    // --------------------------/
+
+    /**
+     * Field extensions.
+     */
+    private List<CoreExtension> extensions;
+
+    /**
+     * Field modelEncoding.
+     */
+    private String modelEncoding = "UTF-8";
+
+    // -----------/
+    // - Methods -/
+    // -----------/
+
+    /**
+     * Method addExtension.
+     *
+     * @param coreExtension a coreExtension object.
+     */
+    public void addExtension(CoreExtension coreExtension) {
+        getExtensions().add(coreExtension);
+    } // -- void addExtension( CoreExtension )
+
+    /**
+     * Method getExtensions.
+     *
+     * @return List
+     */
+    public List<CoreExtension> getExtensions() {
+        if (this.extensions == null) {
+            this.extensions = new ArrayList<CoreExtension>();
+        }
+
+        return this.extensions;
+    } // -- List<CoreExtension> getExtensions()
+
+    /**
+     * Get the modelEncoding field.
+     *
+     * @return String
+     */
+    public String getModelEncoding() {
+        return this.modelEncoding;
+    } // -- String getModelEncoding()
+
+    /**
+     * Method removeExtension.
+     *
+     * @param coreExtension a coreExtension object.
+     */
+    public void removeExtension(CoreExtension coreExtension) {
+        getExtensions().remove(coreExtension);
+    } // -- void removeExtension( CoreExtension )
+
+    /**
+     * Set a set of build extensions to use from this project.
+     *
+     * @param extensions a extensions object.
+     */
+    public void setExtensions(List<CoreExtension> extensions) {
+        this.extensions = extensions;
+    } // -- void setExtensions( List )
+
+    /**
+     * Set the modelEncoding field.
+     *
+     * @param modelEncoding a modelEncoding object.
+     */
+    public void setModelEncoding(String modelEncoding) {
+        this.modelEncoding = modelEncoding;
+    } // -- void setModelEncoding( String )
+}

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/io/xpp3/CoreExtensionsXpp3Reader.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/io/xpp3/CoreExtensionsXpp3Reader.java
@@ -1,0 +1,692 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.internal.extension.model.io.xpp3;
+
+// ---------------------------------/
+// - Imported classes and packages -/
+// ---------------------------------/
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.text.DateFormat;
+
+import org.apache.maven.cli.internal.extension.model.CoreExtension;
+import org.apache.maven.cli.internal.extension.model.CoreExtensions;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
+import org.codehaus.plexus.util.xml.pull.EntityReplacementMap;
+import org.codehaus.plexus.util.xml.pull.MXParser;
+import org.codehaus.plexus.util.xml.pull.XmlPullParser;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+/**
+ * Class CoreExtensionsXpp3Reader.
+ *
+ * @deprecated use {@code org.apache.maven.cling.internal.extension.io.CoreExtensionsStaxReader}
+ */
+@Deprecated
+@SuppressWarnings("all")
+public class CoreExtensionsXpp3Reader {
+
+    // --------------------------/
+    // - Class/Member Variables -/
+    // --------------------------/
+
+    /**
+     * If set the parser will be loaded with all single characters
+     * from the XHTML specification.
+     * The entities used:
+     * <ul>
+     * <li>http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent</li>
+     * <li>http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent</li>
+     * <li>http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent</li>
+     * </ul>
+     */
+    private boolean addDefaultEntities = true;
+
+    /**
+     * Field contentTransformer.
+     */
+    public final ContentTransformer contentTransformer;
+
+    // ----------------/
+    // - Constructors -/
+    // ----------------/
+
+    public CoreExtensionsXpp3Reader() {
+        this(new ContentTransformer() {
+            public String transform(String source, String fieldName) {
+                return source;
+            }
+        });
+    } // -- org.apache.maven.cli.internal.extension.model.io.xpp3.CoreExtensionsXpp3Reader()
+
+    public CoreExtensionsXpp3Reader(ContentTransformer contentTransformer) {
+        this.contentTransformer = contentTransformer;
+    } // -- org.apache.maven.cli.internal.extension.model.io.xpp3.CoreExtensionsXpp3Reader(ContentTransformer)
+
+    // -----------/
+    // - Methods -/
+    // -----------/
+
+    /**
+     * Method checkFieldWithDuplicate.
+     *
+     * @param parser a parser object.
+     * @param parsed a parsed object.
+     * @param alias a alias object.
+     * @param tagName a tagName object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return boolean
+     */
+    private boolean checkFieldWithDuplicate(
+            XmlPullParser parser, String tagName, String alias, java.util.Set<String> parsed)
+            throws XmlPullParserException {
+        if (!(parser.getName().equals(tagName) || parser.getName().equals(alias))) {
+            return false;
+        }
+        if (!parsed.add(tagName)) {
+            throw new XmlPullParserException("Duplicated tag: '" + tagName + "'", parser, null);
+        }
+        return true;
+    } // -- boolean checkFieldWithDuplicate( XmlPullParser, String, String, java.util.Set )
+
+    /**
+     * Method checkUnknownAttribute.
+     *
+     * @param parser a parser object.
+     * @param strict a strict object.
+     * @param tagName a tagName object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @throws IOException IOException if any.
+     */
+    private void checkUnknownAttribute(XmlPullParser parser, String attribute, String tagName, boolean strict)
+            throws XmlPullParserException, IOException {
+        // strictXmlAttributes = true for model: if strict == true, not only elements are checked but attributes too
+        if (strict) {
+            throw new XmlPullParserException(
+                    "Unknown attribute '" + attribute + "' for tag '" + tagName + "'", parser, null);
+        }
+    } // -- void checkUnknownAttribute( XmlPullParser, String, String, boolean )
+
+    /**
+     * Method checkUnknownElement.
+     *
+     * @param parser a parser object.
+     * @param strict a strict object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @throws IOException IOException if any.
+     */
+    private void checkUnknownElement(XmlPullParser parser, boolean strict) throws XmlPullParserException, IOException {
+        if (strict) {
+            throw new XmlPullParserException("Unrecognised tag: '" + parser.getName() + "'", parser, null);
+        }
+
+        for (int unrecognizedTagCount = 1; unrecognizedTagCount > 0; ) {
+            int eventType = parser.next();
+            if (eventType == XmlPullParser.START_TAG) {
+                unrecognizedTagCount++;
+            } else if (eventType == XmlPullParser.END_TAG) {
+                unrecognizedTagCount--;
+            }
+        }
+    } // -- void checkUnknownElement( XmlPullParser, boolean )
+
+    /**
+     * Returns the state of the "add default entities" flag.
+     *
+     * @return boolean
+     */
+    public boolean getAddDefaultEntities() {
+        return addDefaultEntities;
+    } // -- boolean getAddDefaultEntities()
+
+    /**
+     * Method getBooleanValue.
+     *
+     * @param s a s object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return boolean
+     */
+    private boolean getBooleanValue(String s, String attribute, XmlPullParser parser) throws XmlPullParserException {
+        return getBooleanValue(s, attribute, parser, null);
+    } // -- boolean getBooleanValue( String, String, XmlPullParser )
+
+    /**
+     * Method getBooleanValue.
+     *
+     * @param s a s object.
+     * @param defaultValue a defaultValue object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return boolean
+     */
+    private boolean getBooleanValue(String s, String attribute, XmlPullParser parser, String defaultValue)
+            throws XmlPullParserException {
+        if (s != null && s.length() != 0) {
+            return Boolean.valueOf(s).booleanValue();
+        }
+        if (defaultValue != null) {
+            return Boolean.valueOf(defaultValue).booleanValue();
+        }
+        return false;
+    } // -- boolean getBooleanValue( String, String, XmlPullParser, String )
+
+    /**
+     * Method getByteValue.
+     *
+     * @param s a s object.
+     * @param strict a strict object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return byte
+     */
+    private byte getByteValue(String s, String attribute, XmlPullParser parser, boolean strict)
+            throws XmlPullParserException {
+        if (s != null) {
+            try {
+                return Byte.valueOf(s).byteValue();
+            } catch (NumberFormatException nfe) {
+                if (strict) {
+                    throw new XmlPullParserException(
+                            "Unable to parse element '" + attribute + "', must be a byte", parser, nfe);
+                }
+            }
+        }
+        return 0;
+    } // -- byte getByteValue( String, String, XmlPullParser, boolean )
+
+    /**
+     * Method getCharacterValue.
+     *
+     * @param s a s object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return char
+     */
+    private char getCharacterValue(String s, String attribute, XmlPullParser parser) throws XmlPullParserException {
+        if (s != null) {
+            return s.charAt(0);
+        }
+        return 0;
+    } // -- char getCharacterValue( String, String, XmlPullParser )
+
+    /**
+     * Method getDateValue.
+     *
+     * @param s a s object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return Date
+     */
+    private java.util.Date getDateValue(String s, String attribute, XmlPullParser parser)
+            throws XmlPullParserException {
+        return getDateValue(s, attribute, null, parser);
+    } // -- java.util.Date getDateValue( String, String, XmlPullParser )
+
+    /**
+     * Method getDateValue.
+     *
+     * @param s a s object.
+     * @param parser a parser object.
+     * @param dateFormat a dateFormat object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return Date
+     */
+    private java.util.Date getDateValue(String s, String attribute, String dateFormat, XmlPullParser parser)
+            throws XmlPullParserException {
+        if (s != null) {
+            String effectiveDateFormat = dateFormat;
+            if (dateFormat == null) {
+                effectiveDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+            }
+            if ("long".equals(effectiveDateFormat)) {
+                try {
+                    return new java.util.Date(Long.parseLong(s));
+                } catch (NumberFormatException e) {
+                    throw new XmlPullParserException(e.getMessage(), parser, e);
+                }
+            } else {
+                try {
+                    DateFormat dateParser = new java.text.SimpleDateFormat(effectiveDateFormat, java.util.Locale.US);
+                    return dateParser.parse(s);
+                } catch (java.text.ParseException e) {
+                    throw new XmlPullParserException(e.getMessage(), parser, e);
+                }
+            }
+        }
+        return null;
+    } // -- java.util.Date getDateValue( String, String, String, XmlPullParser )
+
+    /**
+     * Method getDoubleValue.
+     *
+     * @param s a s object.
+     * @param strict a strict object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return double
+     */
+    private double getDoubleValue(String s, String attribute, XmlPullParser parser, boolean strict)
+            throws XmlPullParserException {
+        if (s != null) {
+            try {
+                return Double.valueOf(s).doubleValue();
+            } catch (NumberFormatException nfe) {
+                if (strict) {
+                    throw new XmlPullParserException(
+                            "Unable to parse element '" + attribute + "', must be a floating point number",
+                            parser,
+                            nfe);
+                }
+            }
+        }
+        return 0;
+    } // -- double getDoubleValue( String, String, XmlPullParser, boolean )
+
+    /**
+     * Method getFloatValue.
+     *
+     * @param s a s object.
+     * @param strict a strict object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return float
+     */
+    private float getFloatValue(String s, String attribute, XmlPullParser parser, boolean strict)
+            throws XmlPullParserException {
+        if (s != null) {
+            try {
+                return Float.valueOf(s).floatValue();
+            } catch (NumberFormatException nfe) {
+                if (strict) {
+                    throw new XmlPullParserException(
+                            "Unable to parse element '" + attribute + "', must be a floating point number",
+                            parser,
+                            nfe);
+                }
+            }
+        }
+        return 0;
+    } // -- float getFloatValue( String, String, XmlPullParser, boolean )
+
+    /**
+     * Method getIntegerValue.
+     *
+     * @param s a s object.
+     * @param strict a strict object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return int
+     */
+    private int getIntegerValue(String s, String attribute, XmlPullParser parser, boolean strict)
+            throws XmlPullParserException {
+        if (s != null) {
+            try {
+                return Integer.valueOf(s).intValue();
+            } catch (NumberFormatException nfe) {
+                if (strict) {
+                    throw new XmlPullParserException(
+                            "Unable to parse element '" + attribute + "', must be an integer", parser, nfe);
+                }
+            }
+        }
+        return 0;
+    } // -- int getIntegerValue( String, String, XmlPullParser, boolean )
+
+    /**
+     * Method getLongValue.
+     *
+     * @param s a s object.
+     * @param strict a strict object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return long
+     */
+    private long getLongValue(String s, String attribute, XmlPullParser parser, boolean strict)
+            throws XmlPullParserException {
+        if (s != null) {
+            try {
+                return Long.valueOf(s).longValue();
+            } catch (NumberFormatException nfe) {
+                if (strict) {
+                    throw new XmlPullParserException(
+                            "Unable to parse element '" + attribute + "', must be a long integer", parser, nfe);
+                }
+            }
+        }
+        return 0;
+    } // -- long getLongValue( String, String, XmlPullParser, boolean )
+
+    /**
+     * Method getRequiredAttributeValue.
+     *
+     * @param s a s object.
+     * @param strict a strict object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return String
+     */
+    private String getRequiredAttributeValue(String s, String attribute, XmlPullParser parser, boolean strict)
+            throws XmlPullParserException {
+        if (s == null) {
+            if (strict) {
+                throw new XmlPullParserException(
+                        "Missing required value for attribute '" + attribute + "'", parser, null);
+            }
+        }
+        return s;
+    } // -- String getRequiredAttributeValue( String, String, XmlPullParser, boolean )
+
+    /**
+     * Method getShortValue.
+     *
+     * @param s a s object.
+     * @param strict a strict object.
+     * @param parser a parser object.
+     * @param attribute a attribute object.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return short
+     */
+    private short getShortValue(String s, String attribute, XmlPullParser parser, boolean strict)
+            throws XmlPullParserException {
+        if (s != null) {
+            try {
+                return Short.valueOf(s).shortValue();
+            } catch (NumberFormatException nfe) {
+                if (strict) {
+                    throw new XmlPullParserException(
+                            "Unable to parse element '" + attribute + "', must be a short integer", parser, nfe);
+                }
+            }
+        }
+        return 0;
+    } // -- short getShortValue( String, String, XmlPullParser, boolean )
+
+    /**
+     * Method getTrimmedValue.
+     *
+     * @param s a s object.
+     * @return String
+     */
+    private String getTrimmedValue(String s) {
+        if (s != null) {
+            s = s.trim();
+        }
+        return s;
+    } // -- String getTrimmedValue( String )
+
+    /**
+     * Method interpolatedTrimmed.
+     *
+     * @param value a value object.
+     * @param context a context object.
+     * @return String
+     */
+    private String interpolatedTrimmed(String value, String context) {
+        return getTrimmedValue(contentTransformer.transform(value, context));
+    } // -- String interpolatedTrimmed( String, String )
+
+    /**
+     * Method nextTag.
+     *
+     * @param parser a parser object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return int
+     */
+    private int nextTag(XmlPullParser parser) throws IOException, XmlPullParserException {
+        int eventType = parser.next();
+        if (eventType == XmlPullParser.TEXT) {
+            eventType = parser.next();
+        }
+        if (eventType != XmlPullParser.START_TAG && eventType != XmlPullParser.END_TAG) {
+            throw new XmlPullParserException(
+                    "expected START_TAG or END_TAG not " + XmlPullParser.TYPES[eventType], parser, null);
+        }
+        return eventType;
+    } // -- int nextTag( XmlPullParser )
+
+    /**
+     * Method read.
+     *
+     * @param parser a parser object.
+     * @param strict a strict object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return CoreExtensions
+     */
+    public CoreExtensions read(XmlPullParser parser, boolean strict) throws IOException, XmlPullParserException {
+        CoreExtensions coreExtensions = null;
+        int eventType = parser.getEventType();
+        boolean parsed = false;
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            if (eventType == XmlPullParser.START_TAG) {
+                if (strict && !"extensions".equals(parser.getName())) {
+                    throw new XmlPullParserException(
+                            "Expected root element 'extensions' but found '" + parser.getName() + "'", parser, null);
+                } else if (parsed) {
+                    // fallback, already expected a XmlPullParserException due to invalid XML
+                    throw new XmlPullParserException("Duplicated tag: 'extensions'", parser, null);
+                }
+                coreExtensions = parseCoreExtensions(parser, strict);
+                coreExtensions.setModelEncoding(parser.getInputEncoding());
+                parsed = true;
+            }
+            eventType = parser.next();
+        }
+        if (parsed) {
+            return coreExtensions;
+        }
+        throw new XmlPullParserException(
+                "Expected root element 'extensions' but found no element at all: invalid XML document", parser, null);
+    } // -- CoreExtensions read( XmlPullParser, boolean )
+
+    /**
+     * @see XmlStreamReader
+     *
+     * @param reader a reader object.
+     * @param strict a strict object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return CoreExtensions
+     */
+    public CoreExtensions read(Reader reader, boolean strict) throws IOException, XmlPullParserException {
+        XmlPullParser parser =
+                addDefaultEntities ? new MXParser(EntityReplacementMap.defaultEntityReplacementMap) : new MXParser();
+
+        parser.setInput(reader);
+
+        return read(parser, strict);
+    } // -- CoreExtensions read( Reader, boolean )
+
+    /**
+     * @see XmlStreamReader
+     *
+     * @param reader a reader object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return CoreExtensions
+     */
+    public CoreExtensions read(Reader reader) throws IOException, XmlPullParserException {
+        return read(reader, true);
+    } // -- CoreExtensions read( Reader )
+
+    /**
+     * Method read.
+     *
+     * @param in a in object.
+     * @param strict a strict object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return CoreExtensions
+     */
+    public CoreExtensions read(InputStream in, boolean strict) throws IOException, XmlPullParserException {
+        return read(new XmlStreamReader(in), strict);
+    } // -- CoreExtensions read( InputStream, boolean )
+
+    /**
+     * Method read.
+     *
+     * @param in a in object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return CoreExtensions
+     */
+    public CoreExtensions read(InputStream in) throws IOException, XmlPullParserException {
+        return read(new XmlStreamReader(in));
+    } // -- CoreExtensions read( InputStream )
+
+    /**
+     * Method parseCoreExtension.
+     *
+     * @param parser a parser object.
+     * @param strict a strict object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return CoreExtension
+     */
+    private CoreExtension parseCoreExtension(XmlPullParser parser, boolean strict)
+            throws IOException, XmlPullParserException {
+        String tagName = parser.getName();
+        CoreExtension coreExtension = new CoreExtension();
+        for (int i = parser.getAttributeCount() - 1; i >= 0; i--) {
+            String name = parser.getAttributeName(i);
+            String value = parser.getAttributeValue(i);
+
+            if (name.indexOf(':') >= 0) {
+                // just ignore attributes with non-default namespace (for example: xmlns:xsi)
+            } else {
+                checkUnknownAttribute(parser, name, tagName, strict);
+            }
+        }
+        java.util.Set<String> parsed = new java.util.HashSet<String>();
+        while ((strict ? parser.nextTag() : nextTag(parser)) == XmlPullParser.START_TAG) {
+            if (checkFieldWithDuplicate(parser, "groupId", null, parsed)) {
+                coreExtension.setGroupId(interpolatedTrimmed(parser.nextText(), "groupId"));
+            } else if (checkFieldWithDuplicate(parser, "artifactId", null, parsed)) {
+                coreExtension.setArtifactId(interpolatedTrimmed(parser.nextText(), "artifactId"));
+            } else if (checkFieldWithDuplicate(parser, "version", null, parsed)) {
+                coreExtension.setVersion(interpolatedTrimmed(parser.nextText(), "version"));
+            } else if (checkFieldWithDuplicate(parser, "classLoadingStrategy", null, parsed)) {
+                coreExtension.setClassLoadingStrategy(interpolatedTrimmed(parser.nextText(), "classLoadingStrategy"));
+            } else {
+                checkUnknownElement(parser, strict);
+            }
+        }
+        return coreExtension;
+    } // -- CoreExtension parseCoreExtension( XmlPullParser, boolean )
+
+    /**
+     * Method parseCoreExtensions.
+     *
+     * @param parser a parser object.
+     * @param strict a strict object.
+     * @throws IOException IOException if any.
+     * @throws XmlPullParserException XmlPullParserException if
+     * any.
+     * @return CoreExtensions
+     */
+    private CoreExtensions parseCoreExtensions(XmlPullParser parser, boolean strict)
+            throws IOException, XmlPullParserException {
+        String tagName = parser.getName();
+        CoreExtensions coreExtensions = new CoreExtensions();
+        for (int i = parser.getAttributeCount() - 1; i >= 0; i--) {
+            String name = parser.getAttributeName(i);
+            String value = parser.getAttributeValue(i);
+
+            if (name.indexOf(':') >= 0) {
+                // just ignore attributes with non-default namespace (for example: xmlns:xsi)
+            } else if ("xmlns".equals(name)) {
+                // ignore xmlns attribute in root class, which is a reserved attribute name
+            } else {
+                checkUnknownAttribute(parser, name, tagName, strict);
+            }
+        }
+        java.util.Set<String> parsed = new java.util.HashSet<String>();
+        while ((strict ? parser.nextTag() : nextTag(parser)) == XmlPullParser.START_TAG) {
+            if ("extension".equals(parser.getName())) {
+                java.util.List<CoreExtension> extensions = coreExtensions.getExtensions();
+                if (extensions == null) {
+                    extensions = new java.util.ArrayList<CoreExtension>();
+                }
+                extensions.add(parseCoreExtension(parser, strict));
+                coreExtensions.setExtensions(extensions);
+            } else {
+                checkUnknownElement(parser, strict);
+            }
+        }
+        return coreExtensions;
+    } // -- CoreExtensions parseCoreExtensions( XmlPullParser, boolean )
+
+    /**
+     * Sets the state of the "add default entities" flag.
+     *
+     * @param addDefaultEntities a addDefaultEntities object.
+     */
+    public void setAddDefaultEntities(boolean addDefaultEntities) {
+        this.addDefaultEntities = addDefaultEntities;
+    } // -- void setAddDefaultEntities( boolean )
+
+    public static interface ContentTransformer {
+        /**
+         * Interpolate the value read from the xpp3 document
+         * @param source The source value
+         * @param fieldName A description of the field being interpolated. The implementation may use this to
+         *                           log stuff.
+         * @return The interpolated value.
+         */
+        String transform(String source, String fieldName);
+    }
+}

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/io/xpp3/CoreExtensionsXpp3Writer.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/extension/model/io/xpp3/CoreExtensionsXpp3Writer.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cli.internal.extension.model.io.xpp3;
+
+// ---------------------------------/
+// - Imported classes and packages -/
+// ---------------------------------/
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.Iterator;
+
+import org.apache.maven.cli.internal.extension.model.CoreExtension;
+import org.apache.maven.cli.internal.extension.model.CoreExtensions;
+import org.codehaus.plexus.util.xml.pull.MXSerializer;
+import org.codehaus.plexus.util.xml.pull.XmlSerializer;
+
+/**
+ * Class CoreExtensionsXpp3Writer.
+ *
+ * @deprecated use {@code org.apache.maven.cling.internal.extension.io.CoreExtensionsStaxWriter}
+ */
+@Deprecated
+@SuppressWarnings("all")
+public class CoreExtensionsXpp3Writer {
+
+    // --------------------------/
+    // - Class/Member Variables -/
+    // --------------------------/
+
+    /**
+     * Field NAMESPACE.
+     */
+    private static final String NAMESPACE = null;
+
+    /**
+     * Field fileComment.
+     */
+    private String fileComment = null;
+
+    // -----------/
+    // - Methods -/
+    // -----------/
+
+    /**
+     * Method setFileComment.
+     *
+     * @param fileComment a fileComment object.
+     */
+    public void setFileComment(String fileComment) {
+        this.fileComment = fileComment;
+    } // -- void setFileComment( String )
+
+    /**
+     * Method write.
+     *
+     * @param writer a writer object.
+     * @param coreExtensions a coreExtensions object.
+     * @throws IOException IOException if any.
+     */
+    public void write(Writer writer, CoreExtensions coreExtensions) throws IOException {
+        XmlSerializer serializer = new MXSerializer();
+        serializer.setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-indentation", "  ");
+        serializer.setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-line-separator", "\n");
+        serializer.setOutput(writer);
+        serializer.startDocument(coreExtensions.getModelEncoding(), null);
+        writeCoreExtensions(coreExtensions, "extensions", serializer);
+        serializer.endDocument();
+    } // -- void write( Writer, CoreExtensions )
+
+    /**
+     * Method write.
+     *
+     * @param stream a stream object.
+     * @param coreExtensions a coreExtensions object.
+     * @throws IOException IOException if any.
+     */
+    public void write(OutputStream stream, CoreExtensions coreExtensions) throws IOException {
+        XmlSerializer serializer = new MXSerializer();
+        serializer.setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-indentation", "  ");
+        serializer.setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-line-separator", "\n");
+        serializer.setOutput(stream, coreExtensions.getModelEncoding());
+        serializer.startDocument(coreExtensions.getModelEncoding(), null);
+        writeCoreExtensions(coreExtensions, "extensions", serializer);
+        serializer.endDocument();
+    } // -- void write( OutputStream, CoreExtensions )
+
+    /**
+     * Method writeCoreExtension.
+     *
+     * @param coreExtension a coreExtension object.
+     * @param serializer a serializer object.
+     * @param tagName a tagName object.
+     * @throws IOException IOException if any.
+     */
+    private void writeCoreExtension(CoreExtension coreExtension, String tagName, XmlSerializer serializer)
+            throws IOException {
+        serializer.startTag(NAMESPACE, tagName);
+        if (coreExtension.getGroupId() != null) {
+            serializer
+                    .startTag(NAMESPACE, "groupId")
+                    .text(coreExtension.getGroupId())
+                    .endTag(NAMESPACE, "groupId");
+        }
+        if (coreExtension.getArtifactId() != null) {
+            serializer
+                    .startTag(NAMESPACE, "artifactId")
+                    .text(coreExtension.getArtifactId())
+                    .endTag(NAMESPACE, "artifactId");
+        }
+        if (coreExtension.getVersion() != null) {
+            serializer
+                    .startTag(NAMESPACE, "version")
+                    .text(coreExtension.getVersion())
+                    .endTag(NAMESPACE, "version");
+        }
+        if ((coreExtension.getClassLoadingStrategy() != null)
+                && !coreExtension.getClassLoadingStrategy().equals("self-first")) {
+            serializer
+                    .startTag(NAMESPACE, "classLoadingStrategy")
+                    .text(coreExtension.getClassLoadingStrategy())
+                    .endTag(NAMESPACE, "classLoadingStrategy");
+        }
+        serializer.endTag(NAMESPACE, tagName);
+    } // -- void writeCoreExtension( CoreExtension, String, XmlSerializer )
+
+    /**
+     * Method writeCoreExtensions.
+     *
+     * @param coreExtensions a coreExtensions object.
+     * @param serializer a serializer object.
+     * @param tagName a tagName object.
+     * @throws IOException IOException if any.
+     */
+    private void writeCoreExtensions(CoreExtensions coreExtensions, String tagName, XmlSerializer serializer)
+            throws IOException {
+        if (this.fileComment != null) {
+            serializer.comment(this.fileComment);
+        }
+        serializer.setPrefix("", "http://maven.apache.org/EXTENSIONS/1.1.0");
+        serializer.setPrefix("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+        serializer.startTag(NAMESPACE, tagName);
+        serializer.attribute(
+                "",
+                "xsi:schemaLocation",
+                "http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd");
+        if ((coreExtensions.getExtensions() != null)
+                && (coreExtensions.getExtensions().size() > 0)) {
+            for (Iterator iter = coreExtensions.getExtensions().iterator(); iter.hasNext(); ) {
+                CoreExtension o = (CoreExtension) iter.next();
+                writeCoreExtension(o, "extension", serializer);
+            }
+        }
+        serializer.endTag(NAMESPACE, tagName);
+    } // -- void writeCoreExtensions( CoreExtensions, String, XmlSerializer )
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Restore compatibility in maven-embedder (#11320)](https://github.com/apache/maven/pull/11320)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)