### PR TITLE
Warn when profile ID matches a lifecycle phase name

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -99,6 +99,34 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String EMPTY = "";
 
+    private static final Set<String> LIFECYCLE_PHASES = Set.of(
+            "clean",
+            "validate",
+            "initialize",
+            "generate-sources",
+            "process-sources",
+            "generate-resources",
+            "process-resources",
+            "compile",
+            "process-classes",
+            "generate-test-sources",
+            "process-test-sources",
+            "generate-test-resources",
+            "process-test-resources",
+            "test-compile",
+            "process-test-classes",
+            "test",
+            "prepare-package",
+            "package",
+            "pre-integration-test",
+            "integration-test",
+            "post-integration-test",
+            "verify",
+            "install",
+            "deploy",
+            "site",
+            "site-deploy");
+
     private record ActivationFrame(String location, Optional<? extends InputLocationTracker> parent) {}
 
     private static class ActivationWalker extends MavenTransformer {
@@ -563,6 +591,20 @@ public class DefaultModelValidator implements ModelValidator {
                 String prefix = "profiles.profile[" + profile.getId() + "].";
 
                 validateProfileId(prefix, "id", problems, Severity.ERROR, Version.V40, profile.getId(), null, model);
+
+                if (profile.getId() != null && LIFECYCLE_PHASES.contains(profile.getId())) {
+                    addViolation(
+                            problems,
+                            Severity.WARNING,
+                            Version.BASE,
+                            "profiles.profile.id",
+                            null,
+                            "Profile has the same id '"
+                                    + profile.getId() + "' as a Maven lifecycle phase. "
+                                    + "This can accidentally trigger the lifecycle phase "
+                                    + "when the profile name is misused on the command line.",
+                            profile);
+                }
 
                 if (!profileIds.add(profile.getId())) {
                     addViolation(

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -482,6 +482,18 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testLifecyclePhaseProfileId() throws Exception {
+        SimpleProblemCollector result = validateFile("lifecycle-phase-profile-id.xml");
+
+        assertViolations(result, 0, 0, 2);
+
+        assertTrue(result.getWarnings().get(0).contains("integration-test"));
+        assertTrue(result.getWarnings().get(0).contains("lifecycle phase"));
+        assertTrue(result.getWarnings().get(1).contains("deploy"));
+        assertTrue(result.getWarnings().get(1).contains("lifecycle phase"));
+    }
+
+    @Test
     void testBadPluginVersion() throws Exception {
         SimpleProblemCollector result = validate("bad-plugin-version.xml");
 

--- a/impl/maven-impl/src/test/resources/poms/validation/duplicate-plugin-execution.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/duplicate-plugin-execution.xml
@@ -61,7 +61,7 @@ under the License.
 
   <profiles>
     <profile>
-      <id>test</id>
+      <id>test-profile</id>
       <build>
         <pluginManagement>
           <plugins>

--- a/impl/maven-impl/src/test/resources/poms/validation/duplicate-plugin.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/duplicate-plugin.xml
@@ -51,7 +51,7 @@ under the License.
 
   <profiles>
     <profile>
-      <id>test</id>
+      <id>test-profile</id>
       <build>
         <pluginManagement>
           <plugins>

--- a/impl/maven-impl/src/test/resources/poms/validation/lifecycle-phase-profile-id.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/lifecycle-phase-profile-id.xml
@@ -1,0 +1,38 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>aid</artifactId>
+    <groupId>gid</groupId>
+    <version>0.1</version>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <profile>
+            <id>integration-test</id>
+        </profile>
+        <profile>
+            <id>deploy</id>
+        </profile>
+        <profile>
+            <id>my-custom-profile</id>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
When a profile ID matches a default Maven lifecycle phase name (e.g. "test", "deploy", "integration-test"), users can accidentally trigger that phase. This adds a validation warning to alert about the potential confusion.

Includes a new test case with a POM containing both phase-matching and safe profile IDs.

Closes #10310