### PR TITLE
MNG-11800 Exclude Eclipse IDE files and stale build artifacts from …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -825,6 +825,17 @@ under the License.
                 ! Excluded the license files itself cause they do not have a license of themselves.
               -->
               <exclude>src/main/appended-resources/licenses/**</exclude>
+              <!--
+                ! Exclude build output directories (stale or non-module target/ dirs
+                ! are not excluded by RAT's excludeSubProjects and not cleaned by mvn clean)
+              -->
+              <exclude>**/target/**</exclude>
+              <!--
+                ! Exclude Eclipse IDE project files (not cleaned by mvn clean)
+              -->
+              <exclude>**/.classpath</exclude>
+              <exclude>**/.project</exclude>
+              <exclude>**/.settings/**</exclude>
             </excludes>
           </configuration>
         </plugin>


### PR DESCRIPTION
Fixes #11800

Problem : 
RAT license checks were failing because it was scanning files that shouldn't 
be checked — Eclipse IDE files (.classpath, .project, .settings/) and stale 
build artifacts (.plxarc). These patterns are already in .gitignore but RAT 
uses its own exclude configuration.

Added 4 exclude patterns to the apache-rat-plugin configuration in the root pom.xml:
- `**/.classpath`
- `**/.project`  
- `**/.settings/**`
- `**/.plxarc`
