### PR TITLE
Fix #11796: Preserve cross-lifecycle default phase bindings from components.xml

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -226,72 +226,100 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
                 }
 
                 @Override
+                public Collection<Phase> v3phases() {
+                    return buildOwnPhases();
+                }
+
+                @Override
                 public Collection<Phase> phases() {
+                    List<Phase> phases = new ArrayList<>(buildOwnPhases());
+                    // Include phases from getDefaultLifecyclePhases() that bind to phases
+                    // from other lifecycles (e.g. process-sources from the default lifecycle).
+                    // In Maven 3, <default-phases> could bind plugin goals to standard lifecycle
+                    // phases. These cross-lifecycle bindings must be preserved so they survive
+                    // the round-trip conversion back to a legacy Lifecycle.
+                    Map<String, LifecyclePhase> defaultPhases = lifecycle.getDefaultLifecyclePhases();
+                    if (defaultPhases != null) {
+                        Set<String> ownPhases = new HashSet<>(lifecycle.getPhases());
+                        for (String phaseName : defaultPhases.keySet()) {
+                            if (!ownPhases.contains(phaseName)) {
+                                phases.add(createPhase(phaseName, null));
+                            }
+                        }
+                    }
+                    return phases;
+                }
+
+                private List<Phase> buildOwnPhases() {
                     List<String> names = lifecycle.getPhases();
                     List<Phase> phases = new ArrayList<>();
                     for (int i = 0; i < names.size(); i++) {
                         String name = names.get(i);
                         String prev = i > 0 ? names.get(i - 1) : null;
-                        phases.add(new Phase() {
-                            @Override
-                            public String name() {
-                                return name;
-                            }
-
-                            @Override
-                            public List<Phase> phases() {
-                                return List.of();
-                            }
-
-                            @Override
-                            public Stream<Phase> allPhases() {
-                                return Stream.concat(
-                                        Stream.of(this), phases().stream().flatMap(Lifecycle.Phase::allPhases));
-                            }
-
-                            @Override
-                            public List<Plugin> plugins() {
-                                Map<String, LifecyclePhase> lfPhases = lifecycle.getDefaultLifecyclePhases();
-                                LifecyclePhase phase = lfPhases != null ? lfPhases.get(name) : null;
-                                if (phase != null) {
-                                    Map<String, Plugin> plugins = new LinkedHashMap<>();
-                                    DefaultPackagingRegistry.parseLifecyclePhaseDefinitions(plugins, name, phase);
-                                    return plugins.values().stream().toList();
-                                }
-                                return List.of();
-                            }
-
-                            @Override
-                            public Collection<Link> links() {
-                                if (prev == null) {
-                                    return List.of();
-                                } else {
-                                    return List.of(new Link() {
-                                        @Override
-                                        public Kind kind() {
-                                            return Kind.AFTER;
-                                        }
-
-                                        @Override
-                                        public Pointer pointer() {
-                                            return new Pointer() {
-                                                @Override
-                                                public String phase() {
-                                                    return prev;
-                                                }
-
-                                                @Override
-                                                public Type type() {
-                                                    return Type.PROJECT;
-                                                }
-                                            };
-                                        }
-                                    });
-                                }
-                            }
-                        });
+                        phases.add(createPhase(name, prev));
                     }
                     return phases;
+                }
+
+                private Phase createPhase(String name, String prev) {
+                    return new Phase() {
+                        @Override
+                        public String name() {
+                            return name;
+                        }
+
+                        @Override
+                        public List<Phase> phases() {
+                            return List.of();
+                        }
+
+                        @Override
+                        public Stream<Phase> allPhases() {
+                            return Stream.concat(
+                                    Stream.of(this), phases().stream().flatMap(Lifecycle.Phase::allPhases));
+                        }
+
+                        @Override
+                        public List<Plugin> plugins() {
+                            Map<String, LifecyclePhase> lfPhases = lifecycle.getDefaultLifecyclePhases();
+                            LifecyclePhase phase = lfPhases != null ? lfPhases.get(name) : null;
+                            if (phase != null) {
+                                Map<String, Plugin> plugins = new LinkedHashMap<>();
+                                DefaultPackagingRegistry.parseLifecyclePhaseDefinitions(plugins, name, phase);
+                                return plugins.values().stream().toList();
+                            }
+                            return List.of();
+                        }
+
+                        @Override
+                        public Collection<Link> links() {
+                            if (prev == null) {
+                                return List.of();
+                            } else {
+                                return List.of(new Link() {
+                                    @Override
+                                    public Kind kind() {
+                                        return Kind.AFTER;
+                                    }
+
+                                    @Override
+                                    public Pointer pointer() {
+                                        return new Pointer() {
+                                            @Override
+                                            public String phase() {
+                                                return prev;
+                                            }
+
+                                            @Override
+                                            public Type type() {
+                                                return Type.PROJECT;
+                                            }
+                                        };
+                                    }
+                                });
+                            }
+                        }
+                    };
                 }
 
                 @Override

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/DefaultLifecyclesTest.java
@@ -23,18 +23,23 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.maven.internal.impl.DefaultLifecycleRegistry;
 import org.apache.maven.internal.impl.DefaultLookup;
