### PR TITLE
Allow ${project.basedir} in profile activation.condition

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -686,7 +686,8 @@ public class DefaultModelValidator implements ModelValidator {
                 while (matcher.find()) {
                     String propertyName = matcher.group(0);
 
-                    if (path.startsWith("activation.file.") && "${project.basedir}".equals(propertyName)) {
+                    if ((path.startsWith("activation.file.") || path.equals("activation.condition"))
+                            && "${project.basedir}".equals(propertyName)) {
                         continue;
                     }
                     addViolation(

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -968,4 +968,12 @@ class DefaultModelValidatorTest {
         SimpleProblemCollector result = validateFile("raw-model/self-combine-bad.xml");
         assertViolations(result, 0, 1, 0);
     }
+
+    @Test
+    void profileActivationConditionWithBasedirExpression() throws Exception {
+        // Test that ${project.basedir} in activation.condition is allowed (no warnings)
+        SimpleProblemCollector result = validateRaw(
+                "raw-model/profile-activation-condition-with-basedir.xml", ModelValidator.VALIDATION_LEVEL_STRICT);
+        assertViolations(result, 0, 0, 0);
+    }
 }

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/profile-activation-condition-with-basedir.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/profile-activation-condition-with-basedir.xml
@@ -1,0 +1,44 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.1.0</modelVersion>
+  <artifactId>aid</artifactId>
+  <groupId>gid</groupId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <profiles>
+    <!-- This profile uses ${project.basedir} in activation.condition, which should be allowed -->
+    <profile>
+      <id>condition-with-basedir</id>
+      <activation>
+        <condition>exists("${project.basedir}/src/main/java")</condition>
+      </activation>
+    </profile>
+    <!-- This profile uses ${basedir} in activation.condition, which should also be allowed -->
+    <profile>
+      <id>condition-with-basedir-short</id>
+      <activation>
+        <condition>exists("${basedir}/src/test/java")</condition>
+      </activation>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
Previously, `${project.basedir}` was only allowed in `activation.file.exists` and `activation.file.missing`. This change extends the same allowance to `activation.condition`, which is a new Maven 4.0.0 feature that also needs to reference the project base directory for its expressions.

This fixes a false positive warning when using expressions like `exists("${project.basedir}/src/main/java")` in activation conditions.

### Changes
- Updated `DefaultModelValidator` to allow `${project.basedir}` in `activation.condition` path
- Added unit test for the new behavior

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author