### PR TITLE
Feat: collapse maven-executor and apply fixes

### DIFF
--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/Executor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/Executor.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.cli;
+package org.apache.maven.cling.executor;
 
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nonnull;

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorException.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorException.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.cli;
+package org.apache.maven.cling.executor;
 
 import org.apache.maven.api.annotations.Experimental;
 import org.apache.maven.api.annotations.Nullable;

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorHelper.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorHelper.java
@@ -19,9 +19,6 @@
 package org.apache.maven.cling.executor;
 
 import org.apache.maven.api.annotations.Nonnull;
-import org.apache.maven.api.cli.Executor;
-import org.apache.maven.api.cli.ExecutorException;
-import org.apache.maven.api.cli.ExecutorRequest;
 
 /**
  * Helper class for routing Maven execution based on preferences and/or issued execution requests.

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorRequest.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorRequest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.cli;
+package org.apache.maven.cling.executor;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorTool.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/ExecutorTool.java
@@ -21,8 +21,6 @@ package org.apache.maven.cling.executor;
 import java.util.Map;
 
 import org.apache.maven.api.annotations.Nullable;
-import org.apache.maven.api.cli.ExecutorException;
-import org.apache.maven.api.cli.ExecutorRequest;
 
 /**
  * A tool implementing some common Maven operations.

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutor.java
@@ -45,9 +45,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.apache.maven.api.cli.Executor;
-import org.apache.maven.api.cli.ExecutorException;
-import org.apache.maven.api.cli.ExecutorRequest;
+import org.apache.maven.cling.executor.Executor;
+import org.apache.maven.cling.executor.ExecutorException;
+import org.apache.maven.cling.executor.ExecutorRequest;
 
 import static java.util.Objects.requireNonNull;
 
@@ -267,7 +267,11 @@ public class EmbeddedMavenExecutor implements Executor {
                     throw new IllegalArgumentException(getClass().getSimpleName() + " w/ mvn3 does not support command "
                             + executorRequest.command());
                 }
-                keepAlive.add(cliClass.getClassLoader().loadClass("org.fusesource.jansi.internal.JansiLoader"));
+                // 3.9.x
+                mayAddToKeepAlive(keepAlive, cliClass, "org.fusesource.jansi.internal.JansiLoader");
+                // 3.10.x
+                mayAddToKeepAlive(keepAlive, cliClass, "org.jline.nativ.JLineNativeLoader");
+
                 Constructor<?> newMavenCli = cliClass.getConstructor(classWorld.getClass());
                 Object mavenCli = newMavenCli.newInstance(classWorld);
                 Class<?>[] parameterTypes = {String[].class, String.class, PrintStream.class, PrintStream.class};
@@ -292,7 +296,7 @@ public class EmbeddedMavenExecutor implements Executor {
                 });
             } else {
                 // assume 4.x
-                keepAlive.add(cliClass.getClassLoader().loadClass("org.jline.nativ.JLineNativeLoader"));
+                mayAddToKeepAlive(keepAlive, cliClass, "org.jline.nativ.JLineNativeLoader");
                 for (Map.Entry<String, String> cmdEntry : MVN4_MAIN_CLASSES.entrySet()) {
                     Class<?> cmdClass = cliClass.getClassLoader().loadClass(cmdEntry.getValue());
                     Method mainMethod = cmdClass.getMethod(
@@ -334,6 +338,15 @@ public class EmbeddedMavenExecutor implements Executor {
         } finally {
             Thread.currentThread().setContextClassLoader(originalClassLoader);
             System.setProperties(originalProperties);
+        }
+    }
+
+    private boolean mayAddToKeepAlive(List<Object> keepAlive, Class<?> cliClass, String className) {
+        try {
+            keepAlive.add(cliClass.getClassLoader().loadClass(className));
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutor.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutor.java
@@ -33,12 +33,12 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.maven.api.cli.Executor;
-import org.apache.maven.api.cli.ExecutorException;
-import org.apache.maven.api.cli.ExecutorRequest;
+import org.apache.maven.cling.executor.Executor;
+import org.apache.maven.cling.executor.ExecutorException;
+import org.apache.maven.cling.executor.ExecutorRequest;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.maven.api.cli.ExecutorRequest.getCanonicalPath;
+import static org.apache.maven.cling.executor.ExecutorRequest.getCanonicalPath;
 
 /**
  * Forked executor implementation, that spawns a subprocess with Maven from the installation directory. Very costly

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/HelperImpl.java
@@ -23,10 +23,10 @@ import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.api.annotations.Nullable;
-import org.apache.maven.api.cli.Executor;
-import org.apache.maven.api.cli.ExecutorException;
-import org.apache.maven.api.cli.ExecutorRequest;
+import org.apache.maven.cling.executor.Executor;
+import org.apache.maven.cling.executor.ExecutorException;
 import org.apache.maven.cling.executor.ExecutorHelper;
+import org.apache.maven.cling.executor.ExecutorRequest;
 
 import static java.util.Objects.requireNonNull;
 

--- a/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
+++ b/impl/maven-executor/src/main/java/org/apache/maven/cling/executor/internal/ToolboxTool.java
@@ -26,9 +26,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import org.apache.maven.api.cli.ExecutorException;
-import org.apache.maven.api.cli.ExecutorRequest;
+import org.apache.maven.cling.executor.ExecutorException;
 import org.apache.maven.cling.executor.ExecutorHelper;
+import org.apache.maven.cling.executor.ExecutorRequest;
 import org.apache.maven.cling.executor.ExecutorTool;
 
 import static java.util.Objects.requireNonNull;

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/MavenExecutorTestSupport.java
@@ -28,8 +28,6 @@ import java.util.List;
 
 import eu.maveniverse.maven.mimir.testing.MimirInfuser;
 import org.apache.maven.api.annotations.Nullable;
-import org.apache.maven.api.cli.Executor;
-import org.apache.maven.api.cli.ExecutorRequest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutorTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/embedded/EmbeddedMavenExecutorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.cling.executor.embedded;
 
-import org.apache.maven.api.cli.Executor;
+import org.apache.maven.cling.executor.Executor;
 import org.apache.maven.cling.executor.MavenExecutorTestSupport;
 
 /**

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutorTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/forked/ForkedMavenExecutorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.cling.executor.forked;
 
-import org.apache.maven.api.cli.Executor;
+import org.apache.maven.cling.executor.Executor;
 import org.apache.maven.cling.executor.MavenExecutorTestSupport;
 
 /**

--- a/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
+++ b/impl/maven-executor/src/test/java/org/apache/maven/cling/executor/impl/ToolboxToolTest.java
@@ -25,10 +25,10 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 import eu.maveniverse.maven.mimir.testing.MimirInfuser;
-import org.apache.maven.api.cli.Executor;
-import org.apache.maven.api.cli.ExecutorRequest;
 import org.apache.maven.cling.executor.Environment;
+import org.apache.maven.cling.executor.Executor;
 import org.apache.maven.cling.executor.ExecutorHelper;
+import org.apache.maven.cling.executor.ExecutorRequest;
 import org.apache.maven.cling.executor.embedded.EmbeddedMavenExecutor;
 import org.apache.maven.cling.executor.forked.ForkedMavenExecutor;
 import org.apache.maven.cling.executor.internal.HelperImpl;

--- a/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
+++ b/its/core-it-support/maven-it-helper/src/main/java/org/apache/maven/it/Verifier.java
@@ -45,8 +45,8 @@ import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.maven.api.cli.ExecutorException;
-import org.apache.maven.api.cli.ExecutorRequest;
+import org.apache.maven.cling.executor.ExecutorException;
+import org.apache.maven.cling.executor.ExecutorRequest;
 import org.apache.maven.cling.executor.ExecutorHelper;
 import org.apache.maven.cling.executor.ExecutorTool;
 import org.apache.maven.cling.executor.embedded.EmbeddedMavenExecutor;


### PR DESCRIPTION
Changes:
* collapse Maven Executor into single package
* keepAlive made "forgiving", and adjusted to Maven 3.10.x (rc-5 fails with 3.10.x)

Fixes #11975