### PR TITLE
Restore buildConfiguration() callback in deprecated PluginDescriptorBuilder.build() methods

### DIFF
--- a/compat/maven-plugin-api/src/main/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilder.java
+++ b/compat/maven-plugin-api/src/main/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilder.java
@@ -71,7 +71,24 @@ public class PluginDescriptorBuilder {
      */
     @Deprecated
     public PluginDescriptor build(Reader reader, String source) throws PlexusConfigurationException {
-        return build(() -> reader, source);
+        try {
+            BufferedReader br = new BufferedReader(reader, BUFFER_SIZE);
+            br.mark(BUFFER_SIZE);
+            XMLStreamReader xsr = XMLInputFactory.newFactory().createXMLStreamReader(br);
+            xsr.nextTag();
+            String nsUri = xsr.getNamespaceURI();
+            br.reset();
+            if (PLUGIN_2_0_0.equals(nsUri)) {
+                xsr = XMLInputFactory.newFactory().createXMLStreamReader(br);
+                return new PluginDescriptor(new PluginDescriptorStaxReader().read(xsr, true));
+            } else {
+                // Call buildConfiguration() for backward compatibility with subclasses that override it
+                PlexusConfiguration cfg = buildConfiguration(br);
+                return build(source, cfg);
+            }
+        } catch (XMLStreamException | IOException e) {
+            throw new PlexusConfigurationException(e.getMessage(), e);
+        }
     }
 
     public PluginDescriptor build(ReaderSupplier readerSupplier) throws PlexusConfigurationException {
@@ -98,7 +115,24 @@ public class PluginDescriptorBuilder {
      */
     @Deprecated
     public PluginDescriptor build(InputStream input, String source) throws PlexusConfigurationException {
-        return build(() -> input, source);
+        try {
+            BufferedInputStream bis = new BufferedInputStream(input, BUFFER_SIZE);
+            bis.mark(BUFFER_SIZE);
+            XMLStreamReader xsr = XMLInputFactory.newFactory().createXMLStreamReader(bis);
+            xsr.nextTag();
+            String nsUri = xsr.getNamespaceURI();
+            bis.reset();
+            if (PLUGIN_2_0_0.equals(nsUri)) {
+                xsr = XMLInputFactory.newFactory().createXMLStreamReader(bis);
+                return new PluginDescriptor(new PluginDescriptorStaxReader().read(xsr, true));
+            } else {
+                // Call buildConfiguration() for backward compatibility with subclasses that override it
+                PlexusConfiguration cfg = buildConfiguration(bis);
+                return build(source, cfg);
+            }
+        } catch (XMLStreamException | IOException e) {
+            throw new PlexusConfigurationException(e.getMessage(), e);
+        }
     }
 
     public PluginDescriptor build(StreamSupplier inputSupplier) throws PlexusConfigurationException {


### PR DESCRIPTION
## Summary

- Restore `buildConfiguration()` callback in the deprecated `build(Reader, String)` and `build(InputStream, String)` methods
- The [MNG-7947] refactoring inadvertently bypassed this overridable method, breaking subclasses like `EnhancedPluginDescriptorBuilder` in maven-plugin-tools
- The legacy code path now detects the namespace (PLUGIN 2.0.0 vs legacy), and calls `buildConfiguration()` for the legacy format

## Context

This fixes the root cause of apache/maven-plugin-tools#806 and unblocks apache/maven-plugin-tools#1091 (Maven 4 CI).

The `build(Reader, String)` method was changed from:
```java
return build(source, buildConfiguration(reader));
```
to:
```java
return build(() -> reader, source);
```
which skips the `buildConfiguration()` callback entirely. Subclasses that override `buildConfiguration()` to intercept the parsed configuration (e.g., to extract `requiredJavaVersion`) get a null field and NPE.

## Test plan

- [x] `mvn compile test` passes in `compat/maven-plugin-api`
- [ ] Full CI
- [ ] Verify maven-plugin-tools reporting ITs pass with this Maven build

🤖 Generated with [Claude Code](https://claude.com/claude-code)