### PR TITLE
[maven-4.0.x] Disable consumer POM flattening by default and add an opt-in feature (#11347)

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -463,6 +463,18 @@ public final class Constants {
     public static final String MAVEN_CONSUMER_POM = "maven.consumer.pom";
 
     /**
+     * User property for controlling consumer POM flattening behavior.
+     * When set to <code>true</code> (default), consumer POMs are flattened by removing
+     * dependency management and keeping only direct dependencies with transitive scopes.
+     * When set to <code>false</code>, consumer POMs preserve dependency management
+     * like parent POMs, allowing dependency management to be inherited by consumers.
+     *
+     * @since 4.1.0
+     */
+    @Config(type = "java.lang.Boolean", defaultValue = "false")
+    public static final String MAVEN_CONSUMER_POM_FLATTEN = "maven.consumer.pom.flatten";
+
+    /**
      * User property for controlling "maven personality". If activated Maven will behave
      * as previous major version, Maven 3.
      *

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/feature/Features.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/feature/Features.java
@@ -48,6 +48,13 @@ public final class Features {
         return doGet(userProperties, Constants.MAVEN_CONSUMER_POM, !mavenMaven3Personality(userProperties));
     }
 
+    /**
+     * Check if consumer POM flattening is enabled.
+     */
+    public static boolean consumerPomFlatten(@Nullable Map<String, ?> userProperties) {
+        return doGet(userProperties, Constants.MAVEN_CONSUMER_POM_FLATTEN, false);
+    }
+
     private static boolean doGet(Properties userProperties, String key, boolean def) {
         return doGet(userProperties != null ? userProperties.get(key) : null, def);
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -33,6 +33,7 @@ import org.apache.maven.api.DependencyScope;
 import org.apache.maven.api.Node;
 import org.apache.maven.api.PathScope;
 import org.apache.maven.api.SessionData;
+import org.apache.maven.api.feature.Features;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DistributionManagement;
 import org.apache.maven.api.model.Model;
@@ -72,6 +73,15 @@ class DefaultConsumerPomBuilder implements PomBuilder {
     @Override
     public Model build(RepositorySystemSession session, MavenProject project, Path src) throws ModelBuilderException {
         Model model = project.getModel().getDelegate();
+        boolean flattenEnabled = Features.consumerPomFlatten(session.getConfigProperties());
+
+        // Check if consumer POM flattening is disabled
+        if (!flattenEnabled) {
+            // When flattening is disabled, treat non-POM projects like parent POMs
+            // Apply only basic transformations without flattening dependency management
+            return buildPom(session, project, src);
+        }
+        // Default behavior: flatten the consumer POM
         String packaging = model.getPackaging();
         String originalPackaging = project.getOriginalModel().getPackaging();
         if (POM_PACKAGING.equals(packaging)) {
@@ -255,6 +265,7 @@ class DefaultConsumerPomBuilder implements PomBuilder {
             warnNotDowngraded(project);
         }
         model = model.withModelVersion(modelVersion);
+
         return model;
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11084ReactorReaderPreferConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11084ReactorReaderPreferConsumerPomTest.java
@@ -36,7 +36,7 @@ class MavenITgh11084ReactorReaderPreferConsumerPomTest extends AbstractMavenInte
 
         // First build module a to populate project-local-repo with artifacts including consumer POM
         Verifier v1 = newVerifier(testDir.getAbsolutePath());
-        v1.addCliArguments("clean", "package", "-X");
+        v1.addCliArguments("clean", "package", "-X", "-Dmaven.consumer.pom.flatten=true");
         v1.setLogFileName("log-1.txt");
         v1.execute();
         v1.verifyErrorFreeLog();
@@ -44,7 +44,7 @@ class MavenITgh11084ReactorReaderPreferConsumerPomTest extends AbstractMavenInte
         // Now build only module b; ReactorReader should pick consumer POM from project-local-repo
         Verifier v2 = newVerifier(testDir.getAbsolutePath());
         v2.setLogFileName("log-2.txt");
-        v2.addCliArguments("clean", "compile", "-f", "b", "-X");
+        v2.addCliArguments("clean", "compile", "-f", "b", "-X", "-Dmaven.consumer.pom.flatten=true");
         v2.execute();
         v2.verifyErrorFreeLog();
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11162ConsumerPomScopesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11162ConsumerPomScopesTest.java
@@ -46,6 +46,7 @@ class MavenITgh11162ConsumerPomScopesTest extends AbstractMavenIntegrationTestCa
 
         Verifier verifier = newVerifier(basedir.toString());
         verifier.addCliArgument("install");
+        verifier.addCliArgument("-Dmaven.consumer.pom.flatten=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11346DependencyManagementOverrideTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11346DependencyManagementOverrideTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.api.Constants;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This is a test set for dependency management override scenarios when
+ * consumer POM flattening is disabled (maven.consumer.pom.flatten=false).
+ *
+ * Scenario:
+ * - A 1.0 depends on B 1.0 and manages C to 1.2
+ * - B 1.0 has no dependencies
+ * - B 2.0 depends on C 1.1
+ * - D depends on A 1.0 and manages B to 2.0
+ *
+ * Question: Does D depend on C, and which version?
+ *
+ * Expected behavior when flattening is disabled: D should get C 1.2 (from A's dependency management),
+ * not C 1.1 (from B 2.0's dependency), because A's dependency
+ * management applies to D's transitive dependencies.
+ *
+ * @see <a href="https://github.com/apache/maven/issues/11346">gh-11346</a>
+ */
+public class MavenITgh11346DependencyManagementOverrideTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh11346DependencyManagementOverrideTest() {
+        super("[4.0.0,)");
+    }
+
+    /**
+     * Verify that when consumer POM flattening is disabled, dependency management
+     * from intermediate dependencies applies to the consumer's transitive dependencies.
+     * This test uses -Dmaven.consumer.pom.flatten=false to enable dependency management
+     * inheritance from transitive dependencies.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void testDependencyManagementOverride() throws Exception {
+        File testDir = extractResources("/gh-11346-dependency-management-override");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.deleteArtifacts("org.apache.maven.its.mng.depman");
+        // Test with dependency manager transitivity disabled instead of consumer POM flattening
+        verifier.addCliArgument("-D" + Constants.MAVEN_CONSUMER_POM_FLATTEN + "=false");
+        verifier.addCliArgument("verify");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Check module D's classpath
+        List<String> dClasspath = verifier.loadLines("module-d/target/classpath.txt");
+
+        // D should have A 1.0
+        assertTrue(dClasspath.contains("module-a-1.0.jar"), "D should depend on A 1.0: " + dClasspath);
+
+        // D should have B 2.0 (managed by D)
+        assertTrue(dClasspath.contains("module-b-2.0.jar"), "D should depend on B 2.0 (managed by D): " + dClasspath);
+        assertFalse(dClasspath.contains("module-b-1.0.jar"), "D should not depend on B 1.0: " + dClasspath);
+
+        // D should have C 1.2 (from A's dependency management)
+        // A's dependency management of C to 1.2 should apply to D
+        assertTrue(
+                dClasspath.contains("module-c-1.2.jar"),
+                "D should depend on C 1.2 (A's dependency management should apply): " + dClasspath);
+        assertFalse(
+                dClasspath.contains("module-c-1.1.jar"),
+                "D should not depend on C 1.1 (should be managed to 1.2): " + dClasspath);
+    }
+
+    @Test
+    public void testDependencyManagementOverrideNoTransitive() throws Exception {
+        File testDir = extractResources("/gh-11346-dependency-management-override");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.deleteArtifacts("org.apache.maven.its.mng.depman");
+        // Test with dependency manager transitivity disabled instead of consumer POM flattening
+        verifier.addCliArgument("-D" + Constants.MAVEN_CONSUMER_POM_FLATTEN + "=false");
+        verifier.addCliArgument("-D" + Constants.MAVEN_RESOLVER_DEPENDENCY_MANAGER_TRANSITIVITY + "=false");
+        verifier.addCliArgument("verify");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Check module D's classpath
+        List<String> dClasspath = verifier.loadLines("module-d/target/classpath.txt");
+
+        // D should have A 1.0
+        assertTrue(dClasspath.contains("module-a-1.0.jar"), "D should depend on A 1.0: " + dClasspath);
+
+        // D should have B 2.0 (managed by D)
+        assertTrue(dClasspath.contains("module-b-2.0.jar"), "D should depend on B 2.0 (managed by D): " + dClasspath);
+        assertFalse(dClasspath.contains("module-b-1.0.jar"), "D should not depend on B 1.0: " + dClasspath);
+
+        // D should have C 1.1 as the resolver is not transitive
+        assertFalse(
+                dClasspath.contains("module-c-1.2.jar"),
+                "D should depend on C 1.2 (A's dependency management should apply): " + dClasspath);
+        assertTrue(
+                dClasspath.contains("module-c-1.1.jar"),
+                "D should not depend on C 1.1 (should be managed to 1.2): " + dClasspath);
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -68,7 +68,7 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
         verifier.setAutoclean(false);
         verifier.addCliArgument("-Dchangelist=MNG6656");
 
-        verifier.addCliArgument("install");
+        verifier.addCliArguments("install", "-Dmaven.consumer.pom.flatten=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -66,7 +66,7 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
 
         Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
-        verifier.addCliArgument("-Dchangelist=MNG6957");
+        verifier.addCliArguments("-Dchangelist=MNG6957", "-Dmaven.consumer.pom.flatten=true");
 
         verifier.addCliArgument("install");
         verifier.execute();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8414ConsumerPomWithNewFeaturesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8414ConsumerPomWithNewFeaturesTest.java
@@ -48,7 +48,7 @@ class MavenITmng8414ConsumerPomWithNewFeaturesTest extends AbstractMavenIntegrat
                 extractResources("/mng-8414-consumer-pom-with-new-features").toPath();
 
         Verifier verifier = newVerifier(basedir.toString(), null);
-        verifier.addCliArguments("package");
+        verifier.addCliArguments("package", "-Dmaven.consumer.pom.flatten=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
@@ -80,7 +80,7 @@ class MavenITmng8414ConsumerPomWithNewFeaturesTest extends AbstractMavenIntegrat
 
         Verifier verifier = newVerifier(basedir.toString(), null);
         verifier.setLogFileName("log-preserving.txt");
-        verifier.addCliArguments("-f", "pom-preserving.xml", "package");
+        verifier.addCliArguments("-f", "pom-preserving.xml", "package", "-Dmaven.consumer.pom.flatten=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8523ModelPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8523ModelPropertiesTest.java
@@ -46,7 +46,7 @@ class MavenITmng8523ModelPropertiesTest extends AbstractMavenIntegrationTestCase
                 extractResources("/mng-8523-model-properties").getAbsoluteFile().toPath();
 
         Verifier verifier = newVerifier(basedir.toString());
-        verifier.addCliArguments("install", "-DmavenVersion=4.0.0-rc-2");
+        verifier.addCliArguments("install", "-DmavenVersion=4.0.0-rc-2", "-Dmaven.consumer.pom.flatten=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8527ConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8527ConsumerPomTest.java
@@ -47,7 +47,7 @@ class MavenITmng8527ConsumerPomTest extends AbstractMavenIntegrationTestCase {
                 extractResources("/mng-8527-consumer-pom").getAbsoluteFile().toPath();
 
         Verifier verifier = newVerifier(basedir.toString());
-        verifier.addCliArgument("install");
+        verifier.addCliArguments("install", "-Dmaven.consumer.pom.flatten=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -103,6 +103,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITgh11346DependencyManagementOverrideTest.class);
         suite.addTestSuite(MavenITgh11314PluginInjectionTest.class);
         suite.addTestSuite(MavenITgh2576ItrNotHonoredTest.class);
         suite.addTestSuite(MavenITgh11356InvalidTransitiveRepositoryTest.class);

--- a/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-a/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-a/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng.depman</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-a</artifactId>
+  <version>1.0</version>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- A manages C to version 1.2 -->
+      <dependency>
+        <groupId>org.apache.maven.its.mng.depman</groupId>
+        <artifactId>module-c</artifactId>
+        <version>1.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- A depends on B 1.0 -->
+    <dependency>
+      <groupId>org.apache.maven.its.mng.depman</groupId>
+      <artifactId>module-b</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-b-v1/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-b-v1/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng.depman</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-b</artifactId>
+  <version>1.0</version>
+
+  <!-- B 1.0 has no dependencies -->
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-b-v2/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-b-v2/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng.depman</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-b</artifactId>
+  <version>2.0</version>
+
+  <dependencies>
+    <!-- B 2.0 depends on C 1.1 -->
+    <dependency>
+      <groupId>org.apache.maven.its.mng.depman</groupId>
+      <artifactId>module-c</artifactId>
+      <version>1.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-c-v11/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-c-v11/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng.depman</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-c</artifactId>
+  <version>1.1</version>
+
+  <!-- C has no dependencies -->
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-c-v12/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-c-v12/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng.depman</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-c</artifactId>
+  <version>1.2</version>
+
+  <!-- C has no dependencies -->
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-d/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/module-d/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng.depman</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-d</artifactId>
+  <version>1.0</version>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- D manages B to version 2.0 -->
+      <dependency>
+        <groupId>org.apache.maven.its.mng.depman</groupId>
+        <artifactId>module-b</artifactId>
+        <version>2.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- D depends on A 1.0 -->
+    <dependency>
+      <groupId>org.apache.maven.its.mng.depman</groupId>
+      <artifactId>module-a</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11346-dependency-management-override/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.mng.depman</groupId>
+  <artifactId>test</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: Dependency Management Override</name>
+  <description>Verify that dependency management in a consumer project can override
+    transitive dependency versions when the dependency is managed at a higher level.</description>
+
+  <modules>
+    <module>module-a</module>
+    <module>module-b-v1</module>
+    <module>module-b-v2</module>
+    <module>module-c-v11</module>
+    <module>module-c-v12</module>
+    <module>module-d</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-dependency-resolution</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <configuration>
+          <compileClassPath>target/classpath.txt</compileClassPath>
+          <significantPathLevels>1</significantPathLevels>
+        </configuration>
+        <executions>
+          <execution>
+            <id>resolve</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Disable consumer POM flattening by default and add an opt-in feature (#11347)](https://github.com/apache/maven/pull/11347)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)