### PR TITLE
[master] Allow ${project.basedir} in profile activation.condition (#11528)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -738,7 +738,8 @@ public class DefaultModelValidator implements ModelValidator {
                 while (matcher.find()) {
                     String propertyName = matcher.group(0);
 
-                    if (path.startsWith("activation.file.") && "${project.basedir}".equals(propertyName)) {
+                    if ((path.startsWith("activation.file.") || path.equals("activation.condition"))
+                            && "${project.basedir}".equals(propertyName)) {
                         continue;
                     }
                     addViolation(

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -1001,4 +1001,12 @@ class DefaultModelValidatorTest {
         SimpleProblemCollector result = validateFile("raw-model/self-combine-bad.xml");
         assertViolations(result, 0, 1, 0);
     }
+
+    @Test
+    void profileActivationConditionWithBasedirExpression() throws Exception {
+        // Test that ${project.basedir} in activation.condition is allowed (no warnings)
+        SimpleProblemCollector result = validateRaw(
+                "raw-model/profile-activation-condition-with-basedir.xml", ModelValidator.VALIDATION_LEVEL_STRICT);
+        assertViolations(result, 0, 0, 0);
+    }
 }

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/profile-activation-condition-with-basedir.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/profile-activation-condition-with-basedir.xml
@@ -1,0 +1,44 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.1.0</modelVersion>
+  <artifactId>aid</artifactId>
+  <groupId>gid</groupId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <profiles>
+    <!-- This profile uses ${project.basedir} in activation.condition, which should be allowed -->
+    <profile>
+      <id>condition-with-basedir</id>
+      <activation>
+        <condition>exists("${project.basedir}/src/main/java")</condition>
+      </activation>
+    </profile>
+    <!-- This profile uses ${basedir} in activation.condition, which should also be allowed -->
+    <profile>
+      <id>condition-with-basedir-short</id>
+      <activation>
+        <condition>exists("${basedir}/src/test/java")</condition>
+      </activation>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
# Backport

This will backport the following commits from `maven-4.0.x` to `master`:
 - [Allow ${project.basedir} in profile activation.condition (#11528)](https://github.com/apache/maven/pull/11528)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)