### PR TITLE
[MNG-6772] Re-enable integration test for nested import scope repository override

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Test;
  * The test confirms that the dominant repository definition (child) wins while resolving the import POMs.
  *
  */
-@Disabled // This IT has been disabled until it is decided how the solution shall look like
 public class MavenITmng6772NestedImportScopeRepositoryOverride extends AbstractMavenIntegrationTestCase {
 
     // This will test the behavior using ProjectModelResolver


### PR DESCRIPTION
## Summary
- Re-enable `MavenITmng6772NestedImportScopeRepositoryOverride` integration test that was `@Disabled` since April 2021
- Maven 4's session-based model builder architecture fixes the root cause: user-configured repository overrides (including `central` ID overrides) are now properly propagated through nested import scope resolution
- Verified both test scenarios (`testitInProject` and `testitInDependency`) pass on Maven 4

Fixes #8494, fixes #7816

## Test plan
- [x] Manual verification: both test scenarios pass against Maven 4.1.0-SNAPSHOT
- [ ] CI validation via this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)