### PR TITLE
Consumer POM of multi-module project should exclude <build> and <dependencies> elements

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
@@ -96,7 +96,7 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
         }
     }
 
-    TransformedArtifact createConsumerPomArtifact(
+    private TransformedArtifact createConsumerPomArtifact(
             MavenProject project, Path consumer, RepositorySystemSession session) {
         Path actual = project.getFile().toPath();
         Path parent = project.getBaseDirectory();

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -37,6 +37,7 @@ import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DistributionManagement;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.ModelBase;
+import org.apache.maven.api.model.Parent;
 import org.apache.maven.api.model.Profile;
 import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.model.Scm;
@@ -49,6 +50,7 @@ import org.apache.maven.api.services.model.LifecycleBindingsInjector;
 import org.apache.maven.impl.InternalSession;
 import org.apache.maven.model.v4.MavenModelVersion;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.SourceQueries;
 import org.eclipse.aether.RepositorySystemSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +289,7 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         return model;
     }
 
-    static Model transformBom(Model model, MavenProject project) {
+    private static Model transformBom(Model model, MavenProject project) {
         boolean preserveModelVersion = model.isPreserveModelVersion();
 
         Model.Builder builder = prune(
@@ -314,11 +316,25 @@ class DefaultConsumerPomBuilder implements PomBuilder {
 
         // raw to consumer transform
         model = model.withRoot(false).withModules(null).withSubprojects(null);
-        if (model.getParent() != null) {
-            model = model.withParent(model.getParent().withRelativePath(null));
+        Parent parent = model.getParent();
+        if (parent != null) {
+            model = model.withParent(parent.withRelativePath(null));
         }
-
+        var projectSources = project.getBuild().getDelegate().getSources();
+        if (SourceQueries.usesModuleSourceHierarchy(projectSources)) {
+            // Dependencies are dispatched by maven-jar-plugin in the POM generated for each module.
+            model = model.withDependencies(null).withPackaging(POM_PACKAGING);
+        }
         if (!preserveModelVersion) {
+            /*
+             * If the <build> contains <source> elements, it is not compatible with the Maven 4.0.0 model.
+             * Remove the full <build> element instead of removing only the <sources> element, because the
+             * build without sources does not mean much. Reminder: this removal can be disabled by setting
+             * the `preserveModelVersion` XML attribute or `preserve.model.version` property to true.
+             */
+            if (SourceQueries.hasEnabledSources(projectSources)) {
+                model = model.withBuild(null);
+            }
             model = model.withPreserveModelVersion(false);
             String modelVersion = new MavenModelVersion().getModelVersion(model);
             model = model.withModelVersion(modelVersion);
@@ -326,7 +342,7 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         return model;
     }
 
-    static void warnNotDowngraded(MavenProject project) {
+    private static void warnNotDowngraded(MavenProject project) {
         LOGGER.warn("The consumer POM for " + project.getId() + " cannot be downgraded to 4.0.0. "
                 + "If you intent your build to be consumed with Maven 3 projects, you need to remove "
                 + "the features that request a newer model version.  If you're fine with having the "

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -649,7 +649,6 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             // only set those on 2nd phase, ignore on 1st pass
             if (project.getFile() != null) {
                 Build build = project.getBuild().getDelegate();
-                List<org.apache.maven.api.model.Source> sources = build.getSources();
                 Path baseDir = project.getBaseDirectory();
                 Function<ProjectScope, String> outputDirectory = (scope) -> {
                     if (scope == ProjectScope.MAIN) {
@@ -660,23 +659,11 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                         return build.getDirectory();
                     }
                 };
-                // Extract modules from sources to detect modular projects
-                Set<String> modules = extractModules(sources);
-                boolean isModularProject = !modules.isEmpty();
-
-                logger.trace(
-                        "Module detection for project {}: found {} module(s) {} - modular project: {}.",
-                        project.getId(),
-                        modules.size(),
-                        modules,
-                        isModularProject);
-
                 // Create source handling context for unified tracking of all lang/scope combinations
-                SourceHandlingContext sourceContext =
-                        new SourceHandlingContext(project, baseDir, modules, isModularProject, result);
+                final SourceHandlingContext sourceContext = new SourceHandlingContext(project, result);
 
                 // Process all sources, tracking enabled ones and detecting duplicates
-                for (var source : sources) {
+                for (org.apache.maven.api.model.Source source : sourceContext.sources) {
                     var sourceRoot = DefaultSourceRoot.fromModel(session, baseDir, outputDirectory, source);
                     // Track enabled sources for duplicate detection and hasSources() queries
                     // Only add source if it's not a duplicate enabled source (first enabled wins)
@@ -705,7 +692,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                        implicit fallback (only if they match the default, e.g., inherited)
                      - This allows incremental adoption (e.g., custom resources + default Java)
                 */
-                if (sources.isEmpty()) {
+                if (sourceContext.sources.isEmpty()) {
                     // Classic fallback: no <sources> configured, use legacy directories
                     project.addScriptSourceRoot(build.getScriptSourceDirectory());
                     project.addCompileSourceRoot(build.getSourceDirectory());
@@ -718,8 +705,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     if (!sourceContext.hasSources(Language.SCRIPT, ProjectScope.MAIN)) {
                         project.addScriptSourceRoot(build.getScriptSourceDirectory());
                     }
-
-                    if (isModularProject) {
+                    if (sourceContext.usesModuleSourceHierarchy()) {
                         // Modular: reject ALL legacy directory configurations
                         failIfLegacyDirectoryPresent(
                                 build.getSourceDirectory(),
@@ -1235,22 +1221,6 @@ public class DefaultProjectBuilder implements ProjectBuilder {
             }
             return delegate.entrySet();
         }
-    }
-
-    /**
-     * Extracts unique module names from the given list of source elements.
-     * A project is considered modular if it has at least one module name.
-     *
-     * @param sources list of source elements from the build
-     * @return set of non-blank module names
-     */
-    private static Set<String> extractModules(List<org.apache.maven.api.model.Source> sources) {
-        return sources.stream()
-                .map(org.apache.maven.api.model.Source::getModule)
-                .filter(Objects::nonNull)
-                .map(String::trim)
-                .filter(s -> !s.isBlank())
-                .collect(Collectors.toSet());
     }
 
     private Model injectLifecycleBindings(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/SourceQueries.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/SourceQueries.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.project;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.maven.api.model.Source;
+
+/**
+ * Static utility methods for analyzing {@code <source>} elements of a project.
+ * <p>
+ * <strong>Warning:</strong> This is an internal utility class, not part of the public API.
+ * It can be changed or removed without prior notice.
+ *
+ * @since 4.0.0
+ */
+public final class SourceQueries {
+    private SourceQueries() {}
+
+    /**
+     * Returns whether at least one source in the collection has a non-blank module name,
+     * indicating a modular source hierarchy.
+     *
+     * @param sources the source elements to check
+     * @return {@code true} if at least one source declares a module
+     */
+    public static boolean usesModuleSourceHierarchy(Collection<Source> sources) {
+        return sources.stream().map(Source::getModule).filter(Objects::nonNull).anyMatch(s -> !s.isBlank());
+    }
+
+    /**
+     * Returns whether at least one source in the collection is enabled.
+     *
+     * @param sources the source elements to check
+     * @return {@code true} if at least one source is enabled
+     */
+    public static boolean hasEnabledSources(Collection<Source> sources) {
+        for (Source source : sources) {
+            if (source.isEnabled()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Extracts unique, non-blank module names from the source elements, preserving declaration order.
+     * The following relationship should always be true:
+     *
+     * <pre>getModuleNames(sources).isEmpty() == !usesModuleSourceHierarchy(sources)</pre>
+     *
+     * @param sources the source elements to extract module names from
+     * @return set of non-blank module names in declaration order
+     */
+    public static Set<String> getModuleNames(Collection<Source> sources) {
+        var modules = new LinkedHashSet<String>();
+        sources.stream()
+                .map(Source::getModule)
+                .filter(Objects::nonNull)
+                .map(String::strip)
+                .filter(s -> !s.isEmpty())
+                .forEach(modules::add);
+        return modules;
+    }
+}

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
@@ -51,6 +51,7 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,15 +89,22 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
         return services;
     }
 
-    @Test
-    void testTrivialConsumer() throws Exception {
-        InternalMavenSession.from(InternalSession.from(session))
+    /**
+     * Configures {@link #session} with the root directory of a test in {@code src/test/resources/consumer}.
+     * Returns the request in case the caller wants to apply more configuration.
+     */
+    private MavenExecutionRequest setRootDirectory(String test) {
+        MavenExecutionRequest request = InternalMavenSession.from(InternalSession.from(session))
                 .getMavenSession()
-                .getRequest()
-                .setRootDirectory(Paths.get("src/test/resources/consumer/trivial"));
+                .getRequest();
+        request.setRootDirectory(Paths.get("src/test/resources/consumer", test));
+        return request;
+    }
 
-        Path file = Paths.get("src/test/resources/consumer/trivial/child/pom.xml");
-
+    /**
+     * Builds the effective model for the given {@code pom.xml} file.
+     */
+    private MavenProject getEffectiveModel(Path file) {
         ModelBuilder.ModelBuilderSession mbs = modelBuilder.newSession();
         InternalSession.from(session).getData().set(SessionData.key(ModelBuilder.ModelBuilderSession.class), mbs);
         Model orgModel = mbs.build(ModelBuilderRequest.builder()
@@ -108,37 +116,69 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
 
         MavenProject project = new MavenProject(orgModel);
         project.setOriginalModel(new org.apache.maven.model.Model(orgModel));
+        return project;
+    }
+
+    @Test
+    void testTrivialConsumer() throws Exception {
+        setRootDirectory("trivial");
+        Path file = Paths.get("src/test/resources/consumer/trivial/child/pom.xml");
+
+        MavenProject project = getEffectiveModel(file);
         Model model = builder.build(session, project, Sources.buildSource(file));
 
         assertNotNull(model);
+        assertNotNull(model.getDependencies());
     }
 
     @Test
     void testSimpleConsumer() throws Exception {
-        MavenExecutionRequest request = InternalMavenSession.from(InternalSession.from(session))
-                .getMavenSession()
-                .getRequest();
-        request.setRootDirectory(Paths.get("src/test/resources/consumer/simple"));
+        MavenExecutionRequest request = setRootDirectory("simple");
         request.getUserProperties().setProperty("changelist", "MNG6957");
-
         Path file = Paths.get("src/test/resources/consumer/simple/simple-parent/simple-weather/pom.xml");
 
-        ModelBuilder.ModelBuilderSession mbs = modelBuilder.newSession();
-        InternalSession.from(session).getData().set(SessionData.key(ModelBuilder.ModelBuilderSession.class), mbs);
-        Model orgModel = mbs.build(ModelBuilderRequest.builder()
-                        .session(InternalSession.from(session))
-                        .source(Sources.buildSource(file))
-                        .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
-                        .build())
-                .getEffectiveModel();
-
-        MavenProject project = new MavenProject(orgModel);
-        project.setOriginalModel(new org.apache.maven.model.Model(orgModel));
+        MavenProject project = getEffectiveModel(file);
         request.setRootDirectory(Paths.get("src/test/resources/consumer/simple"));
         Model model = builder.build(session, project, Sources.buildSource(file));
 
         assertNotNull(model);
+        assertFalse(model.getDependencies().isEmpty());
         assertTrue(model.getProfiles().isEmpty());
+    }
+
+    @Test
+    void testMultiModuleConsumer() throws Exception {
+        setRootDirectory("multi-module");
+        Path file = Paths.get("src/test/resources/consumer/multi-module/pom.xml");
+
+        MavenProject project = getEffectiveModel(file);
+        Model model = builder.build(session, project, Sources.buildSource(file));
+
+        assertNotNull(model);
+        assertNull(model.getBuild());
+        assertTrue(model.getDependencies().isEmpty());
+        assertFalse(model.getDependencyManagement().getDependencies().isEmpty());
+    }
+
+    /**
+     * Same test as {@link #testMultiModuleConsumer()}, but verifies that
+     * {@code <build>} is preserved when {@code preserveModelVersion=true}.
+     */
+    @Test
+    void testMultiModuleConsumerPreserveModelVersion() throws Exception {
+        setRootDirectory("multi-module");
+        Path file = Paths.get("src/test/resources/consumer/multi-module/pom.xml");
+
+        MavenProject project = getEffectiveModel(file);
+        Model model = getEffectiveModel(file).getModel().getDelegate();
+        model = Model.newBuilder(model, true).preserveModelVersion(true).build();
+
+        Model transformed = DefaultConsumerPomBuilder.transformPom(model, project);
+
+        assertNotNull(transformed);
+        assertNotNull(transformed.getBuild());
+        assertTrue(transformed.getDependencies().isEmpty());
+        assertFalse(transformed.getDependencyManagement().getDependencies().isEmpty());
     }
 
     @Test

--- a/impl/maven-core/src/test/resources/consumer/multi-module/pom.xml
+++ b/impl/maven-core/src/test/resources/consumer/multi-module/pom.xml
@@ -1,0 +1,41 @@
+<project root="true" xmlns="http://maven.apache.org/POM/4.1.0">
+  <groupId>org.my.group</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.9</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sources>
+      <source>
+        <module>org.foo</module>
+      </source>
+      <source>
+        <module>org.foo.bar</module>
+      </source>
+    </sources>
+  </build>
+
+</project>


### PR DESCRIPTION
This is a backport of #11639. It modifies the code that already exists in Maven core for deriving consumer POM. The modification consists in excluding `<build>` and `<dependencies>` when the project is a multi-module project. The rational is explained in #11639. Note that for classical Maven projects, nothing change.