### PR TITLE
Document deprecation of Language.SCRIPT

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Language.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Language.java
@@ -51,7 +51,7 @@ public interface Language extends ExtensibleEnum {
     Language RESOURCES = language("resources");
 
     /**
-     * The {@code "script"} language. This constant is retained for backward compatibility with Maven 3.
+     * The "script" language. This constant is retained for backward compatibility with Maven 3.
      *
      * @deprecated Use {@link #RESOURCES} instead.
      */


### PR DESCRIPTION
### Summary
Improves documentation for the deprecated `Language.SCRIPT` constant.

### Motivation
`Language.SCRIPT` is deprecated but lacked structured deprecation metadata.
This change clarifies the rationale, adds `since` information, and documents
the recommended replacement.

### Changes
- Added deprecation rationale to Javadoc
- Added `@Deprecated(since = "4.0.0-alpha", forRemoval = false)`
- No behavioral or compatibility changes

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/

Note: This change is documentation-only and does not affect runtime behavior.