### PR TITLE
[4.0.x] Use Mimir mirror feature (#11622)

### DIFF
--- a/.github/ci-mimir-session.properties
+++ b/.github/ci-mimir-session.properties
@@ -19,3 +19,5 @@
 
 # do not waste time on this; we maintain the version
 mimir.daemon.autoupdate=false
+# CI uses US Mirror
+mimir.session.mirrors=central(https://maven-central.storage-download.googleapis.com/maven2/)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,10 +32,11 @@ concurrency:
 permissions: {}
 
 env:
-  MIMIR_VERSION: 0.10.6
+  MIMIR_VERSION: 0.11.2
   MIMIR_BASEDIR: ~/.mimir
   MIMIR_LOCAL: ~/.mimir/local
   MAVEN_OPTS: -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/java_heapdump.hprof
+  MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
 
 jobs:
   initial-build:
@@ -71,7 +72,7 @@ jobs:
 
       - name: Set up Maven
         shell: bash
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=4.0.0-rc-4"
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=4.0.0-rc-5"
 
       - name: Prepare Mimir for Maven 4.x
         shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -693,7 +693,7 @@ under the License.
       <dependency>
         <groupId>eu.maveniverse.maven.mimir</groupId>
         <artifactId>testing</artifactId>
-        <version>0.10.6</version>
+        <version>0.11.2</version>
       </dependency>
     </dependencies>
     <!--bootstrap-start-comment-->


### PR DESCRIPTION
Use latest Mimir 0.11.2 + mirror feature. CI is now redirected to Google US Mirror.

We identified 3 problems affected by unstable Central (fails the CI runs if any of these get 4xx/5xx):
* wrapper - fixed by using alt URL
* Mimir extension loading from Central (not solved by this PR)
* two UTs `RequestTraceTest` and `TestApiStandalone` going directly to Central (not solved by this PR)
