### PR TITLE
Revert the quoting of filenames in `JavaPathType.option(…)`.

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/JavaPathType.java
@@ -244,6 +244,7 @@ public enum JavaPathType implements PathType {
      * Returns the option followed by a string representation of the given path elements.
      * For example, if this type is {@link #MODULES}, then the option is {@code "--module-path"}
      * followed by the specified path elements.
+     * The paths are <em>not</em> quoted.
      *
      * @param paths the path to format as a tool option
      * @return the option associated to this path type followed by the given path elements,
@@ -263,8 +264,8 @@ public enum JavaPathType implements PathType {
         if (option == null) {
             throw new IllegalStateException("No option is associated to this path type.");
         }
-        String prefix = (moduleName == null) ? "\"" : (moduleName + "=\"");
-        StringJoiner joiner = new StringJoiner(File.pathSeparator, prefix, "\"");
+        String prefix = (moduleName == null) ? "" : (moduleName + '=');
+        StringJoiner joiner = new StringJoiner(File.pathSeparator, prefix, "");
         joiner.setEmptyValue("");
         for (Path p : paths) {
             joiner.add(p.toString());
@@ -365,6 +366,7 @@ public enum JavaPathType implements PathType {
          * Returns the option followed by a string representation of the given path elements.
          * The path elements are separated by an option-specific or platform-specific separator.
          * If the given {@code paths} argument contains no element, then this method returns an empty string.
+         * The paths are <em>not</em> quoted.
          *
          * @param paths the path to format as a string
          * @return the option associated to this path type followed by the given path elements,

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/JavaPathTypeTest.java
@@ -53,7 +53,7 @@ public class JavaPathTypeTest {
         String[] formatted = JavaPathType.MODULES.option(paths());
         assertEquals(2, formatted.length);
         assertEquals("--module-path", formatted[0]);
-        assertEquals(toPlatformSpecific("\"src/foo.java:src/bar.java\""), formatted[1]);
+        assertEquals(toPlatformSpecific("src/foo.java:src/bar.java"), formatted[1]);
     }
 
     /**
@@ -64,7 +64,7 @@ public class JavaPathTypeTest {
         String[] formatted = JavaPathType.patchModule("my.module").option(paths());
         assertEquals(2, formatted.length);
         assertEquals("--patch-module", formatted[0]);
-        assertEquals(toPlatformSpecific("my.module=\"src/foo.java:src/bar.java\""), formatted[1]);
+        assertEquals(toPlatformSpecific("my.module=src/foo.java:src/bar.java"), formatted[1]);
     }
 
     /**


### PR DESCRIPTION
This is a partial revert of https://github.com/apache/maven/pull/2505 based on the observation that above PR has not been merged in 4.0.x. For making the two branches consistent, we need to either port or revert 2505. A revert is less disruptive as no Maven 4.1.x version has been released yet and it would avoid https://github.com/apache/maven-compiler-plugin/pull/991.