### PR TITLE
Maven 4.x w/ Resolver 2.0.14

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -DsessionRootDirectory=${session.rootDirectory}
+

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -545,7 +545,10 @@ public final class Constants {
      *     <li>"release" - query only release repositories to discover versions</li>
      *     <li>"snapshot" - query only snapshot repositories to discover versions</li>
      * </ul>
-     * Default (when unset) is existing Maven behaviour: "release_or_snapshots".
+     * Default (when unset) is using request carried nature. Hence, this configuration really makes sense with value
+     * {@code "auto"}, while ideally callers needs update and use newly added method on version range request to
+     * express preference.
+     *
      * @since 4.0.0
      */
     @Config(defaultValue = "release_or_snapshot")

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionRangeResolverRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/VersionRangeResolverRequest.java
@@ -32,83 +32,210 @@ import org.apache.maven.api.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * A request to resolve a version range to a list of matching versions.
+ * This request is used by {@link VersionRangeResolver} to expand version ranges
+ * (e.g., "[3.8,4.0)") into concrete versions available in the configured repositories.
  *
  * @since 4.0.0
  */
 @Experimental
 public interface VersionRangeResolverRequest extends RepositoryAwareRequest {
 
+    /**
+     * Specifies which type of repositories to query when resolving version ranges.
+     * This controls whether to search in release repositories, snapshot repositories, or both.
+     *
+     * @since 4.0.0
+     */
+    enum Nature {
+        /**
+         * Query only release repositories to discover versions.
+         */
+        RELEASE,
+        /**
+         * Query only snapshot repositories to discover versions.
+         */
+        SNAPSHOT,
+        /**
+         * Query both release and snapshot repositories to discover versions.
+         * This is the default behavior.
+         */
+        RELEASE_OR_SNAPSHOT
+    }
+
+    /**
+     * Gets the artifact coordinates whose version range should be resolved.
+     * The coordinates may contain a version range (e.g., "[1.0,2.0)") or a single version.
+     *
+     * @return the artifact coordinates, never {@code null}
+     */
     @Nonnull
     ArtifactCoordinates getArtifactCoordinates();
 
+    /**
+     * Gets the nature of repositories to query when resolving the version range.
+     * This determines whether to search in release repositories, snapshot repositories, or both.
+     *
+     * @return the repository nature, never {@code null}
+     */
+    @Nonnull
+    Nature getNature();
+
+    /**
+     * Creates a version range resolver request using the session's repositories.
+     *
+     * @param session the session to use, must not be {@code null}
+     * @param artifactCoordinates the artifact coordinates whose version range should be resolved, must not be {@code null}
+     * @return the version range resolver request, never {@code null}
+     */
     @Nonnull
     static VersionRangeResolverRequest build(
             @Nonnull Session session, @Nonnull ArtifactCoordinates artifactCoordinates) {
-        return build(session, artifactCoordinates, null);
+        return build(session, artifactCoordinates, null, null);
     }
 
+    /**
+     * Creates a version range resolver request.
+     *
+     * @param session the session to use, must not be {@code null}
+     * @param artifactCoordinates the artifact coordinates whose version range should be resolved, must not be {@code null}
+     * @param repositories the repositories to use, or {@code null} to use the session's repositories
+     * @return the version range resolver request, never {@code null}
+     */
     @Nonnull
     static VersionRangeResolverRequest build(
             @Nonnull Session session,
             @Nonnull ArtifactCoordinates artifactCoordinates,
             @Nullable List<RemoteRepository> repositories) {
+        return build(session, artifactCoordinates, repositories, null);
+    }
+
+    /**
+     * Creates a version range resolver request.
+     *
+     * @param session the session to use, must not be {@code null}
+     * @param artifactCoordinates the artifact coordinates whose version range should be resolved, must not be {@code null}
+     * @param repositories the repositories to use, or {@code null} to use the session's repositories
+     * @param nature the nature of repositories to query when resolving the version range, or {@code null} to use the default
+     * @return the version range resolver request, never {@code null}
+     */
+    @Nonnull
+    static VersionRangeResolverRequest build(
+            @Nonnull Session session,
+            @Nonnull ArtifactCoordinates artifactCoordinates,
+            @Nullable List<RemoteRepository> repositories,
+            @Nullable Nature nature) {
         return builder()
                 .session(requireNonNull(session, "session cannot be null"))
                 .artifactCoordinates(requireNonNull(artifactCoordinates, "artifactCoordinates cannot be null"))
                 .repositories(repositories)
+                .nature(nature)
                 .build();
     }
 
+    /**
+     * Creates a new builder for version range resolver requests.
+     *
+     * @return a new builder, never {@code null}
+     */
     @Nonnull
     static VersionResolverRequestBuilder builder() {
         return new VersionResolverRequestBuilder();
     }
 
+    /**
+     * Builder for {@link VersionRangeResolverRequest}.
+     */
     @NotThreadSafe
     class VersionResolverRequestBuilder {
         Session session;
         RequestTrace trace;
         ArtifactCoordinates artifactCoordinates;
         List<RemoteRepository> repositories;
+        Nature nature = Nature.RELEASE_OR_SNAPSHOT;
 
+        /**
+         * Sets the session to use for the request.
+         *
+         * @param session the session, must not be {@code null}
+         * @return this builder, never {@code null}
+         */
         public VersionResolverRequestBuilder session(Session session) {
             this.session = session;
             return this;
         }
 
+        /**
+         * Sets the request trace for debugging and diagnostics.
+         *
+         * @param trace the request trace, may be {@code null}
+         * @return this builder, never {@code null}
+         */
         public VersionResolverRequestBuilder trace(RequestTrace trace) {
             this.trace = trace;
             return this;
         }
 
+        /**
+         * Sets the artifact coordinates whose version range should be resolved.
+         *
+         * @param artifactCoordinates the artifact coordinates, must not be {@code null}
+         * @return this builder, never {@code null}
+         */
         public VersionResolverRequestBuilder artifactCoordinates(ArtifactCoordinates artifactCoordinates) {
             this.artifactCoordinates = artifactCoordinates;
             return this;
         }
 
+        /**
+         * Sets the nature of repositories to query when resolving the version range.
+         * If {@code null} is provided, defaults to {@link Nature#RELEASE_OR_SNAPSHOT}.
+         *
+         * @param nature the repository nature, or {@code null} to use the default
+         * @return this builder, never {@code null}
+         */
+        public VersionResolverRequestBuilder nature(Nature nature) {
+            this.nature = Objects.requireNonNullElse(nature, Nature.RELEASE_OR_SNAPSHOT);
+            return this;
+        }
+
+        /**
+         * Sets the repositories to use for resolving the version range.
+         *
+         * @param repositories the repositories, or {@code null} to use the session's repositories
+         * @return this builder, never {@code null}
+         */
         public VersionResolverRequestBuilder repositories(List<RemoteRepository> repositories) {
             this.repositories = repositories;
             return this;
         }
 
+        /**
+         * Builds the version range resolver request.
+         *
+         * @return the version range resolver request, never {@code null}
+         */
         public VersionRangeResolverRequest build() {
-            return new DefaultVersionResolverRequest(session, trace, artifactCoordinates, repositories);
+            return new DefaultVersionResolverRequest(session, trace, artifactCoordinates, repositories, nature);
         }
 
         private static class DefaultVersionResolverRequest extends BaseRequest<Session>
                 implements VersionRangeResolverRequest {
             private final ArtifactCoordinates artifactCoordinates;
             private final List<RemoteRepository> repositories;
+            private final Nature nature;
 
             @SuppressWarnings("checkstyle:ParameterNumber")
             DefaultVersionResolverRequest(
                     @Nonnull Session session,
                     @Nullable RequestTrace trace,
                     @Nonnull ArtifactCoordinates artifactCoordinates,
-                    @Nullable List<RemoteRepository> repositories) {
+                    @Nullable List<RemoteRepository> repositories,
+                    @Nonnull Nature nature) {
                 super(session, trace);
-                this.artifactCoordinates = artifactCoordinates;
+                this.artifactCoordinates = requireNonNull(artifactCoordinates);
                 this.repositories = validate(repositories);
+                this.nature = requireNonNull(nature);
             }
 
             @Nonnull
@@ -123,23 +250,31 @@ public interface VersionRangeResolverRequest extends RepositoryAwareRequest {
                 return repositories;
             }
 
+            @Nonnull
+            @Override
+            public Nature getNature() {
+                return nature;
+            }
+
             @Override
             public boolean equals(Object o) {
                 return o instanceof DefaultVersionResolverRequest that
                         && Objects.equals(artifactCoordinates, that.artifactCoordinates)
-                        && Objects.equals(repositories, that.repositories);
+                        && Objects.equals(repositories, that.repositories)
+                        && nature == that.nature;
             }
 
             @Override
             public int hashCode() {
-                return Objects.hash(artifactCoordinates, repositories);
+                return Objects.hash(artifactCoordinates, repositories, nature);
             }
 
             @Override
             public String toString() {
                 return "VersionResolverRequest[" + "artifactCoordinates="
                         + artifactCoordinates + ", repositories="
-                        + repositories + ']';
+                        + repositories + ", nature="
+                        + nature + ']';
             }
         }
     }

--- a/compat/maven-compat/pom.xml
+++ b/compat/maven-compat/pom.xml
@@ -115,6 +115,10 @@ under the License.
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -210,11 +214,6 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-spi</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/LegacyRepositorySystemTest.java
@@ -61,6 +61,7 @@ import org.codehaus.plexus.testing.PlexusTest;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.internal.impl.DefaultRepositoryKeyFunctionFactory;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
@@ -151,7 +152,9 @@ class LegacyRepositorySystemTest {
                 new SimpleLookup(List.of(
                         new DefaultRequestCacheFactory(),
                         new DefaultRepositoryFactory(new DefaultRemoteRepositoryManager(
-                                new DefaultUpdatePolicyAnalyzer(), new DefaultChecksumPolicyProvider())),
+                                new DefaultUpdatePolicyAnalyzer(),
+                                new DefaultChecksumPolicyProvider(),
+                                new DefaultRepositoryKeyFunctionFactory())),
                         new DefaultVersionParser(new DefaultModelVersionParser(new GenericVersionScheme())),
                         new DefaultArtifactCoordinatesFactory(),
                         new DefaultArtifactResolver(),

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
@@ -30,6 +30,7 @@ import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
 import org.apache.maven.artifact.repository.metadata.RepositoryMetadata;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +58,8 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        updateCheckManager = new DefaultUpdateCheckManager(new ConsoleLogger(Logger.LEVEL_DEBUG, "test"));
+        updateCheckManager = new DefaultUpdateCheckManager(
+                new ConsoleLogger(Logger.LEVEL_DEBUG, "test"), new DefaultTrackingFileManager());
     }
 
     @Test

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
@@ -73,6 +73,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.internal.impl.DefaultRepositoryKeyFunctionFactory;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.WorkspaceReader;
@@ -272,7 +273,9 @@ public class BootstrapCoreExtensionManager {
                 return (T) new DefaultArtifactManager(this);
             } else if (clazz == RepositoryFactory.class) {
                 return (T) new DefaultRepositoryFactory(new DefaultRemoteRepositoryManager(
-                        new DefaultUpdatePolicyAnalyzer(), new DefaultChecksumPolicyProvider()));
+                        new DefaultUpdatePolicyAnalyzer(),
+                        new DefaultChecksumPolicyProvider(),
+                        new DefaultRepositoryKeyFunctionFactory()));
             } else if (clazz == Interpolator.class) {
                 return (T) new DefaultInterpolator();
                 // } else if (clazz == ModelResolver.class) {

--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -117,9 +117,7 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver {
             } else {
                 Metadata.Nature wantedNature;
                 String natureString = ConfigUtils.getString(
-                        session,
-                        Metadata.Nature.RELEASE_OR_SNAPSHOT.name(),
-                        Constants.MAVEN_VERSION_RANGE_RESOLVER_NATURE_OVERRIDE);
+                        session, request.getNature().name(), Constants.MAVEN_VERSION_RANGE_RESOLVER_NATURE_OVERRIDE);
                 if ("auto".equals(natureString)) {
                     org.eclipse.aether.artifact.Artifact lowerArtifact = lowerBound != null
                             ? request.getArtifact()

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
@@ -76,6 +76,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.internal.impl.DefaultRepositoryKeyFunctionFactory;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.WorkspaceReader;
@@ -270,6 +271,7 @@ public class BootstrapCoreExtensionManager {
             return new SimpleSession(mavenSession, getRepositorySystem(), repositories);
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public <T extends Service> T getService(Class<T> clazz) throws NoSuchElementException {
             if (clazz == ArtifactCoordinatesFactory.class) {
@@ -284,7 +286,9 @@ public class BootstrapCoreExtensionManager {
                 return (T) new DefaultArtifactManager(this);
             } else if (clazz == RepositoryFactory.class) {
                 return (T) new DefaultRepositoryFactory(new DefaultRemoteRepositoryManager(
-                        new DefaultUpdatePolicyAnalyzer(), new DefaultChecksumPolicyProvider()));
+                        new DefaultUpdatePolicyAnalyzer(),
+                        new DefaultChecksumPolicyProvider(),
+                        new DefaultRepositoryKeyFunctionFactory()));
             } else if (clazz == Interpolator.class) {
                 return (T) new DefaultInterpolator();
                 // } else if (clazz == ModelResolver.class) {

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/AbstractRepositoryTestCase.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/AbstractRepositoryTestCase.java
@@ -40,6 +40,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.internal.impl.DefaultRepositoryKeyFunctionFactory;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.scope.ScopeManagerImpl;
 import org.eclipse.aether.repository.LocalRepository;
@@ -91,7 +92,9 @@ public abstract class AbstractRepositoryTestCase {
     protected List<Object> getSessionServices() {
         return List.of(
                 new DefaultRepositoryFactory(new DefaultRemoteRepositoryManager(
-                        new DefaultUpdatePolicyAnalyzer(), new DefaultChecksumPolicyProvider())),
+                        new DefaultUpdatePolicyAnalyzer(),
+                        new DefaultChecksumPolicyProvider(),
+                        new DefaultRepositoryKeyFunctionFactory())),
                 new DefaultInterpolator());
     }
 

--- a/impl/maven-core/src/test/java/org/apache/maven/model/ModelBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/model/ModelBuilderTest.java
@@ -44,6 +44,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.internal.impl.DefaultRepositoryKeyFunctionFactory;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.junit.jupiter.api.Test;
 
@@ -84,7 +85,9 @@ public class ModelBuilderTest {
                 new SimpleLookup(List.of(
                         new DefaultRequestCacheFactory(),
                         new DefaultRepositoryFactory(new DefaultRemoteRepositoryManager(
-                                new DefaultUpdatePolicyAnalyzer(), new DefaultChecksumPolicyProvider())))),
+                                new DefaultUpdatePolicyAnalyzer(),
+                                new DefaultChecksumPolicyProvider(),
+                                new DefaultRepositoryKeyFunctionFactory())))),
                 null);
         InternalSession.associate(rsession, session);
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultVersionRangeResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultVersionRangeResolver.java
@@ -33,6 +33,7 @@ import org.apache.maven.api.services.VersionRangeResolverException;
 import org.apache.maven.api.services.VersionRangeResolverRequest;
 import org.apache.maven.api.services.VersionRangeResolverResult;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
