### PR TITLE
Fix typo: 'textOccurencesInLog' -> 'textOccurrencesInLog'

### DIFF
--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -614,6 +614,14 @@ public class Verifier {
     }
 
     /**
+     * @deprecated Use {@link #textOccurrencesInLog(List, String)} instead
+     */
+    @Deprecated
+    public static long textOccurencesInLog(List<String> lines, String text) {
+        return textOccurrencesInLog(lines, text);
+    }
+
+    /**
      * Checks whether the specified line is just an error message from Velocity. Especially old versions of Doxia employ
      * a very noisy Velocity instance.
      *


### PR DESCRIPTION
Fix typo in method name: 'textOccurencesInLog' -> 'textOccurrencesInLog'