### PR TITLE
Fix #11856: Improve error message for prefix-based remote repository filtering errors

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -40,6 +40,7 @@ import org.apache.maven.plugin.PluginContainerException;
 import org.apache.maven.plugin.PluginExecutionException;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingResult;
+import org.eclipse.aether.transfer.ArtifactFilteredOutException;
 
 /*
 
@@ -177,6 +178,9 @@ public class DefaultExceptionHandler implements ExceptionHandler {
                         reference = ConnectException.class.getSimpleName();
                     }
                 }
+                if (findCause(exception, ArtifactFilteredOutException.class) != null) {
+                    reference = "https://maven.apache.org/resolver/remote-repository-filtering.html";
+                }
             } else if (exception instanceof LinkageError) {
                 reference = LinkageError.class.getSimpleName();
             } else if (exception instanceof PluginExecutionException) {
@@ -207,7 +211,9 @@ public class DefaultExceptionHandler implements ExceptionHandler {
             }
         }
 
-        if ((reference != null && !reference.isEmpty()) && !reference.startsWith("http:")) {
+        if ((reference != null && !reference.isEmpty())
+                && !reference.startsWith("http:")
+                && !reference.startsWith("https:")) {
             reference = "http://cwiki.apache.org/confluence/display/MAVEN/" + reference;
         }
 
@@ -228,6 +234,8 @@ public class DefaultExceptionHandler implements ExceptionHandler {
 
     private String getMessage(String message, Throwable exception) {
         String fullMessage = (message != null) ? message : "";
+
+        boolean hasArtifactFilteredOut = false;
 
         // To break out of possible endless loop when getCause returns "this", or dejaVu for n-level recursion (n>1)
         Set<Throwable> dejaVu = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -260,13 +268,41 @@ public class DefaultExceptionHandler implements ExceptionHandler {
                 fullMessage = join(fullMessage, exceptionMessage);
             }
 
+            if (t instanceof ArtifactFilteredOutException) {
+                hasArtifactFilteredOut = true;
+            }
+
             if (!dejaVu.add(t)) {
                 fullMessage = join(fullMessage, "[CIRCULAR REFERENCE]");
                 break;
             }
         }
 
+        if (hasArtifactFilteredOut) {
+            fullMessage += System.lineSeparator()
+                    + System.lineSeparator()
+                    + "This error indicates that the remote repository's prefix file does not list"
+                    + " this artifact's group. This commonly happens with repository managers"
+                    + " using virtual/group repositories that do not properly aggregate prefix files."
+                    + System.lineSeparator()
+                    + "To disable prefix-based filtering, add"
+                    + " -Daether.remoteRepositoryFilter.prefixes=false"
+                    + " to your command line or to .mvn/maven.config."
+                    + System.lineSeparator()
+                    + "See https://maven.apache.org/resolver/remote-repository-filtering.html";
+        }
+
         return fullMessage.trim();
+    }
+
+    private static <T extends Throwable> T findCause(Throwable exception, Class<T> type) {
+        Set<Throwable> dejaVu = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Throwable t = exception; t != null && dejaVu.add(t); t = t.getCause()) {
+            if (type.isInstance(t)) {
+                return type.cast(t);
+            }
+        }
+        return null;
     }
 
     private String join(String message1, String message2) {

--- a/impl/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -279,20 +279,13 @@ public class DefaultExceptionHandler implements ExceptionHandler {
         }
 
         if (hasArtifactFilteredOut) {
-            fullMessage += System.lineSeparator()
-                    + System.lineSeparator()
-                    + "This error indicates that a remote repository filter has rejected this artifact."
-                    + " This commonly happens with repository managers using virtual/group repositories"
-                    + " that do not properly aggregate prefix files."
-                    + System.lineSeparator()
-                    + "To disable remote repository filtering, add one or both of these"
-                    + " to your command line or to .mvn/maven.config:"
-                    + System.lineSeparator()
-                    + "  -Daether.remoteRepositoryFilter.prefixes=false"
-                    + System.lineSeparator()
-                    + "  -Daether.remoteRepositoryFilter.groupId=false"
-                    + System.lineSeparator()
-                    + "See https://maven.apache.org/resolver/remote-repository-filtering.html";
+            fullMessage += """
+
+                This error indicates that a remote repository filter has rejected this artifact. This commonly happens with repository managers using virtual/group repositories that do not properly aggregate prefix files.
+                To disable remote repository filtering, add one or both of these to your command line or to .mvn/maven.config:
+                  -Daether.remoteRepositoryFilter.prefixes=false
+                  -Daether.remoteRepositoryFilter.groupId=false
+                See https://maven.apache.org/resolver/remote-repository-filtering.html""";
         }
 
         return fullMessage.trim();

--- a/impl/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/exception/DefaultExceptionHandler.java
@@ -281,13 +281,16 @@ public class DefaultExceptionHandler implements ExceptionHandler {
         if (hasArtifactFilteredOut) {
             fullMessage += System.lineSeparator()
                     + System.lineSeparator()
-                    + "This error indicates that the remote repository's prefix file does not list"
-                    + " this artifact's group. This commonly happens with repository managers"
-                    + " using virtual/group repositories that do not properly aggregate prefix files."
+                    + "This error indicates that a remote repository filter has rejected this artifact."
+                    + " This commonly happens with repository managers using virtual/group repositories"
+                    + " that do not properly aggregate prefix files."
                     + System.lineSeparator()
-                    + "To disable prefix-based filtering, add"
-                    + " -Daether.remoteRepositoryFilter.prefixes=false"
-                    + " to your command line or to .mvn/maven.config."
+                    + "To disable remote repository filtering, add one or both of these"
+                    + " to your command line or to .mvn/maven.config:"
+                    + System.lineSeparator()
+                    + "  -Daether.remoteRepositoryFilter.prefixes=false"
+                    + System.lineSeparator()
+                    + "  -Daether.remoteRepositoryFilter.groupId=false"
                     + System.lineSeparator()
                     + "See https://maven.apache.org/resolver/remote-repository-filtering.html";
         }

--- a/impl/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
@@ -29,9 +29,15 @@ import org.apache.maven.plugin.PluginContainerException;
 import org.apache.maven.plugin.PluginExecutionException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.transfer.ArtifactFilteredOutException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  */
