### PR TITLE
Update formatting of prerequisites-requirements error to improve readability

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/MavenPluginPrerequisitesChecker.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/MavenPluginPrerequisitesChecker.java
@@ -31,7 +31,7 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 public interface MavenPluginPrerequisitesChecker extends Consumer<PluginDescriptor> {
     /**
      *
-     * @param pluginDescriptor
+     * @param pluginDescriptor the plugin descriptor to check
      * @throws IllegalStateException in case the checked prerequisites are not met
      */
     @Override

--- a/maven-core/src/main/java/org/apache/maven/plugin/PluginIncompatibleException.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/PluginIncompatibleException.java
@@ -26,10 +26,6 @@ import org.apache.maven.model.Plugin;
 public class PluginIncompatibleException extends PluginManagerException {
 
     public PluginIncompatibleException(Plugin plugin, String message) {
-        this(plugin, message, null);
-    }
-
-    public PluginIncompatibleException(Plugin plugin, String message, Throwable cause) {
-        super(plugin, message, cause);
+        super(plugin, message, (Throwable) null);
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -296,15 +296,15 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
         });
         // aggregate all exceptions
         if (!prerequisiteExceptions.isEmpty()) {
+            String ln = System.lineSeparator();
             String messages = prerequisiteExceptions.stream()
                     .map(IllegalStateException::getMessage)
-                    .collect(Collectors.joining(", "));
+                    .collect(Collectors.joining(ln + '\t'));
             PluginIncompatibleException pie = new PluginIncompatibleException(
                     pluginDescriptor.getPlugin(),
-                    "The plugin " + pluginDescriptor.getId() + " has unmet prerequisites: " + messages,
-                    prerequisiteExceptions.get(0));
-            // the first exception is added as cause, all other ones as suppressed exceptions
-            prerequisiteExceptions.stream().skip(1).forEach(pie::addSuppressed);
+                    ln + "The plugin " + pluginDescriptor.getId() + " has unmet prerequisites: " + ln + '\t'
+                            + messages);
+            prerequisiteExceptions.forEach(pie::addSuppressed);
             throw pie;
         }
     }


### PR DESCRIPTION
Message at the end of error line is not readable ... so add some new lines and tabs to make it more readable

before:

<img width="1611" height="90" alt="image" src="https://github.com/user-attachments/assets/b1781ceb-844f-46c0-93f1-757b87eea595" />

aftre:

<img width="1611" height="85" alt="image" src="https://github.com/user-attachments/assets/c48b0e43-00a6-449f-9318-9f4d421a2f29" />

related to:
 - #11479