### PR TITLE
Fix NullPointerException when clearing project properties

### DIFF
--- a/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
@@ -66,4 +66,17 @@ class ModelTest {
     void testToStringNullSafe() {
         assertNotNull(new Model().toString());
     }
+
+    @Test
+    void testPropertiesClear() {
+        // Test for issue #11552: NullPointerException when clearing properties
+        Model model = new Model();
+        model.addProperty("key1", "value1");
+        model.addProperty("key2", "value2");
+        assertEquals(2, model.getProperties().size());
+
+        // This should not throw NullPointerException
+        model.getProperties().clear();
+        assertEquals(0, model.getProperties().size());
+    }
 }

--- a/src/mdo/java/WrapperProperties.java
+++ b/src/mdo/java/WrapperProperties.java
@@ -376,6 +376,12 @@ class WrapperProperties extends Properties {
         }
 
         @Override
+        public synchronized void clear() {
+            keyOrder.clear();
+            super.clear();
+        }
+
+        @Override
         public synchronized void forEach(BiConsumer<? super Object, ? super Object> action) {
             entrySet().forEach(e -> action.accept(e.getKey(), e.getValue()));
         }

--- a/src/mdo/model-v3.vm
+++ b/src/mdo/model-v3.vm
@@ -204,7 +204,11 @@ public class ${class.name}
         }
       #elseif( $field.type == "java.util.Properties" )
         LinkedHashMap<String, String> map = new LinkedHashMap<>();
-        ${field.name}.forEach((key, value) -> map.put(key.toString(), value.toString()));
+        ${field.name}.forEach((key, value) -> {
+            if (value != null) {
+                map.put(key.toString(), value.toString());
+            }
+        });
         if (!Objects.equals(map, getDelegate().get${cap}())) {
             update(getDelegate().with${cap}(map));
         }


### PR DESCRIPTION
## Problem

Calling `clear()` on model properties throws NPE in m2e:

```
java.lang.NullPointerException: Cannot invoke "Object.toString()" because "value" is null
	at org.apache.maven.model.ModelBase.lambda$setProperties$5(ModelBase.java:112)
	at org.apache.maven.model.WrapperProperties$OrderedProperties.lambda$forEach$0(WrapperProperties.java:383)
```

Root cause: Two bugs compound the issue:
1. `OrderedProperties.clear()` clears the hashtable but not `keyOrder`, leaving stale keys
2. `forEach()` iterates stale keys, retrieving null values, then calls `toString()` without null-check

## Changes

**WrapperProperties.java**
- Override `clear()` in `OrderedProperties` to clear both `keyOrder` list and parent properties

**model-v3.vm**
- Add null-check before `value.toString()` in generated `setProperties()` method: `value != null ? value.toString() : null`

**ModelTest.java**
- Add test case validating `clear()` on properties doesn't throw NPE

Fix #11552

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/


