### PR TITLE
feat: Improve the matching of required versions

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.toolchain;
 
+import java.util.regex.Pattern;
+
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
@@ -66,7 +68,7 @@ public final class RequirementMatcherFactory {
         @Override
         public boolean matches(String requirement) {
             try {
-                VersionRange range = VersionRange.createFromVersionSpec(requirement);
+                VersionRange range = convertRequirementToVersionRange(requirement);
                 if (range.hasRestrictions()) {
                     return range.containsVersion(version);
                 } else {
@@ -77,6 +79,29 @@ public final class RequirementMatcherFactory {
                 ex.printStackTrace();
                 return false;
             }
+        }
+
+        private VersionRange convertRequirementToVersionRange(String requirement)
+                throws InvalidVersionSpecificationException {
+            // Specific for Version _requirement_ matching;
+            // If the version is a simple integer (like "25")
+            // then treat this as the requirement "the major version is 25"
+            if (Pattern.matches("^[0-9]+$", requirement)) {
+                int majorVersion = Integer.parseInt(requirement);
+                return VersionRange.createFromVersionSpec("[" + majorVersion + "," + (majorVersion + 1) + ")");
+            }
+
+            // If the version is a major.minor (like "1.5")
+            // then treat this as the requirement "the major version is 1 and the minor is 5"
+            if (Pattern.matches("^[0-9]\\.[0-9]+$", requirement)) {
+                String[] split = requirement.split("\\.", 2);
+                int majorVersion = Integer.parseInt(split[0]);
+                int minorVersion = Integer.parseInt(split[1]);
+                return VersionRange.createFromVersionSpec(
+                        "[" + majorVersion + "." + minorVersion + "," + majorVersion + "." + (minorVersion + 1) + ")");
+            }
+
+            return VersionRange.createFromVersionSpec(requirement);
         }
 
         @Override

--- a/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
@@ -81,19 +81,21 @@ public final class RequirementMatcherFactory {
             }
         }
 
+        private static final Pattern PATTERN_MAJOR_VERSION = Pattern.compile("^[0-9]+$");
+        private static final Pattern PATTERN_MAJOR_MINOR_VERSION = Pattern.compile("^[0-9]\\.[0-9]+$");
         private VersionRange convertRequirementToVersionRange(String requirement)
                 throws InvalidVersionSpecificationException {
             // Specific for Version _requirement_ matching;
             // If the version is a simple integer (like "25")
             // then treat this as the requirement "the major version is 25"
-            if (Pattern.matches("^[0-9]+$", requirement)) {
+            if (PATTERN_MAJOR_VERSION.matcher(requirement).matches()) {
                 int majorVersion = Integer.parseInt(requirement);
                 return VersionRange.createFromVersionSpec("[" + majorVersion + "," + (majorVersion + 1) + ")");
             }
 
             // If the version is a major.minor (like "1.5")
             // then treat this as the requirement "the major version is 1 and the minor is 5"
-            if (Pattern.matches("^[0-9]\\.[0-9]+$", requirement)) {
+            if (PATTERN_MAJOR_MINOR_VERSION.matcher(requirement).matches()) {
                 String[] split = requirement.split("\\.", 2);
                 int majorVersion = Integer.parseInt(split[0]);
                 int minorVersion = Integer.parseInt(split[1]);

--- a/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
@@ -83,6 +83,7 @@ public final class RequirementMatcherFactory {
 
         private static final Pattern PATTERN_MAJOR_VERSION = Pattern.compile("^[0-9]+$");
         private static final Pattern PATTERN_MAJOR_MINOR_VERSION = Pattern.compile("^[0-9]+\\.[0-9]+$");
+
         private VersionRange convertRequirementToVersionRange(String requirement)
                 throws InvalidVersionSpecificationException {
             // Specific for Version _requirement_ matching;

--- a/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/RequirementMatcherFactory.java
@@ -82,7 +82,7 @@ public final class RequirementMatcherFactory {
         }
 
         private static final Pattern PATTERN_MAJOR_VERSION = Pattern.compile("^[0-9]+$");
-        private static final Pattern PATTERN_MAJOR_MINOR_VERSION = Pattern.compile("^[0-9]\\.[0-9]+$");
+        private static final Pattern PATTERN_MAJOR_MINOR_VERSION = Pattern.compile("^[0-9]+\\.[0-9]+$");
         private VersionRange convertRequirementToVersionRange(String requirement)
                 throws InvalidVersionSpecificationException {
             // Specific for Version _requirement_ matching;

--- a/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
@@ -50,11 +50,18 @@ public class RequirementMatcherFactoryTest {
     public void testCreateVersionMatcher() {
         RequirementMatcher matcher;
         matcher = RequirementMatcherFactory.createVersionMatcher("1.5.2");
-        assertFalse(matcher.matches("1.5"));
-        assertTrue(matcher.matches("1.5.2"));
+        assertTrue(matcher.matches("1")); // Major matches
+        assertTrue(matcher.matches("1.5")); // Major.Minor matches
+        assertTrue(matcher.matches("1.5.2")); // Full match
+        assertFalse(matcher.matches("1.6")); // Wrong minor
+        assertFalse(matcher.matches("2")); // Wrong major
+        assertFalse(matcher.matches("2.5")); // Wrong major, right minor
         assertFalse(matcher.matches("[1.4,1.5)"));
         assertFalse(matcher.matches("[1.5,1.5.2)"));
+        assertTrue(matcher.matches("[1.5,1.5.3)"));
+        assertTrue(matcher.matches("(1.5.1,1.6)"));
         assertFalse(matcher.matches("(1.5.2,1.6)"));
+        assertTrue(matcher.matches("[1.5.2,1.6)"));
         assertTrue(matcher.matches("(1.4,1.5.2]"));
         assertTrue(matcher.matches("(1.5,)"));
         assertEquals("1.5.2", matcher.toString());

--- a/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
@@ -70,4 +70,31 @@ public class RequirementMatcherFactoryTest {
         matcher = RequirementMatcherFactory.createVersionMatcher("1.5");
         assertEquals("1.5", matcher.toString());
     }
+
+    @Test
+    public void testCreateVersionMatcherMultiDigit() {
+        RequirementMatcher matcher;
+        matcher = RequirementMatcherFactory.createVersionMatcher("11.55.22");
+        assertTrue(matcher.matches("11")); // Major matches
+        assertTrue(matcher.matches("11.55")); // Major.Minor matches
+        assertTrue(matcher.matches("11.55.22")); // Full match
+        assertFalse(matcher.matches("11.66")); // Wrong minor
+        assertFalse(matcher.matches("22")); // Wrong major
+        assertFalse(matcher.matches("22.55")); // Wrong major, right minor
+        assertFalse(matcher.matches("[11.54,11.55)"));
+        assertFalse(matcher.matches("[11.55,11.55.22)"));
+        assertTrue(matcher.matches("[11.55,11.55.33)"));
+        assertTrue(matcher.matches("(11.55.11,11.56)"));
+        assertFalse(matcher.matches("(11.55.22,11.56)"));
+        assertTrue(matcher.matches("[11.55.22,11.56)"));
+        assertTrue(matcher.matches("(11.54,11.55.22]"));
+        assertTrue(matcher.matches("(11.55,)"));
+        assertEquals("11.55.22", matcher.toString());
+
+        // Ensure it is not printed as 1.5.0
+        matcher = RequirementMatcherFactory.createVersionMatcher("11.55");
+        assertEquals("11.55", matcher.toString());
+    }
+
+
 }

--- a/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
+++ b/maven-core/src/test/java/org/apache/maven/toolchain/RequirementMatcherFactoryTest.java
@@ -95,6 +95,4 @@ public class RequirementMatcherFactoryTest {
         matcher = RequirementMatcherFactory.createVersionMatcher("11.55");
         assertEquals("11.55", matcher.toString());
     }
-
-
 }


### PR DESCRIPTION
@cstamas Followup of this discussion on Slack https://the-asf.slack.com/archives/C7Q9JB404/p1773056234905829?thread_ts=1773053661.648449&cid=C7Q9JB404 

When people write in (for example) the maven-invoker-plugin something like `invoker.toolchain.jdk.version = 11` it is implemented as an exact match on the mentioned version specified in the toolchains.xml .
Historically people would write this config manually and then the exact version `11` works as expected.

With the automatic generation of the toolchains.xml more places will contain the `full` version of the JDK like `<version>11.0.29</version>` instead of the more simple `<version>11</version>`.

The effect of people using these automatically generated toolchains.xml files is that now things still work as designed, but not as expected.

This is a quick implementation of my proposal to simply treat the requirement of a single number X as "the major version must be X".
I have also included the same for a "major.minor" requirement to accept all patch versions under that also.

This means a change from a mismatch to a match in cases like this:
```
matcher = RequirementMatcherFactory.createVersionMatcher("1.5.2");
matcher.matches("1.5");
```

**I'm unsure if this change is "too breaking" to be implemented.**



Following this checklist to help us incorporate your contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.



- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
