### PR TITLE
Remove site plugin from default lifecycle registry

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -108,7 +108,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
     @Inject
     public DefaultLifecycleRegistry(List<LifecycleProvider> providers) {
         List<LifecycleProvider> p = new ArrayList<>(providers);
-        p.add(() -> List.of(new CleanLifecycle(), new DefaultLifecycle(), new SiteLifecycle()));
+        p.add(() -> List.of(new CleanLifecycle(), new DefaultLifecycle()));
         this.providers = p;
         // validate lifecycle
         for (Lifecycle lifecycle : this) {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 @Named
 @Singleton
 public class DefaultLifecycles {
-    public static final String[] STANDARD_LIFECYCLES = {"clean", "default", "site"};
+    public static final String[] STANDARD_LIFECYCLES = {"clean", "default"};
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -48,8 +48,8 @@ class DefaultLifecyclesTest {
     @Test
     void testDefaultLifecycles() {
         final List<Lifecycle> lifecycles = defaultLifeCycles.getLifeCycles();
-        assertEquals(3, lifecycles.size());
-        assertEquals(3, DefaultLifecycles.STANDARD_LIFECYCLES.length);
+        assertEquals(2, lifecycles.size());
+        assertEquals(2, DefaultLifecycles.STANDARD_LIFECYCLES.length);
     }
 
     @Test
@@ -64,13 +64,6 @@ class DefaultLifecyclesTest {
         final Lifecycle lifecycle = getLifeCycleById("clean");
         assertEquals("clean", lifecycle.getId());
         assertEquals(3, lifecycle.getPhases().size());
-    }
-
-    @Test
-    void testSiteLifecycle() {
-        final Lifecycle lifecycle = getLifeCycleById("site");
-        assertEquals("site", lifecycle.getId());
-        assertEquals(6, lifecycle.getPhases().size());
     }
 
     @Test
@@ -92,8 +85,7 @@ class DefaultLifecyclesTest {
 
         assertEquals("clean", dl.getLifeCycles().get(0).getId());
         assertEquals("default", dl.getLifeCycles().get(1).getId());
-        assertEquals("site", dl.getLifeCycles().get(2).getId());
-        assertEquals("etl", dl.getLifeCycles().get(3).getId());
+        assertEquals("etl", dl.getLifeCycles().get(2).getId());
     }
 
     private Lifecycle getLifeCycleById(String id) {

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
@@ -286,7 +286,7 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     void testLifecyclePluginsRetrievalForDefaultLifecycle() throws Exception {
         List<Plugin> plugins = new ArrayList<>(lifecycleExecutor.getPluginsBoundByDefaultToAllLifecycles("jar"));
 
-        assertEquals(8, plugins.size(), plugins.toString());
+        assertEquals(7, plugins.size(), plugins.toString());
     }
 
     @Test


### PR DESCRIPTION
Remove of maven-site-plugin from default lifecycle registry. Related issue: #11759 

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

It breaks backwards compatibility, checked with core-its test suit.