@@ -73,6 +74,7 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver {
                                             request.getRepositories() != null
                                                     ? request.getRepositories()
                                                     : session.getRemoteRepositories()),
+                                    toResolver(request.getNature()),
                                     trace.context())
                             .setTrace(trace.trace()));
 
@@ -113,5 +115,13 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver {
         } finally {
             RequestTraceHelper.exit(trace);
         }
+    }
+
+    private Metadata.Nature toResolver(VersionRangeResolverRequest.Nature nature) {
+        return switch (nature) {
+            case RELEASE_OR_SNAPSHOT -> Metadata.Nature.RELEASE_OR_SNAPSHOT;
+            case SNAPSHOT -> Metadata.Nature.SNAPSHOT;
+            case RELEASE -> Metadata.Nature.RELEASE;
+        };
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultVersionRangeResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultVersionRangeResolver.java
@@ -113,9 +113,7 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver {
             } else {
                 Metadata.Nature wantedNature;
                 String natureString = ConfigUtils.getString(
-                        session,
-                        Metadata.Nature.RELEASE_OR_SNAPSHOT.name(),
-                        Constants.MAVEN_VERSION_RANGE_RESOLVER_NATURE_OVERRIDE);
+                        session, request.getNature().name(), Constants.MAVEN_VERSION_RANGE_RESOLVER_NATURE_OVERRIDE);
                 if ("auto".equals(natureString)) {
                     org.eclipse.aether.artifact.Artifact lowerArtifact = lowerBound != null
                             ? request.getArtifact()

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.maven.api.annotations.Nullable;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Provides;
+import org.apache.maven.api.di.Singleton;
 import org.apache.maven.impl.resolver.validator.MavenValidatorFactory;
 import org.eclipse.aether.RepositoryListener;
 import org.eclipse.aether.RepositorySystem;
@@ -62,6 +63,7 @@ import org.eclipse.aether.internal.impl.DefaultPathProcessor;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
 import org.eclipse.aether.internal.impl.DefaultRepositoryConnectorProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositoryEventDispatcher;
+import org.eclipse.aether.internal.impl.DefaultRepositoryKeyFunctionFactory;
 import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
@@ -91,6 +93,7 @@ import org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.filter.FilteringPipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
+import org.eclipse.aether.internal.impl.filter.PrefixesLockingInhibitorFactory;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.offline.OfflinePipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
@@ -126,6 +129,8 @@ import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractorStrategy
 import org.eclipse.aether.spi.io.ChecksumProcessor;
 import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
+import org.eclipse.aether.spi.locking.LockingInhibitorFactory;
+import org.eclipse.aether.spi.remoterepo.RepositoryKeyFunctionFactory;
 import org.eclipse.aether.spi.resolution.ArtifactResolverPostProcessor;
 import org.eclipse.aether.spi.synccontext.SyncContextFactory;
 import org.eclipse.aether.spi.validator.ValidatorFactory;
@@ -138,6 +143,7 @@ import org.eclipse.aether.spi.validator.ValidatorFactory;
 @SuppressWarnings({"unused", "checkstyle:ParameterNumber"})
 public class RepositorySystemSupplier {
 
+    @Singleton
     @Provides
     static MetadataResolver newMetadataResolver(
             RepositoryEventDispatcher repositoryEventDispatcher,
@@ -159,11 +165,13 @@ public class RepositorySystemSupplier {
                 pathProcessor);
     }
 
+    @Singleton
     @Provides
     static RepositoryEventDispatcher newRepositoryEventDispatcher(@Nullable Map<String, RepositoryListener> listeners) {
         return new DefaultRepositoryEventDispatcher(listeners != null ? listeners : Map.of());
     }
 
+    @Singleton
     @Provides
     static UpdateCheckManager newUpdateCheckManager(
             TrackingFileManager trackingFileManager,
@@ -172,16 +180,25 @@ public class RepositorySystemSupplier {
         return new DefaultUpdateCheckManager(trackingFileManager, updatePolicyAnalyzer, pathProcessor);
     }
 
+    @Singleton
+    @Provides
+    static RepositoryKeyFunctionFactory newRepositoryKeyFunctionFactory() {
+        return new DefaultRepositoryKeyFunctionFactory();
+    }
+
+    @Singleton
     @Provides
     static TrackingFileManager newTrackingFileManager() {
         return new DefaultTrackingFileManager();
     }
 
+    @Singleton
     @Provides
     static UpdatePolicyAnalyzer newUpdatePolicyAnalyzer() {
         return new DefaultUpdatePolicyAnalyzer();
     }
 
+    @Singleton
     @Provides
     static RepositoryConnectorProvider newRepositoryConnectorProvider(
             Map<String, RepositoryConnectorFactory> connectorFactories,
@@ -189,6 +206,7 @@ public class RepositorySystemSupplier {
         return new DefaultRepositoryConnectorProvider(connectorFactories, pipelineConnectorFactories);
     }
 
+    @Singleton
     @Named("basic")
     @Provides
     static BasicRepositoryConnectorFactory newBasicRepositoryConnectorFactory(
@@ -207,6 +225,7 @@ public class RepositorySystemSupplier {
                 providedChecksumsSources);
     }
 
+    @Singleton
     @Named(OfflinePipelineRepositoryConnectorFactory.NAME)
     @Provides
     static OfflinePipelineRepositoryConnectorFactory newOfflinePipelineConnectorFactory(
@@ -214,6 +233,7 @@ public class RepositorySystemSupplier {
         return new OfflinePipelineRepositoryConnectorFactory(offlineController);
     }
 
+    @Singleton
     @Named(FilteringPipelineRepositoryConnectorFactory.NAME)
     @Provides
     static FilteringPipelineRepositoryConnectorFactory newFilteringPipelineConnectorFactory(
@@ -221,11 +241,13 @@ public class RepositorySystemSupplier {
         return new FilteringPipelineRepositoryConnectorFactory(remoteRepositoryFilterManager);
     }
 
+    @Singleton
     @Provides
     static RepositoryLayoutProvider newRepositoryLayoutProvider(Map<String, RepositoryLayoutFactory> layoutFactories) {
         return new DefaultRepositoryLayoutProvider(layoutFactories);
     }
 
+    @Singleton
     @Provides
     @Named(Maven2RepositoryLayoutFactory.NAME)
     static Maven2RepositoryLayoutFactory newMaven2RepositoryLayoutFactory(
@@ -234,54 +256,70 @@ public class RepositorySystemSupplier {
         return new Maven2RepositoryLayoutFactory(checksumAlgorithmFactorySelector, artifactPredicateFactory);
     }
 
+    @Singleton
     @Provides
     static SyncContextFactory newSyncContextFactory(NamedLockFactoryAdapterFactory namedLockFactoryAdapterFactory) {
         return new DefaultSyncContextFactory(namedLockFactoryAdapterFactory);
     }
 
+    @Singleton
     @Provides
     static OfflineController newOfflineController() {
         return new DefaultOfflineController();
     }
 
+    @Singleton
     @Provides
     static RemoteRepositoryFilterManager newRemoteRepositoryFilterManager(
             Map<String, RemoteRepositoryFilterSource> sources) {
         return new DefaultRemoteRepositoryFilterManager(sources);
     }
 
+    @Singleton
     @Provides
     @Named(GroupIdRemoteRepositoryFilterSource.NAME)
     static GroupIdRemoteRepositoryFilterSource newGroupIdRemoteRepositoryFilterSource(
-            RepositorySystemLifecycle repositorySystemLifecycle, PathProcessor pathProcessor) {
-        return new GroupIdRemoteRepositoryFilterSource(repositorySystemLifecycle, pathProcessor);
+            RepositoryKeyFunctionFactory repositoryKeyFunctionFactory,
+            RepositorySystemLifecycle repositorySystemLifecycle,
+            PathProcessor pathProcessor) {
+        return new GroupIdRemoteRepositoryFilterSource(
+                repositoryKeyFunctionFactory, repositorySystemLifecycle, pathProcessor);
     }
 
+    @Singleton
     @Provides
     @Named(PrefixesRemoteRepositoryFilterSource.NAME)
     static PrefixesRemoteRepositoryFilterSource newPrefixesRemoteRepositoryFilterSource(
+            RepositoryKeyFunctionFactory repositoryKeyFunctionFactory,
             MetadataResolver metadataResolver,
             RemoteRepositoryManager remoteRepositoryManager,
             RepositoryLayoutProvider repositoryLayoutProvider) {
         return new PrefixesRemoteRepositoryFilterSource(
-                () -> metadataResolver, () -> remoteRepositoryManager, repositoryLayoutProvider);
+                repositoryKeyFunctionFactory,
+                () -> metadataResolver,
+                () -> remoteRepositoryManager,
+                repositoryLayoutProvider);
     }
 
+    @Singleton
     @Provides
     static PathProcessor newPathProcessor() {
         return new DefaultPathProcessor();
     }
 
+    @Singleton
     @Provides
     static List<ValidatorFactory> newValidatorFactories() {
         return List.of(new MavenValidatorFactory());
     }
 
+    @Singleton
     @Provides
     static RepositorySystemValidator newRepositorySystemValidator(List<ValidatorFactory> validatorFactories) {
         return new DefaultRepositorySystemValidator(validatorFactories);
     }
 
+    @Singleton
     @Provides
     static RepositorySystem newRepositorySystem(
             VersionResolver versionResolver,
@@ -315,84 +353,130 @@ public class RepositorySystemSupplier {
                 repositorySystemValidator);
     }
 
+    @Singleton
     @Provides
     static RemoteRepositoryManager newRemoteRepositoryManager(
-            UpdatePolicyAnalyzer updatePolicyAnalyzer, ChecksumPolicyProvider checksumPolicyProvider) {
-        return new DefaultRemoteRepositoryManager(updatePolicyAnalyzer, checksumPolicyProvider);
+            UpdatePolicyAnalyzer updatePolicyAnalyzer,
+            ChecksumPolicyProvider checksumPolicyProvider,
+            RepositoryKeyFunctionFactory repositoryKeyFunctionFactory) {
+        return new DefaultRemoteRepositoryManager(
+                updatePolicyAnalyzer, checksumPolicyProvider, repositoryKeyFunctionFactory);
     }
 
+    @Singleton
     @Provides
     static ChecksumPolicyProvider newChecksumPolicyProvider() {
         return new DefaultChecksumPolicyProvider();
     }
 
+    @Singleton
+    @Provides
+    @Named(PrefixesLockingInhibitorFactory.NAME)
+    static LockingInhibitorFactory newPrefixesLockingInhibitorFactory() {
+        return new PrefixesLockingInhibitorFactory();
+    }
+
+    @Singleton
     @Provides
     static NamedLockFactoryAdapterFactory newNamedLockFactoryAdapterFactory(
             Map<String, NamedLockFactory> factories,
             Map<String, NameMapper> nameMappers,
+            Map<String, LockingInhibitorFactory> lockingInhibitorFactories,
             RepositorySystemLifecycle lifecycle) {
-        return new NamedLockFactoryAdapterFactoryImpl(factories, nameMappers, lifecycle);
+        return new NamedLockFactoryAdapterFactoryImpl(factories, nameMappers, lockingInhibitorFactories, lifecycle);
     }
 
+    @Singleton
     @Provides
     @Named(FileLockNamedLockFactory.NAME)
     static FileLockNamedLockFactory newFileLockNamedLockFactory() {
         return new FileLockNamedLockFactory();
     }
 
+    @Singleton
     @Provides
     @Named(LocalReadWriteLockNamedLockFactory.NAME)
     static LocalReadWriteLockNamedLockFactory newLocalReadWriteLockNamedLockFactory() {
         return new LocalReadWriteLockNamedLockFactory();
     }
 
+    @Singleton
     @Provides
     @Named(LocalSemaphoreNamedLockFactory.NAME)
     static LocalSemaphoreNamedLockFactory newLocalSemaphoreNamedLockFactory() {
         return new LocalSemaphoreNamedLockFactory();
     }
 
+    @Singleton
     @Provides
     @Named(NoopNamedLockFactory.NAME)
     static NoopNamedLockFactory newNoopNamedLockFactory() {
         return new NoopNamedLockFactory();
     }
 
+    @Singleton
     @Provides
     @Named(NameMappers.STATIC_NAME)
     static NameMapper staticNameMapper() {
         return NameMappers.staticNameMapper();
     }
 
+    @Singleton
     @Provides
     @Named(NameMappers.GAV_NAME)
     static NameMapper gavNameMapper() {
         return NameMappers.gavNameMapper();
     }
 
+    @Singleton
+    @Provides
+    @Named(NameMappers.GAECV_NAME)
+    static NameMapper gaecvNameMapper() {
+        return NameMappers.gaecvNameMapper();
+    }
+
+    @Singleton
     @Provides
     @Named(NameMappers.DISCRIMINATING_NAME)
     static NameMapper discriminatingNameMapper() {
         return NameMappers.discriminatingNameMapper();
     }
 
+    @Singleton
     @Provides
     @Named(NameMappers.FILE_GAV_NAME)
     static NameMapper fileGavNameMapper() {
         return NameMappers.fileGavNameMapper();
     }
 
+    @Singleton
+    @Provides
+    @Named(NameMappers.FILE_GAECV_NAME)
+    static NameMapper fileGaecvNameMapper() {
+        return NameMappers.fileGaecvNameMapper();
+    }
+
+    @Singleton
     @Provides
     @Named(NameMappers.FILE_HGAV_NAME)
     static NameMapper fileHashingGavNameMapper() {
         return NameMappers.fileHashingGavNameMapper();
     }
 
+    @Singleton
+    @Provides
+    @Named(NameMappers.FILE_HGAECV_NAME)
+    static NameMapper fileHashingGaecvNameMapper() {
+        return NameMappers.fileHashingGaecvNameMapper();
+    }
+
+    @Singleton
     @Provides
     static RepositorySystemLifecycle newRepositorySystemLifecycle() {
         return new DefaultRepositorySystemLifecycle();
     }
 
+    @Singleton
     @Provides
     static ArtifactResolver newArtifactResolver(
             PathProcessor pathProcessor,
@@ -418,11 +502,13 @@ public class RepositorySystemSupplier {
                 remoteRepositoryFilterManager);
     }
 
+    @Singleton
     @Provides
     static DependencyCollector newDependencyCollector(Map<String, DependencyCollectorDelegate> delegates) {
         return new DefaultDependencyCollector(delegates);
     }
 
+    @Singleton
     @Provides
     @Named(BfDependencyCollector.NAME)
     static BfDependencyCollector newBfDependencyCollector(
@@ -437,6 +523,7 @@ public class RepositorySystemSupplier {
                 artifactDecoratorFactories != null ? artifactDecoratorFactories : Map.of());
     }
 
+    @Singleton
     @Provides
     @Named(DfDependencyCollector.NAME)
     static DfDependencyCollector newDfDependencyCollector(
@@ -451,6 +538,7 @@ public class RepositorySystemSupplier {
                 artifactDecoratorFactories != null ? artifactDecoratorFactories : Map.of());
     }
 
+    @Singleton
     @Provides
     static Installer newInstaller(
             PathProcessor pathProcessor,
@@ -467,6 +555,7 @@ public class RepositorySystemSupplier {
                 syncContextFactory);
     }
 
+    @Singleton
     @Provides
     static Deployer newDeployer(
             PathProcessor pathProcessor,
@@ -491,66 +580,79 @@ public class RepositorySystemSupplier {
                 offlineController);
     }
 
+    @Singleton
     @Provides
     static LocalRepositoryProvider newLocalRepositoryProvider(
             Map<String, LocalRepositoryManagerFactory> localRepositoryManagerFactories) {
         return new DefaultLocalRepositoryProvider(localRepositoryManagerFactories);
     }
 
+    @Singleton
     @Provides
     @Named(EnhancedLocalRepositoryManagerFactory.NAME)
     static EnhancedLocalRepositoryManagerFactory newEnhancedLocalRepositoryManagerFactory(
             LocalPathComposer localPathComposer,
             TrackingFileManager trackingFileManager,
-            LocalPathPrefixComposerFactory localPathPrefixComposerFactory) {
+            LocalPathPrefixComposerFactory localPathPrefixComposerFactory,
+            RepositoryKeyFunctionFactory repositoryKeyFunctionFactory) {
         return new EnhancedLocalRepositoryManagerFactory(
-                localPathComposer, trackingFileManager, localPathPrefixComposerFactory);
+                localPathComposer, trackingFileManager, localPathPrefixComposerFactory, repositoryKeyFunctionFactory);
     }
 
+    @Singleton
     @Provides
     @Named(SimpleLocalRepositoryManagerFactory.NAME)
     static SimpleLocalRepositoryManagerFactory newSimpleLocalRepositoryManagerFactory(
-            LocalPathComposer localPathComposer) {
-        return new SimpleLocalRepositoryManagerFactory(localPathComposer);
+            LocalPathComposer localPathComposer, RepositoryKeyFunctionFactory repositoryKeyFunctionFactory) {
+        return new SimpleLocalRepositoryManagerFactory(localPathComposer, repositoryKeyFunctionFactory);
     }
 
+    @Singleton
     @Provides
     static LocalPathComposer newLocalPathComposer() {
         return new DefaultLocalPathComposer();
     }
 
+    @Singleton
     @Provides
-    static LocalPathPrefixComposerFactory newLocalPathPrefixComposerFactory() {
-        return new DefaultLocalPathPrefixComposerFactory();
+    static LocalPathPrefixComposerFactory newLocalPathPrefixComposerFactory(
+            RepositoryKeyFunctionFactory repositoryKeyFunctionFactory) {
+        return new DefaultLocalPathPrefixComposerFactory(repositoryKeyFunctionFactory);
     }
 
+    @Singleton
     @Provides
     static TransporterProvider newTransportProvider(@Nullable Map<String, TransporterFactory> transporterFactories) {
         return new DefaultTransporterProvider(transporterFactories != null ? transporterFactories : Map.of());
     }
 
+    @Singleton
     @Provides
     static ChecksumProcessor newChecksumProcessor(PathProcessor pathProcessor) {
         return new DefaultChecksumProcessor(pathProcessor);
     }
 
+    @Singleton
     @Provides
     static ChecksumExtractor newChecksumExtractor(Map<String, ChecksumExtractorStrategy> strategies) {
         return new DefaultChecksumExtractor(strategies);
     }
 
+    @Singleton
     @Provides
     @Named(Nx2ChecksumExtractor.NAME)
     static Nx2ChecksumExtractor newNx2ChecksumExtractor() {
         return new Nx2ChecksumExtractor();
     }
 
+    @Singleton
     @Provides
     @Named(XChecksumExtractor.NAME)
     static XChecksumExtractor newXChecksumExtractor() {
         return new XChecksumExtractor();
     }
 
+    @Singleton
     @Provides
     @Named(TrustedToProvidedChecksumsSourceAdapter.NAME)
     static TrustedToProvidedChecksumsSourceAdapter newTrustedToProvidedChecksumsSourceAdapter(
@@ -558,52 +660,65 @@ public class RepositorySystemSupplier {
         return new TrustedToProvidedChecksumsSourceAdapter(trustedChecksumsSources);
     }
 
+    @Singleton
     @Provides
     @Named(SparseDirectoryTrustedChecksumsSource.NAME)
     static SparseDirectoryTrustedChecksumsSource newSparseDirectoryTrustedChecksumsSource(
-            ChecksumProcessor checksumProcessor, LocalPathComposer localPathComposer) {
-        return new SparseDirectoryTrustedChecksumsSource(checksumProcessor, localPathComposer);
+            RepositoryKeyFunctionFactory repositoryKeyFunctionFactory,
+            ChecksumProcessor checksumProcessor,
+            LocalPathComposer localPathComposer) {
+        return new SparseDirectoryTrustedChecksumsSource(
+                repositoryKeyFunctionFactory, checksumProcessor, localPathComposer);
     }
 
+    @Singleton
     @Provides
     @Named(SummaryFileTrustedChecksumsSource.NAME)
     static SummaryFileTrustedChecksumsSource newSummaryFileTrustedChecksumsSource(
+            RepositoryKeyFunctionFactory repositoryKeyFunctionFactory,
             LocalPathComposer localPathComposer,
             RepositorySystemLifecycle repositorySystemLifecycle,
             PathProcessor pathProcessor) {
-        return new SummaryFileTrustedChecksumsSource(localPathComposer, repositorySystemLifecycle, pathProcessor);
+        return new SummaryFileTrustedChecksumsSource(
+                repositoryKeyFunctionFactory, localPathComposer, repositorySystemLifecycle, pathProcessor);
     }
 
+    @Singleton
     @Provides
     static ChecksumAlgorithmFactorySelector newChecksumAlgorithmFactorySelector(
             Map<String, ChecksumAlgorithmFactory> factories) {
         return new DefaultChecksumAlgorithmFactorySelector(factories);
     }
 
+    @Singleton
     @Provides
     @Named(Md5ChecksumAlgorithmFactory.NAME)
     static Md5ChecksumAlgorithmFactory newMd5ChecksumAlgorithmFactory() {
         return new Md5ChecksumAlgorithmFactory();
     }
 
+    @Singleton
     @Provides
     @Named(Sha1ChecksumAlgorithmFactory.NAME)
     static Sha1ChecksumAlgorithmFactory newSh1ChecksumAlgorithmFactory() {
         return new Sha1ChecksumAlgorithmFactory();
     }
 
+    @Singleton
     @Provides
     @Named(Sha256ChecksumAlgorithmFactory.NAME)
     static Sha256ChecksumAlgorithmFactory newSh256ChecksumAlgorithmFactory() {
         return new Sha256ChecksumAlgorithmFactory();
     }
 
+    @Singleton
     @Provides
     @Named(Sha512ChecksumAlgorithmFactory.NAME)
     static Sha512ChecksumAlgorithmFactory newSh512ChecksumAlgorithmFactory() {
         return new Sha512ChecksumAlgorithmFactory();
     }
 
+    @Singleton
     @Provides
     static ArtifactPredicateFactory newArtifactPredicateFactory(
             ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3477DependencyResolutionErrorMessageTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3477DependencyResolutionErrorMessageTest.java
@@ -92,9 +92,11 @@ class MavenITmng3477DependencyResolutionErrorMessageTest extends AbstractMavenIn
         testit(
                 54312,
                 new String[] { // JDK "Connection to..." Apache "Connect to..."
+                    // with removal of connector hack https://github.com/apache/maven-resolver/pull/1676
+                    // the order is not stable anymore, so repoId may be any of two
                     ".*The following artifacts could not be resolved: org.apache.maven.its.plugins:maven-it-plugin-not-exists:pom:1.2.3 \\(absent\\): "
                             + "Could not transfer artifact org.apache.maven.its.plugins:maven-it-plugin-not-exists:pom:1.2.3 from/to "
-                            + "central \\(http://localhost:.*/repo\\):.*Connect.*refused.*"
+                            + "(central|maven-core-it) \\(http://localhost:.*/repo\\):.*Connect.*refused.*"
                 },
                 "pom-plugin.xml");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ under the License.
     <plexusInterpolationVersion>1.29</plexusInterpolationVersion>
     <plexusTestingVersion>2.0.2</plexusTestingVersion>
     <plexusXmlVersion>4.1.0</plexusXmlVersion>
-    <resolverVersion>2.0.13</resolverVersion>
+    <resolverVersion>2.0.14</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
     <sisuVersion>0.9.0.M4</sisuVersion>
     <slf4jVersion>2.0.17</slf4jVersion>


### PR DESCRIPTION
Changes:
* update to Resolver 2.0.14
* use per-request metadata nature in version range requests
* apply required code changes
* use new TrackingFileManager in maven-compat upgrade check manager
