### PR TITLE
Maven Resolver 2.0.15

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -DsessionRootDirectory=${session.rootDirectory}
+-Dapache.snapshots
 

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ under the License.
     <plexusInterpolationVersion>1.29</plexusInterpolationVersion>
     <plexusTestingVersion>2.1.0</plexusTestingVersion>
     <plexusXmlVersion>4.1.1</plexusXmlVersion>
-    <resolverVersion>2.0.15</resolverVersion>
+    <resolverVersion>2.0.16-SNAPSHOT</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
     <sisuVersion>1.0.0</sisuVersion>
     <slf4jVersion>2.0.17</slf4jVersion>


### PR DESCRIPTION
Update from 2.0.14

Release notes:
https://github.com/apache/maven-resolver/releases/tag/maven-resolver-2.0.15

EDIT: testing with 2.0.16-SNAPSHOT now that contains a single commit, fix for JDK transport `Content-Length` header.