### PR TITLE
Mimir Cache-Purge w Pre-seed (#11315)

### DIFF
--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -19,6 +19,5 @@
 
 # Pre-seed itself
 mimir.daemon.preSeedItself=true
-# OFF for now; Windows issues
-# mimir.file.exclusiveAccess=true
-# mimir.file.cachePurge=ON_BEGIN
+mimir.file.exclusiveAccess=true
+mimir.file.cachePurge=ON_BEGIN

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ concurrency:
 permissions: {}
 
 env:
-  MIMIR_VERSION: 0.10.3
+  MIMIR_VERSION: 0.10.4
   MIMIR_BASEDIR: ~/.mimir
   MIMIR_LOCAL: ~/.mimir/local
 

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -96,6 +96,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
+      <version>${plexusUtilsVersion}</version>
       <!-- NOTE: Use compile scope for transitivity. -->
     </dependency>
 
@@ -503,6 +504,31 @@ under the License.
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <skipInstallation>true</skipInstallation>
+          <localRepositoryPath>${preparedUserHome}/.m2/repository</localRepositoryPath>
+          <extraArtifacts>
+            <extraArtifact>eu.maveniverse.maven.plugins:toolbox:${toolboxVersion}:maven-plugin</extraArtifact>
+            <!--
+            Required by:
+            MavenITmng0449PluginVersionResolutionTest
+            MavenITmng0479OverrideCentralRepoTest
+            -->
+            <extraArtifact>org.apache.maven:maven-plugin-api:3.8.6</extraArtifact>
+          </extraArtifacts>
+        </configuration>
+        <executions>
+          <execution>
+            <id>install</id>
+            <goals>
+              <goal>install</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5230MakeReactorWithExcludesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5230MakeReactorWithExcludesTest.java
@@ -49,7 +49,7 @@ public class MavenITmng5230MakeReactorWithExcludesTest extends AbstractMavenInte
     public void testitMakeWithExclude() throws Exception {
         File testDir = extractResources("/mng-5230-make-reactor-with-excludes");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), true);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.addCliArgument("-X");
         verifier.setAutoclean(false);
         clean(verifier);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5669ReadPomsOnce.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5669ReadPomsOnce.java
