### PR TITLE
Fix #11885: Disable ANSI colors when stdout is piped on JDK 22+

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -342,7 +342,7 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
             context.coloredOutput = context.coloredOutput != null ? context.coloredOutput : false;
             context.closeables.add(out::flush);
         } else {
-            builder.systemOutput(TerminalBuilder.SystemOutput.ForcedSysOut);
+            builder.systemOutput(TerminalBuilder.SystemOutput.SysOut);
         }
         if (context.coloredOutput != null) {
             builder.color(context.coloredOutput);
@@ -354,12 +354,10 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
      */
     protected final void doConfigureWithTerminal(C context, Terminal terminal) {
         context.terminal = terminal;
-        // tricky thing: align what JLine3 detected and Maven thinks:
+        // Align Maven's color setting with JLine's terminal detection:
         // if embedded, we default to context.coloredOutput=false unless overridden (see above)
-        // if not embedded, JLine3 may detect redirection and will create dumb terminal.
+        // if not embedded, JLine detects redirection via SysOut and will create dumb terminal.
         // To align Maven with outcomes, we set here color enabled based on these premises.
-        // Note: Maven3 suffers from similar thing: if you do `mvn3 foo > log.txt`, the output will
-        // not be not colored (good), but Maven will print out "Message scheme: color".
         MessageUtils.setColorEnabled(
                 context.coloredOutput != null ? context.coloredOutput : !Terminal.TYPE_DUMB.equals(terminal.getType()));
 


### PR DESCRIPTION
## Summary

- Change `ForcedSysOut` to `SysOut` in JLine's `TerminalBuilder` configuration so that JLine properly checks whether stdout is a TTY before creating a system terminal
- `ForcedSysOut` bypasses TTY detection, causing a non-dumb terminal to be created even when stdout is piped (because stdin is still a TTY), resulting in ANSI escape codes in piped output on JDK 22+ where the FFM provider creates a terminal from stdin alone

## Root Cause

JLine's `SystemOutput.ForcedSysOut` always returns `SystemStream.Output` in `select()` without checking if stdout is actually a TTY. On JDK 21, the exec/JNI providers would fail to create a system terminal when stdout was piped, falling back to dumb. On JDK 22+ with the FFM provider, the terminal is created successfully (stdin is a TTY), producing a non-dumb terminal with colors enabled even when piped.

`SystemOutput.SysOut` does the right thing: it checks if stdout is a TTY first. If not, `systemStream` is null, and JLine falls back to a dumb terminal — exactly the correct behavior.

## Test plan

- [ ] `mvn help:help -X | less` should show plain text (no ANSI codes) on JDK 25+
- [ ] `mvn help:help -X > /tmp/out.txt` should produce plain text on JDK 25+
- [ ] `mvn help:help -X` should still show colored output on a real terminal
- [ ] `mvn --color=always help:help -X | less` should still show ANSI codes (forced)
- [ ] `mvn --color=never help:help -X` should show plain text
- [ ] Behavior unchanged on JDK 17/21

Fixes #11885

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)