### PR TITLE
Remove redundant required attributes from Maven model

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -491,7 +491,6 @@ public class MavenProject implements Cloneable {
     }
 
     public String getName() {
-        // TODO this should not be allowed to be null.
         if (getModel().getName() != null) {
             return getModel().getName();
         } else {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -878,4 +878,16 @@ public class DefaultModelValidatorTest {
                         + "${project.version} expressions are not supported during profile activation.",
                 result.getWarnings().get(1));
     }
+
+    @Test
+    public void testMinimalWithParent() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/minimal-with-parent.xml");
+        assertViolations(result, 0, 0, 0);
+    }
+
+    @Test
+    public void testMinimalWithoutParent() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/minimal-without-parent.xml");
+        assertViolations(result, 0, 0, 0);
+    }
 }

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-with-parent.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-with-parent.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.validation</groupId>
+    <artifactId>parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>project</artifactId>
+
+</project>

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-without-parent.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-without-parent.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>groupId</groupId>
+  <artifactId>project</artifactId>
+  <version>project</version>
+
+</project>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -167,7 +167,7 @@
         <field xdoc.separator="blank">
           <name>name</name>
           <version>3.0.0+</version>
-          <description>The full name of the project. If not specified aretifactId will be used.</description>
+          <description>The full name of the project. If not specified, the artifactId will be used.</description>
           <type>String</type>
         </field>
         <field>
@@ -774,7 +774,6 @@
         <field>
           <name>sourceDirectory</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description><![CDATA[
             This element specifies a directory containing the source of the project. The
             generated build system will compile the sources from this directory when the project is
@@ -786,7 +785,6 @@
         <field>
           <name>scriptSourceDirectory</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description><![CDATA[
             This element specifies a directory containing the script sources of the
             project. This directory is meant to be different from the sourceDirectory, in that its
@@ -799,7 +797,6 @@
         <field>
           <name>testSourceDirectory</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description><![CDATA[
             This element specifies a directory containing the unit test source of the
             project. The generated build system will compile these directories when the project is

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -117,7 +117,6 @@
         <field xdoc.separator="blank">
           <name>groupId</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description>
             <![CDATA[
             A universally unique identifier for a project. It is normal to
@@ -140,7 +139,6 @@
         <field>
           <name>version</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>The current version of the artifact produced by this project.</description>
           <type>String</type>
         </field>
@@ -169,8 +167,7 @@
         <field xdoc.separator="blank">
           <name>name</name>
           <version>3.0.0+</version>
-          <required>true</required>
-          <description>The full name of the project.</description>
+          <description>The full name of the project. If not specified aretifactId will be used.</description>
           <type>String</type>
         </field>
         <field>
@@ -212,7 +209,6 @@
         <field>
           <name>inceptionYear</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description>The year of the project's inception, specified with 4 digits. This value is
             used when generating copyright notices as well as being informational.</description>
           <type>String</type>
@@ -334,7 +330,6 @@
         <field xdoc.separator="blank" xml.insertParentFieldsUpTo="pluginRepositories">
           <name>build</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description>Information required to build the project.</description>
           <association>
             <type>Build</type>
@@ -2760,7 +2755,6 @@
         <field xml.tagName="build">
           <name>build</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>Information required to build the project.</description>
           <association>
             <type>BuildBase</type>
@@ -3001,7 +2995,6 @@
           <name>groupId</name>
           <version>4.0.0+</version>
           <type>String</type>
-          <required>true</required>
           <defaultValue>org.apache.maven.plugins</defaultValue>
           <description>The group ID of the reporting plugin in the repository.</description>
         </field>
@@ -3106,7 +3099,6 @@
         <field>
           <name>id</name>
           <type>String</type>
-          <required>true</required>
           <description>The unique id for this report set, to be used during POM inheritance and profile injection
             for merging of report sets.
           </description>
@@ -3115,7 +3107,6 @@
         <field>
           <name>reports</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>The list of reports from this plugin which should be generated from this set.</description>
           <association>
             <type>String</type>

--- a/maven-model/src/main/mdo/maven.mdo
+++ b/maven-model/src/main/mdo/maven.mdo
@@ -2732,7 +2732,6 @@
       <fields>
         <field>
           <name>id</name>
-          <required>true</required>
           <version>4.0.0+</version>
           <type>String</type>
           <defaultValue>default</defaultValue>


### PR DESCRIPTION
After the fix in the modello plugin required fields are propagated to documentation and xsd.

We should remove reduntant one which is not effectively required.

Also add additional test for validator.
