### PR TITLE
Silence warning with latest Java LTS (25) in maven 3.9.x

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -205,6 +205,10 @@ if "$JAVACMD" --enable-native-access=ALL-UNNAMED -version >/dev/null 2>&1; then
   fi
 fi
 
+if "$JAVACMD" --sun-misc-unsafe-memory-access=allow -version >/dev/null 2>&1; then
+  MAVEN_OPTS="--sun-misc-unsafe-memory-access=allow $MAVEN_OPTS"
+fi
+
 exec "$JAVACMD" \
   $MAVEN_OPTS \
   $MAVEN_DEBUG_OPTS \

--- a/apache-maven/src/bin/mvn.cmd
+++ b/apache-maven/src/bin/mvn.cmd
@@ -182,6 +182,12 @@ if ERRORLEVEL 1 goto skipEnableNativeAccess
 set "INTERNAL_MAVEN_OPTS=--enable-native-access=ALL-UNNAMED %INTERNAL_MAVEN_OPTS%"
 :skipEnableNativeAccess
 
+
+"%JAVACMD%" --sun-misc-unsafe-memory-access=allow -version >nul 2>&1
+if ERRORLEVEL 1 goto skipSunMemoryAccess
+set "INTERNAL_MAVEN_OPTS=--sun-misc-unsafe-memory-access=allow %INTERNAL_MAVEN_OPTS%"
+:skipSunMemoryAccess
+
 "%JAVACMD%" ^
   %JVM_CONFIG_MAVEN_PROPS% ^
   %INTERNAL_MAVEN_OPTS% ^


### PR DESCRIPTION
When used with latest Java LTS (i.e. 25 at the moment), maven 3.9.x outputs a warning:

WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper (file:/usr/share/maven/lib/guava.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release

Properly fixing this in 3.9.x branch would mean upgrading Guava to newer version, which I understood is impossible due to dependency version collisions/limitations.
This fix silences the warning, in similar manner to MNG-8248

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
