### PR TITLE
Fix MAVEN_ARGS parsing to handle quoted strings with spaces

### DIFF
--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
@@ -31,7 +31,6 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -225,9 +224,9 @@ public class EmbeddedMavenExecutor implements Executor {
         ArrayList<String> mavenArgs = new ArrayList<>();
         String mavenArgsEnv = System.getenv("MAVEN_ARGS");
         if (useMavenArgsEnv && mavenArgsEnv != null && !mavenArgsEnv.isEmpty()) {
-            Arrays.stream(mavenArgsEnv.split(" "))
-                    .filter(s -> !s.trim().isEmpty())
-                    .forEach(s -> mavenArgs.add(0, s));
+            List<String> parsed = parseArguments(mavenArgsEnv);
+            Collections.reverse(parsed);
+            mavenArgs.addAll(parsed);
         }
 
         Properties properties = prepareProperties(executorRequest);
@@ -440,5 +439,48 @@ public class EmbeddedMavenExecutor implements Executor {
             }
             return UNKNOWN_VERSION;
         }
+    }
+
+    /**
+     * Parses a string of arguments respecting quoted strings.
+     * Handles both single and double quotes, and preserves backslashes
+     * (important for Windows paths).
+     */
+    static List<String> parseArguments(String args) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inDoubleQuotes = false;
+        boolean inSingleQuotes = false;
+        for (int i = 0; i < args.length(); i++) {
+            char c = args.charAt(i);
+            if (inDoubleQuotes) {
+                if (c == '"') {
+                    inDoubleQuotes = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (inSingleQuotes) {
+                if (c == '\'') {
+                    inSingleQuotes = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (c == '"') {
+                inDoubleQuotes = true;
+            } else if (c == '\'') {
+                inSingleQuotes = true;
+            } else if (Character.isWhitespace(c)) {
+                if (!current.isEmpty()) {
+                    result.add(current.toString());
+                    current.setLength(0);
+                }
+            } else {
+                current.append(c);
+            }
+        }
+        if (!current.isEmpty()) {
+            result.add(current.toString());
+        }
+        return result;
     }
 }

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutor.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -116,9 +115,7 @@ public class ForkedMavenExecutor implements Executor {
 
         String mavenArgsEnv = System.getenv("MAVEN_ARGS");
         if (useMavenArgsEnv && mavenArgsEnv != null && !mavenArgsEnv.isEmpty()) {
-            Arrays.stream(mavenArgsEnv.split(" "))
-                    .filter(s -> !s.trim().isEmpty())
-                    .forEach(cmdAndArguments::add);
+            cmdAndArguments.addAll(parseArguments(mavenArgsEnv));
         }
 
         cmdAndArguments.addAll(executorRequest.arguments());
@@ -222,5 +219,48 @@ public class ForkedMavenExecutor implements Executor {
         if (closed.compareAndExchange(false, true)) {
             // nothing yet
         }
+    }
+
+    /**
+     * Parses a string of arguments respecting quoted strings.
+     * Handles both single and double quotes, and preserves backslashes
+     * (important for Windows paths).
+     */
+    static List<String> parseArguments(String args) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inDoubleQuotes = false;
+        boolean inSingleQuotes = false;
+        for (int i = 0; i < args.length(); i++) {
+            char c = args.charAt(i);
+            if (inDoubleQuotes) {
+                if (c == '"') {
+                    inDoubleQuotes = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (inSingleQuotes) {
+                if (c == '\'') {
+                    inSingleQuotes = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (c == '"') {
+                inDoubleQuotes = true;
+            } else if (c == '\'') {
+                inSingleQuotes = true;
+            } else if (Character.isWhitespace(c)) {
+                if (!current.isEmpty()) {
+                    result.add(current.toString());
+                    current.setLength(0);
+                }
+            } else {
+                current.append(c);
+            }
+        }
+        if (!current.isEmpty()) {
+            result.add(current.toString());
+        }
+        return result;
     }
 }

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutorTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutorTest.java
@@ -18,8 +18,13 @@
  */
 package org.apache.maven.cling.executor.embedded;
 
+import java.util.List;
+
 import org.apache.maven.api.cli.Executor;
 import org.apache.maven.cling.executor.MavenExecutorTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Embedded executor UT
@@ -29,5 +34,35 @@ public class EmbeddedMavenExecutorTest extends MavenExecutorTestSupport {
     @Override
     protected Executor doSelectExecutor() {
         return new EmbeddedMavenExecutor();
+    }
+
+    @Test
+    void testParseArgumentsSimple() {
+        assertEquals(
+                List.of("-T", "4", "clean", "install"), EmbeddedMavenExecutor.parseArguments("-T 4 clean install"));
+    }
+
+    @Test
+    void testParseArgumentsDoubleQuoted() {
+        assertEquals(
+                List.of("-f", "C:\\Program Files\\project\\pom.xml"),
+                EmbeddedMavenExecutor.parseArguments("-f \"C:\\Program Files\\project\\pom.xml\""));
+    }
+
+    @Test
+    void testParseArgumentsSingleQuoted() {
+        assertEquals(
+                List.of("-f", "/path with spaces/pom.xml"),
+                EmbeddedMavenExecutor.parseArguments("-f '/path with spaces/pom.xml'"));
+    }
+
+    @Test
+    void testParseArgumentsEmpty() {
+        assertEquals(List.of(), EmbeddedMavenExecutor.parseArguments(""));
+    }
+
+    @Test
+    void testParseArgumentsExtraWhitespace() {
+        assertEquals(List.of("clean", "install"), EmbeddedMavenExecutor.parseArguments("  clean   install  "));
     }
 }

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutorTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutorTest.java
@@ -18,8 +18,13 @@
  */
 package org.apache.maven.cling.executor.forked;
 
+import java.util.List;
+
 import org.apache.maven.api.cli.Executor;
 import org.apache.maven.cling.executor.MavenExecutorTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Forked executor UT
@@ -29,5 +34,34 @@ public class ForkedMavenExecutorTest extends MavenExecutorTestSupport {
     @Override
     protected Executor doSelectExecutor() {
         return new ForkedMavenExecutor();
+    }
+
+    @Test
+    void testParseArgumentsSimple() {
+        assertEquals(List.of("-T", "4", "clean", "install"), ForkedMavenExecutor.parseArguments("-T 4 clean install"));
+    }
+
+    @Test
+    void testParseArgumentsDoubleQuoted() {
+        assertEquals(
+                List.of("-f", "C:\\Program Files\\project\\pom.xml"),
+                ForkedMavenExecutor.parseArguments("-f \"C:\\Program Files\\project\\pom.xml\""));
+    }
+
+    @Test
+    void testParseArgumentsSingleQuoted() {
+        assertEquals(
+                List.of("-f", "/path with spaces/pom.xml"),
+                ForkedMavenExecutor.parseArguments("-f '/path with spaces/pom.xml'"));
+    }
+
+    @Test
+    void testParseArgumentsEmpty() {
+        assertEquals(List.of(), ForkedMavenExecutor.parseArguments(""));
+    }
+
+    @Test
+    void testParseArgumentsExtraWhitespace() {
+        assertEquals(List.of("clean", "install"), ForkedMavenExecutor.parseArguments("  clean   install  "));
     }
 }


### PR DESCRIPTION
## Summary
- Replace naive `String.split(" ")` with a proper argument parser that handles single and double quoted strings, preserving backslashes for Windows paths
- Applied to both `EmbeddedMavenExecutor` and `ForkedMavenExecutor`
- Added unit tests for both executors covering simple args, quoted paths, empty input, and extra whitespace

Fixes #11487

## Test plan
- [x] Unit tests for `parseArguments()` method in both executor implementations
- [ ] Manual test with `MAVEN_ARGS='-f "C:\Program Files\project\pom.xml"'` on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)