### PR TITLE
Add command line information to Verifier log files for easier IT reproduction

### DIFF
--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -276,8 +276,7 @@ public class Verifier {
             String commandLineHeader = null;
             if (logFileName != null && !isQuietLogging(args)) {
                 try {
-                    String commandLine = formatCommandLine(request, mode);
-                    commandLineHeader = "# Command line used for this execution:\n" + commandLine + "\n\n";
+                    commandLineHeader = formatCommandLine(request, mode);
                 } catch (Exception e) {
                     // Don't fail the execution if we can't format the command line, just log it
                     System.err.println("Warning: Could not format command line: " + e.getMessage());
@@ -451,6 +450,7 @@ public class Verifier {
     private String formatCommandLine(ExecutorRequest request, ExecutorHelper.Mode mode) {
         StringBuilder cmdLine = new StringBuilder();
 
+        cmdLine.append("# Command line: ");
         // Add the Maven executable path
         Path mavenExecutable = request.installationDirectory()
                 .resolve("bin")
@@ -511,6 +511,7 @@ public class Verifier {
         cmdLine.append("\n# Working directory: ").append(request.cwd().toString());
         cmdLine.append("\n# Execution mode: ").append(mode.toString());
 
+        cmdLine.append("\n");
         return cmdLine.toString();
     }
 


### PR DESCRIPTION
## Summary

When running integration tests, the Verifier dumps output to a log file (usually log.txt). This change adds the full command line used for execution at the beginning of the log file to make it easy to reproduce the test outside the IT environment.

## Changes

- Added `formatCommandLine()` method to generate human-readable command line representation
- Modified `execute()` method to prepend command line information to log file after Maven execution
- Includes comprehensive execution context: executable path, arguments, environment variables, JVM properties, working directory, and execution mode

## Benefits

- **Easy Reproduction**: Developers can copy the exact command line from log files to reproduce IT tests manually
- **Complete Context**: All relevant execution context is captured for debugging
- **Non-Intrusive**: Doesn't interfere with Maven's normal execution or logging
- **Error Handling**: Failures in command line formatting don't break test execution

## Example Output

```
# Command line used for this execution:
/opt/maven/bin/mvn -l log.txt --errors --batch-mode validate -Dtest.property=value
# Environment variables:
# TEST_ENV=test_value
# MAVEN_OPTS=-Duser.home=/path/to/user.home -Dsystem.prop=value
# MAVEN_SKIP_RC=true
# Working directory: /path/to/test/project
# Execution mode: AUTO

[INFO] Scanning for projects...
...
```

## Testing

- Compiled successfully with existing Maven build
- Tested with simple and complex scenarios (custom arguments, system properties, environment variables)
- Verified command line appears at beginning of log file
- Confirmed no impact on normal Maven execution

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author