### PR TITLE
Trim `threadConfiguration` to accept input surrounded with spaces

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1477,17 +1477,17 @@ public class MavenCli {
             }
         } else {
             try {
-                int threads = Integer.parseInt(originalThreadConfiguration);
+                int threads = Integer.parseInt(threadConfiguration);
 
                 if (threads <= 0) {
                     throw new IllegalArgumentException(
-                            "Invalid threads value: '" + originalThreadConfiguration + "'. Value must be positive.");
+                            "Invalid threads value: '" + threadConfiguration + "'. Value must be positive.");
                 }
 
                 return threads;
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(
-                        "Invalid threads value: '" + originalThreadConfiguration + "'. Supported are integer values.");
+                        "Invalid threads value: '" + threadConfiguration + "'. Supported are integer values.");
             }
         }
     }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1453,7 +1453,8 @@ public class MavenCli {
         return request;
     }
 
-    int calculateDegreeOfConcurrency(String threadConfiguration) {
+    int calculateDegreeOfConcurrency(String originalThreadConfiguration) {
+        String threadConfiguration = originalThreadConfiguration.trim();
         if (threadConfiguration.endsWith("C")) {
             threadConfiguration = threadConfiguration.substring(0, threadConfiguration.length() - 1);
 
@@ -1476,17 +1477,17 @@ public class MavenCli {
             }
         } else {
             try {
-                int threads = Integer.parseInt(threadConfiguration);
+                int threads = Integer.parseInt(originalThreadConfiguration);
 
                 if (threads <= 0) {
                     throw new IllegalArgumentException(
-                            "Invalid threads value: '" + threadConfiguration + "'. Value must be positive.");
+                            "Invalid threads value: '" + originalThreadConfiguration + "'. Value must be positive.");
                 }
 
                 return threads;
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(
-                        "Invalid threads value: '" + threadConfiguration + "'. Supported are integer values.");
+                        "Invalid threads value: '" + originalThreadConfiguration + "'. Supported are integer values.");
             }
         }
     }

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -92,6 +92,8 @@ public class MavenCliTest {
         assertEquals(1, cli.calculateDegreeOfConcurrency("0.0001C"));
         assertEquals(1 * cpus, cli.calculateDegreeOfConcurrency(" 1C"));
         assertEquals(1 * cpus, cli.calculateDegreeOfConcurrency(" 1C "));
+        assertEquals(1, cli.calculateDegreeOfConcurrency(" 1"));
+        assertEquals(1, cli.calculateDegreeOfConcurrency(" 1 "));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("-2.2C"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("0C"));
     }

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -90,6 +90,7 @@ public class MavenCliTest {
         int cpus = Runtime.getRuntime().availableProcessors();
         assertEquals((int) (cpus * 2.2), cli.calculateDegreeOfConcurrency("2.2C"));
         assertEquals(1, cli.calculateDegreeOfConcurrency("0.0001C"));
+        assertEquals(1 * cpus, cli.calculateDegreeOfConcurrency(" 1C"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("-2.2C"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("0C"));
     }

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -82,6 +82,10 @@ public class MavenCliTest {
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("2C2"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("CXXX"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("XXXC"));
+        assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("1c"));
+        assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency(" 1c"));
+        assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("1c "));
+        assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency(" 1c "));
 
         int cpus = Runtime.getRuntime().availableProcessors();
         assertEquals((int) (cpus * 2.2), cli.calculateDegreeOfConcurrency("2.2C"));

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -91,6 +91,7 @@ public class MavenCliTest {
         assertEquals((int) (cpus * 2.2), cli.calculateDegreeOfConcurrency("2.2C"));
         assertEquals(1, cli.calculateDegreeOfConcurrency("0.0001C"));
         assertEquals(1 * cpus, cli.calculateDegreeOfConcurrency(" 1C"));
+        assertEquals(1 * cpus, cli.calculateDegreeOfConcurrency(" 1C "));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("-2.2C"));
         assertThrows(IllegalArgumentException.class, () -> cli.calculateDegreeOfConcurrency("0C"));
     }


### PR DESCRIPTION
- space-prefixed core multiplier - is already _supported_ - added support for space-suffix
- extended that behaviour for direct number of threads argument
- can be used in bizarre command line like `mvn -T ' 1 '` or - why I'm here - with value indented in `maven.config`:
```
--threads
  1
```


-----
https://github.com/apache/maven/blob/9ac23b040017e7b14877fbc9e74c696d36cba3f9/CONTRIBUTING.md?plain=1#L58

```
[WARNING] The requested profile "run-its" could not be activated because it does not exist.
```

-----

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


-----

- #11850