### PR TITLE
EXPERIMENT: Core Override Type and support for it

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
+++ b/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.classrealm.ClassRealmRequest.RealmType;
@@ -156,10 +157,14 @@ public class DefaultClassRealmManager implements ClassRealmManager {
         Set<String> artifactIds = new LinkedHashSet<>();
 
         List<ClassRealmConstituent> constituents = new ArrayList<>();
+        List<Artifact> coreOverrides = new ArrayList<>();
 
         if (artifacts != null) {
             for (Artifact artifact : artifacts) {
                 if (!isProvidedArtifact(artifact)) {
+                    if (isCoreOverrideArtifact(artifact)) {
+                        coreOverrides.add(artifact);
+                    }
                     artifactIds.add(getId(artifact));
                     if (artifact.getFile() != null) {
                         constituents.add(new ArtifactClassRealmConstituent(artifact));
@@ -189,6 +194,24 @@ public class DefaultClassRealmManager implements ClassRealmManager {
         callDelegates(classRealm, type, parent, parentImports, foreignImports, constituents);
 
         wireRealm(classRealm, parentImports, foreignImports);
+
+        if (!coreOverrides.isEmpty()) {
+            ClassRealm overrideClassRealm = newRealm(baseRealmId + "-core-override");
+            for (Artifact coreOverride : coreOverrides) {
+                try {
+                    overrideClassRealm.addURL(coreOverride.getFile().toURI().toURL());
+                } catch (MalformedURLException e) {
+                    // Not going to happen
+                    logger.error(e.getMessage(), e);
+                }
+            }
+            // collect Gs (and assume packages == G for the experiment sake)
+            Set<String> packages =
+                    coreOverrides.stream().map(Artifact::getGroupId).collect(Collectors.toSet());
+            for (String pkg : packages) {
+                classRealm.importFrom(overrideClassRealm, pkg);
+            }
+        }
 
         Set<String> includedIds = populateRealm(classRealm, constituents);
 
@@ -229,8 +252,13 @@ public class DefaultClassRealmManager implements ClassRealmManager {
         return createRealm(getKey(plugin, true), RealmType.Extension, parent, null, foreignImports, artifacts);
     }
 
+    private boolean isCoreOverrideArtifact(Artifact artifact) {
+        return "core-override-jar".equals(artifact.getProperties().get("type"));
+    }
+
     private boolean isProvidedArtifact(Artifact artifact) {
-        return providedArtifacts.contains(artifact.getGroupId() + ":" + artifact.getArtifactId());
+        return !isCoreOverrideArtifact(artifact)
+                && providedArtifacts.contains(artifact.getGroupId() + ":" + artifact.getArtifactId());
     }
 
     public ClassRealm createPluginRealm(

--- a/maven-core/src/main/resources/META-INF/plexus/artifact-handlers.xml
+++ b/maven-core/src/main/resources/META-INF/plexus/artifact-handlers.xml
@@ -54,6 +54,21 @@ Artifact handlers are required by the dependency resolution mechanism.
     </component>
 
     <!--
+     | core override JAR
+     |-->
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>core-override-jar</role-hint>
+      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+      <configuration>
+        <type>core-override-jar</type>
+        <extension>jar</extension>
+        <language>java</language>
+        <addedToClasspath>true</addedToClasspath>
+      </configuration>
+    </component>
+
+    <!--
      | EJB
      |-->
     <component>


### PR DESCRIPTION
This is a hack, that allows a plugins to _override_ Maven Core exported artifact and replace it with "own", for example to use Slf4j 2.x instead of core exported 1.x one.