### PR TITLE
Add missing test scope for plexus-testing in maven-core

### DIFF
--- a/maven-core/pom.xml
+++ b/maven-core/pom.xml
@@ -169,6 +169,7 @@ under the License.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-testing</artifactId>
       <version>2.1.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Summary

- Add missing `<scope>test</scope>` to `plexus-testing` dependency in `maven-core/pom.xml`
- Without this, `plexus-testing` and its transitive dependencies (junit-jupiter-api, junit-platform-commons, apiguardian-api, opentest4j) are included in the Maven distribution

Fixes #11762