### PR TITLE
Fix gh-11740: Add missing null check in validateProfileId()

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1792,7 +1792,7 @@ public class DefaultModelValidator implements ModelValidator {
             String id,
             @Nullable SourceHint sourceHint,
             InputLocationTracker tracker) {
-        if (validProfileIds.contains(id)) {
+        if (id != null && validProfileIds.contains(id)) {
             return true;
         }
         if (!validateStringNotEmpty(prefix, fieldName, problems, severity, version, id, sourceHint, tracker)) {


### PR DESCRIPTION
## Summary
Add missing null check before `validProfileIds.contains(id)` in `validateProfileId()` to prevent `NullPointerException` and make it consistent with `validateCoordinateId()`.

## Problem
In `impl/maven-impl/.../DefaultModelValidator.java`, the `validateProfileId()` method calls `validProfileIds.contains(id)` without checking if `id` is null first.

Since `validProfileIds` uses `ConcurrentHashMap.newKeySet()` which doesn't allow null keys, a null profile ID would cause a `NullPointerException` instead of a proper validation error message.

**Inconsistency in the same file:**
```java
// Line 1744 - validateCoordinateId() has null check ✓
if (id != null && validCoordinatesIds.contains(id)) {

// Line 1795 - validateProfileId() was missing null check ✗
if (validProfileIds.contains(id)) {  // NPE if id is null
```

## Solution
Add the same null check pattern used in `validateCoordinateId()`:
```java
if (id != null && validProfileIds.contains(id)) {
```

## Test Plan
- [x] `mvn spotless:apply` - formatting verified
- [x] `mvn test -pl impl/maven-impl -Dtest=DefaultModelValidatorTest` - all 76 tests pass

## Compatibility
This is a backward-compatible fix. Null profile IDs will now be properly handled by `validateStringNotEmpty()` instead of throwing NPE.

Fixes #11740

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)