### PR TITLE
Fix thread-safety issue in DefaultModelValidator (#11618)

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -89,7 +90,9 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String EMPTY = "";
 
-    private final Set<String> validIds = new HashSet<>();
+    // Thread-safe set required because class is @Singleton and validIds is accessed concurrently
+    // See: https://github.com/apache/maven/issues/11618
+    private final Set<String> validIds = ConcurrentHashMap.newKeySet();
 
     private ModelVersionProcessor versionProcessor;
 

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -1128,7 +1128,7 @@ public class DefaultModelValidator implements ModelValidator {
             String id,
             String sourceHint,
             InputLocationTracker tracker) {
-        if (validIds.contains(id)) {
+        if (id != null && validIds.contains(id)) {
             return true;
         }
         if (!validateStringNotEmpty(prefix, fieldName, problems, severity, version, id, sourceHint, tracker)) {

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -22,6 +22,9 @@ import java.io.InputStream;
 import java.io.Serial;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 
 import org.apache.maven.model.Model;
@@ -920,14 +923,14 @@ class DefaultModelValidatorTest {
     void testConcurrentValidation() throws Exception {
         int threadCount = 10;
         int iterationsPerThread = 100;
-        java.util.concurrent.CountDownLatch startLatch = new java.util.concurrent.CountDownLatch(1);
-        java.util.concurrent.CountDownLatch doneLatch = new java.util.concurrent.CountDownLatch(threadCount);
-        java.util.concurrent.atomic.AtomicReference<Throwable> failure = new java.util.concurrent.atomic.AtomicReference<>();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
 
         // Create multiple threads that will validate models concurrently
         for (int t = 0; t < threadCount; t++) {
             final int threadId = t;
-            new Thread(() -> {
+            Thread thread = new Thread(() -> {
                 try {
                     startLatch.await(); // Wait for all threads to be ready
                     for (int i = 0; i < iterationsPerThread; i++) {
@@ -945,14 +948,17 @@ class DefaultModelValidatorTest {
                 } finally {
                     doneLatch.countDown();
                 }
-            }).start();
+            });
+            thread.setName("validator-test-" + threadId);
+            thread.setDaemon(true);
+            thread.start();
         }
 
         // Start all threads simultaneously
         startLatch.countDown();
 
         // Wait for all threads to complete
-        assertTrue(doneLatch.await(30, java.util.concurrent.TimeUnit.SECONDS), "Threads did not complete in time");
+        assertTrue(doneLatch.await(30, TimeUnit.SECONDS), "Threads did not complete in time");
 
         // Check if any thread encountered an error
         if (failure.get() != null) {

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -962,7 +962,8 @@ class DefaultModelValidatorTest {
 
         // Check if any thread encountered an error
         if (failure.get() != null) {
-            throw new AssertionError("Concurrent validation failed: " + failure.get().getMessage(), failure.get());
+            throw new AssertionError(
+                    "Concurrent validation failed: " + failure.get().getMessage(), failure.get());
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix thread-safety issue where concurrent model validation causes `ClassCastException`
- Aligns compat layer with Maven 4 implementation which already uses thread-safe collections
- Adds regression test for concurrent validation

## Problem

`DefaultModelValidator` is a `@Singleton` with a shared mutable `HashSet` (`validIds`). When multiple threads validate models concurrently (e.g., using breadth-first dependency collector with `aether.dependencyCollector.impl=bf`), concurrent read/write operations on the HashSet cause:

```
java.lang.ClassCastException: class java.util.HashMap$Node cannot
be cast to class java.util.HashMap$TreeNode
    at java.util.HashMap$TreeNode.putTreeVal(HashMap.java:2079)
    at java.util.HashMap.putVal(HashMap.java:634)
    at java.util.HashSet.add(HashSet.java:220)
    at o.a.m.model.validation.DefaultModelValidator.validateId(DefaultModelValidator.java:1145)
```

This affects users of:
- Clojure tools-deps
- Leiningen with `aether.dependencyCollector.impl=bf`
- NetBeans IDE

## Fix Approach

Replace `new HashSet<>()` with `ConcurrentHashMap.newKeySet()` - identical to the solution already implemented in Maven 4's `maven-impl` module (lines 296, 298).

## Files Changed

| File | Change |
|------|--------|
| `compat/maven-model-builder/.../DefaultModelValidator.java` | Replace `HashSet` → `ConcurrentHashMap.newKeySet()` + explanatory comment |
| `compat/maven-model-builder/.../DefaultModelValidatorTest.java` | Add concurrent validation test (10 threads × 100 models) |

## Test Plan

- [x] New test `testConcurrentValidation()` added
- [ ] `mvn -pl compat/maven-model-builder test`
- [ ] `mvn -Prun-its verify` (optional, if reviewer deems necessary)

## Compatibility

- **Backwards compatible**: `ConcurrentHashMap.newKeySet()` provides same `Set` interface
- **No behavioral change**: Same validation logic, just thread-safe storage
- **Aligns with Maven 4**: Mirrors the implementation in `maven-impl` module

## Risk Assessment

**Low risk**:
- Minimal diff (3 lines of production code including comment)
- Same fix pattern already proven in Maven 4
- Thread-safe collection is a drop-in replacement

Fixes #11618