### PR TITLE
[GH-11772] Generate dual consumer POMs for parent POMs with 4.1.0 features

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -1814,6 +1814,16 @@
           </description>
           <type>String</type>
         </field>
+        <field>
+          <name>classifier</name>
+          <version>4.1.0+</version>
+          <description>
+            The classifier of the parent POM to resolve from the repository.
+            This is used by consumer POMs to reference the full-fidelity consumer POM
+            of the parent project, which is deployed with a classifier (e.g., {@code consumer}).
+          </description>
+          <type>String</type>
+        </field>
       </fields>
       <codeSegments>
         <codeSegment>

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
@@ -32,11 +32,12 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.apache.maven.api.feature.Features;
-import org.apache.maven.api.model.Model;
 import org.apache.maven.api.services.ModelBuilderException;
 import org.apache.maven.api.services.ModelSource;
 import org.apache.maven.api.services.Source;
@@ -58,11 +59,15 @@ import org.eclipse.sisu.PreDestroy;
 @Singleton
 @Named
 class ConsumerPomArtifactTransformer extends TransformerSupport {
-    private static final String CONSUMER_POM_CLASSIFIER = "consumer";
+    static final String CONSUMER_POM_CLASSIFIER = "consumer";
+
+    private static final String CONSUMER_POM_FULL_CLASSIFIER = "consumer-full";
 
     private static final String BUILD_POM_CLASSIFIER = "build";
 
     private final Set<Path> toDelete = new CopyOnWriteArraySet<>();
+    private final Map<Path, byte[]> consumerFullCache = new ConcurrentHashMap<>();
+    private final Set<Path> consumerFullPaths = ConcurrentHashMap.newKeySet();
 
     private final PomBuilder builder;
 
@@ -89,7 +94,15 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
                     : Files.createTempFile(CONSUMER_POM_CLASSIFIER + "-", ".pom");
             deferDeleteFile(consumer);
 
+            Path consumerFull = buildDir != null
+                    ? Files.createTempFile(buildDir, CONSUMER_POM_FULL_CLASSIFIER + "-", ".pom")
+                    : Files.createTempFile(CONSUMER_POM_FULL_CLASSIFIER + "-", ".pom");
+            deferDeleteFile(consumerFull);
+            consumerFullPaths.add(consumerFull.toAbsolutePath());
+
             project.addAttachedArtifact(createConsumerPomArtifact(project, consumer, session));
+            project.addAttachedArtifact(
+                    createConsumerPomArtifact(project, consumerFull, session, CONSUMER_POM_FULL_CLASSIFIER));
         } else if (project.getModel().getDelegate().isRoot()) {
             throw new IllegalStateException(
                     "The use of the root attribute on the model requires the buildconsumer feature to be active");
@@ -98,6 +111,11 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
 
     TransformedArtifact createConsumerPomArtifact(
             MavenProject project, Path consumer, RepositorySystemSession session) {
+        return createConsumerPomArtifact(project, consumer, session, CONSUMER_POM_CLASSIFIER);
+    }
+
+    TransformedArtifact createConsumerPomArtifact(
+            MavenProject project, Path consumer, RepositorySystemSession session, String classifier) {
         Path actual = project.getFile().toPath();
         Path parent = project.getBaseDirectory();
         ModelSource source = new ModelSource() {
@@ -133,21 +151,51 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
             }
         };
         return new TransformedArtifact(
-                this,
-                project,
-                consumer,
-                session,
-                new ProjectArtifact(project),
-                () -> source,
-                CONSUMER_POM_CLASSIFIER,
-                "pom");
+                this, project, consumer, session, new ProjectArtifact(project), () -> source, classifier, "pom");
     }
 
     @Override
     public void transform(MavenProject project, RepositorySystemSession session, ModelSource src, Path tgt)
             throws ModelBuilderException, XMLStreamException, IOException {
-        Model model = builder.build(session, project, src);
-        write(model, tgt);
+        if (consumerFullPaths.contains(tgt.toAbsolutePath())) {
+            // This is the consumer-full artifact — check if we have cached content
+            byte[] cached = consumerFullCache.remove(tgt.toAbsolutePath());
+            if (cached != null) {
+                Files.write(tgt, cached);
+            }
+            // If no cached content, leave the file empty (will be skipped during deploy)
+        } else {
+            // This is the main consumer artifact
+            PomBuilder.ConsumerPomBuildResult result = builder.buildConsumerPoms(session, project, src);
+            write(result.main(), tgt);
+            if (result.consumer() != null) {
+                // Cache the consumer-full content for later
+                Path consumerFullPath = findConsumerFullPath(tgt);
+                if (consumerFullPath != null) {
+                    java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+                    try (java.io.OutputStream os = baos) {
+                        new org.apache.maven.model.v4.MavenStaxWriter().write(os, result.consumer());
+                    }
+                    consumerFullCache.put(consumerFullPath, baos.toByteArray());
+                }
+            }
+        }
+    }
+
+    private Path findConsumerFullPath(Path mainPath) {
+        // Find the consumer-full path that's in the same directory as the main path
+        Path dir = mainPath.getParent();
+        for (Path p : consumerFullPaths) {
+            if (p.getParent().equals(dir)) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    boolean hasConsumerFullContent(Path path) {
+        return consumerFullCache.containsKey(path.toAbsolutePath())
+                || (Files.exists(path) && path.toFile().length() > 0);
     }
 
     private void deferDeleteFile(Path generatedFile) {
@@ -188,10 +236,13 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
 
     private Collection<Artifact> replacePom(Collection<Artifact> artifacts) {
         List<Artifact> consumers = new ArrayList<>();
+        List<Artifact> consumerFulls = new ArrayList<>();
         List<Artifact> mains = new ArrayList<>();
         for (Artifact artifact : artifacts) {
             if ("pom".equals(artifact.getExtension()) || artifact.getExtension().startsWith("pom.")) {
-                if (CONSUMER_POM_CLASSIFIER.equals(artifact.getClassifier())) {
+                if (CONSUMER_POM_FULL_CLASSIFIER.equals(artifact.getClassifier())) {
+                    consumerFulls.add(artifact);
+                } else if (CONSUMER_POM_CLASSIFIER.equals(artifact.getClassifier())) {
                     consumers.add(artifact);
                 } else if ("".equals(artifact.getClassifier())) {
                     mains.add(artifact);
@@ -200,6 +251,7 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
         }
         if (!mains.isEmpty() && !consumers.isEmpty()) {
             ArrayList<Artifact> result = new ArrayList<>(artifacts);
+            // original POM → build classifier
             for (Artifact main : mains) {
                 result.remove(main);
                 result.add(new DefaultArtifact(
@@ -211,6 +263,7 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
                         main.getProperties(),
                         main.getPath()));
             }
+            // consumer POM → main (no classifier)
             for (Artifact consumer : consumers) {
                 result.remove(consumer);
                 result.add(new DefaultArtifact(
@@ -221,6 +274,20 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
                         consumer.getVersion(),
                         consumer.getProperties(),
                         consumer.getPath()));
+            }
+            // consumer-full POM → consumer classifier (only if it has content)
+            for (Artifact consumerFull : consumerFulls) {
+                result.remove(consumerFull);
+                if (consumerFull.getPath() != null && hasConsumerFullContent(consumerFull.getPath())) {
+                    result.add(new DefaultArtifact(
+                            consumerFull.getGroupId(),
+                            consumerFull.getArtifactId(),
+                            CONSUMER_POM_CLASSIFIER,
+                            consumerFull.getExtension(),
+                            consumerFull.getVersion(),
+                            consumerFull.getProperties(),
+                            consumerFull.getPath()));
+                }
             }
             artifacts = result;
         }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -33,8 +33,11 @@ import org.apache.maven.api.Node;
 import org.apache.maven.api.PathScope;
 import org.apache.maven.api.SessionData;
 import org.apache.maven.api.feature.Features;
+import org.apache.maven.api.model.Activation;
+import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DistributionManagement;
+import org.apache.maven.api.model.Extension;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.ModelBase;
 import org.apache.maven.api.model.Profile;
@@ -101,6 +104,47 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         } else {
             return buildNonPom(session, project, src);
         }
+    }
+
+    @Override
+    public ConsumerPomBuildResult buildConsumerPoms(
+            RepositorySystemSession session, MavenProject project, ModelSource src) throws ModelBuilderException {
+        Model model = project.getModel().getDelegate();
+        boolean flattenEnabled = Features.consumerPomFlatten(session.getConfigProperties());
+        String packaging = model.getPackaging();
+        String originalPackaging = project.getOriginalModel().getPackaging();
+
+        boolean isBom = BOM_PACKAGING.equals(originalPackaging);
+
+        if (!flattenEnabled) {
+            if (POM_PACKAGING.equals(packaging) && !isBom) {
+                return buildPomConsumerPoms(session, project, src);
+            }
+        } else {
+            if (POM_PACKAGING.equals(packaging) && !isBom) {
+                return buildPomConsumerPoms(session, project, src);
+            }
+        }
+        // For non-POM, BOMs, etc., fall back to single POM
+        return new ConsumerPomBuildResult(build(session, project, src), null);
+    }
+
+    protected ConsumerPomBuildResult buildPomConsumerPoms(
+            RepositorySystemSession session, MavenProject project, ModelSource src) throws ModelBuilderException {
+        ModelBuilderResult result = buildModel(session, src);
+        Model rawModel = result.getRawModel();
+        Model consumerModel = transformPom(rawModel, project);
+
+        String modelVersion = consumerModel.getModelVersion();
+        if (ModelBuilder.MODEL_VERSION_4_0_0.equals(modelVersion) || consumerModel.isPreserveModelVersion()) {
+            return new ConsumerPomBuildResult(consumerModel, null);
+        }
+
+        // Generate dual consumer POMs: main (4.0.0) + consumer (4.1.0)
+        Model consumer410 = addConsumerClassifierToParent(consumerModel);
+        Model main400 = stripTo400(consumerModel);
+
+        return new ConsumerPomBuildResult(main400, consumer410);
     }
 
     protected Model buildPom(RepositorySystemSession session, MavenProject project, ModelSource src)
@@ -379,5 +423,66 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         return repositories.stream()
                 .filter(r -> !org.apache.maven.api.Repository.CENTRAL_ID.equals(r.getId()))
                 .collect(Collectors.toList());
+    }
+
+    static Model stripTo400(Model model) {
+        // Strip profile condition and packaging activation (4.1.0 features)
+        if (!model.getProfiles().isEmpty()) {
+            List<Profile> strippedProfiles = model.getProfiles().stream()
+                    .map(DefaultConsumerPomBuilder::stripProfileTo400)
+                    .collect(Collectors.toList());
+            model = model.withProfiles(strippedProfiles);
+        }
+
+        // Strip build sources (4.1.0 feature)
+        if (model.getBuild() != null) {
+            model = model.withBuild(stripBuildTo400(model.getBuild()));
+        }
+
+        // Strip subprojects (4.1.0 feature, should already be stripped by transformPom but be safe)
+        model = model.withSubprojects(null);
+
+        // Force model version to 4.0.0
+        model = model.withModelVersion(ModelBuilder.MODEL_VERSION_4_0_0);
+        model = model.withPreserveModelVersion(false);
+        model = model.withRoot(false);
+
+        return model;
+    }
+
+    private static Profile stripProfileTo400(Profile profile) {
+        if (profile.getActivation() != null) {
+            Activation activation = profile.getActivation();
+            if (activation.getCondition() != null || activation.getPackaging() != null) {
+                activation = Activation.newBuilder(activation, true)
+                        .condition(null)
+                        .packaging(null)
+                        .build();
+                profile = profile.withActivation(activation);
+            }
+        }
+        return profile;
+    }
+
+    private static Build stripBuildTo400(Build build) {
+        // Strip sources (4.1.0 feature)
+        if (!build.getSources().isEmpty()) {
+            build = build.withSources(null);
+        }
+        // Strip extension configuration (4.1.0 feature)
+        if (!build.getExtensions().isEmpty()) {
+            List<Extension> strippedExtensions = build.getExtensions().stream()
+                    .map(ext -> ext.getConfiguration() != null ? ext.withConfiguration(null) : ext)
+                    .collect(Collectors.toList());
+            build = build.withExtensions(strippedExtensions);
+        }
+        return build;
+    }
+
+    static Model addConsumerClassifierToParent(Model model) {
+        if (model.getParent() != null) {
+            model = model.withParent(model.getParent().withClassifier("consumer"));
+        }
+        return model;
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/PomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/PomBuilder.java
@@ -35,4 +35,12 @@ import org.eclipse.aether.RepositorySystemSession;
 interface PomBuilder {
     Model build(RepositorySystemSession session, MavenProject project, ModelSource src)
             throws ModelBuilderException, IOException, XMLStreamException;
+
+    default ConsumerPomBuildResult buildConsumerPoms(
+            RepositorySystemSession session, MavenProject project, ModelSource src)
+            throws ModelBuilderException, IOException, XMLStreamException {
+        return new ConsumerPomBuildResult(build(session, project, src), null);
+    }
+
+    record ConsumerPomBuildResult(Model main, Model consumer) {}
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1050,7 +1050,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 Set<String> parentChain)
                 throws ModelBuilderException {
             Model parentModel = null;
-            if (isBuildRequest()) {
+            if (isBuildRequest() && parent.getClassifier() == null) {
                 parentModel = readParentLocally(childModel, parent, profileActivationContext, parentChain);
             }
             if (parentModel == null) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultModelResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultModelResolver.java
@@ -68,7 +68,7 @@ public class DefaultModelResolver implements ModelResolver {
                         parent.getGroupId(),
                         parent.getArtifactId(),
                         parent.getVersion(),
-                        null),
+                        parent.getClassifier()),
                 parent.getLocation("version"),
                 "parent");
         if (result.version() != null) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11772DualConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11772DualConsumerPomTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.maven.api.model.Model;
+import org.apache.maven.model.v4.MavenStaxReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test for <a href="https://github.com/apache/maven/issues/11772">GH-11772</a>.
+ * <p>
+ * Verifies that when a POM-packaged project (parent) uses model version 4.1.0 features
+ * (like profile condition activation), Maven generates dual consumer POMs:
+ * <ul>
+ *   <li>Main POM (no classifier): 4.0.0-compatible, 4.1.0 features stripped</li>
+ *   <li>Consumer classifier POM: 4.1.0 full-fidelity, parent references consumer classifier</li>
+ * </ul>
+ */
+class MavenITgh11772DualConsumerPomTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh11772DualConsumerPomTest() {
+        super("[4.0.0-rc-2,)");
+    }
+
+    private static final String GROUP_ID = "org.apache.maven.its.gh11772";
+
+    @Test
+    void testDualConsumerPomsForParent() throws Exception {
+        Path basedir = extractResources("/gh-11772-dual-consumer-pom").toPath();
+
+        Verifier verifier = newVerifier(basedir.toString(), null);
+        verifier.addCliArguments("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Verify parent POM artifacts in project-local-repo
+        Path parentDir = basedir.resolve(Paths.get(
+                "target",
+                "project-local-repo",
+                "org.apache.maven.its.gh11772",
+                "parent",
+                "1.0.0-SNAPSHOT"));
+
+        Path parentMainPom = parentDir.resolve("parent-1.0.0-SNAPSHOT.pom");
+        Path parentConsumerPom = parentDir.resolve("parent-1.0.0-SNAPSHOT-consumer.pom");
+        Path parentBuildPom = parentDir.resolve("parent-1.0.0-SNAPSHOT-build.pom");
+
+        assertTrue("Parent main POM should exist", Files.exists(parentMainPom));
+        assertTrue("Parent consumer POM should exist", Files.exists(parentConsumerPom));
+        assertTrue("Parent build POM should exist", Files.exists(parentBuildPom));
+
+        // Main POM should be 4.0.0-compatible
+        Model mainModel;
+        try (Reader r = Files.newBufferedReader(parentMainPom)) {
+            mainModel = new MavenStaxReader().read(r);
+        }
+        assertEquals("4.0.0", mainModel.getModelVersion());
+
+        // Main POM should NOT have condition activation (stripped for 4.0.0 compat)
+        for (var profile : mainModel.getProfiles()) {
+            if (profile.getActivation() != null) {
+                assertNull(
+                        "Main POM profiles should not have condition activation",
+                        profile.getActivation().getCondition());
+            }
+        }
+
+        // Consumer POM should be 4.1.0 full-fidelity
+        Model consumerModel;
+        try (Reader r = Files.newBufferedReader(parentConsumerPom)) {
+            consumerModel = new MavenStaxReader().read(r);
+        }
+        assertEquals("4.1.0", consumerModel.getModelVersion());
+
+        // Verify child POM
+        Path childDir = basedir.resolve(Paths.get(
+                "target",
+                "project-local-repo",
+                "org.apache.maven.its.gh11772",
+                "child",
+                "1.0.0-SNAPSHOT"));
+        Path childMainPom = childDir.resolve("child-1.0.0-SNAPSHOT.pom");
+        assertTrue("Child main POM should exist", Files.exists(childMainPom));
+
+        Model childModel;
+        try (Reader r = Files.newBufferedReader(childMainPom)) {
+            childModel = new MavenStaxReader().read(r);
+        }
+        assertNotNull("Child POM should have a parent reference", childModel.getParent());
+        assertEquals(GROUP_ID, childModel.getParent().getGroupId());
+        assertEquals("parent", childModel.getParent().getArtifactId());
+        assertNull(
+                "Child POM parent should not have a classifier",
+                childModel.getParent().getClassifier());
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11772-dual-consumer-pom/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11772-dual-consumer-pom/child/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+
+  <parent>
+    <groupId>org.apache.maven.its.gh11772</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11772-dual-consumer-pom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11772-dual-consumer-pom/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+
+  <groupId>org.apache.maven.its.gh11772</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>child</subproject>
+  </subprojects>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.9</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <id>test-profile</id>
+      <activation>
+        <!-- 4.1.0 feature: condition-based activation -->
+        <condition>${project.artifactId} == 'parent'</condition>
+      </activation>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
## Problem

When a POM-packaged project (e.g., a parent POM) uses model version 4.1.0 features such as profile condition activation (`<condition>`), `<subprojects>`, or build `<sources>`, the current consumer POM transformation simply strips these features and emits a 4.0.0 POM. However, this means that **any Maven 4 project consuming such a parent loses all 4.1.0 features** — the full-fidelity model is never published.

This effectively makes it impossible to use 4.1.0 features in any parent POM that will be deployed to a repository, since downstream projects resolving the parent from the repository would get the stripped 4.0.0 version.

Fixes #11772

## Why dual consumer POMs are necessary

### Stripping features is a dead end

The current approach of stripping 4.1.0 features to produce a single 4.0.0-compatible consumer POM works as a short-term compatibility measure, but it's fundamentally unsustainable:

1. **Model version 4.1.0** introduces features like profile condition activation, packaging-based activation, build sources, and extension configuration. These can be stripped without losing essential content because they're mostly syntactic sugar or build-time concerns.

2. **Model version 4.2.0 introduces mixins** — structural composition of POM configuration from multiple sources. Mixins bring in actual content (dependencies, plugins, properties) that becomes part of the project's effective model. **You cannot strip a mixin reference without losing the content it provides.** There is no 4.0.0 equivalent — the content simply disappears.

This means the "strip and flatten" approach has a hard ceiling. Without dual consumer POMs, Maven would be stuck on model version 4.0.0 for any published parent POM, making the entire model evolution story dead on arrival.

### The right architecture

By publishing **two** consumer POMs, we get the best of both worlds:

- **Main POM** (no classifier): A 4.0.0-compatible POM with 4.1.0+ features stripped. This ensures backward compatibility with Maven 3, Gradle, and any tool that only understands 4.0.0.
- **Consumer classifier POM** (`consumer` classifier): The full-fidelity 4.1.0+ POM. Maven 4 consumers resolve this via a `classifier` field on the `<parent>` reference, getting the complete model with all features intact.

This architecture scales naturally to future model versions (4.2.0 mixins, etc.) without requiring any changes to the dual POM mechanism itself.

### Relationship to #11346 (managed dependency removal)

During analysis, we examined whether the real issue was about flattening managed dependencies rather than model version features. The key insight from the #11346 IT is:

- When a consumer POM's dependency management entries are removed because they appear "unused" in the current dependency tree, this can break downstream consumers who override transitive dependency versions, bringing in new transitive deps that the removed management would have controlled.
- However, this is a **separate concern** from model version compatibility. The managed dependency removal issue exists regardless of whether we use single or dual consumer POMs.
- The "depth" concern raised in #11346 (about flattening parent hierarchy) is a red herring: dependency resolution depth counts **graph hops between dependencies** (A→B→C), not levels in the POM parent hierarchy. Flattening parent-to-child inheritance doesn't change the dependency graph depth.

The managed dependency removal issue should be addressed in a separate PR by not filtering out "unused" managed dependencies during consumer POM transformation.

## How it works

### POM generation (`DefaultConsumerPomBuilder`)

When a POM-packaged project has model version > 4.0.0:
1. Build the normal consumer POM (flattened, with inheritance resolved)
2. Create the **4.1.0 consumer POM**: add `classifier="consumer"` to the parent reference so downstream 4.1.0 consumers can resolve the full-fidelity parent
3. Create the **4.0.0 main POM**: strip all 4.1.0+ features (condition activation, packaging activation, build sources, extension config) and set model version to 4.0.0

### Artifact handling (`ConsumerPomArtifactTransformer`)

During the build, both POMs are attached as artifacts:
- The main POM (4.0.0-compatible) replaces the original POM artifact (no classifier)
- The consumer POM (4.1.0 full-fidelity) is deployed with the `consumer` classifier
- The original build POM is deployed with the `build` classifier (as before)

### Parent resolution (`DefaultModelBuilder` / `DefaultModelResolver`)

- When a parent reference includes a `classifier`, the model resolver passes it to the artifact resolver, which fetches the classifier POM from the repository
- Local parent resolution is skipped when a classifier is set (classified POMs are only relevant for repository-resolved parents)

### Model schema (`maven.mdo`)

A `classifier` field is added to the `Parent` type for model version 4.1.0+, allowing consumer POMs to reference the full-fidelity parent POM.

## Changes

- `api/maven-api-model/src/main/mdo/maven.mdo`: Add `classifier` field to `Parent` (4.1.0+)
- `impl/maven-core/.../DefaultConsumerPomBuilder.java`: Add `stripTo400()` and dual POM generation
- `impl/maven-core/.../ConsumerPomArtifactTransformer.java`: Handle dual artifact lifecycle and remap during install/deploy
- `impl/maven-impl/.../DefaultModelResolver.java`: Pass parent classifier during resolution
- `impl/maven-impl/.../DefaultModelBuilder.java`: Skip local parent resolution when classifier is set

## Test plan

- [x] New IT `MavenITgh11772DualConsumerPomTest` verifies:
  - Parent main POM exists and is model version 4.0.0 with condition activation stripped
  - Parent consumer POM exists and is model version 4.1.0 (full fidelity)
  - Parent build POM exists (original)
  - Child POM parent reference has no classifier
- [x] Existing consumer POM ITs pass without regressions (MavenITmng8414, MavenITmng8527, MavenITgh11084, MavenITgh11456, MavenITmng8645)