### PR TITLE
Feat: Ability to disable site lifecycle

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
@@ -52,8 +52,7 @@ import org.codehaus.plexus.util.StringUtils;
 public class DefaultLifecycles {
     private static final List<String> BUILT_IN_LIFECYCLES =
             Arrays.asList(CleanLifecycleProvider.NAME, DefaultLifecycleProvider.NAME, SiteLifecycleProvider.NAME);
-    private static final boolean SITE_ENABLED =
-            Boolean.parseBoolean(System.getProperty("maven.site.lifecycle.enabled", "true"));
+    private static final boolean SITE_DISABLED = Boolean.getBoolean("maven.site.lifecycle.disabled");
 
     /**
      * @deprecated Use {@link #getStandardLifecycles()} instead.
@@ -81,7 +80,7 @@ public class DefaultLifecycles {
 
     private boolean isEnabled(String lifecycleId) {
         if (SiteLifecycleProvider.NAME.equals(lifecycleId)) {
-            return SITE_ENABLED;
+            return !SITE_DISABLED;
         } else {
             return true;
         }

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/DefaultLifecycles.java
@@ -30,7 +30,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.apache.maven.lifecycle.providers.lifecycle.CleanLifecycleProvider;
+import org.apache.maven.lifecycle.providers.lifecycle.DefaultLifecycleProvider;
+import org.apache.maven.lifecycle.providers.lifecycle.SiteLifecycleProvider;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.Logger;
@@ -46,7 +50,18 @@ import org.codehaus.plexus.util.StringUtils;
 @Singleton
 @Named
 public class DefaultLifecycles {
-    public static final String[] STANDARD_LIFECYCLES = {"clean", "default", "site"};
+    private static final List<String> BUILT_IN_LIFECYCLES =
+            Arrays.asList(CleanLifecycleProvider.NAME, DefaultLifecycleProvider.NAME, SiteLifecycleProvider.NAME);
+    private static final boolean SITE_ENABLED =
+            Boolean.parseBoolean(System.getProperty("maven.site.lifecycle.enabled", "true"));
+
+    /**
+     * @deprecated Use {@link #getStandardLifecycles()} instead.
+     */
+    @Deprecated
+    public static final String[] STANDARD_LIFECYCLES = {
+        CleanLifecycleProvider.NAME, DefaultLifecycleProvider.NAME, SiteLifecycleProvider.NAME
+    };
 
     @Inject
     private Map<String, Lifecycle> lifecycles;
@@ -60,9 +75,20 @@ public class DefaultLifecycles {
     public DefaultLifecycles() {}
 
     public DefaultLifecycles(Map<String, Lifecycle> lifecycles, Logger logger) {
-        this.lifecycles = new LinkedHashMap<>();
-        this.logger = logger;
         this.lifecycles = lifecycles;
+        this.logger = logger;
+    }
+
+    private boolean isEnabled(String lifecycleId) {
+        if (SiteLifecycleProvider.NAME.equals(lifecycleId)) {
+            return SITE_ENABLED;
+        } else {
+            return true;
+        }
+    }
+
+    public List<String> getStandardLifecycles() {
+        return BUILT_IN_LIFECYCLES.stream().filter(this::isEnabled).collect(Collectors.toList());
     }
 
     public Lifecycle get(String key) {
@@ -113,6 +139,9 @@ public class DefaultLifecycles {
         // in some tests container is not injected
         if (this.plexusContainer != null) {
             for (String name : this.lifecycles.keySet()) {
+                if (!isEnabled(name)) {
+                    continue;
+                }
                 try {
                     lifecycles.put(name, plexusContainer.lookup(Lifecycle.class, name));
                 } catch (ComponentLookupException e) {
@@ -123,7 +152,7 @@ public class DefaultLifecycles {
             lifecycles.putAll(this.lifecycles);
         }
 
-        LinkedHashSet<String> lifecycleNames = new LinkedHashSet<>(Arrays.asList(STANDARD_LIFECYCLES));
+        LinkedHashSet<String> lifecycleNames = new LinkedHashSet<>(getStandardLifecycles());
         lifecycleNames.addAll(lifecycles.keySet());
 
         ArrayList<Lifecycle> result = new ArrayList<>();

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -230,7 +229,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
         }
 
         LifecycleMappingDelegate delegate;
-        if (Arrays.binarySearch(DefaultLifecycles.STANDARD_LIFECYCLES, lifecycle.getId()) >= 0) {
+        if (defaultLifeCycles.getStandardLifecycles().contains(lifecycle.getId())) {
             delegate = standardDelegate;
         } else {
             delegate = delegates.get(lifecycle.getId());


### PR DESCRIPTION
Ability to suppress site lifecycle from Maven "default lifecycles". This PR **does not** remove "site" lifecycle component, but Maven will not consider site lifecycle among "defaults", if disabled.

Note: hence, with this option enabled, the IT suite will never (and cannot) pass, as IT suite contains ITs running/expecting site lifecycle.

Fixes #11759
