### PR TITLE
Fix a `ConcurrentModificationException`.

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
@@ -21,11 +21,11 @@ package org.apache.maven.impl;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -85,7 +85,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
      */
     public DefaultDependencyResolver() {
         // TODO: the cache should not be instantiated here, but should rather be session-wide.
-        moduleCaches = new HashMap<>();
+        moduleCaches = new ConcurrentHashMap<>();
     }
 
     /**


### PR DESCRIPTION
The exception was observed in the `MCOMPILER-170` integration test of Maven Compiler Plugin, which launches Maven with the `-T4` option. Relevant stack trace was:

```
Caused by: java.util.ConcurrentModificationException
    at java.util.HashMap.computeIfAbsent(HashMap.java:1230)
    at org.apache.maven.impl.DefaultDependencyResolver.moduleCache(DefaultDependencyResolver:98)
```

This exception occurs with Maven 4.0.0-RC-5 but did not occurred with RC-4, I'm not sure why.