### PR TITLE
Add default implementation for new method in MavenPluginManager

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/MavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/MavenPluginManager.java
@@ -74,7 +74,9 @@ public interface MavenPluginManager {
      * @deprecated Use {@link #checkPrerequisites(PluginDescriptor)} instead.
      */
     @Deprecated
-    void checkRequiredMavenVersion(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException;
+    default void checkRequiredMavenVersion(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
+        checkPrerequisites(pluginDescriptor);
+    }
 
     /**
      * Verifies that the specified plugin's prerequisites are met.
@@ -82,7 +84,9 @@ public interface MavenPluginManager {
      * @param pluginDescriptor The descriptor of the plugin to check, must not be {@code null}.
      * @since 3.9.12
      */
-    void checkPrerequisites(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException;
+    default void checkPrerequisites(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
+        checkRequiredMavenVersion(pluginDescriptor);
+    }
 
     /**
      * Sets up the class realm for the specified plugin. Both the class realm and the plugin artifacts that constitute

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -309,12 +309,6 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
         }
     }
 
-    @Override
-    @Deprecated
-    public void checkRequiredMavenVersion(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
-        checkPrerequisites(pluginDescriptor);
-    }
-
     public void setupPluginRealm(
             PluginDescriptor pluginDescriptor,
             MavenSession session,


### PR DESCRIPTION
MavenPluginManager can be implemented by user extension new method in interface can brake an implementation.

We can add default implementation in interface to avoid braking change.


Discovered during build creadur-rat project with develocity extension, without fix we will have:

```
Exception in thread "main" java.lang.AbstractMethodError: Receiver class com.gradle.maven.cache.extension.g.c does not define or inherit an implementation of the resolved method 'abstract void checkPrerequisites(org.apache.maven.plugin.descriptor.PluginDescriptor)' of interface org.apache.maven.plugin.MavenPluginManager.
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:187)
```

introduced in: 
 - #11479
 

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
