### PR TITLE
Bug: make all collected args use single quote

### DIFF
--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -291,7 +291,7 @@ cmd="\"$JAVACMD\" \
 
 # Add remaining arguments with proper quoting
 for arg in "$@"; do
-    cmd="$cmd \"$arg\""
+    cmd="$cmd '$arg'"
 done
 
 if [ -n "$MAVEN_DEBUG_SCRIPT" ]; then


### PR DESCRIPTION
Thus, preventing expansion, if applicable.

Fixes #10421