### PR TITLE
Update Resolver to 2.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
     <javaVersion>8</javaVersion>
     <version.sisu-maven-plugin>1.0.0</version.sisu-maven-plugin>
     <asmVersion>9.9.1</asmVersion>
-    <classWorldsVersion>2.10.0</classWorldsVersion>
+    <classWorldsVersion>2.9.0</classWorldsVersion>
     <commonsCliVersion>1.11.0</commonsCliVersion>
     <commonsIoVersion>2.21.0</commonsIoVersion>
     <hamcrestVersion>3.0</hamcrestVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
     <javaVersion>8</javaVersion>
     <version.sisu-maven-plugin>1.0.0</version.sisu-maven-plugin>
     <asmVersion>9.9.1</asmVersion>
-    <classWorldsVersion>2.9.0</classWorldsVersion>
+    <classWorldsVersion>2.10.0</classWorldsVersion>
     <commonsCliVersion>1.11.0</commonsCliVersion>
     <commonsIoVersion>2.21.0</commonsIoVersion>
     <hamcrestVersion>3.0</hamcrestVersion>
@@ -143,7 +143,7 @@ under the License.
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
     <cipherVersion>2.0</cipherVersion>
     <jxpathVersion>1.4.0</jxpathVersion>
-    <resolverVersion>2.0.15</resolverVersion>
+    <resolverVersion>2.0.16</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.11.0</xmlunitVersion>
     <powermockVersion>2.0.9</powermockVersion>


### PR DESCRIPTION
Update minors of dependencies:
* ~plexus-classworlds 2.10.0~ explodes due `NoClassDefFoundError: org/codehaus/classworlds/ClassRealmReverseAdapter`
* resolver 2.0.16
