### PR TITLE
[maven-4.0.x] Fix profile source tracking in multi-module projects (fixes #11409) (#11440)

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilderResult.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilderResult.java
@@ -19,6 +19,7 @@
 package org.apache.maven.api.services;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;
@@ -80,6 +81,27 @@ public interface ModelBuilderResult extends Result<ModelBuilderRequest> {
      */
     @Nonnull
     List<Profile> getActivePomProfiles();
+
+    /**
+     * Gets the profiles that were active during model building for a specific model in the hierarchy.
+     * This allows tracking which profiles came from which model (parent vs child).
+     *
+     * @param modelId The identifier of the model (groupId:artifactId:version) or empty string for the super POM.
+     * @return The active profiles for the specified model or an empty list if the model has no active profiles.
+     * @since 4.0.0
+     */
+    @Nonnull
+    List<Profile> getActivePomProfiles(String modelId);
+
+    /**
+     * Gets a map of all active POM profiles organized by model ID.
+     * The map keys are model IDs (groupId:artifactId:version) and values are lists of active profiles for each model.
+     *
+     * @return A map of model IDs to their active profiles, never {@code null}.
+     * @since 4.0.0
+     */
+    @Nonnull
+    Map<String, List<Profile>> getActivePomProfilesByModel();
 
     /**
      * Gets the external profiles that were active during model building. External profiles are those that were

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -708,8 +708,21 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                             .toList());
 
             project.setInjectedProfileIds("external", getProfileIds(result.getActiveExternalProfiles()));
-            project.setInjectedProfileIds(
-                    result.getEffectiveModel().getId(), getProfileIds(result.getActivePomProfiles()));
+
+            // Track profile sources correctly by using the per-model profile tracking
+            Map<String, List<org.apache.maven.api.model.Profile>> profilesByModel =
+                    result.getActivePomProfilesByModel();
+
+            if (profilesByModel.isEmpty()) {
+                // Fallback to old behavior if map is empty
+                // This happens when no profiles are active or there's an issue with profile tracking
+                project.setInjectedProfileIds(
+                        result.getEffectiveModel().getId(), getProfileIds(result.getActivePomProfiles()));
+            } else {
+                for (Map.Entry<String, List<org.apache.maven.api.model.Profile>> entry : profilesByModel.entrySet()) {
+                    project.setInjectedProfileIds(entry.getKey(), getProfileIds(entry.getValue()));
+                }
+            }
 
             //
             // All the parts that were taken out of MavenProject for Maven 4.0.0

--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -337,12 +337,12 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
 
         MavenProject project = projectBuilder.build(testPom, request).getProject();
 
-        assertTrue(project.getInjectedProfileIds().keySet().containsAll(List.of("external", project.getId())));
+        String id = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+        assertTrue(project.getInjectedProfileIds().keySet().containsAll(List.of("external", id)));
         assertTrue(project.getInjectedProfileIds().get("external").isEmpty());
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().anyMatch("profile1"::equals));
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().noneMatch("profile2"::equals));
-        assertTrue(
-                project.getInjectedProfileIds().get(project.getId()).stream().noneMatch("active-by-default"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().anyMatch("profile1"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().noneMatch("profile2"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().noneMatch("active-by-default"::equals));
     }
 
     @Test
@@ -354,11 +354,12 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
 
         MavenProject project = projectBuilder.build(testPom, request).getProject();
 
-        assertTrue(project.getInjectedProfileIds().keySet().containsAll(List.of("external", project.getId())));
+        String id = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+        assertTrue(project.getInjectedProfileIds().keySet().containsAll(List.of("external", id)));
         assertTrue(project.getInjectedProfileIds().get("external").isEmpty());
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().noneMatch("profile1"::equals));
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().noneMatch("profile2"::equals));
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().anyMatch("active-by-default"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().noneMatch("profile1"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().noneMatch("profile2"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().anyMatch("active-by-default"::equals));
 
         InternalMavenSession session = Mockito.mock(InternalMavenSession.class);
         List<org.apache.maven.api.model.Profile> activeProfiles =
@@ -392,11 +393,12 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
 
         MavenProject project = projectBuilder.build(testPom, request).getProject();
 
-        assertTrue(project.getInjectedProfileIds().keySet().containsAll(List.of("external", project.getId())));
+        String id = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+        assertTrue(project.getInjectedProfileIds().keySet().containsAll(List.of("external", id)));
         assertTrue(project.getInjectedProfileIds().get("external").stream().anyMatch("external-profile"::equals));
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().noneMatch("profile1"::equals));
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().noneMatch("profile2"::equals));
-        assertTrue(project.getInjectedProfileIds().get(project.getId()).stream().anyMatch("active-by-default"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().noneMatch("profile1"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().noneMatch("profile2"::equals));
+        assertTrue(project.getInjectedProfileIds().get(id).stream().anyMatch("active-by-default"::equals));
 
         InternalMavenSession session = Mockito.mock(InternalMavenSession.class);
         List<org.apache.maven.api.model.Profile> activeProfiles =

--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectBuilderTest.java
@@ -197,6 +197,16 @@ class DefaultProjectBuilderTest {
         }
 
         @Override
+        public List<Profile> getActivePomProfiles(String modelId) {
+            return List.of();
+        }
+
+        @Override
+        public java.util.Map<String, List<Profile>> getActivePomProfilesByModel() {
+            return java.util.Map.of();
+        }
+
+        @Override
         public List<Profile> getActiveExternalProfiles() {
             return List.of();
         }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1115,7 +1115,11 @@ public class DefaultModelBuilder implements ModelBuilder {
             try {
                 ModelBuilderSessionState derived = derive(candidateSource);
                 Model candidateModel = derived.readAsParentModel(profileActivationContext, parentChain);
-                addActivePomProfiles(derived.result.getActivePomProfiles());
+                // Add profiles from parent, preserving model ID tracking
+                for (Map.Entry<String, List<Profile>> entry :
+                        derived.result.getActivePomProfilesByModel().entrySet()) {
+                    addActivePomProfiles(entry.getKey(), entry.getValue());
+                }
 
                 String groupId = getGroupId(candidateModel);
                 String artifactId = candidateModel.getArtifactId();
@@ -1263,7 +1267,13 @@ public class DefaultModelBuilder implements ModelBuilder {
                     .source(modelSource)
                     .build();
 
-            Model parentModel = derive(lenientRequest).readAsParentModel(profileActivationContext, parentChain);
+            ModelBuilderSessionState derived = derive(lenientRequest);
+            Model parentModel = derived.readAsParentModel(profileActivationContext, parentChain);
+            // Add profiles from parent, preserving model ID tracking
+            for (Map.Entry<String, List<Profile>> entry :
+                    derived.result.getActivePomProfilesByModel().entrySet()) {
+                addActivePomProfiles(entry.getKey(), entry.getValue());
+            }
 
             if (!parent.getVersion().equals(version)) {
                 String rawChildModelVersion = childModel.getVersion();
@@ -1378,12 +1388,19 @@ public class DefaultModelBuilder implements ModelBuilder {
             // profile activation
             profileActivationContext.setModel(model);
 
-            // profile injection
+            // Activate profiles from the input model (before inheritance) to get only local profiles
+            // Parent profiles are already added when the parent model is read
+            List<Profile> localActivePomProfiles =
+                    getActiveProfiles(inputModel.getProfiles(), profileActivationContext);
+
+            // profile injection - inject all profiles (local + inherited) into the model
             List<Profile> activePomProfiles = getActiveProfiles(model.getProfiles(), profileActivationContext);
             model = profileInjector.injectProfiles(model, activePomProfiles, request, this);
             model = profileInjector.injectProfiles(model, activeExternalProfiles, request, this);
 
-            addActivePomProfiles(activePomProfiles);
+            // Track only the local profiles for this model
+            // Use ModelProblemUtils.toId() to get groupId:artifactId:version format (without packaging)
+            addActivePomProfiles(ModelProblemUtils.toId(model), localActivePomProfiles);
 
             // model interpolation
             Model resultModel = model;
@@ -1411,12 +1428,10 @@ public class DefaultModelBuilder implements ModelBuilder {
             return resultModel;
         }
 
-        private void addActivePomProfiles(List<Profile> activePomProfiles) {
-            if (activePomProfiles != null) {
-                if (result.getActivePomProfiles() == null) {
-                    result.setActivePomProfiles(new ArrayList<>());
-                }
-                result.getActivePomProfiles().addAll(activePomProfiles);
+        private void addActivePomProfiles(String modelId, List<Profile> activePomProfiles) {
+            if (activePomProfiles != null && !activePomProfiles.isEmpty()) {
+                // Track profiles by model ID
+                result.setActivePomProfiles(modelId, activePomProfiles);
             }
         }
 
@@ -1805,7 +1820,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                         replayRecordIntoContext(e.getKey(), profileActivationContext);
                     }
                     // Add the activated profiles from cache to the result
-                    addActivePomProfiles(cached.activatedProfiles());
+                    addActivePomProfiles(cached.model().getId(), cached.activatedProfiles());
                     return cached.model();
                 }
             }
@@ -1821,7 +1836,9 @@ public class DefaultModelBuilder implements ModelBuilder {
             replayRecordIntoContext(record, profileActivationContext);
 
             parentsPerContext.put(record, modelWithProfiles);
-            addActivePomProfiles(modelWithProfiles.activatedProfiles());
+            // Use ModelProblemUtils.toId() to get groupId:artifactId:version format (without packaging)
+            addActivePomProfiles(
+                    ModelProblemUtils.toId(modelWithProfiles.model()), modelWithProfiles.activatedProfiles());
             return modelWithProfiles.model();
         }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11409ProfileSourceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11409ProfileSourceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test for <a href="https://github.com/apache/maven/issues/11409">GH-11409</a>.
+ * Verifies that profiles activated in parent POMs are correctly reported with the parent POM
+ * as the source, not the child project.
+ *
+ * @since 4.0.0
+ */
+class MavenITgh11409ProfileSourceTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that help:active-profiles reports correct source for profiles activated in parent POM.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    void testProfileSourceInMultiModuleProject() throws Exception {
+        File testDir = extractResources("/gh-11409");
+
+        Verifier verifier = newVerifier(new File(testDir, "subproject").getAbsolutePath());
+        verifier.addCliArgument("help:active-profiles");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Verify that the parent profile is reported with the parent as the source
+        // Note: Profile sources use groupId:artifactId:version format (without packaging)
+        verifier.verifyTextInLog("parent-profile (source: test.gh11409:parent:1.0-SNAPSHOT)");
+
+        // Verify that the child profile is reported with the child as the source
+        verifier.verifyTextInLog("child-profile (source: test.gh11409:subproject:1.0-SNAPSHOT)");
+    }
+}
+

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11409ProfileSourceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11409ProfileSourceTest.java
@@ -31,6 +31,10 @@ import org.junit.jupiter.api.Test;
  */
 class MavenITgh11409ProfileSourceTest extends AbstractMavenIntegrationTestCase {
 
+    MavenITgh11409ProfileSourceTest() {
+        super("[4.0.0-rc-4,)");
+    }
+
     /**
      * Verify that help:active-profiles reports correct source for profiles activated in parent POM.
      *

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8477MultithreadedFileActivationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8477MultithreadedFileActivationTest.java
@@ -43,6 +43,6 @@ class MavenITmng8477MultithreadedFileActivationTest extends AbstractMavenIntegra
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        verifier.verifyTextInLog("- xxx (source: test:m2:jar:1)");
+        verifier.verifyTextInLog("- xxx (source: test:project:1)");
     }
 }

--- a/its/core-it-suite/src/test/resources/gh-11409/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11409/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test.gh11409</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>GH-11409 Parent</name>
+  <description>Test for profile source tracking in multi-module projects</description>
+
+  <modules>
+    <module>subproject</module>
+  </modules>
+
+  <profiles>
+    <profile>
+      <id>parent-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <parent.profile.active>true</parent.profile.active>
+      </properties>
+    </profile>
+  </profiles>
+</project>
+

--- a/its/core-it-suite/src/test/resources/gh-11409/subproject/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11409/subproject/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test.gh11409</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>subproject</artifactId>
+
+  <name>GH-11409 Subproject</name>
+  <description>Child project for testing profile source tracking</description>
+
+  <profiles>
+    <profile>
+      <id>child-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <child.profile.active>true</child.profile.active>
+      </properties>
+    </profile>
+  </profiles>
+</project>
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `maven-4.0.x`:
 - [Fix profile source tracking in multi-module projects (fixes #11409) (#11440)](https://github.com/apache/maven/pull/11440)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)