### PR TITLE
Fix gh-11618: Make DefaultModelValidator thread-safe

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -89,7 +90,7 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String EMPTY = "";
 
-    private final Set<String> validIds = new HashSet<>();
+    private final Set<String> validIds = ConcurrentHashMap.newKeySet();
 
     private ModelVersionProcessor versionProcessor;
 
@@ -1125,7 +1126,7 @@ public class DefaultModelValidator implements ModelValidator {
             String id,
             String sourceHint,
             InputLocationTracker tracker) {
-        if (validIds.contains(id)) {
+        if (id != null && validIds.contains(id)) {
             return true;
         }
         if (!validateStringNotEmpty(prefix, fieldName, problems, severity, version, id, sourceHint, tracker)) {


### PR DESCRIPTION
## Summary
- Make `validIds` field in `DefaultModelValidator` thread-safe using `ConcurrentHashMap.newKeySet()`
- Add null check before `contains()` since `ConcurrentHashMap` doesn't allow null keys

## Problem
`DefaultModelValidator.validIds` is a non-thread-safe `HashSet` that can cause `ClassCastException` when accessed concurrently from multiple threads:

```
java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode
    at java.base/java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1900)
    at java.base/java.util.HashMap$TreeNode.putTreeVal(HashMap.java:2079)
    at java.base/java.util.HashMap.putVal(HashMap.java:634)
    at java.base/java.util.HashMap.put(HashMap.java:608)
    at java.base/java.util.HashSet.add(HashSet.java:220)
    at org.apache.maven.model.validation.DefaultModelValidator.validateId(DefaultModelValidator.java:852)
```

This issue manifests when using the BF dependency collector strategy (`aether.dependencyCollector.impl=bf`) which uses multiple threads for dependency resolution.

## Solution
Replace `HashSet` with `ConcurrentHashMap.newKeySet()`, which is the same approach already used in the Maven 4 impl module (`impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java`).

## Test Plan
- [x] `mvn spotless:apply` - formatting verified
- [x] `mvn test -pl compat/maven-model-builder` - all 161 tests pass
- [x] `git diff --check` - no whitespace issues

## Compatibility
This is a backward-compatible fix. The behavior remains the same, but now thread-safe.

Fixes #11618

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)