+import org.apache.maven.lifecycle.mapping.LifecyclePhase;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +99,49 @@ class DefaultLifecyclesTest {
         assertEquals("default", dl.getLifeCycles().get(1).getId());
         assertEquals("site", dl.getLifeCycles().get(2).getId());
         assertEquals("etl", dl.getLifeCycles().get(3).getId());
+    }
+
+    @Test
+    void testCustomLifecycleWithCrossLifecycleDefaultPhases() throws ComponentLookupException {
+        // Simulates a plugin that registers a custom lifecycle via components.xml
+        // with <default-phases> binding goals to standard lifecycle phases (e.g. process-sources)
+        // rather than to phases of the custom lifecycle itself. This is the Maven 3 mechanism
+        // for extension plugins to bind goals to standard phases without requiring <executions>.
+        Map<String, LifecyclePhase> defaultPhases = new HashMap<>();
+        defaultPhases.put("process-sources", new LifecyclePhase("com.example:my-plugin:1.0:touch"));
+
+        Lifecycle customLifecycle = new Lifecycle("my-custom-lifecycle", Arrays.asList("custom-phase"), defaultPhases);
+
+        List<Lifecycle> myLifecycles = new ArrayList<>();
+        myLifecycles.add(customLifecycle);
+        myLifecycles.addAll(defaultLifeCycles.getLifeCycles());
+
+        Map<String, Lifecycle> lifeCycles = myLifecycles.stream().collect(Collectors.toMap(Lifecycle::getId, l -> l));
+        PlexusContainer mockedPlexusContainer = mock(PlexusContainer.class);
+        when(mockedPlexusContainer.lookupMap(Lifecycle.class)).thenReturn(lifeCycles);
+
+        DefaultLifecycles dl = new DefaultLifecycles(
+                new DefaultLifecycleRegistry(
+                        List.of(new DefaultLifecycleRegistry.LifecycleWrapperProvider(mockedPlexusContainer))),
+                new DefaultLookup(mockedPlexusContainer));
+
+        Lifecycle resolved = dl.getLifeCycles().stream()
+                .filter(l -> "my-custom-lifecycle".equals(l.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        // Cross-lifecycle default phase bindings must survive the round-trip conversion
+        Map<String, LifecyclePhase> resolvedDefaultPhases = resolved.getDefaultLifecyclePhases();
+        assertNotNull(resolvedDefaultPhases);
+        assertTrue(
+                resolvedDefaultPhases.containsKey("process-sources"),
+                "Cross-lifecycle binding to 'process-sources' should be preserved");
+
+        // The lifecycle's own phase list should NOT include cross-lifecycle phases
+        assertFalse(
+                resolved.getPhases().contains("process-sources"),
+                "Cross-lifecycle phase should not appear in the lifecycle's own phase list");
+        assertTrue(resolved.getPhases().contains("custom-phase"), "Lifecycle's own phase should be present");
     }
 
     private Lifecycle getLifeCycleById(String id) {


### PR DESCRIPTION
## Summary

- Fixes Maven 4 ignoring `<default-phases>` from `components.xml` when they bind goals to standard lifecycle phases (e.g. `process-sources`) rather than to the custom lifecycle's own phases
- The `LifecycleWrapperProvider.wrap()` method now separates `v3phases()` (for phase ordering) from `phases()` (for plugin binding extraction), preserving cross-lifecycle bindings during the round-trip conversion
- Adds test verifying that cross-lifecycle default phase bindings survive the legacy-to-API-to-legacy Lifecycle conversion

Closes #11796

## Test plan

- [x] New unit test `testCustomLifecycleWithCrossLifecycleDefaultPhases` verifies cross-lifecycle bindings are preserved
- [x] All 544 existing maven-core tests pass with no regressions
- [ ] Manual test with reproducer from https://github.com/mariuszs/extension-maven-plugin


🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_