### PR TITLE
Fix #11899: Default addLocationInformation to false in Settings and Toolchains XML writers

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsXmlFactory.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.function.Function;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.di.Named;
@@ -31,6 +32,7 @@ import org.apache.maven.api.services.xml.XmlReaderException;
 import org.apache.maven.api.services.xml.XmlReaderRequest;
 import org.apache.maven.api.services.xml.XmlWriterException;
 import org.apache.maven.api.services.xml.XmlWriterRequest;
+import org.apache.maven.api.settings.InputLocation;
 import org.apache.maven.api.settings.InputSource;
 import org.apache.maven.api.settings.Settings;
 import org.apache.maven.settings.v4.SettingsStaxReader;
@@ -79,10 +81,20 @@ public class DefaultSettingsXmlFactory implements SettingsXmlFactory {
             throw new IllegalArgumentException("writer or outputStream must be non null");
         }
         try {
+            SettingsStaxWriter xmlWriter = new SettingsStaxWriter();
+            xmlWriter.setAddLocationInformation(false);
+
+            Function<Object, String> formatter = request.getInputLocationFormatter();
+            if (formatter != null) {
+                xmlWriter.setAddLocationInformation(true);
+                Function<InputLocation, String> adapter = formatter::apply;
+                xmlWriter.setStringFormatter(adapter);
+            }
+
             if (writer != null) {
-                new SettingsStaxWriter().write(writer, content);
+                xmlWriter.write(writer, content);
             } else {
-                new SettingsStaxWriter().write(outputStream, content);
+                xmlWriter.write(outputStream, content);
             }
         } catch (Exception e) {
             throw new XmlWriterException("Unable to write settings: " + getMessage(e), getLocation(e), e);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultToolchainsXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultToolchainsXmlFactory.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.apache.maven.api.annotations.Nonnull;
 import org.apache.maven.api.di.Named;
@@ -32,6 +33,7 @@ import org.apache.maven.api.services.xml.XmlReaderException;
 import org.apache.maven.api.services.xml.XmlReaderRequest;
 import org.apache.maven.api.services.xml.XmlWriterException;
 import org.apache.maven.api.services.xml.XmlWriterRequest;
+import org.apache.maven.api.toolchain.InputLocation;
 import org.apache.maven.api.toolchain.InputSource;
 import org.apache.maven.api.toolchain.PersistedToolchains;
 import org.apache.maven.toolchain.v4.MavenToolchainsStaxReader;
@@ -81,10 +83,20 @@ public class DefaultToolchainsXmlFactory implements ToolchainsXmlFactory {
             throw new IllegalArgumentException("writer or outputStream must be non null");
         }
         try {
+            MavenToolchainsStaxWriter xmlWriter = new MavenToolchainsStaxWriter();
+            xmlWriter.setAddLocationInformation(false);
+
+            Function<Object, String> formatter = request.getInputLocationFormatter();
+            if (formatter != null) {
+                xmlWriter.setAddLocationInformation(true);
+                Function<InputLocation, String> adapter = formatter::apply;
+                xmlWriter.setStringFormatter(adapter);
+            }
+
             if (writer != null) {
-                new MavenToolchainsStaxWriter().write(writer, content);
+                xmlWriter.write(writer, content);
             } else {
-                new MavenToolchainsStaxWriter().write(outputStream, content);
+                xmlWriter.write(outputStream, content);
             }
         } catch (Exception e) {
             throw new XmlWriterException("Unable to write toolchains: " + getMessage(e), getLocation(e), e);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsXmlFactoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.function.Function;
+
+import org.apache.maven.api.services.xml.XmlReaderRequest;
+import org.apache.maven.api.services.xml.XmlWriterRequest;
+import org.apache.maven.api.settings.Settings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultSettingsXmlFactoryTest {
+
+    private DefaultSettingsXmlFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new DefaultSettingsXmlFactory();
+    }
+
+    @Test
+    void testWriteWithoutFormatterDisablesLocationTracking() throws Exception {
+        String xml = """
+                <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
+                  <localRepository>/path/to/local/repo</localRepository>
+                  <mirrors>
+                    <mirror>
+                      <mirrorOf>external:http:*</mirrorOf>
+                      <name>Pseudo repository</name>
+                      <url>http://0.0.0.0/</url>
+                      <id>pseudo</id>
+                    </mirror>
+                  </mirrors>
+                </settings>""";
+
+        Settings settings = factory.read(XmlReaderRequest.builder()
+                .reader(new StringReader(xml))
+                .strict(true)
+                .build());
+
+        StringWriter out = new StringWriter();
+        factory.write(XmlWriterRequest.<Settings>builder()
+                .writer(out)
+                .content(settings)
+                .build());
+
+        String result = out.toString();
+        assertFalse(result.contains("<!--"), "No XML comments should be present when no formatter is provided");
+    }
+
+    @Test
+    void testWriteWithFormatterEnablesLocationTracking() throws Exception {
+        String xml = """
+                <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
+                  <localRepository>/path/to/local/repo</localRepository>
+                  <mirrors>
+                    <mirror>
+                      <mirrorOf>external:http:*</mirrorOf>
+                      <name>Pseudo repository</name>
+                      <url>http://0.0.0.0/</url>
+                      <id>pseudo</id>
+                    </mirror>
+                  </mirrors>
+                </settings>""";
+
+        Settings settings = factory.read(XmlReaderRequest.builder()
+                .reader(new StringReader(xml))
+                .location("settings.xml")
+                .strict(true)
+                .build());
+
+        StringWriter out = new StringWriter();
+        Function<Object, String> formatter = o -> "LOC_MARK";
+
+        factory.write(XmlWriterRequest.<Settings>builder()
+                .writer(out)
+                .content(settings)
+                .inputLocationFormatter(formatter)
+                .build());
+
+        String result = out.toString();
+        assertTrue(result.contains("LOC_MARK"), "Expected formatter marker in output when tracking is enabled");
+    }
+}

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultToolchainsXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultToolchainsXmlFactoryTest.java
@@ -24,85 +24,85 @@ import java.util.function.Function;
 
 import org.apache.maven.api.services.xml.XmlReaderRequest;
 import org.apache.maven.api.services.xml.XmlWriterRequest;
-import org.apache.maven.api.settings.Settings;
+import org.apache.maven.api.toolchain.PersistedToolchains;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class DefaultSettingsXmlFactoryTest {
+class DefaultToolchainsXmlFactoryTest {
 
-    private DefaultSettingsXmlFactory factory;
+    private DefaultToolchainsXmlFactory factory;
 
     @BeforeEach
     void setUp() {
-        factory = new DefaultSettingsXmlFactory();
+        factory = new DefaultToolchainsXmlFactory();
     }
 
     @Test
     void testWriteWithoutFormatterDisablesLocationTracking() throws Exception {
         String xml = """
-                <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
-                  <localRepository>/path/to/local/repo</localRepository>
-                  <mirrors>
-                    <mirror>
-                      <mirrorOf>external:http:*</mirrorOf>
-                      <name>Pseudo repository</name>
-                      <url>http://0.0.0.0/</url>
-                      <id>pseudo</id>
-                    </mirror>
-                  </mirrors>
-                </settings>""";
+                <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0">
+                  <toolchain>
+                    <type>jdk</type>
+                    <provides>
+                      <version>17</version>
+                    </provides>
+                    <configuration>
+                      <jdkHome>/usr/lib/jvm/java-17</jdkHome>
+                    </configuration>
+                  </toolchain>
+                </toolchains>""";
 
-        Settings settings = factory.read(XmlReaderRequest.builder()
+        PersistedToolchains toolchains = factory.read(XmlReaderRequest.builder()
                 .reader(new StringReader(xml))
                 .strict(true)
                 .build());
 
         StringWriter out = new StringWriter();
-        factory.write(XmlWriterRequest.<Settings>builder()
+        factory.write(XmlWriterRequest.<PersistedToolchains>builder()
                 .writer(out)
-                .content(settings)
+                .content(toolchains)
                 .build());
 
         String result = out.toString();
-        assertTrue(result.contains("<localRepository>"), "Expected settings content to be written to output");
+        assertTrue(result.contains("<type>jdk</type>"), "Expected toolchains content to be written to output");
         assertFalse(result.contains("<!--"), "No XML comments should be present when no formatter is provided");
     }
 
     @Test
     void testWriteWithFormatterEnablesLocationTracking() throws Exception {
         String xml = """
-                <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
-                  <localRepository>/path/to/local/repo</localRepository>
-                  <mirrors>
-                    <mirror>
-                      <mirrorOf>external:http:*</mirrorOf>
-                      <name>Pseudo repository</name>
-                      <url>http://0.0.0.0/</url>
-                      <id>pseudo</id>
-                    </mirror>
-                  </mirrors>
-                </settings>""";
+                <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0">
+                  <toolchain>
+                    <type>jdk</type>
+                    <provides>
+                      <version>17</version>
+                    </provides>
+                    <configuration>
+                      <jdkHome>/usr/lib/jvm/java-17</jdkHome>
+                    </configuration>
+                  </toolchain>
+                </toolchains>""";
 
-        Settings settings = factory.read(XmlReaderRequest.builder()
+        PersistedToolchains toolchains = factory.read(XmlReaderRequest.builder()
                 .reader(new StringReader(xml))
-                .location("settings.xml")
+                .location("toolchains.xml")
                 .strict(true)
                 .build());
 
         StringWriter out = new StringWriter();
         Function<Object, String> formatter = o -> "LOC_MARK";
 
-        factory.write(XmlWriterRequest.<Settings>builder()
+        factory.write(XmlWriterRequest.<PersistedToolchains>builder()
                 .writer(out)
-                .content(settings)
+                .content(toolchains)
                 .inputLocationFormatter(formatter)
                 .build());
 
         String result = out.toString();
-        assertTrue(result.contains("<localRepository>"), "Expected settings content to be written to output");
+        assertTrue(result.contains("<type>jdk</type>"), "Expected toolchains content to be written to output");
         assertTrue(result.contains("LOC_MARK"), "Expected formatter marker in output when tracking is enabled");
     }
 }


### PR DESCRIPTION
## Summary

- Default `addLocationInformation` to `false` in `DefaultSettingsXmlFactory.write()` and `DefaultToolchainsXmlFactory.write()`
- Respect `inputLocationFormatter` from `XmlWriterRequest` — only emit location comments when explicitly requested
- Align behavior with `DefaultModelXmlFactory.write()`, which already handles this correctly

## Problem

`DefaultSettingsXmlFactory.write()` always emits `InputLocation` comments (e.g. `<!-- /path/to/settings.xml:163 -->`) because it creates a bare `new SettingsStaxWriter()` whose `addLocationInformation` field defaults to `true`. It also ignores the `inputLocationFormatter` from the `XmlWriterRequest`.

This is inconsistent with `DefaultModelXmlFactory.write()`, which correctly defaults location tracking to `false` and only enables it when an explicit `inputLocationFormatter` is provided.

The same issue exists in `DefaultToolchainsXmlFactory.write()`.

## Solution

Applied the same pattern from `DefaultModelXmlFactory.write()` (lines 165-174) to both:
1. Create the StaxWriter instance
2. Set `addLocationInformation(false)` by default
3. Check `request.getInputLocationFormatter()` — if provided, enable location information and set the string formatter

## Test Plan

- [x] `mvn -pl impl/maven-impl -am test` — 461 tests pass, 0 failures
- [x] `mvn spotless:apply` — formatting applied
- [x] `git diff --check` — no whitespace issues

## Compatibility

- No breaking changes — callers that don't provide `inputLocationFormatter` now get cleaner XML
- Callers that explicitly provide `inputLocationFormatter` will continue to get location comments

Fixes #11899