### PR TITLE
Add @Aggregate annotation for Maven DI collection contributions

### DIFF
--- a/api/maven-api-di/src/main/java/org/apache/maven/api/di/Aggregate.java
+++ b/api/maven-api-di/src/main/java/org/apache/maven/api/di/Aggregate.java
@@ -170,7 +170,7 @@ import java.lang.annotation.Target;
  * Map<String, LifecycleProvider> allLifecycles; // Contains contributions from all modules
  * }</pre>
  *
- * @since 4.0.0
+ * @since 4.1.0
  * @see Provides
  * @see Named
  * @see Inject

--- a/api/maven-api-di/src/main/java/org/apache/maven/api/di/Aggregate.java
+++ b/api/maven-api-di/src/main/java/org/apache/maven/api/di/Aggregate.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api.di;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a {@link Provides} method contributes to an aggregated collection
+ * rather than replacing it.
+ *
+ * <p>Maven DI automatically aggregates beans into collections when injecting {@code List<T>}
+ * or {@code Map<String, T>}. By default, if an explicit {@code @Provides} method returns
+ * a collection of the same type, it <strong>replaces</strong> the auto-aggregation.
+ * The {@code @Aggregate} annotation changes this behavior to <strong>contribute</strong>
+ * entries to the aggregated collection instead.</p>
+ *
+ * <h2>Collection Aggregation Rules</h2>
+ *
+ * <h3>Without explicit {@code @Provides}:</h3>
+ * <ul>
+ *   <li>{@code List<T>} - automatically aggregates all beans of type {@code T}</li>
+ *   <li>{@code Map<String, T>} - automatically aggregates all {@code @Named} beans of type {@code T},
+ *       using their name as the key</li>
+ * </ul>
+ *
+ * <h3>With {@code @Provides} (no {@code @Aggregate}):</h3>
+ * <ul>
+ *   <li>The explicit provider <strong>replaces</strong> auto-aggregation</li>
+ *   <li>Only the provided collection is available for injection</li>
+ * </ul>
+ *
+ * <h3>With {@code @Provides @Aggregate}:</h3>
+ * <ul>
+ *   <li>The provider <strong>contributes to</strong> auto-aggregation</li>
+ *   <li>Multiple {@code @Aggregate} providers can coexist and all contribute</li>
+ *   <li>If both {@code @Aggregate} and non-{@code @Aggregate} providers exist,
+ *       the non-{@code @Aggregate} provider takes precedence</li>
+ * </ul>
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <h3>Contributing to a Map</h3>
+ * <pre>{@code
+ * @Provides
+ * @Aggregate
+ * Map<String, PluginService> corePlugins() {
+ *     Map<String, PluginService> plugins = new HashMap<>();
+ *     plugins.put("compile", new CompilePlugin());
+ *     plugins.put("test", new TestPlugin());
+ *     return plugins;
+ * }
+ *
+ * @Provides
+ * @Aggregate
+ * Map<String, PluginService> extraPlugins() {
+ *     Map<String, PluginService> plugins = new HashMap<>();
+ *     plugins.put("deploy", new DeployPlugin());
+ *     return plugins;
+ * }
+ *
+ * // Injection point receives all entries
+ * @Inject
+ * Map<String, PluginService> allPlugins; // Contains: compile, test, deploy
+ * }</pre>
+ *
+ * <h3>Contributing to a List</h3>
+ * <pre>{@code
+ * @Provides
+ * @Aggregate
+ * List<Validator> customValidators() {
+ *     return Arrays.asList(
+ *         new PomValidator(),
+ *         new DependencyValidator()
+ *     );
+ * }
+ *
+ * @Inject
+ * List<Validator> allValidators; // Contains all @Named Validator beans + custom ones
+ * }</pre>
+ *
+ * <h3>Contributing Single Beans</h3>
+ * <pre>{@code
+ * // Single bean contributions are implicitly aggregated (no @Aggregate needed)
+ * @Provides
+ * @Named("foo")
+ * MyService foo() {
+ *     return new FooService();
+ * }
+ *
+ * @Provides
+ * @Named("bar")
+ * MyService bar() {
+ *     return new BarService();
+ * }
+ *
+ * @Inject
+ * Map<String, MyService> services; // Contains: foo, bar
+ * }</pre>
+ *
+ * <h3>Replacing Auto-Aggregation</h3>
+ * <pre>{@code
+ * @Named("service1")
+ * class Service1 implements MyService {}
+ *
+ * @Named("service2")
+ * class Service2 implements MyService {}
+ *
+ * // Without @Aggregate, this REPLACES the auto-aggregated map
+ * @Provides
+ * Map<String, MyService> customMap() {
+ *     return Map.of("only", new OnlyService());
+ * }
+ *
+ * @Inject
+ * Map<String, MyService> services; // Contains only: "only" -> OnlyService
+ * }</pre>
+ *
+ * <h2>Priority and Ordering</h2>
+ * <p>When contributing to {@code List<T>}, entries follow priority ordering rules:</p>
+ * <ul>
+ *   <li>Beans with {@link Priority} annotation are ordered by priority (highest first)</li>
+ *   <li>Beans without priority come after prioritized beans</li>
+ *   <li>Collections contributed via {@code @Aggregate} are merged respecting these rules</li>
+ * </ul>
+ *
+ * <h2>Duplicate Keys</h2>
+ * <p>When multiple {@code @Aggregate} providers contribute the same key to a {@code Map<String, T>},
+ * the behavior is last-write-wins (though this may result in a warning or error in future versions).</p>
+ *
+ * <h2>Plugin Architecture Pattern</h2>
+ * <p>This annotation is particularly useful for Maven's plugin architecture, where different
+ * modules need to register their services without depending on a central registry:</p>
+ * <pre>{@code
+ * // In plugin module A
+ * @Provides
+ * @Aggregate
+ * Map<String, LifecycleProvider> lifecycleProviders() {
+ *     return Map.of("clean", new CleanLifecycle());
+ * }
+ *
+ * // In plugin module B
+ * @Provides
+ * @Aggregate
+ * Map<String, LifecycleProvider> moreLifecycleProviders() {
+ *     return Map.of("deploy", new DeployLifecycle());
+ * }
+ *
+ * // In core
+ * @Inject
+ * Map<String, LifecycleProvider> allLifecycles; // Contains contributions from all modules
+ * }</pre>
+ *
+ * @since 4.0.0
+ * @see Provides
+ * @see Named
+ * @see Inject
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Aggregate {}

