### PR TITLE
Optimize log level rendering in MavenSimpleLogger

### DIFF
--- a/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLogger.java
@@ -29,24 +29,38 @@ import static org.apache.maven.jline.MessageUtils.builder;
  */
 public class MavenSimpleLogger extends SimpleLogger {
 
+    private String traceRenderedLevel;
+    private String debugRenderedLevel;
+    private String infoRenderedLevel;
+    private String warnRenderedLevel;
+    private String errorRenderedLevel;
+
     MavenSimpleLogger(String name) {
         super(name);
     }
 
     @Override
     protected String renderLevel(int level) {
+        if (traceRenderedLevel == null) {
+            traceRenderedLevel = builder().trace("TRACE").build();
+            debugRenderedLevel = builder().debug("DEBUG").build();
+            infoRenderedLevel = builder().info("INFO").build();
+            warnRenderedLevel = builder().warning("WARNING").build();
+            errorRenderedLevel = builder().error("ERROR").build();
+        }
+
         switch (level) {
             case LOG_LEVEL_TRACE:
-                return builder().trace("TRACE").toString();
+                return traceRenderedLevel;
             case LOG_LEVEL_DEBUG:
-                return builder().debug("DEBUG").toString();
+                return debugRenderedLevel;
             case LOG_LEVEL_INFO:
-                return builder().info("INFO").toString();
+                return infoRenderedLevel;
             case LOG_LEVEL_WARN:
-                return builder().warning("WARNING").toString();
+                return warnRenderedLevel;
             case LOG_LEVEL_ERROR:
             default:
-                return builder().error("ERROR").toString();
+                return errorRenderedLevel;
         }
     }
 

--- a/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLogger.java
@@ -29,26 +29,23 @@ import static org.apache.maven.jline.MessageUtils.builder;
  */
 public class MavenSimpleLogger extends SimpleLogger {
 
-    private String traceRenderedLevel;
-    private String debugRenderedLevel;
-    private String infoRenderedLevel;
-    private String warnRenderedLevel;
-    private String errorRenderedLevel;
+    private final String traceRenderedLevel;
+    private final String debugRenderedLevel;
+    private final String infoRenderedLevel;
+    private final String warnRenderedLevel;
+    private final String errorRenderedLevel;
 
     MavenSimpleLogger(String name) {
         super(name);
+        traceRenderedLevel = builder().trace("TRACE").build();
+        debugRenderedLevel = builder().debug("DEBUG").build();
+        infoRenderedLevel = builder().info("INFO").build();
+        warnRenderedLevel = builder().warning("WARNING").build();
+        errorRenderedLevel = builder().error("ERROR").build();
     }
 
     @Override
     protected String renderLevel(int level) {
-        if (traceRenderedLevel == null) {
-            traceRenderedLevel = builder().trace("TRACE").build();
-            debugRenderedLevel = builder().debug("DEBUG").build();
-            infoRenderedLevel = builder().info("INFO").build();
-            warnRenderedLevel = builder().warning("WARNING").build();
-            errorRenderedLevel = builder().error("ERROR").build();
-        }
-
         switch (level) {
             case LOG_LEVEL_TRACE:
                 return traceRenderedLevel;

--- a/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLogger.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLogger.java
@@ -29,23 +29,28 @@ import static org.apache.maven.jline.MessageUtils.builder;
  */
 public class MavenSimpleLogger extends SimpleLogger {
 
-    private final String traceRenderedLevel;
-    private final String debugRenderedLevel;
-    private final String infoRenderedLevel;
-    private final String warnRenderedLevel;
-    private final String errorRenderedLevel;
+    private String traceRenderedLevel;
+    private String debugRenderedLevel;
+    private String infoRenderedLevel;
+    private String warnRenderedLevel;
+    private String errorRenderedLevel;
 
     MavenSimpleLogger(String name) {
         super(name);
-        traceRenderedLevel = builder().trace("TRACE").build();
-        debugRenderedLevel = builder().debug("DEBUG").build();
-        infoRenderedLevel = builder().info("INFO").build();
-        warnRenderedLevel = builder().warning("WARNING").build();
-        errorRenderedLevel = builder().error("ERROR").build();
     }
 
     @Override
     protected String renderLevel(int level) {
+        // lazy initialization at first use
+        // cannot be done in constructor because ansi terminals are not configured yet
+        if (traceRenderedLevel == null) {
+            traceRenderedLevel = builder().trace("TRACE").build();
+            debugRenderedLevel = builder().debug("DEBUG").build();
+            infoRenderedLevel = builder().info("INFO").build();
+            warnRenderedLevel = builder().warning("WARNING").build();
+            errorRenderedLevel = builder().error("ERROR").build();
+        }
+
         switch (level) {
             case LOG_LEVEL_TRACE:
                 return traceRenderedLevel;

--- a/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLoggerFactory.java
+++ b/maven-slf4j-provider/src/main/java/org/slf4j/simple/MavenSimpleLoggerFactory.java
@@ -24,19 +24,6 @@ import org.slf4j.Logger;
  * MavenSimpleLoggerFactory
  */
 public class MavenSimpleLoggerFactory extends SimpleLoggerFactory {
-    /**
-     * Return an appropriate {@link MavenSimpleLogger} instance by name.
-     */
-    public Logger getLogger(String name) {
-        Logger simpleLogger = loggerMap.get(name);
-        if (simpleLogger != null) {
-            return simpleLogger;
-        } else {
-            Logger newInstance = new MavenSimpleLogger(name);
-            Logger oldInstance = loggerMap.putIfAbsent(name, newInstance);
-            return oldInstance == null ? newInstance : oldInstance;
-        }
-    }
 
     @Override
     protected Logger createLogger(String name) {


### PR DESCRIPTION
What changed:
- Cached rendered log level strings to improve performance.
- Removed redundant calls to the builder for each log level.
- Initialize rendered levels only once during the first call.

Why:
- Enhances efficiency by reducing object creation during logging.
- Improves overall logging performance in Maven.

