### PR TITLE
fix: propagate addResource() to model Build for Maven 3 compat

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -778,11 +778,13 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     sourceContext.handleResourceConfiguration(ProjectScope.TEST);
                 }
 
-                // Sync model Build resources from sources set so that
-                // project.getBuild().getResources() is consistent with project.getResources().
-                // This is needed for Maven 3 plugin compatibility, since some plugins
-                // (e.g. maven-source-plugin) access resources via project.getBuild().getResources().
-                project.syncBuildResources();
+                // When resources are defined via <sources> (4.1.0 model), sync them to
+                // the model's Build so project.getBuild().getResources() is consistent.
+                // For legacy <resources>, the model already has the correct resources.
+                if (sourceContext.hasSources(Language.RESOURCES, ProjectScope.MAIN)
+                        || sourceContext.hasSources(Language.RESOURCES, ProjectScope.TEST)) {
+                    project.syncBuildResources();
+                }
             }
 
             project.setActiveProfiles(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -777,6 +777,12 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     sourceContext.handleResourceConfiguration(ProjectScope.MAIN);
                     sourceContext.handleResourceConfiguration(ProjectScope.TEST);
                 }
+
+                // Sync model Build resources from sources set so that
+                // project.getBuild().getResources() is consistent with project.getResources().
+                // This is needed for Maven 3 plugin compatibility, since some plugins
+                // (e.g. maven-source-plugin) access resources via project.getBuild().getResources().
+                project.syncBuildResources();
             }
 
             project.setActiveProfiles(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -848,16 +848,21 @@ public class MavenProject implements Cloneable {
     }
 
     /**
-     * @deprecated {@link Resource} is replaced by {@link SourceRoot}.
+     * Syncs {@code Build.resources/testResources} from the {@code sources} set
+     * for Maven 3 plugin compatibility (e.g. when resources come from {@code <sources>}).
      */
+    void syncBuildResources() {
+        getModelBuild().setResources(new java.util.ArrayList<>(getResources()));
+        getModelBuild().setTestResources(new java.util.ArrayList<>(getTestResources()));
+    }
+
+    /** @deprecated {@link Resource} is replaced by {@link SourceRoot}. */
     @Deprecated(since = "4.0.0")
     public void addResource(Resource resource) {
         addResource(ProjectScope.MAIN, resource);
     }
 
-    /**
-     * @deprecated {@link Resource} is replaced by {@link SourceRoot}.
-     */
+    /** @deprecated {@link Resource} is replaced by {@link SourceRoot}. */
     @Deprecated(since = "4.0.0")
     public void addTestResource(Resource testResource) {
         addResource(ProjectScope.TEST, testResource);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -838,6 +838,13 @@ public class MavenProject implements Cloneable {
 
     private void addResource(ProjectScope scope, Resource resource) {
         addSourceRoot(new DefaultSourceRoot(getBaseDirectory(), scope, resource.getDelegate()));
+        // Also update the model's Build to maintain compatibility with code that
+        // accesses resources via project.getBuild().getResources()
+        if (scope == ProjectScope.MAIN) {
+            getModelBuild().addResource(resource);
+        } else {
+            getModelBuild().addTestResource(resource);
+        }
     }
 
     /**

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ResourceIncludeTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ResourceIncludeTest.java
@@ -281,4 +281,62 @@ class ResourceIncludeTest {
                 placeholderResult.getTargetPath(),
                 "Property placeholder in targetPath should be preserved");
     }
+
+    /**
+     * Verifies that resources added via {@code project.addResource()} or
+     * {@code project.getResources().add()} are visible through both
+     * {@code project.getResources()} and {@code project.getBuild().getResources()}.
+     * This is important for Maven 3 compatibility, since plugins may access
+     * resources through either path.
+     *
+     * @see <a href="https://github.com/apache/maven-source-plugin/pull/281">maven-source-plugin#281</a>
+     */
+    @Test
+    void testAddResourceVisibleViaBuildGetResources() {
+        // Initial state: one resource in sources, none added dynamically
+        assertEquals(1, project.getResources().size());
+        int initialBuildResources = project.getBuild().getResources().size();
+
+        // Add a resource dynamically (simulating what maven-remote-resources-plugin does)
+        Resource dynamicResource = new Resource();
+        dynamicResource.setDirectory("target/maven-shared-archive-resources");
+        project.addResource(dynamicResource);
+
+        // Verify visible via project.getResources()
+        List<Resource> projectResources = project.getResources();
+        assertEquals(2, projectResources.size(), "Dynamic resource should be visible via project.getResources()");
+
+        // Verify ALSO visible via project.getBuild().getResources()
+        List<Resource> buildResources = project.getBuild().getResources();
+        assertEquals(
+                initialBuildResources + 1,
+                buildResources.size(),
+                "Dynamic resource should also be visible via project.getBuild().getResources()");
+
+        boolean found =
+                buildResources.stream().anyMatch(r -> r.getDirectory().contains("maven-shared-archive-resources"));
+        assertTrue(found, "getBuild().getResources() should contain the dynamically added resource");
+    }
+
+    /**
+     * Same as above but using {@code project.getResources().add()} path.
+     */
+    @Test
+    void testAddResourceViaListVisibleViaBuildGetResources() {
+        int initialBuildResources = project.getBuild().getResources().size();
+
+        Resource dynamicResource = new Resource();
+        dynamicResource.setDirectory("target/maven-shared-archive-resources");
+        project.getResources().add(dynamicResource);
+
+        List<Resource> buildResources = project.getBuild().getResources();
+        assertEquals(
+                initialBuildResources + 1,
+                buildResources.size(),
+                "Resource added via getResources().add() should be visible via getBuild().getResources()");
+
+        boolean found =
+                buildResources.stream().anyMatch(r -> r.getDirectory().contains("maven-shared-archive-resources"));
+        assertTrue(found, "getBuild().getResources() should contain the resource added via getResources().add()");
+    }
 }


### PR DESCRIPTION
## Summary

- When a Maven 3 plugin dynamically adds a resource via `project.addResource()` or `project.getResources().add()`, propagate the change to the model's `Build.resources` so that `project.getBuild().getResources()` stays in sync with `project.getResources()`
- After project building, sync `Build.resources`/`Build.testResources` from the `sources` set so that resources defined via `<sources>` (Maven 4.1.0) are also visible through `project.getBuild().getResources()`
- This fixes resource ordering issues when running Maven 3 plugins (e.g. maven-source-plugin 3.x) on Maven 4

### Root cause

In Maven 3, `project.getResources()` and `project.getBuild().getResources()` return the **same** mutable list. In Maven 4's compatibility layer, they are disconnected: `getResources()` returns a virtual list backed by the internal `sources` set, while `getBuild().getResources()` returns a WrapperList backed by the model.

When `maven-remote-resources-plugin` adds a resource directory, only the `sources` set was updated. The `maven-source-plugin`'s `createArchiver()` method uses `project.getBuild().getResources()` to find the `maven-shared-archive-resources` directory and add META-INF files first in the JAR — but in Maven 4 it couldn't find it, causing the META-INF entries to appear at the end instead of the beginning.

Additionally, when resources are defined via `<sources>` (Maven 4.1.0 model), they were only added to the `sources` set but not reflected in `Build.resources`, making them invisible to Maven 3 plugins accessing resources via `project.getBuild().getResources()`.

See: https://github.com/apache/maven-source-plugin/pull/281

## Test plan

- [x] Existing `ResourceIncludeTest` passes (10 tests)
- [x] Full `maven-core` test suite passes (545 tests)
- [ ] Verify with maven-source-plugin 3.x reproducible IT on Maven 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)