### PR TITLE
[MNG-8604] Fix concurrent builder crash with reactor plugins

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -268,6 +268,21 @@ public class BuildPlanExecutor {
                 Stream.of(pplan, setup, teardown).forEach(step -> plan.addStep(project, step.name, step));
             }
 
+            // Handle reactor plugins: if a project uses a plugin that is also a reactor module,
+            // the project's PLAN step must wait for the plugin project's READY step.
+            // This must be done after PLAN/READY steps are created above.
+            Map<String, MavenProject> reactorGavs =
+                    plan.getAllProjects().keySet().stream().collect(Collectors.toMap(BuildPlanExecutor::gav, p -> p));
+            for (MavenProject project : plan.getAllProjects().keySet()) {
+                for (Plugin plugin : project.getBuild().getPlugins()) {
+                    MavenProject pluginProject = reactorGavs.get(gav(plugin));
+                    if (pluginProject != null && pluginProject != project) {
+                        plan.step(project, PLAN)
+                                .ifPresent(pp -> plan.step(pluginProject, READY).ifPresent(pp::executeAfter));
+                    }
+                }
+            }
+
             return plan;
         }
 
@@ -968,24 +983,16 @@ public class BuildPlanExecutor {
                 });
             });
 
-            // Keep projects in reactors by GAV
+            // Eagerly resolve all non-reactor plugins in parallel
             Map<String, MavenProject> reactorGavs =
                     projects.keySet().stream().collect(Collectors.toMap(BuildPlanExecutor::gav, p -> p));
-
-            // Go through all plugins
             List<Runnable> toResolve = new ArrayList<>();
             projects.keySet()
                     .forEach(project -> project.getBuild().getPlugins().forEach(plugin -> {
-                        MavenProject pluginProject = reactorGavs.get(gav(plugin));
-                        if (pluginProject != null) {
-                            // In order to plan the project, we need all its plugins...
-                            plan.requiredStep(project, PLAN).executeAfter(plan.requiredStep(pluginProject, READY));
-                        } else {
+                        if (reactorGavs.get(gav(plugin)) == null) {
                             toResolve.add(() -> resolvePlugin(session, project.getRemotePluginRepositories(), plugin));
                         }
                     }));
-
-            // Eagerly resolve all plugins in parallel
             toResolve.parallelStream().forEach(Runnable::run);
 
             // Keep track of phase aliases

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanCreatorTest.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.apache.maven.internal.impl.DefaultLifecycleRegistry;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
@@ -129,41 +130,41 @@ class BuildPlanCreatorTest {
         return context.calculateLifecycleMappings(projects, phase);
     }
 
-    /*
     @Test
-    void testPlugins() {
-        DefaultLifecycleRegistry lifecycles =
-                new DefaultLifecycleRegistry(Collections.emptyList(), Collections.emptyMap());
-        BuildPlanCreator builder = new BuildPlanCreator(null, null, null, null, null, lifecycles);
+    void testReactorPlugin() {
         MavenProject p1 = new MavenProject();
         p1.setGroupId("g");
         p1.setArtifactId("p1");
-        p1.getBuild().getPlugins().add(new Plugin(org.apache.maven.api.model.Plugin.newBuilder()
-                .groupId("g").artifactId("p2")
-                .
-                .build()))
+        p1.setVersion("1.0");
+        p1.setCollectedProjects(List.of());
+        Plugin plugin = new Plugin();
+        plugin.setGroupId("g");
+        plugin.setArtifactId("p2");
+        plugin.setVersion("1.0");
+        p1.getBuild().addPlugin(plugin);
+
         MavenProject p2 = new MavenProject();
         p2.setGroupId("g");
         p2.setArtifactId("p2");
+        p2.setVersion("1.0");
+        p2.setCollectedProjects(List.of());
 
         Map<MavenProject, List<MavenProject>> projects = new HashMap<>();
         projects.put(p1, Collections.emptyList());
         projects.put(p2, Collections.singletonList(p1));
-        Lifecycle lifecycle = lifecycles.require("default");
-        BuildPlan plan = builder.calculateLifecycleMappings(null, projects, lifecycle, "verify");
-        plan.then(builder.calculateLifecycleMappings(null, projects, lifecycle, "install"));
+
+        BuildPlan plan = calculateLifecycleMappings(projects, "verify");
+        plan.then(calculateLifecycleMappings(projects, "install"));
 
         Stream.of(p1, p2).forEach(project -> {
-            plan.requiredStep(project, "post:resources").addMojo(new MojoExecution(null), 0);
-            plan.requiredStep(project, "post:test-resources").addMojo(new MojoExecution(null), 0);
+            plan.requiredStep(project, "after:resources").addMojo(new MojoExecution(null), 0);
+            plan.requiredStep(project, "after:test-resources").addMojo(new MojoExecution(null), 0);
             plan.requiredStep(project, "compile").addMojo(new MojoExecution(null), 0);
             plan.requiredStep(project, "test-compile").addMojo(new MojoExecution(null), 0);
             plan.requiredStep(project, "test").addMojo(new MojoExecution(null), 0);
             plan.requiredStep(project, "package").addMojo(new MojoExecution(null), 0);
             plan.requiredStep(project, "install").addMojo(new MojoExecution(null), 0);
         });
-
-        plan.condense();
 
         new BuildPlanLogger() {
             @Override
@@ -175,5 +176,4 @@ class BuildPlanCreatorTest {
                     pred -> assertTrue(plan.step(pred.project, pred.name).isPresent(), "Phase not present: " + pred));
         });
     }
-     */
 }


### PR DESCRIPTION
## Summary

- Fixes a crash (`Step $plan$ not found`) when using `--builder concurrent` on projects where a reactor module is also used as a build plugin (e.g., Apache CXF's `cxf-codegen-plugin`)
- Moves reactor plugin ordering logic from `calculateLifecycleMappings()` to `buildInitialPlan()`, where PLAN/READY steps already exist
- Simplifies plugin resolution to only eagerly resolve non-reactor plugins

## Details

The root cause is that `calculateLifecycleMappings()` calls `plan.requiredStep(project, PLAN)` to set up ordering between reactor plugins and their consuming projects, but the PLAN steps are only created later in `buildInitialPlan()`. Moving this logic to after the PLAN/READY step creation fixes the crash.

Tested successfully on Apache CXF, Maven Resolver, Commons Lang, and Maven Surefire with `-T4 --builder concurrent`.

## Test plan

- [x] Existing `BuildPlanCreatorTest` tests pass
- [x] Verified on Apache CXF (`mvn verify -T4 --builder concurrent`) — previously crashed, now builds successfully
- [x] Verified on Maven Resolver, Commons Lang, Maven Surefire with concurrent builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)