### PR TITLE
Fix ANSI colors not disabled when piped on JDK 25+

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -532,6 +532,10 @@ public class MavenCli {
                             || commandLine.hasOption(CLIManager.NON_INTERACTIVE));
             if (isBatchMode || commandLine.hasOption(CLIManager.LOG_FILE)) {
                 MessageUtils.setColorEnabled(false);
+            } else if (!isConsoleTerminal()) {
+                // On JDK 22+, System.console() returns non-null even when stdout is
+                // redirected to a pipe or file. Use Console.isTerminal() to detect this.
+                MessageUtils.setColorEnabled(false);
             }
         }
 
@@ -625,6 +629,32 @@ public class MavenCli {
         }
         if (fail) {
             throw new ExitException(1);
+        }
+    }
+
+    /**
+     * Checks whether the JVM console is connected to a real terminal.
+     * On JDK 22+, {@code Console.isTerminal()} returns {@code false} when stdout is redirected
+     * to a pipe or file, even though {@code System.console()} returns non-null.
+     * On older JDKs (before 22), falls back to checking {@code System.console() != null},
+     * which is the pre-existing behavior.
+     */
+    static boolean isConsoleTerminal() {
+        Console cons = System.console();
+        if (cons == null) {
+            return false;
+        }
+        try {
+            // JDK 22+ provides Console.isTerminal() to distinguish a real terminal
+            // from a redirected console (pipe or file).
+            java.lang.reflect.Method isTerminal = cons.getClass().getMethod("isTerminal");
+            return (Boolean) isTerminal.invoke(cons);
+        } catch (NoSuchMethodException e) {
+            // JDK < 22: System.console() != null was the best heuristic
+            return true;
+        } catch (ReflectiveOperationException e) {
+            // Unexpected reflection error; fall back to assuming terminal
+            return true;
         }
     }
 

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -360,8 +360,13 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
         // To align Maven with outcomes, we set here color enabled based on these premises.
         // Note: Maven3 suffers from similar thing: if you do `mvn3 foo > log.txt`, the output will
         // not be not colored (good), but Maven will print out "Message scheme: color".
-        MessageUtils.setColorEnabled(
-                context.coloredOutput != null ? context.coloredOutput : !Terminal.TYPE_DUMB.equals(terminal.getType()));
+        boolean colorEnabled;
+        if (context.coloredOutput != null) {
+            colorEnabled = context.coloredOutput;
+        } else {
+            colorEnabled = !Terminal.TYPE_DUMB.equals(terminal.getType()) && isConsoleTerminal();
+        }
+        MessageUtils.setColorEnabled(colorEnabled);
 
         // handle rawStreams: some would like to act on true, some on false
         if (context.options().rawStreams().orElse(false)) {
@@ -399,6 +404,32 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
         System.setOut(psOut);
         System.setErr(psErr);
         // no need to set them back, this is already handled by MessageUtils.systemUninstall() above
+    }
+
+    /**
+     * Checks whether the JVM console is connected to a real terminal.
+     * On JDK 22+, {@code Console.isTerminal()} returns {@code false} when stdout is redirected
+     * to a pipe or file, even though {@code System.console()} returns non-null.
+     * On older JDKs (before 22), falls back to checking {@code System.console() != null},
+     * which is the pre-existing behavior.
+     */
+    static boolean isConsoleTerminal() {
+        java.io.Console console = System.console();
+        if (console == null) {
+            return false;
+        }
+        try {
+            // JDK 22+ provides Console.isTerminal() to distinguish a real terminal
+            // from a redirected console (pipe or file).
+            java.lang.reflect.Method isTerminal = console.getClass().getMethod("isTerminal");
+            return (Boolean) isTerminal.invoke(console);
+        } catch (NoSuchMethodException e) {
+            // JDK < 22: System.console() != null was the best heuristic
+            return true;
+        } catch (ReflectiveOperationException e) {
+            // Unexpected reflection error; fall back to assuming terminal
+            return true;
+        }
     }
 
     protected Consumer<String> determineWriter(C context) {


### PR DESCRIPTION
On JDK 22+, `System.console()` returns a non-null Console even when stdout is redirected to a pipe or file. This caused Maven to select the color message scheme when output was piped.

Uses `Console.isTerminal()` (JDK 22+) via reflection to correctly detect piped output. On JDK < 22, falls back to the previous `System.console() != null` check.

Applied to both Maven 4 (LookupInvoker) and Maven 3 compat (MavenCli) code paths.

Closes #11885