### PR TITLE
[maven-4.0.x] Maven 4.0.x proper isolation

### DIFF
--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
@@ -56,7 +56,7 @@ public abstract class MavenExecutorTestSupport {
     @BeforeEach
     void beforeEach(TestInfo testInfo) throws Exception {
         cwd = tempDir.resolve(testInfo.getTestMethod().orElseThrow().getName()).resolve("cwd");
-        Files.createDirectories(cwd);
+        Files.createDirectories(cwd.resolve(".mvn"));
         userHome = tempDir.resolve(testInfo.getTestMethod().orElseThrow().getName())
                 .resolve("home");
         Files.createDirectories(userHome);
@@ -380,7 +380,6 @@ public abstract class MavenExecutorTestSupport {
     }
 
     protected void layDownFiles(Path cwd) throws IOException {
-        Files.createDirectory(cwd.resolve(".mvn"));
         Path pom = cwd.resolve("pom.xml").toAbsolutePath();
         Files.writeString(pom, POM_STRING);
         Path appJava = cwd.resolve("src/main/java/org/apache/maven/samples/sample/App.java");

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -60,7 +60,7 @@ public class ToolboxToolTest {
         String testName = testInfo.getTestMethod().orElseThrow().getName();
         userHome = tempDir.resolve(testName);
         cwd = userHome.resolve("cwd");
-        Files.createDirectories(cwd);
+        Files.createDirectories(cwd.resolve(".mvn"));
 
         if (MimirInfuser.isMimirPresentUW()) {
             if (testName.contains("3")) {


### PR DESCRIPTION
They lacked in some cases the `.mvn` directory, and it caused Maven to "bubble up" all way to Maven Project own `.mvn`.

Now the UT properly confine the test within CWD by creating `.mvn` in it.

Backport of 23d38a2d9088e0fb331c9071e55456d6e9e5b0b1