--- a/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
+++ b/impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.AbstractList;
@@ -35,6 +36,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +49,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.di.Aggregate;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Qualifier;
 import org.apache.maven.api.di.Singleton;
@@ -184,7 +187,7 @@ public class InjectorImpl implements Injector {
     }
 
     protected <U> Injector bind(Key<U> key, Binding<U> b) {
-        Set<Binding<?>> bindingSet = bindings.computeIfAbsent(key, $ -> new HashSet<>());
+        Set<Binding<?>> bindingSet = bindings.computeIfAbsent(key, $ -> new LinkedHashSet<>());
         bindingSet.add(b);
         return this;
     }
@@ -222,43 +225,28 @@ public class InjectorImpl implements Injector {
     public <Q> Supplier<Q> doGetCompiledBinding(Dependency<Q> dep) {
         Key<Q> key = dep.key();
         Set<Binding<Q>> res = getBindings(key);
+
         if (res != null && !res.isEmpty()) {
+            // Check if this is a List/Map and all bindings are @Aggregate
+            // If so, use aggregation logic instead of explicit binding
+            if (key.getRawType() == List.class && areAllAggregateListProviders(res)) {
+                return handleListAggregation(key);
+            }
+            if (key.getRawType() == Map.class && areAllAggregateMapProviders(res)) {
+                return handleMapAggregation(key);
+            }
+
+            // Use explicit binding (highest priority wins)
             List<Binding<Q>> bindingList = new ArrayList<>(res);
             bindingList.sort(getPriorityComparator());
             Binding<Q> binding = bindingList.get(0);
             return compile(binding);
         }
         if (key.getRawType() == List.class) {
-            Set<Binding<Object>> res2 = getBindings(key.getTypeParameter(0));
-            if (res2 != null) {
-                // Sort bindings by priority (highest first) for deterministic ordering
-                List<Binding<Object>> sortedBindings = new ArrayList<>(res2);
-                sortedBindings.sort(getPriorityComparator());
-
-                List<Supplier<Object>> list =
-                        sortedBindings.stream().map(this::compile).collect(Collectors.toList());
-                //noinspection unchecked
-                return () -> (Q) list(list, Supplier::get);
-            }
+            return handleListAggregation(key);
         }
         if (key.getRawType() == Map.class) {
-            Key<?> k = key.getTypeParameter(0);
-            Key<Object> v = key.getTypeParameter(1);
-            Set<Binding<Object>> res2 = getBindings(v);
-            if (k.getRawType() == String.class && res2 != null) {
-                Map<String, Supplier<Object>> map = res2.stream()
-                        .filter(b -> b.getOriginalKey() == null
-                                || b.getOriginalKey().getQualifier() == null
-                                || b.getOriginalKey().getQualifier() instanceof String)
-                        .collect(Collectors.toMap(
-                                b -> (String)
-                                        (b.getOriginalKey() != null
-                                                ? b.getOriginalKey().getQualifier()
-                                                : null),
-                                this::compile));
-                //noinspection unchecked
-                return () -> (Q) map(map, Supplier::get);
-            }
+            return handleMapAggregation(key);
         }
         if (dep.optional()) {
             return () -> null;
@@ -271,6 +259,332 @@ public class InjectorImpl implements Injector {
                         .sorted()
                         .distinct()
                         .collect(Collectors.joining("\n - ", " - ", "")));
+    }
+
+    /**
+     * Handle aggregation for List<T> injection.
+     * Rules:
+     * 1. If there's an explicit (non-@Aggregate) provider for List<T>, use only that
+     * 2. Otherwise, aggregate all beans of type T (including @Aggregate contributions)
+     * 3. Sort by priority (highest first)
+     */
+    @SuppressWarnings("unchecked")
+    private <Q> Supplier<Q> handleListAggregation(Key<Q> key) {
+        Key<Object> elementKey = key.getTypeParameter(0);
+        Set<Binding<Object>> elementBindings = getBindings(elementKey);
+        Set<Binding<Q>> listBindings = getBindings(key);
+
+        if ((elementBindings == null || elementBindings.isEmpty())
+                && (listBindings == null || listBindings.isEmpty())) {
+            // No elements found, return empty list
+            return () -> (Q) new ArrayList<>();
+        }
+
+        if (elementBindings == null) {
+            elementBindings = new HashSet<>();
+        }
+
+        // Check if there's an explicit (non-@Aggregate) List<T> provider in both element and list bindings
+        Binding<Object> explicitListProvider = findExplicitListProvider(elementBindings);
+        if (explicitListProvider == null && listBindings != null) {
+            explicitListProvider = (Binding<Object>) listBindings.stream()
+                    .filter(binding -> isListProvider(binding) && !isAggregate(binding))
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (explicitListProvider != null) {
+            // Use explicit provider, ignore aggregation
+            Supplier<Object> compiled = compile(explicitListProvider);
+            return () -> (Q) compiled.get();
+        }
+
+        // Aggregate all beans including @Aggregate contributions
+        List<Binding<Object>> allBindings = new ArrayList<>();
+
+        // Process element bindings (individual beans)
+        for (Binding<Object> binding : elementBindings) {
+
+            if (isAggregateListProvider(binding)) {
+                // This is an @Aggregate List<T> provider, expand its elements
+                allBindings.addAll(expandAggregateList(binding));
+            } else if (!isListProvider(binding)) {
+                // Regular bean (not a List provider), add it directly
+                allBindings.add(binding);
+            }
+        }
+
+        // Process list bindings (@Aggregate List providers)
+        if (listBindings != null) {
+            for (Binding<Q> binding : listBindings) {
+                Binding<Object> objBinding = (Binding<Object>) binding;
+
+                if (isAggregateListProvider(objBinding)) {
+                    // This is an @Aggregate List<T> provider, expand its elements
+                    allBindings.addAll(expandAggregateList(objBinding));
+                }
+            }
+        }
+
+        // Sort by priority (highest first)
+        allBindings.sort(getPriorityComparator());
+
+        List<Supplier<Object>> suppliers =
+                allBindings.stream().map(this::compile).collect(Collectors.toList());
+
+        return () -> (Q) list(suppliers, Supplier::get);
+    }
+
+    /**
+     * Handle aggregation for Map<String, T> injection.
+     * Rules:
+     * 1. If there's an explicit (non-@Aggregate) provider for Map<String, T>, use only that
+     * 2. Otherwise, aggregate all @Named beans of type T (including @Aggregate contributions)
+     * 3. Use @Named qualifier value as the key
+     */
+    @SuppressWarnings("unchecked")
+    private <Q> Supplier<Q> handleMapAggregation(Key<Q> key) {
+        Key<?> keyType = key.getTypeParameter(0);
+        Key<Object> valueType = key.getTypeParameter(1);
+        Set<Binding<Object>> valueBindings = getBindings(valueType);
+        Set<Binding<Q>> mapBindings = getBindings(key);
+
+        if (keyType.getRawType() != String.class) {
+            // Only support Map<String, T>
+            return null;
+        }
+
+        if ((valueBindings == null || valueBindings.isEmpty()) && (mapBindings == null || mapBindings.isEmpty())) {
+            // No elements found, return empty map
+            return () -> (Q) new LinkedHashMap<>();
+        }
+
+        // Ensure valueBindings is not null for the loop below
+        if (valueBindings == null) {
+            valueBindings = new HashSet<>();
+        }
+
+        // Check if there's an explicit (non-@Aggregate) Map<String, T> provider
+        // Look in both value bindings and map bindings
+        Binding<Object> explicitMapProvider = findExplicitMapProvider(valueBindings);
+        if (explicitMapProvider == null && mapBindings != null) {
+            explicitMapProvider = (Binding<Object>) mapBindings.stream()
+                    .filter(binding -> isMapProvider(binding) && !isAggregate(binding))
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (explicitMapProvider != null) {
+            // Use explicit provider, ignore aggregation
+            Supplier<Object> compiled = compile(explicitMapProvider);
+            return () -> (Q) compiled.get();
+        }
+
+        // Aggregate all @Named beans including @Aggregate contributions
+        Map<String, Binding<Object>> aggregatedBindings = new LinkedHashMap<>();
+
+        // Process value bindings (individual @Named beans)
+        for (Binding<Object> binding : valueBindings) {
+            if (isAggregateMapProvider(binding)) {
+                // This is an @Aggregate Map<String, T> provider, expand its entries
+                Map<String, Binding<Object>> expanded = expandAggregateMap(binding);
+                aggregatedBindings.putAll(expanded);
+            } else if (!isMapProvider(binding)) {
+                // Regular bean with @Named qualifier
+                String name = extractNamedQualifier(binding);
+                if (name != null) {
+                    aggregatedBindings.put(name, binding);
+                }
+            }
+        }
+
+        // Process map bindings (@Aggregate Map providers)
+        if (mapBindings != null) {
+            for (Binding<Q> binding : mapBindings) {
+                Binding<Object> objBinding = (Binding<Object>) binding;
+                if (isAggregateMapProvider(objBinding)) {
+                    // This is an @Aggregate Map<String, T> provider, expand its entries
+                    Map<String, Binding<Object>> expanded = expandAggregateMap(objBinding);
+                    aggregatedBindings.putAll(expanded);
+                }
+            }
+        }
+
+        Map<String, Supplier<Object>> supplierMap = aggregatedBindings.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> compile(e.getValue()),
+                        (a, b) -> b, // Last write wins on duplicate keys
+                        LinkedHashMap::new));
+
+        return () -> (Q) map(supplierMap, Supplier::get);
+    }
+
+    /**
+     * Find an explicit (non-@Aggregate) List<T> provider
+     */
+    private Binding<Object> findExplicitListProvider(Set<Binding<Object>> bindings) {
+        for (Binding<Object> binding : bindings) {
+            if (isListProvider(binding) && !isAggregate(binding)) {
+                return binding;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find an explicit (non-@Aggregate) Map<String, T> provider
+     */
+    private Binding<Object> findExplicitMapProvider(Set<Binding<Object>> bindings) {
+        for (Binding<Object> binding : bindings) {
+            if (isMapProvider(binding) && !isAggregate(binding)) {
+                return binding;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Check if a binding is for a List type
+     */
+    private boolean isListProvider(Binding<?> binding) {
+        Key<?> originalKey = binding.getOriginalKey();
+        if (originalKey == null) {
+            return false;
+        }
+        Type type = originalKey.getType();
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType) type;
+            return pt.getRawType() == List.class;
+        }
+        return false;
+    }
+
+    /**
+     * Check if a binding is for a Map type
+     */
+    private boolean isMapProvider(Binding<?> binding) {
+        Key<?> originalKey = binding.getOriginalKey();
+        if (originalKey == null) {
+            return false;
+        }
+        Type type = originalKey.getType();
+        return isMapType(type);
+    }
+
+    /**
+     * Check if a Type is a Map type
+     */
+    private boolean isMapType(Type type) {
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType) type;
+            return pt.getRawType() == Map.class;
+        }
+        return false;
+    }
+
+    /**
+     * Check if a Type is a List type
+     */
+    private boolean isListType(Type type) {
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType) type;
+            return pt.getRawType() == List.class;
+        }
+        return false;
+    }
+
+    /**
+     * Check if a binding has @Aggregate annotation
+     */
+    private boolean isAggregate(Binding<?> binding) {
+        // Check if the binding's source method has @Aggregate
+        if (binding instanceof Binding.BindingToMethod) {
+            Method method = ((Binding.BindingToMethod<?>) binding).getMethod();
+            return method.isAnnotationPresent(Aggregate.class);
+        }
+        return false;
+    }
+
+    /**
+     * Check if all bindings are @Aggregate List providers
+     */
+    private <Q> boolean areAllAggregateListProviders(Set<Binding<Q>> bindings) {
+        return bindings.stream().allMatch(binding -> isAggregateListProvider((Binding<Object>) binding));
+    }
+
+    /**
+     * Check if all bindings are @Aggregate Map providers
+     */
+    private <Q> boolean areAllAggregateMapProviders(Set<Binding<Q>> bindings) {
+        return bindings.stream().allMatch(binding -> isAggregateMapProvider((Binding<Object>) binding));
+    }
+
+    /**
+     * Check if this is an @Aggregate List<T> provider
+     */
+    private boolean isAggregateListProvider(Binding<?> binding) {
+        return isListProvider(binding) && isAggregate(binding);
+    }
+
+    /**
+     * Check if this is an @Aggregate Map<String, T> provider
+     */
+    private boolean isAggregateMapProvider(Binding<?> binding) {
+        return isMapProvider(binding) && isAggregate(binding);
+    }
+
+    /**
+     * Expand an @Aggregate List<T> provider into individual bindings
+     */
+    @SuppressWarnings("unchecked")
+    private List<Binding<Object>> expandAggregateList(Binding<Object> listBinding) {
+        List<Binding<Object>> result = new ArrayList<>();
+        Supplier<Object> compiled = compile(listBinding);
+        List<Object> elements = (List<Object>) compiled.get();
+
+        if (elements != null) {
+            for (Object element : elements) {
+                // Create instance binding for each element, inheriting priority from the original binding
+                Binding<Object> elementBinding = (Binding<Object>) Binding.toInstance(element);
+                elementBinding = elementBinding.prioritize(listBinding.getPriority());
+                result.add(elementBinding);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Expand an @Aggregate Map<String, T> provider into individual bindings
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Binding<Object>> expandAggregateMap(Binding<Object> mapBinding) {
+        Map<String, Binding<Object>> result = new LinkedHashMap<>();
+        Supplier<Object> compiled = compile(mapBinding);
+        Map<String, Object> entries = (Map<String, Object>) compiled.get();
+
+        if (entries != null) {
+            for (Map.Entry<String, Object> entry : entries.entrySet()) {
+                // Create instance binding for each entry
+                result.put(entry.getKey(), (Binding<Object>) Binding.toInstance(entry.getValue()));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Extract @Named qualifier value from a binding
+     */
+    private String extractNamedQualifier(Binding<?> binding) {
+        Key<?> originalKey = binding.getOriginalKey();
+        if (originalKey == null) {
+            return null;
+        }
+        Object qualifier = originalKey.getQualifier();
+        if (qualifier instanceof String str && !str.isEmpty()) {
+            return str;
+        }
+        return null;
     }
 
     @SuppressWarnings("unchecked")
@@ -323,6 +637,7 @@ public class InjectorImpl implements Injector {
                 Type returnType = method.getGenericReturnType();
                 Set<Class<?>> types = getBoundTypes(method.getAnnotation(Typed.class), Types.getRawType(returnType));
                 Binding<Object> bind = ReflectionUtils.bindingFromMethod(method).scope(scope);
+
                 for (Type t : Types.getAllSuperTypes(returnType)) {
                     if (types == null || types.contains(Types.getRawType(t))) {
                         bind(Key.ofType(t, qualifier), bind);
@@ -331,7 +646,111 @@ public class InjectorImpl implements Injector {
                         }
                     }
                 }
+
+                // Special handling for @Aggregate providers
+                if (method.isAnnotationPresent(Aggregate.class)) {
+                    if (isMapType(returnType)) {
+                        // Register individual named bindings for each map entry
+                        registerAggregateMapEntries(method, bind);
+                    } else if (isListType(returnType)) {
+                        // Register individual bindings for each list element
+                        registerAggregateListEntries(method, bind);
+                    }
+                }
             }
+        }
+    }
+
+    /**
+     * Register individual named bindings for entries in an @Aggregate Map<String, T> provider
+     */
+    @SuppressWarnings("unchecked")
+    private void registerAggregateMapEntries(Method method, Binding<Object> mapBinding) {
+        try {
+            // Get the value type from Map<String, T>
+            Type returnType = method.getGenericReturnType();
+            if (!(returnType instanceof ParameterizedType)) {
+                return;
+            }
+            ParameterizedType pt = (ParameterizedType) returnType;
+            Type[] typeArgs = pt.getActualTypeArguments();
+            if (typeArgs.length != 2 || typeArgs[0] != String.class) {
+                return; // Only support Map<String, T>
+            }
+            Type valueType = typeArgs[1];
+
+            // Execute the map provider to get the actual map
+            Supplier<Object> compiled = compile(mapBinding);
+            Map<String, Object> map = (Map<String, Object>) compiled.get();
+
+            if (map != null) {
+                // Register each map entry as a named binding
+                for (Map.Entry<String, Object> entry : map.entrySet()) {
+                    String name = entry.getKey();
+                    Object value = entry.getValue();
+
+                    if (name != null && !name.isEmpty() && value != null) {
+                        // Create a binding for this individual service
+                        Binding<Object> valueBinding = (Binding<Object>) Binding.toInstance(value);
+
+                        // Bind it with the @Named qualifier
+                        Key<Object> namedKey = (Key<Object>) Key.ofType(valueType, name);
+                        bind(namedKey, valueBinding);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // If we can't execute the provider at binding time, that's okay
+            // The individual services will be resolved through map aggregation at runtime
+        }
+    }
+
+    /**
+     * Register individual bindings for elements in an @Aggregate List<T> provider
+     * Only registers individual bindings if there are no existing individual bindings for that type
+     */
+    @SuppressWarnings("unchecked")
+    private void registerAggregateListEntries(Method method, Binding<Object> listBinding) {
+        try {
+            // Get the element type from List<T>
+            Type returnType = method.getGenericReturnType();
+            if (!(returnType instanceof ParameterizedType)) {
+                return;
+            }
+            ParameterizedType pt = (ParameterizedType) returnType;
+            Type[] typeArgs = pt.getActualTypeArguments();
+            if (typeArgs.length != 1) {
+                return; // Only support List<T>
+            }
+            Type elementType = typeArgs[0];
+            Key<Object> elementKey = (Key<Object>) Key.ofType(elementType);
+
+            // Only register individual bindings if there are no existing individual bindings for this type
+            Set<Binding<Object>> existingBindings = getBindings(elementKey);
+            if (existingBindings != null && !existingBindings.isEmpty()) {
+                // There are already individual bindings for this type, don't add more
+                return;
+            }
+
+            // Execute the list provider to get the actual list
+            Supplier<Object> compiled = compile(listBinding);
+            List<Object> list = (List<Object>) compiled.get();
+
+            if (list != null) {
+                // Register each list element as an individual binding
+                for (Object element : list) {
+                    if (element != null) {
+                        // Create a binding for this individual service
+                        Binding<Object> elementBinding = (Binding<Object>) Binding.toInstance(element);
+
+                        // Bind it without any qualifier (so it can be injected as @Inject T)
+                        bind(elementKey, elementBinding);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // If we can't execute the provider at binding time, that's okay
+            // The individual services will be resolved through list aggregation at runtime
         }
     }
 
@@ -469,7 +888,7 @@ public class InjectorImpl implements Injector {
     }
 
     /**
-     * Release all internal state so this Injector can be GC’d
+     * Release all internal state so this Injector can be GC'd
      * (and so that subsequent tests start from a clean slate).
      * @since 4.1
      */


### PR DESCRIPTION
## Overview

This PR introduces the `@Aggregate` annotation to Maven's dependency injection framework, enabling modular contribution to aggregated collections without replacing the entire collection.

## Key Features

- **@Aggregate annotation** for `@Provides` methods that return `List<T>` or `Map<String, T>`
- **Multiple contributors**: Allows multiple modules to contribute entries to the same collection
- **Preserves auto-aggregation**: Maintains existing auto-aggregation behavior while enabling explicit contributions
- **Priority support**: Supports priority-based ordering for `List<T>` aggregations

## Behavior

1. **Without @Aggregate**: An explicit `@Provides` method for `List<T>` or `Map<String, T>` replaces the auto-aggregated collection entirely
2. **With @Aggregate**: The `@Provides` method contributes entries to the auto-aggregated collection, allowing multiple providers to coexist
3. **Mixed mode**: If both `@Aggregate` and non-`@Aggregate` providers exist, the non-`@Aggregate` provider takes precedence

## Use Cases

- **Plugin architecture**: Different modules can register services without depending on a central registry
- **Lifecycle providers**: Multiple modules can contribute lifecycle phases
- **Extensible service registries**: Core and extension modules can contribute services to the same map/list

## Implementation Details

- New `Binding.BindingToMethod` class to track the source method for bindings
- Enhanced `InjectorImpl` with aggregation logic for List and Map injection
- Support for `@Priority` ordering in aggregated lists
- Comprehensive test coverage with 30+ test cases

## Example Usage

```java
// Module A
@Provides
@Aggregate
Map<String, LifecycleProvider> lifecycleProviders() {
    return Map.of("clean", new CleanLifecycle());
}

// Module B
@Provides
@Aggregate
Map<String, LifecycleProvider> moreLifecycleProviders() {
    return Map.of("deploy", new DeployLifecycle());
}

// Consumer
@Inject
Map<String, LifecycleProvider> allLifecycles; // Contains all contributions
```

## Files Changed

- `api/maven-api-di/src/main/java/org/apache/maven/api/di/Aggregate.java` - New annotation with comprehensive documentation
- `impl/maven-di/src/main/java/org/apache/maven/di/impl/Binding.java` - Added `BindingToMethod` class
- `impl/maven-di/src/main/java/org/apache/maven/di/impl/InjectorImpl.java` - Aggregation logic implementation
- `impl/maven-di/src/main/java/org/apache/maven/di/impl/ReflectionUtils.java` - Updated to use `BindingToMethod`
- `impl/maven-di/src/test/java/org/apache/maven/di/impl/InjectorImplTest.java` - Comprehensive test coverage

## Testing

Added 30+ test cases covering:
- Basic map and list aggregation
- Multiple `@Aggregate` providers
- Explicit providers (with and without `@Aggregate`)
- Priority ordering
- Empty collections
- Duplicate keys
- Mixed scenarios
- Integration with existing DI features

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author