### PR TITLE
Remove release-profile from super POM

### DIFF
--- a/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -93,52 +93,5 @@ under the License.
     <outputDirectory>${project.build.directory}/site</outputDirectory>
   </reporting>
 
-  <profiles>
-    <!-- NOTE: The release profile will be removed from future versions of the super POM -->
-    <profile>
-      <id>release-profile</id>
-
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
-
-      <build>
-        <plugins>
-          <plugin>
-            <inherited>true</inherited>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <inherited>true</inherited>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <inherited>true</inherited>
-            <artifactId>maven-deploy-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>
 <!-- END SNIPPET: superpom -->


### PR DESCRIPTION
Each project should define its own release profile

fixed ITs:
- https://github.com/apache/maven-integration-testing/pull/425

