### PR TITLE
Fix broken reference links in site.xml for Maven 4.x

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -59,11 +59,11 @@ under the License.
     </menu>
 
     <menu inherit="bottom" name="Reference">
-      <item name="Lifecycles" href="./impl/maven-core/lifecycles.html"/>
-      <item name="Plugin Bindings to Default Lifecycle" href="./impl/maven-core/default-bindings.html"/>
-      <item name="Artifact Handlers" href="./impl/maven-core/artifact-handlers.html"/>
-      <item name="CLI options" href="./compat/maven-embedder/cli.html"/>
-      <item name="Super POM" href="./compat/maven-model-builder/super-pom.html"/>
+      <item name="Lifecycles" href="./maven-impl-modules/maven-core/lifecycles.html"/>
+      <item name="Plugin Bindings to Default Lifecycle" href="./maven-impl-modules/maven-core/default-bindings.html"/>
+      <item name="Artifact Handlers" href="./maven-impl-modules/maven-core/artifact-handlers.html"/>
+      <item name="CLI options" href="./maven-compat-modules/maven-embedder/cli.html"/>
+      <item name="Super POM" href="./maven-compat-modules/maven-model-builder/super-pom.html"/>
     </menu>
 
     <menu inherit="bottom" name="Development">


### PR DESCRIPTION
The Reference menu links were pointing to outdated paths (impl/ and compat/) that do not exist on the deployed Maven 4 reference site, resulting in 404 errors.

This PR updates the Reference menu URLs to match the current deployed site structure (maven-impl-modules/ and maven-compat-modules), fixing navigation for Lifecycles, Plugin Bindings, Artifact Handlers, CLI options, and Super POM.

Related to #2502.
<img width="2996" height="1800" alt="2026-01-04_23-18-24" src="https://github.com/user-attachments/assets/0df032ac-52e2-40fe-a14e-7a75a7029f2c" />
<img width="3020" height="1708" alt="2026-01-04_23-18-21" src="https://github.com/user-attachments/assets/4b473526-9607-48ec-a00b-c885f55b240a" />
