### PR TITLE
Nuance the message about filename-based automodules detected on the module path

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
@@ -236,7 +236,7 @@ final class PathModularization {
     /**
      * If the module has no name, adds the filename of the JAR file in the given collection.
      * This method should be invoked for dependencies placed on {@link JavaPathType#MODULES}
-     * for preparing a warning asking to not deploy the build artifact on a public repository.
+     * for preparing a warning saying that this project may fail to resolve these modules.
      * If the module has an explicit name either with a {@code module-info.class} file or with
      * an {@code "Automatic-Module-Name"} attribute in the {@code META-INF/MANIFEST.MF} file,
      * then this method does nothing.

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularization.java
@@ -234,12 +234,15 @@ final class PathModularization {
     }
 
     /**
-     * If the module has no name, adds the filename of the JAR file in the given collection.
-     * This method should be invoked for dependencies placed on {@link JavaPathType#MODULES}
-     * for preparing a warning saying that this project may fail to resolve these modules.
-     * If the module has an explicit name either with a {@code module-info.class} file or with
-     * an {@code "Automatic-Module-Name"} attribute in the {@code META-INF/MANIFEST.MF} file,
-     * then this method does nothing.
+     * If the JAR has no {@code module-info.class} entry and no {@code Automatic-Module-Name}
+     * attribute in JAR's manifest, adds the filename of the JAR file in the given collection.
+     * This method should be invoked for all dependencies placed on the module-path,
+     * e.g. all dependencies of type {@link JavaPathType#MODULES}.
+     * If the module described by the {@code PathModularization} instance has an explicit name
+     * either with a {@code module-info.class} file or with an {@code "Automatic-Module-Name"}
+     * attribute in the {@code META-INF/MANIFEST.MF} file, then this method does nothing.
+     * Otherwise, this method adds an element in the given {@code automodulesDetected} collection.
+     * That collection will be used later for preparing a warning message.
      */
     public void addIfFilenameBasedAutomodules(Collection<String> automodulesDetected) {
         if (descriptors.isEmpty()) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularizationCache.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularizationCache.java
@@ -189,10 +189,12 @@ final class PathModularizationCache {
             return Optional.empty();
         }
         String lineSeparator = System.lineSeparator();
+        String fileSeparator = lineSeparator + "  - ";
         var joiner = new StringJoiner(
-                lineSeparator + "  - ",
-                "Filename-based automodules detected on the module path: " + lineSeparator + "  - ",
-                lineSeparator + "Please don't publish this project to a public artifact repository.");
+                fileSeparator,
+                "Filename-based automodules detected on the module path: " + fileSeparator,
+                lineSeparator + "This project may not work in applications that do not use "
+                        + "these dependencies with exactly the same filenames as listed above.");
         automodulesDetected.forEach(joiner::add);
         return Optional.of(joiner.toString());
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularizationCache.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathModularizationCache.java
@@ -193,8 +193,8 @@ final class PathModularizationCache {
         var joiner = new StringJoiner(
                 fileSeparator,
                 "Filename-based automodules detected on the module path: " + fileSeparator,
-                lineSeparator + "This project may not work in applications that do not use "
-                        + "these dependencies with exactly the same filenames as listed above.");
+                lineSeparator + "This project may not work if consumers use "
+                        + "these dependencies with different filenames.");
         automodulesDetected.forEach(joiner::add);
         return Optional.of(joiner.toString());
     }


### PR DESCRIPTION
Instead of _"Please don't publish this project to a public artifact repository"_, said _"This project may not work in applications that do not use these dependencies with exactly the same filenames as listed above"_.

**Rational:** it can be considered okay to publish the project on a public Maven repository, because the artifact filenames are quite deterministic with Maven. For a pure-Maven project and for bundle generated by the Maven assembly plugin, there is no reason why these filenames would not be stable. Therefore, we can warn the users about the fragility of filename-based automodules but let them decide whether they want to publish anyway.