@@ -122,6 +128,35 @@ class DefaultExceptionHandlerTest {
 
         String expectedReference = "http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException";
         assertEquals(expectedReference, summary.getReference());
+    }
+
+    @Test
+    void testArtifactFilteredOutException() {
+        RemoteRepository repo =
+                new RemoteRepository.Builder("my-repo", "default", "https://repo.example.com/maven").build();
+        ArtifactFilteredOutException filterEx = new ArtifactFilteredOutException(
+                new DefaultArtifact("com.example:my-lib:jar:1.0"),
+                repo,
+                "Prefix com/example/my-lib/1.0/my-lib-1.0.jar NOT allowed from my-repo"
+                        + " (https://repo.example.com/maven, default, releases)");
+        ArtifactResult artifactResult = new ArtifactResult(new org.eclipse.aether.resolution.ArtifactRequest(
+                new DefaultArtifact("com.example:my-lib:jar:1.0"), java.util.List.of(repo), null));
+        artifactResult.addException(filterEx);
+        ArtifactResolutionException resolutionEx =
+                new ArtifactResolutionException(java.util.List.of(artifactResult), "Could not resolve artifact");
+        MojoExecutionException mojoEx = new MojoExecutionException("Resolution failed", resolutionEx);
+
+        DefaultExceptionHandler handler = new DefaultExceptionHandler();
+        ExceptionSummary summary = handler.handleException(mojoEx);
+
+        assertTrue(
+                summary.getMessage().contains("-Daether.remoteRepositoryFilter.prefixes=false"),
+                "Message should contain the workaround property");
+        assertTrue(summary.getMessage().contains("prefix file"), "Message should explain the prefix file cause");
+        assertEquals(
+                "https://maven.apache.org/resolver/remote-repository-filtering.html",
+                summary.getReference(),
+                "Reference should point to the RRF documentation");
     }
 
     @Test

--- a/impl/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/exception/DefaultExceptionHandlerTest.java
@@ -151,8 +151,13 @@ class DefaultExceptionHandlerTest {
 
         assertTrue(
                 summary.getMessage().contains("-Daether.remoteRepositoryFilter.prefixes=false"),
-                "Message should contain the workaround property");
-        assertTrue(summary.getMessage().contains("prefix file"), "Message should explain the prefix file cause");
+                "Message should contain the prefixes workaround property");
+        assertTrue(
+                summary.getMessage().contains("-Daether.remoteRepositoryFilter.groupId=false"),
+                "Message should contain the groupId workaround property");
+        assertTrue(
+                summary.getMessage().contains("remote repository filter"),
+                "Message should explain the filtering cause");
         assertEquals(
                 "https://maven.apache.org/resolver/remote-repository-filtering.html",
                 summary.getReference(),


### PR DESCRIPTION
## Summary

- Detect `ArtifactFilteredOutException` in the exception cause chain and append actionable guidance explaining that the remote repository's prefix file doesn't list the artifact's group
- Suggest the workaround `-Daether.remoteRepositoryFilter.prefixes=false` and link to RRF documentation
- Fix `getReference()` to return the RRF docs URL instead of the generic MojoExecutionException wiki page
- Support `https:` reference URLs (previously only `http:` was recognized as an absolute URL)

Closes #11856

## Test plan

- [x] Added `DefaultExceptionHandlerTest.testArtifactFilteredOutException()` verifying both the hint message and reference URL
- [ ] Manual verification with a repository manager serving incomplete prefix files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_