### PR TITLE
Fix typo: 'occured' -> 'occurred' in Javadoc

### DIFF
--- a/its/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/ForkTestMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/ForkTestMojo.java
@@ -36,7 +36,7 @@ public class ForkTestMojo extends AbstractMojo {
     /**
      * Runs this mojo.
      *
-     * @throws MojoExecutionException If an error occured.
+     * @throws MojoExecutionException If an error occurred.
      */
     public void execute() throws MojoExecutionException {
         getLog().info("[MAVEN-CORE-IT-LOG] Forked test mojo");

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/InjectMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/InjectMojo.java
@@ -68,7 +68,7 @@ public class InjectMojo extends AbstractMojo {
     /**
      * Runs this mojo.
      *
-     * @throws MojoExecutionException If an error occured.
+     * @throws MojoExecutionException If an error occurred.
      */
     public void execute() throws MojoExecutionException {
         Set artifactKeys = new LinkedHashSet();


### PR DESCRIPTION
Fix typo in Javadoc: 'occured' -> 'occurred'