### PR TITLE
Fix multiple SLF4J providers warning in tests

### DIFF
--- a/compat/maven-resolver-provider/pom.xml
+++ b/compat/maven-resolver-provider/pom.xml
@@ -157,8 +157,8 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-logging</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/impl/maven-core/pom.xml
+++ b/impl/maven-core/pom.xml
@@ -201,11 +201,6 @@ under the License.
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-jxpath</groupId>
       <artifactId>commons-jxpath</artifactId>
       <scope>test</scope>

--- a/impl/maven-impl/pom.xml
+++ b/impl/maven-impl/pom.xml
@@ -131,8 +131,8 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-logging</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary
- Remove `slf4j-simple` test dependency from `maven-core` (which already has `maven-logging`)
- Replace `slf4j-simple` with `maven-logging` in `maven-impl` and `maven-resolver-provider` test dependencies
- Eliminates "multiple SLF4J providers" warnings when running tests

## Background
Maven has its own SLF4J provider (`org.apache.maven.slf4j.MavenServiceProvider`) in the `maven-logging` module. Having `slf4j-simple` as a test dependency creates a conflict that produces warnings like:

```
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [org.apache.maven.slf4j.MavenServiceProvider@5c45d770]
SLF4J(W): Found provider [org.slf4j.simple.SimpleServiceProvider@2ce6c6ec]
```

## Changes
- **maven-core**: Removed `slf4j-simple` test dependency (already depends on `maven-logging`)
- **maven-impl**: Replaced `slf4j-simple` with `maven-logging` test dependency
- **maven-resolver-provider**: Replaced `slf4j-simple` with `maven-logging` test dependency

This ensures all modules use Maven's own SLF4J provider consistently.

## Test plan
- [x] Full test suite passes (`mvn -Prun-its verify`)
- [x] No SLF4J multiple provider warnings in test output
- [ ] CI build succeeds

Fixes #10949