### PR TITLE
Fix jdk21 tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,34 @@ under the License.
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-component-metadata</artifactId>
           <version>${plexusVersion}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+            <argLine>-Xmx256m @{jacocoArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
+            <systemPropertyVariables combine.children="append">
+              <version.toolbox>${toolboxVersion}</version.toolbox>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <systemPropertyVariables combine.children="append">
+              <version.toolbox>${toolboxVersion}</version.toolbox>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <!-- enforce backwards compatibility -->
+        <plugin>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <version>0.25.1</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
Fixes #11398

# Pull Request: Fix JDK 21+ test failures by propagating `--add-opens` to forked test JVM

Fixes #11398

## Overview

This pull request fixes test failures on JDK 21+ caused by missing module opens
in the forked Surefire JVM.

The change ensures that required `--add-opens` options are propagated correctly
alongside the JaCoCo agent using Surefire’s supported `@{jacocoArgLine}` mechanism.

> **Note:**  
> This pull request has been rebased onto the `maven-3.9.x` branch as requested,
> since issue #11398 is reported against Maven 3.9.9. The branch was force-pushed
> after rebasing, without introducing any additional changes.

## What this PR does

- Appends required `--add-opens` JVM options to the existing Surefire `argLine`
- Preserves the current JaCoCo setup and forked JVM behavior
- Ensures tests relying on reflective access continue to work on JDK 21+

## Why this change is needed

Starting with JDK 21, Java enforces strong module encapsulation more strictly.
Tests that rely on reflective access to JDK internals (for example
`java.lang` and `java.lang.reflect`) fail with `InaccessibleObjectException`
unless the corresponding modules are explicitly opened at JVM startup.

Although the build already used `@{jacocoArgLine}` to inject the JaCoCo agent,
the forked test JVM did not receive the required `--add-opens` options.
As a result, tests passed on JDK 17 but failed on JDK 21+.

This change ensures the required JVM options are present at fork time,
which is the only point where module opens are honored by the JVM.

## How the change works

The Surefire `argLine` configuration is extended to include the required
`--add-opens` options in addition to `@{jacocoArgLine}`.

This approach:

- Uses documented Surefire behavior
- Avoids illegal reflective access at runtime
- Keeps the change scoped strictly to test execution

No production code behavior is affected.

## Testing

- Verified locally with `mvn verify` on JDK 17 and JDK 21
- On JDK 22+, some Maven Core tests fail due to Guice/Sisu injection behavior
  unrelated to this change

## Checklist

- [x] Single issue addressed
- [x] Clear PR description
- [x] Meaningful commit
- [x] Existing tests fail without this change and pass once applied
- [x] `mvn verify` run (JDK 17 / 21)
- [ ] Core ITs (executed by CI)

## License Declaration

- [x] I hereby declare this contribution to be licensed under the
      Apache License Version 2.0, January 2004
