### PR TITLE
[#11486] replace '@' with pipe in sed

### DIFF
--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -179,8 +179,8 @@ concat_lines() {
     while read -r arg; do
       # Replace variables first
       arg=$(echo "$arg" | sed \
-        -e "s@\${MAVEN_PROJECTBASEDIR}@$MAVEN_PROJECTBASEDIR@g" \
-        -e "s@\$MAVEN_PROJECTBASEDIR@$MAVEN_PROJECTBASEDIR@g")
+        -e "s|\${MAVEN_PROJECTBASEDIR}|${MAVEN_PROJECTBASEDIR}|g" \
+        -e "s|\$MAVEN_PROJECTBASEDIR|${MAVEN_PROJECTBASEDIR}|g")
 
       echo "$arg"
     done | \


### PR DESCRIPTION
* replace `@` with `|` as separator, worked well before, fixes #11486 
* use `${}` instead of plain `$`