### PR TITLE
Accept Java module names as attached artifactId even if they differ from the project's artifactId

### DIFF
--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultProjectManagerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultProjectManagerTest.java
@@ -20,11 +20,15 @@ package org.apache.maven.internal.impl;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Supplier;
 
+import org.apache.maven.api.Language;
 import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Project;
+import org.apache.maven.api.ProjectScope;
 import org.apache.maven.api.services.ArtifactManager;
 import org.apache.maven.impl.DefaultModelVersionParser;
+import org.apache.maven.impl.DefaultSourceRoot;
 import org.apache.maven.impl.DefaultVersionParser;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.util.version.GenericVersionScheme;
@@ -32,21 +36,30 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 class DefaultProjectManagerTest {
+
+    private DefaultProjectManager projectManager;
+
+    private Project project;
+
+    private ProducedArtifact artifact;
+
+    private Path artifactPath;
 
     @Test
     void attachArtifact() {
         InternalMavenSession session = Mockito.mock(InternalMavenSession.class);
         ArtifactManager artifactManager = Mockito.mock(ArtifactManager.class);
         MavenProject mavenProject = new MavenProject();
-        Project project = new DefaultProject(session, mavenProject);
-        ProducedArtifact artifact = Mockito.mock(ProducedArtifact.class);
-        Path path = Paths.get("");
+        project = new DefaultProject(session, mavenProject);
+        artifact = Mockito.mock(ProducedArtifact.class);
+        artifactPath = Paths.get("");
         DefaultVersionParser versionParser =
                 new DefaultVersionParser(new DefaultModelVersionParser(new GenericVersionScheme()));
-        DefaultProjectManager projectManager = new DefaultProjectManager(session, artifactManager);
+        projectManager = new DefaultProjectManager(session, artifactManager);
 
         mavenProject.setGroupId("myGroup");
         mavenProject.setArtifactId("myArtifact");
@@ -54,9 +67,55 @@ class DefaultProjectManagerTest {
         when(artifact.getGroupId()).thenReturn("myGroup");
         when(artifact.getArtifactId()).thenReturn("myArtifact");
         when(artifact.getBaseVersion()).thenReturn(versionParser.parseVersion("1.0-SNAPSHOT"));
-        projectManager.attachArtifact(project, artifact, path);
+        projectManager.attachArtifact(project, artifact, artifactPath);
 
+        // Verify that an exception is thrown when the artifactId differs
         when(artifact.getArtifactId()).thenReturn("anotherArtifact");
-        assertThrows(IllegalArgumentException.class, () -> projectManager.attachArtifact(project, artifact, path));
+        assertExceptionMessageContains("myGroup:myArtifact:1.0-SNAPSHOT", "myGroup:anotherArtifact:1.0-SNAPSHOT");
+
+        // Add a Java module. It should relax the restriction on artifactId.
+        projectManager.addSourceRoot(
+                project,
+                new DefaultSourceRoot(
+                        ProjectScope.MAIN,
+                        Language.JAVA_FAMILY,
+                        "org.foo.bar",
+                        null,
+                        Path.of("myProject"),
+                        null,
+                        null,
+                        false,
+                        null,
+                        true));
+
+        // Verify that we get the same exception when the artifactId does not match the module name
+        assertExceptionMessageContains("", "anotherArtifact");
+
+        // Verify that no exception is thrown when the artifactId is the module name
+        when(artifact.getArtifactId()).thenReturn("org.foo.bar");
+        projectManager.attachArtifact(project, artifact, artifactPath);
+
+        // Verify that an exception is thrown when the groupId differs
+        when(artifact.getGroupId()).thenReturn("anotherGroup");
+        assertExceptionMessageContains("myGroup:myArtifact:1.0-SNAPSHOT", "anotherGroup:org.foo.bar:1.0-SNAPSHOT");
+    }
+
+    /**
+     * Verifies that {@code projectManager.attachArtifact(…)} throws an exception,
+     * and that the expecption message contains the expected and actual <abbr>GAV</abbr>.
+     *
+     * @param expectedGAV the actual <abbr>GAV</abbr> that the exception message should contain
+     * @param actualGAV the actual <abbr>GAV</abbr> that the exception message should contain
+     */
+    private void assertExceptionMessageContains(String expectedGAV, String actualGAV) {
+        String cause = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> projectManager.attachArtifact(project, artifact, artifactPath))
+                .getMessage();
+        Supplier<String> message = () ->
+                String.format("The exception message does not contain the expected GAV. Message was:%n%s%n", cause);
+
+        assertTrue(cause.contains(expectedGAV), message);
+        assertTrue(cause.contains(actualGAV), message);
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -94,7 +94,7 @@ public record DefaultSourceRoot(
             @Nonnull Language language,
             @Nullable String moduleName,
             @Nullable Version targetVersionOrNull,
-            @Nullable Path directory,
+            @Nonnull Path directory,
             @Nullable List<String> includes,
             @Nullable List<String> excludes,
             boolean stringFiltering,


### PR DESCRIPTION
Backport of #11549.