### PR TITLE
Add Javadoc for deprecated Artifact constants

### DIFF
--- a/compat/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
+++ b/compat/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
@@ -38,17 +38,14 @@ import org.apache.maven.artifact.versioning.VersionRange;
  */
 public interface Artifact extends Comparable<Artifact> {
     /**
-     * @deprecated since 4.0.0.
-     *             Use an explicit version instead.
+     * @deprecated Use {@link #VERSION} instead.
      */
-
     @Deprecated(since = "4.0.0")
     String RELEASE_VERSION = "RELEASE";
-    /**
-     * @deprecated since 4.0.0.
-     *             Avoid using "LATEST"; prefer an explicit version instead.
-     */
 
+    /**
+     * @deprecated Avoid using {@code LATEST}; prefer an explicit version instead.
+     */
     @Deprecated(since = "4.0.0")
     String LATEST_VERSION = "LATEST";
 


### PR DESCRIPTION
Adds Javadoc to the deprecated RELEASE_VERSION and LATEST_VERSION
constants in Artifact to indicate preferred alternatives, as requested
in issue #11504.
