### PR TITLE
Fix BUILD_CONSUMER profile activation for locally-resolved parent POMs

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1160,7 +1160,13 @@ public class DefaultModelBuilder implements ModelBuilder {
             }
 
             try {
-                ModelBuilderSessionState derived = derive(candidateSource);
+                ModelBuilderSessionState derived = derive(
+                        request.getRequestType() == ModelBuilderRequest.RequestType.BUILD_CONSUMER
+                                ? ModelBuilderRequest.builder(request)
+                                        .requestType(ModelBuilderRequest.RequestType.CONSUMER_PARENT)
+                                        .source(candidateSource)
+                                        .build()
+                                : ModelBuilderRequest.build(request, candidateSource));
 
                 // Check GA match BEFORE readAsParentModel() which recursively resolves
                 // the candidate's parent chain and can trigger false cycle detection (GH-12074).
@@ -1174,7 +1180,6 @@ public class DefaultModelBuilder implements ModelBuilder {
                     mismatchRelativePathAndGA(childModel, parent, fileGroupId, fileArtifactId);
                     return null;
                 }
-
                 Model candidateModel = derived.readAsParentModel(profileActivationContext, parentChain);
                 // Add profiles from parent, preserving model ID tracking
                 for (Map.Entry<String, List<Profile>> entry :

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -416,7 +416,7 @@ class DefaultModelBuilderTest {
         assertEquals(
                 "1.2.3",
                 managedDep.getVersion(),
-                "Managed dependency version should be interpolated, not ${managed.version}")
+                "Managed dependency version should be interpolated, not ${managed.version}");
     }
 
     private Path getPom(String name) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -38,6 +38,7 @@ import org.apache.maven.impl.standalone.ApiRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -370,6 +371,52 @@ class DefaultModelBuilderTest {
         assertTrue(
                 derived.getExternalRepositories().stream().anyMatch(r -> "custom-repo".equals(r.getId())),
                 "Derived session externalRepositories should include the custom repo from the request");
+    }
+
+    /**
+     * Verifies that BUILD_CONSUMER resolves properties defined in parent POM profiles
+     * when the parent is found via reactor model resolution (mappedSources).
+     */
+    @Test
+    public void testBuildConsumerResolvesParentProfileProperties() {
+        Path parentPom = getPom("consumer-profile-property-parent");
+        Path childPom = getPom("consumer-profile-property-child");
+
+        ModelBuilder.ModelBuilderSession mbs = builder.newSession();
+
+        mbs.build(ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(parentPom))
+                .build());
+
+        ModelBuilderResult consumerResult = assertDoesNotThrow(
+                () -> mbs.build(ModelBuilderRequest.builder()
+                        .session(session)
+                        .requestType(ModelBuilderRequest.RequestType.BUILD_CONSUMER)
+                        .source(Sources.buildSource(childPom))
+                        .build()),
+                "BUILD_CONSUMER should not fail when parent defines properties in profiles");
+
+        assertNotNull(consumerResult);
+        Model effectiveModel = consumerResult.getEffectiveModel();
+        assertNotNull(effectiveModel);
+
+        assertEquals(
+                "1.2.3",
+                effectiveModel.getProperties().get("managed.version"),
+                "Property from parent's profile should be resolved in BUILD_CONSUMER effective model");
+
+        assertNotNull(effectiveModel.getDependencyManagement());
+        Dependency managedDep = effectiveModel.getDependencyManagement().getDependencies().stream()
+                .filter(d -> "managed-lib".equals(d.getArtifactId()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(managedDep, "Managed dependency from parent should be inherited");
+        assertEquals(
+                "1.2.3",
+                managedDep.getVersion(),
+                "Managed dependency version should be interpolated, not ${managed.version}")
     }
 
     private Path getPom(String name) {

--- a/impl/maven-impl/src/test/resources/poms/factory/consumer-profile-property-child.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/consumer-profile-property-child.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+    <parent>
+        <groupId>org.apache.maven.tests</groupId>
+        <artifactId>consumer-profile-property-parent</artifactId>
+        <relativePath>consumer-profile-property-parent.xml</relativePath>
+    </parent>
+    <artifactId>consumer-profile-property-child</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/consumer-profile-property-parent.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/consumer-profile-property-parent.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+    <groupId>org.apache.maven.tests</groupId>
+    <artifactId>consumer-profile-property-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <!--
+      The property "managed.version" is ONLY defined inside a profile
+      with property-based activation. This simulates the real-world
+      scenario where parent POMs define version properties in profiles.
+    -->
+    <profiles>
+        <profile>
+            <id>default-versions</id>
+            <activation>
+                <property>
+                    <name>!skipDefaultVersions</name>
+                </property>
+            </activation>
+            <properties>
+                <managed.version>1.2.3</managed.version>
+            </properties>
+        </profile>
+    </profiles>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>managed-lib</artifactId>
+                <version>${managed.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11798ConsumerPomProfileActivationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11798ConsumerPomProfileActivationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify that consumer POM generation preserves profile activation for locally-resolved parent POMs.
+ * When a parent POM defines properties inside a profile with property-based activation,
+ * those properties must be resolved during BUILD_CONSUMER so that BOM imports using
+ * those properties do not fail with "Invalid Version Range Request".
+ *
+ * @see <a href="https://github.com/apache/maven/issues/11798">GH-11798</a>
+ */
+class MavenITgh11798ConsumerPomProfileActivationTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void testConsumerPomResolvesParentProfileProperties() throws Exception {
+        Path basedir = extractResources("/gh-11798-consumer-pom-profile-activation").toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/child/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <modelVersion>4.1.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh11798</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>child</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh11798</groupId>
+        <artifactId>test-bom</artifactId>
+        <version>${dep.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh11798</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child</module>
+  </modules>
+
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <checksumPolicy>ignore</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>local-test-repo</id>
+      <url>file://${project.rootDirectory}/repo</url>
+    </repository>
+  </repositories>
+
+  <profiles>
+    <profile>
+      <id>default-versions</id>
+      <activation>
+        <property>
+          <name>!skipDefaultVersions</name>
+        </property>
+      </activation>
+      <properties>
+        <dep.version>1.0</dep.version>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/repo/org/apache/maven/its/gh11798/test-bom/1.0/test-bom-1.0.pom
+++ b/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/repo/org/apache/maven/its/gh11798/test-bom/1.0/test-bom-1.0.pom
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.its.gh11798</groupId>
+    <artifactId>test-bom</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+</project>


### PR DESCRIPTION
Fixes #11798

When readParentLocally() finds a parent via resolveReactorModel() during BUILD_CONSUMER processing, derive(candidateSource) preserves the BUILD_CONSUMER request type. Since isBuildRequestWithActivation() returns false for BUILD_CONSUMER, POM profile activation is skipped for all parent POMs in the chain, leaving profile-defined properties (like BOM import versions) unresolved.

In contrast, resolveAndReadParentExternally() correctly creates a CONSUMER_PARENT request which allows profile activation.

The fix ensures readParentLocally() also uses CONSUMER_PARENT when the current request is BUILD_CONSUMER, consistent with the external resolution path.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