@@ -47,7 +47,7 @@ public class MavenITmng5669ReadPomsOnce extends AbstractMavenIntegrationTestCase
     public void testWithoutBuildConsumer() throws Exception {
         // prepare JavaAgent
         File testDir = extractResources("/mng-5669-read-poms-once");
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         Map<String, String> filterProperties = Collections.singletonMap(
                 "${javaAgentJar}",
                 verifier.getSupportArtifactPath("org.apache.maven.its", "core-it-javaagent", "2.1-SNAPSHOT", "jar"));
@@ -82,7 +82,7 @@ public class MavenITmng5669ReadPomsOnce extends AbstractMavenIntegrationTestCase
     public void testWithBuildConsumer() throws Exception {
         // prepare JavaAgent
         File testDir = extractResources("/mng-5669-read-poms-once");
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         Map<String, String> filterProperties = Collections.singletonMap(
                 "${javaAgentJar}",
                 verifier.getArtifactPath("org.apache.maven.its", "core-it-javaagent", "2.1-SNAPSHOT", "jar"));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5895CIFriendlyUsageWithPropertyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5895CIFriendlyUsageWithPropertyTest.java
@@ -50,7 +50,7 @@ public class MavenITmng5895CIFriendlyUsageWithPropertyTest extends AbstractMaven
     public void testitShouldResolveTheDependenciesWithoutBuildConsumer() throws Exception {
         File testDir = extractResources("/mng-5895-ci-friendly-usage-with-property");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         // verifier.setLogFileName( "log-only.txt" );
@@ -67,7 +67,7 @@ public class MavenITmng5895CIFriendlyUsageWithPropertyTest extends AbstractMaven
     public void testitShouldResolveTheDependenciesWithBuildConsumer() throws Exception {
         File testDir = extractResources("/mng-5895-ci-friendly-usage-with-property");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("log-bc.txt");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5965ParallelBuildMultipliesWorkTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5965ParallelBuildMultipliesWorkTest.java
@@ -40,7 +40,7 @@ public class MavenITmng5965ParallelBuildMultipliesWorkTest extends AbstractMaven
     public void testItShouldOnlyRunEachTaskOnce() throws Exception {
         File testDir = extractResources("/mng-5965-parallel-build-multiplies-work");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("log-only.txt");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6057CheckReactorOrderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6057CheckReactorOrderTest.java
@@ -51,7 +51,7 @@ public class MavenITmng6057CheckReactorOrderTest extends AbstractMavenIntegratio
     public void testitReactorShouldResultInExpectedOrder() throws Exception {
         File testDir = extractResources("/mng-6057-check-reactor-order");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("log-only.txt");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6065FailOnSeverityTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6065FailOnSeverityTest.java
@@ -41,7 +41,7 @@ public class MavenITmng6065FailOnSeverityTest extends AbstractMavenIntegrationTe
     public void testItShouldFailOnWarnLogMessages() throws Exception {
         File testDir = extractResources("/mng-6065-fail-on-severity");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setLogFileName("warn.log");
         verifier.addCliArgument("--fail-on-severity");
         verifier.addCliArgument("WARN");
@@ -64,7 +64,7 @@ public class MavenITmng6065FailOnSeverityTest extends AbstractMavenIntegrationTe
     public void testItShouldSucceedOnWarnLogMessagesWhenFailLevelIsError() throws Exception {
         File testDir = extractResources("/mng-6065-fail-on-severity");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setLogFileName("error.log");
         verifier.addCliArgument("--fail-on-severity");
         verifier.addCliArgument("ERROR");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6090CIFriendlyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6090CIFriendlyTest.java
@@ -50,7 +50,7 @@ public class MavenITmng6090CIFriendlyTest extends AbstractMavenIntegrationTestCa
     public void testitShouldResolveTheDependenciesWithoutBuildConsumer() throws Exception {
         File testDir = extractResources("/mng-6090-ci-friendly");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.addCliArgument("-Drevision=1.2");
@@ -60,7 +60,7 @@ public class MavenITmng6090CIFriendlyTest extends AbstractMavenIntegrationTestCa
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        verifier = newVerifier(testDir.getAbsolutePath(), false);
+        verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.addCliArgument("-Drevision=1.2");
@@ -75,7 +75,7 @@ public class MavenITmng6090CIFriendlyTest extends AbstractMavenIntegrationTestCa
     public void testitShouldResolveTheDependenciesWithBuildConsumer() throws Exception {
         File testDir = extractResources("/mng-6090-ci-friendly");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setForkJvm(true); // TODO: why?
 
@@ -86,7 +86,7 @@ public class MavenITmng6090CIFriendlyTest extends AbstractMavenIntegrationTestCa
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        verifier = newVerifier(testDir.getAbsolutePath(), false);
+        verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setForkJvm(true); // TODO: why?
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6118SubmoduleInvocation.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6118SubmoduleInvocation.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
  *     <li>lib</li>
  * </ul>
  *
+ * This IT manually manages {@code .mvn} directories, so instructs Verifier to NOT create any.
+ *
  * @author Maarten Mulders
  * @author Martin Kanters
  */
@@ -53,12 +55,12 @@ public class MavenITmng6118SubmoduleInvocation extends AbstractMavenIntegrationT
     @Test
     public void testInSubModule() throws Exception {
         // Compile the whole project first.
-        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
         verifier.addCliArgument("package");
         verifier.execute();
 
         final File submoduleDirectory = new File(testDir, "app");
-        verifier = newVerifier(submoduleDirectory.getAbsolutePath());
+        verifier = newVerifier(submoduleDirectory.getAbsolutePath(), false);
         verifier.setAutoclean(false);
         verifier.setLogFileName("log-insubmodule.txt");
         verifier.addCliArgument("compile");
@@ -73,7 +75,7 @@ public class MavenITmng6118SubmoduleInvocation extends AbstractMavenIntegrationT
     @Test
     public void testWithFile() throws Exception {
         // Compile the whole project first.
-        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
         verifier.addCliArgument("package");
         verifier.execute();
 
@@ -93,7 +95,7 @@ public class MavenITmng6118SubmoduleInvocation extends AbstractMavenIntegrationT
      */
     @Test
     public void testWithFileAndAlsoMake() throws Exception {
-        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
         verifier.addCliArgument("-am");
         verifier.addCliArgument("-f");
         verifier.addCliArgument("app/pom.xml");
@@ -111,7 +113,7 @@ public class MavenITmng6118SubmoduleInvocation extends AbstractMavenIntegrationT
     @Test
     public void testInSubModuleWithAlsoMake() throws Exception {
         File submoduleDirectory = new File(testDir, "app");
-        Verifier verifier = newVerifier(submoduleDirectory.getAbsolutePath());
+        Verifier verifier = newVerifier(submoduleDirectory.getAbsolutePath(), false);
         verifier.addCliArgument("-am");
         verifier.setLogFileName("log-insubmodulealsomake.txt");
         verifier.addCliArgument("compile");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
@@ -54,7 +54,7 @@ public class MavenITmng6391PrintVersionTest extends AbstractMavenIntegrationTest
     public void testitShouldPrintVersionAtTopAndAtBottom() throws Exception {
         File testDir = extractResources("/mng-6391-print-version");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("version-log.txt");
@@ -95,7 +95,7 @@ public class MavenITmng6391PrintVersionTest extends AbstractMavenIntegrationTest
     public void testitShouldPrintVersionInAllLines() throws Exception {
         File testDir = extractResources("/mng-6391-print-version-aggregator");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("version-log.txt");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6562WarnDefaultBindings.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6562WarnDefaultBindings.java
@@ -33,7 +33,7 @@ public class MavenITmng6562WarnDefaultBindings extends AbstractMavenIntegrationT
         File testDir = extractResources("/mng-6562-default-bindings");
 
         String phase = "validate";
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setLogFileName(phase + ".txt");
         verifier.addCliArgument("-fos");
@@ -49,7 +49,7 @@ public class MavenITmng6562WarnDefaultBindings extends AbstractMavenIntegrationT
         File testDir = extractResources("/mng-6562-default-bindings");
 
         String phase = "process-resources";
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setLogFileName(phase + ".txt");
         verifier.addCliArgument("-fos");
@@ -65,7 +65,7 @@ public class MavenITmng6562WarnDefaultBindings extends AbstractMavenIntegrationT
         File testDir = extractResources("/mng-6562-default-bindings");
 
         String phase = "compile";
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setLogFileName(phase + ".txt");
         verifier.addCliArgument(phase);
@@ -80,7 +80,7 @@ public class MavenITmng6562WarnDefaultBindings extends AbstractMavenIntegrationT
         File testDir = extractResources("/mng-6562-default-bindings");
 
         String phase = "process-test-resources";
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setLogFileName(phase + ".txt");
         verifier.addCliArgument(phase);
@@ -96,7 +96,7 @@ public class MavenITmng6562WarnDefaultBindings extends AbstractMavenIntegrationT
         File testDir = extractResources("/mng-6562-default-bindings");
 
         String phase = "test-compile";
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setLogFileName(phase + ".txt");
         verifier.addCliArgument(phase);
@@ -112,7 +112,7 @@ public class MavenITmng6562WarnDefaultBindings extends AbstractMavenIntegrationT
         File testDir = extractResources("/mng-6562-default-bindings");
 
         String phase = "test";
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.setLogFileName(phase + ".txt");
         verifier.addCliArgument(phase);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -64,7 +64,7 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
     public void testPublishedPoms() throws Exception {
         File testDir = extractResources("/mng-6656-buildconsumer");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.addCliArgument("-Dchangelist=MNG6656");
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6720FailFastTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6720FailFastTest.java
@@ -42,7 +42,7 @@ class MavenITmng6720FailFastTest extends AbstractMavenIntegrationTestCase {
     void testItShouldWaitForConcurrentModulesToFinish() throws Exception {
         File testDir = extractResources("/mng-6720-fail-fast");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.addCliArguments("-T", "2");
         verifier.addCliArgument("-Dmaven.test.redirectTestOutputToFile=true");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -64,7 +64,7 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
     public void testPublishedPoms() throws Exception {
         File testDir = extractResources("/mng-6957-buildconsumer");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.addCliArgument("-Dchangelist=MNG6957");
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7038RootdirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7038RootdirTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * This IT manually manages {@code .mvn} directories, so instructs Verifier to NOT create any.
+ */
 public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng7038RootdirTest() {
@@ -35,7 +38,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
     @Test
     public void testRootdir() throws IOException, VerificationException {
         File testDir = extractResources("/mng-7038-rootdir");
-        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
 
         verifier.addCliArgument("validate");
         verifier.execute();
@@ -123,7 +126,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
     @Test
     public void testRootdirWithTopdirAndRoot() throws IOException, VerificationException {
         File testDir = extractResources("/mng-7038-rootdir");
-        Verifier verifier = newVerifier(new File(testDir, "module-a").getAbsolutePath());
+        Verifier verifier = newVerifier(new File(testDir, "module-a").getAbsolutePath(), false);
 
         verifier.addCliArgument("validate");
         verifier.execute();
@@ -181,7 +184,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
     @Test
     public void testRootdirWithTopdirAndNoRoot() throws IOException, VerificationException {
         File testDir = extractResources("/mng-7038-rootdir");
-        Verifier verifier = newVerifier(new File(testDir, "module-b").getAbsolutePath());
+        Verifier verifier = newVerifier(new File(testDir, "module-b").getAbsolutePath(), false);
 
         verifier.addCliArgument("validate");
         verifier.execute();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7390SelectModuleOutsideCwdTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7390SelectModuleOutsideCwdTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
  * This test suite tests whether other modules in the same multi-module project can be selected when invoking Maven from a submodule.
  * Related JIRA issue: <a href="https://issues.apache.org/jira/browse/MNG-7390">MNG-7390</a>.
  *
+ * This IT manually manages {@code .mvn} directories, so instructs Verifier to NOT create any.
+ *
  * @author Martin Kanters
  */
 public class MavenITmng7390SelectModuleOutsideCwdTest extends AbstractMavenIntegrationTestCase {
@@ -42,7 +44,7 @@ public class MavenITmng7390SelectModuleOutsideCwdTest extends AbstractMavenInteg
         moduleADir = extractResources("/mng-7390-pl-outside-cwd/module-a");
 
         // Clean up target files from earlier runs (verifier.setAutoClean does not work, as we are reducing the reactor)
-        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath());
+        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath(), false);
         verifier.addCliArgument("-f");
         verifier.addCliArgument("..");
         verifier.addCliArgument("clean");
@@ -51,7 +53,7 @@ public class MavenITmng7390SelectModuleOutsideCwdTest extends AbstractMavenInteg
 
     @Test
     public void testSelectModuleByCoordinate() throws Exception {
-        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath());
+        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath(), false);
 
         verifier.addCliArgument("-pl");
         verifier.addCliArgument(":module-b");
@@ -65,7 +67,7 @@ public class MavenITmng7390SelectModuleOutsideCwdTest extends AbstractMavenInteg
 
     @Test
     public void testSelectMultipleModulesByCoordinate() throws Exception {
-        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath());
+        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath(), false);
 
         verifier.addCliArgument("-pl");
         verifier.addCliArgument(":module-b,:module-a");
@@ -79,7 +81,7 @@ public class MavenITmng7390SelectModuleOutsideCwdTest extends AbstractMavenInteg
 
     @Test
     public void testSelectModuleByRelativePath() throws Exception {
-        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath());
+        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath(), false);
 
         verifier.addCliArgument("-pl");
         verifier.addCliArgument("../module-b");
@@ -93,7 +95,7 @@ public class MavenITmng7390SelectModuleOutsideCwdTest extends AbstractMavenInteg
 
     @Test
     public void testSelectModulesByRelativePath() throws Exception {
-        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath());
+        final Verifier verifier = newVerifier(moduleADir.getAbsolutePath(), false);
 
         verifier.addCliArgument("-pl");
         verifier.addCliArgument("../module-b,.");
@@ -113,7 +115,7 @@ public class MavenITmng7390SelectModuleOutsideCwdTest extends AbstractMavenInteg
     public void testSelectModulesOutsideCwdDoesNotWorkWhenDotMvnIsNotPresent() throws Exception {
         final String noDotMvnPath = "/mng-7390-pl-outside-cwd-no-dotmvn/module-a";
         final File noDotMvnDir = extractResources(noDotMvnPath);
-        final Verifier verifier = newVerifier(noDotMvnDir.getAbsolutePath());
+        final Verifier verifier = newVerifier(noDotMvnDir.getAbsolutePath(), false);
 
         verifier.addCliArgument("-pl");
         verifier.addCliArgument("../module-b");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8744CIFriendlyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8744CIFriendlyTest.java
@@ -49,7 +49,7 @@ public class MavenITmng8744CIFriendlyTest extends AbstractMavenIntegrationTestCa
     public void testitShouldResolveTheInstalledDependencies() throws Exception {
         File testDir = extractResources("/mng-8744-ci-friendly");
 
-        Verifier verifier = newVerifier(testDir.getAbsolutePath(), false);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.addCliArgument("-Drevision=1.2");
@@ -59,13 +59,13 @@ public class MavenITmng8744CIFriendlyTest extends AbstractMavenIntegrationTestCa
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        verifier = newVerifier(testDir.getAbsolutePath(), false);
+        verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
         verifier.addCliArgument("clean");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        verifier = newVerifier(testDir.getAbsolutePath(), false);
+        verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
 
         verifier.addCliArgument("-Drevision=1.2");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -64,7 +64,7 @@ public class TestSuiteOrdering implements ClassOrderer {
             System.clearProperty("maven.conf");
             System.clearProperty("classworlds.conf");
 
-            Verifier verifier = new Verifier("");
+            Verifier verifier = new Verifier("", false);
             String mavenVersion = verifier.getMavenVersion();
             String executable = verifier.getExecutable();
             ExecutorHelper.Mode defaultMode = verifier.getDefaultMode();

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-settings/pom.xml
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-settings/pom.xml
@@ -52,6 +52,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
+      <version>${plexusUtilsVersion}</version>
     </dependency>
 
   </dependencies>

--- a/its/core-it-support/maven-it-helper/pom.xml
+++ b/its/core-it-support/maven-it-helper/pom.xml
@@ -46,6 +46,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
+      <version>${plexusUtilsVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/AbstractMavenIntegrationTestCase.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/AbstractMavenIntegrationTestCase.java
@@ -247,19 +247,19 @@ public abstract class AbstractMavenIntegrationTestCase {
     }
 
     protected Verifier newVerifier(String basedir) throws VerificationException {
-        return newVerifier(basedir, false);
+        return newVerifier(basedir, true);
     }
 
     protected Verifier newVerifier(String basedir, String settings) throws VerificationException {
-        return newVerifier(basedir, settings, false);
+        return newVerifier(basedir, settings, true);
     }
 
-    protected Verifier newVerifier(String basedir, boolean debug) throws VerificationException {
-        return newVerifier(basedir, "remote", debug);
+    protected Verifier newVerifier(String basedir, boolean createDotMvn) throws VerificationException {
+        return newVerifier(basedir, "remote", createDotMvn);
     }
 
-    protected Verifier newVerifier(String basedir, String settings, boolean debug) throws VerificationException {
-        Verifier verifier = new Verifier(basedir);
+    protected Verifier newVerifier(String basedir, String settings, boolean createDotMvn) throws VerificationException {
+        Verifier verifier = new Verifier(basedir, createDotMvn);
 
         // try to get jacoco arg from command line if any then use it to start IT to populate jacoco data
         // we use a different file than the main one

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -135,19 +135,31 @@ public class Verifier {
         this(basedir, null);
     }
 
+    public Verifier(String basedir, List<String> defaultCliArguments) throws VerificationException {
+        this(basedir, defaultCliArguments, true);
+    }
+
+    public Verifier(String basedir, boolean createDotMvn) throws VerificationException {
+        this(basedir, null, createDotMvn);
+    }
+
     /**
      * Creates verifier instance using passed in basedir as "cwd" and passed in default CLI arguments (if not null).
      * The discovery of user home and Maven installation directory is performed as well.
      *
      * @param basedir The basedir, cannot be {@code null}
      * @param defaultCliArguments The defaultCliArguments override, may be {@code null}
+     * @param createDotMvn If {@code true}, Verifier will create {@code .mvn} in passed basedir.
      *
      * @see #DEFAULT_CLI_ARGUMENTS
      */
-    public Verifier(String basedir, List<String> defaultCliArguments) throws VerificationException {
+    public Verifier(String basedir, List<String> defaultCliArguments, boolean createDotMvn) throws VerificationException {
         requireNonNull(basedir);
         try {
             this.basedir = Paths.get(basedir).toAbsolutePath();
+            if (createDotMvn) {
+                Files.createDirectories(this.basedir.resolve(".mvn"));
+            }
             this.tempBasedir = Files.createTempDirectory("verifier");
             this.userHomeDirectory = Paths.get(System.getProperty("maven.test.user.home", "user.home"));
             Files.createDirectories(this.userHomeDirectory);
@@ -230,6 +242,10 @@ public class Verifier {
             args.add(0, logFileName);
             args.add(0, "-l");
         }
+
+        // TODO: disable RRF for now until https://github.com/apache/maven-resolver/issues/1641 can be fixed
+        args.add("-Daether.remoteRepositoryFilter.groupId=false");
+        args.add("-Daether.remoteRepositoryFilter.prefixes=false");
 
         try {
             ExecutorRequest.Builder builder = executorHelper

--- a/its/core-it-support/maven-it-plugin-bootstrap/pom.xml
+++ b/its/core-it-support/maven-it-plugin-bootstrap/pom.xml
@@ -58,6 +58,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
+      <version>${plexusUtilsVersion}</version>
     </dependency>
   </dependencies>
 

--- a/its/core-it-support/pom.xml
+++ b/its/core-it-support/pom.xml
@@ -46,6 +46,14 @@ under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- WARNING: Do not manage plexus-utils at this level, as we have ITs adding custom versions of it to
+      plugin dependencies, and Maven 4 transitive depMgr would override that!
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>${plexusUtilsVersion}</version>
+      </dependency-->
+      <!-- Plugin tools -->
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -21,9 +21,10 @@ under the License.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.maven</groupId>
-    <artifactId>maven</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>35</version>
+    <relativePath />
   </parent>
 
   <groupId>org.apache.maven.its</groupId>
@@ -73,12 +74,34 @@ under the License.
     <!--    <maven.compiler.source>8</maven.compiler.source>-->
     <!--    <maven.compiler.target>8</maven.compiler.target>-->
 
-    <maven-version>4.0.0-SNAPSHOT</maven-version>
     <maven-plugin-tools-version>3.15.2</maven-plugin-tools-version>
+    <!-- Maven version being tested - must match the parent project version -->
+    <maven-version>4.0.0-SNAPSHOT</maven-version>
+    <!-- Support artifacts version - kept separate from Maven version -->
+    <core-it-support-version>2.1-SNAPSHOT</core-it-support-version>
+
+    <maven.compiler.release>17</maven.compiler.release>
+
+    <wagonVersion>3.5.3</wagonVersion>
+    <asmVersion>9.9</asmVersion>
+    <plexusUtilsVersion>4.0.2</plexusUtilsVersion>
+    <plexusXmlVersion>4.1.0</plexusXmlVersion>
+
+    <!-- Set as system property in surefire/failsafe to propagate to tests and IT Verifier -->
+    <toolboxVersion>0.14.1</toolboxVersion>
+    <jacocoArgLine />
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>6.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
@@ -241,6 +264,22 @@ under the License.
       </dependency>
 
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.17</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-xml</artifactId>
+        <version>${plexusXmlVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.maven.shared</groupId>
         <artifactId>maven-verifier</artifactId>
         <version>2.0.0-M1</version>
@@ -277,13 +316,26 @@ under the License.
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-component-metadata</artifactId>
+          <version>2.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>sisu-maven-plugin</artifactId>
+          <version>0.9.0.M4</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <environmentVariables>
-              <JENKINS_MAVEN_AGENT_DISABLED>true</JENKINS_MAVEN_AGENT_DISABLED>
-            </environmentVariables>
-          </configuration>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>extra-enforcer-rules</artifactId>
+              <version>1.10.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -301,7 +353,6 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-publish-plugin</artifactId>
-          <version>3.3.0</version>
           <configuration>
             <serverId>apache.releases.https</serverId>
           </configuration>
@@ -334,13 +385,30 @@ under the License.
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>${maven-plugin-tools-version}</version>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <systemPropertyVariables combine.children="append">
+              <version.toolbox>${toolboxVersion}</version.toolbox>
+            </systemPropertyVariables>
+          </configuration>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-metadata</artifactId>
-          <version>2.2.0</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <systemPropertyVariables combine.children="append">
+              <version.toolbox>${toolboxVersion}</version.toolbox>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>${maven-plugin-tools-version}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -693,7 +693,7 @@ under the License.
       <dependency>
         <groupId>eu.maveniverse.maven.mimir</groupId>
         <artifactId>testing</artifactId>
-        <version>0.10.3</version>
+        <version>0.10.4</version>
       </dependency>
     </dependencies>
     <!--bootstrap-start-comment-->


### PR DESCRIPTION
For this to work in Windows, we need latest 0.10.4 and also some changes/fixes in ITs.

Changes:
* update to Mimir 0.10.4 + enable cache purge
* dropped ctor `Verifier(String basedir, boolean debug)` as `debug` was unused, instead introduced `Verifier(String basedir, boolean createDotMvn)` that auto-creates `.mvn` folder in basedir for each ITs. If IT does not want this, it must use alt method and have a Javadoc telling why.
* detached `its` parent POM from Maven parent POM, as it interferes with IT support built plugins (we have ITs that uses plugin built in core-it-support but in POM adds an IT specific dependency that in turn pulls in stub plexus-utils dependency; by having depMgt in plugin POM, due Maven 4 transitive dep mgmt, the 4th level p-u was NOT used, but a managed one was used instead)
* disabled RRF in ITs due https://github.com/apache/maven-resolver/issues/1641 and parallel running of IT just exacerbates this issue

Note: due cache rename this commit when merged is at the mercy of Central (HTTP 500 and so on), so will probably need several runs to stabilize (populate caches).

Backport of 598857d9c607751e901f38539bacee56502fa32f
