### PR TITLE
Fix BOM packaging in consumer POMs

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11427BomConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11427BomConsumerPomTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This is a test set for BOM consumer POM issues.
+ * Verifies that:
+ * 1. BOM packaging is transformed to POM in consumer POMs (not "bom" which is invalid in Maven 4.0.0)
+ * 2. Dependency versions are preserved in dependencyManagement when using flatten=true
+ *
+ * @since 4.0.0
+ */
+class MavenITgh11427BomConsumerPomTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify BOM consumer POM without flattening has correct packaging.
+     */
+    @Test
+    void testBomConsumerPomWithoutFlatten() throws Exception {
+        Path basedir = extractResources("/gh-11427-bom-consumer-pom")
+                .getAbsoluteFile()
+                .toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArguments("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Path consumerPomPath = Paths.get(
+                verifier.getArtifactPath("org.apache.maven.its.gh-11427", "bom", "1.0.0-SNAPSHOT", "pom"));
+
+        assertTrue(Files.exists(consumerPomPath), "consumer pom not found at " + consumerPomPath);
+
+        List<String> consumerPomLines;
+        try (Stream<String> lines = Files.lines(consumerPomPath)) {
+            consumerPomLines = lines.toList();
+        }
+
+        // Verify packaging is "pom" not "bom"
+        assertTrue(
+                consumerPomLines.stream().anyMatch(s -> s.contains("<packaging>pom</packaging>")),
+                "Consumer pom should have <packaging>pom</packaging>");
+        assertFalse(
+                consumerPomLines.stream().anyMatch(s -> s.contains("<packaging>bom</packaging>")),
+                "Consumer pom should NOT have <packaging>bom</packaging>");
+
+        // Verify dependencyManagement is present
+        assertTrue(
+                consumerPomLines.stream().anyMatch(s -> s.contains("<dependencyManagement>")),
+                "Consumer pom should have dependencyManagement");
+    }
+
+    /**
+     * Verify BOM consumer POM with flattening has correct packaging and versions.
+     */
+    @Test
+    void testBomConsumerPomWithFlatten() throws Exception {
+        Path basedir = extractResources("/gh-11427-bom-consumer-pom")
+                .getAbsoluteFile()
+                .toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArguments("install", "-Dmaven.consumer.pom.flatten=true");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Path consumerPomPath = Paths.get(
+                verifier.getArtifactPath("org.apache.maven.its.gh-11427", "bom", "1.0.0-SNAPSHOT", "pom"));
+
+        assertTrue(Files.exists(consumerPomPath), "consumer pom not found at " + consumerPomPath);
+
+        List<String> consumerPomLines;
+        try (Stream<String> lines = Files.lines(consumerPomPath)) {
+            consumerPomLines = lines.toList();
+        }
+
+        // Verify packaging is "pom" not "bom"
+        assertTrue(
+                consumerPomLines.stream().anyMatch(s -> s.contains("<packaging>pom</packaging>")),
+                "Consumer pom should have <packaging>pom</packaging>");
+        assertFalse(
+                consumerPomLines.stream().anyMatch(s -> s.contains("<packaging>bom</packaging>")),
+                "Consumer pom should NOT have <packaging>bom</packaging>");
+
+        // Verify dependencyManagement is present
+        assertTrue(
+                consumerPomLines.stream().anyMatch(s -> s.contains("<dependencyManagement>")),
+                "Consumer pom should have dependencyManagement");
+
+        // Verify versions are present in dependencies
+        String content = String.join("\n", consumerPomLines);
+        assertTrue(
+                content.contains("<version>1.0.0-SNAPSHOT</version>") || content.contains("<version>${"),
+                "Consumer pom should have version for module dependency");
+        assertTrue(
+                content.contains("<version>4.13.2</version>"),
+                "Consumer pom should have version for junit dependency");
+    }
+}
+

--- a/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/bom/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh-11427</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bom</artifactId>
+  <packaging>bom</packaging>
+
+  <name>GH-11427 BOM</name>
+
+    <properties>
+        <junit.version>4.13.2</junit.version>
+    </properties>
+
+    <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh-11427</groupId>
+        <artifactId>module</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+

--- a/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/module/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/module/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh-11427</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module</artifactId>
+  <packaging>jar</packaging>
+
+  <name>GH-11427 Module</name>
+
+    <properties>
+        <junit.version>4.13.2</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh-11427</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>GH-11427 BOM Consumer POM Test</name>
+
+  <modules>
+    <module>bom</module>
+    <module>module</module>
+  </modules>
+</project>
+


### PR DESCRIPTION
This PR addresses two issues with BOM (Bill of Materials) handling in consumer POMs reported in https://lists.apache.org/thread/41q40v598pd8mr32lmgwdfb2xm7lzm6l:

## Issues Fixed

### 1. BOM packaging not transformed to POM in consumer POMs
When a project uses `packaging=bom`, the consumer POM was incorrectly retaining this packaging type. Since 'bom' is not a valid packaging type in Maven 4.0.0 model, this caused errors when the consumer POM was used.

### 2. Dependency versions preserved in dependencyManagement
When using `-Dmaven.consumer.pom.flatten=true` with a BOM, dependencies in dependencyManagement were missing their version tags.

## Solution

The fix ensures that:
- BOM packaging is always transformed to 'pom' in consumer POMs, regardless of whether flattening is enabled
- Dependency versions are properly preserved in the consumer POM for both flattened and non-flattened BOMs

## Changes

- Modified `DefaultConsumerPomBuilder.build()` to detect BOMs based on original packaging and handle them appropriately
- Added `buildBomWithoutFlatten()` method to handle BOMs when flattening is disabled, using the raw model but still transforming packaging
- Added integration test to verify both issues are fixed

## Testing

Manual testing confirms:
- Consumer POMs for BOMs now have `packaging=pom` instead of `packaging=bom`
- Dependency versions are preserved in dependencyManagement sections
- Both with and without `-Dmaven.consumer.pom.flatten=true` work correctly

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author