### PR TITLE
Deps: Upgrade to Resolver 2.0.17

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
--DsessionRootDirectory=${session.rootDirectory}
+-D
+sessionRootDirectory=${session.rootDirectory}

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
@@ -30,7 +30,7 @@ import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
 import org.apache.maven.artifact.repository.metadata.RepositoryMetadata;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
-import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
+import org.eclipse.aether.internal.impl.LegacyTrackingFileManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +59,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
         super.setUp();
 
         updateCheckManager = new DefaultUpdateCheckManager(
-                new ConsoleLogger(Logger.LEVEL_DEBUG, "test"), new DefaultTrackingFileManager());
+                new ConsoleLogger(Logger.LEVEL_DEBUG, "test"), new LegacyTrackingFileManager());
     }
 
     @Test

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
@@ -37,6 +37,7 @@ import org.eclipse.aether.impl.Installer;
 import org.eclipse.aether.impl.LocalRepositoryProvider;
 import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.MetadataResolver;
+import org.eclipse.aether.impl.NamedLockFactorySelector;
 import org.eclipse.aether.impl.OfflineController;
 import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -68,11 +69,11 @@ import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemValidator;
-import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.DefaultTransporterProvider;
 import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.internal.impl.LegacyTrackingFileManager;
 import org.eclipse.aether.internal.impl.LocalPathComposer;
 import org.eclipse.aether.internal.impl.LocalPathPrefixComposerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
@@ -95,6 +96,7 @@ import org.eclipse.aether.internal.impl.filter.FilteringPipelineRepositoryConnec
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.filter.PrefixesLockingInhibitorFactory;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
+import org.eclipse.aether.internal.impl.named.DefaultNamedLockFactorySelector;
 import org.eclipse.aether.internal.impl.offline.OfflinePipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
@@ -189,7 +191,7 @@ public class RepositorySystemSupplier {
     @Singleton
     @Provides
     static TrackingFileManager newTrackingFileManager() {
-        return new DefaultTrackingFileManager();
+        return new LegacyTrackingFileManager();
     }
 
     @Singleton
@@ -378,12 +380,18 @@ public class RepositorySystemSupplier {
 
     @Singleton
     @Provides
+    static NamedLockFactorySelector newNamedLockFactorySelector(
+            Map<String, NamedLockFactory> factories, RepositorySystemLifecycle lifecycle) {
+        return new DefaultNamedLockFactorySelector(factories, lifecycle);
+    }
+
+    @Singleton
+    @Provides
     static NamedLockFactoryAdapterFactory newNamedLockFactoryAdapterFactory(
-            Map<String, NamedLockFactory> factories,
+            NamedLockFactorySelector namedLockFactorySelector,
             Map<String, NameMapper> nameMappers,
-            Map<String, LockingInhibitorFactory> lockingInhibitorFactories,
-            RepositorySystemLifecycle lifecycle) {
-        return new NamedLockFactoryAdapterFactoryImpl(factories, nameMappers, lockingInhibitorFactories, lifecycle);
+            Map<String, LockingInhibitorFactory> lockingInhibitorFactories) {
+        return new NamedLockFactoryAdapterFactoryImpl(namedLockFactorySelector, nameMappers, lockingInhibitorFactories);
     }
 
     @Singleton

--- a/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/RepositorySystemSupplier.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/RepositorySystemSupplier.java
@@ -70,6 +70,7 @@ import org.eclipse.aether.impl.Installer;
 import org.eclipse.aether.impl.LocalRepositoryProvider;
 import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.MetadataResolver;
+import org.eclipse.aether.impl.NamedLockFactorySelector;
 import org.eclipse.aether.impl.OfflineController;
 import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -101,11 +102,11 @@ import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemValidator;
-import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.DefaultTransporterProvider;
 import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.internal.impl.LegacyTrackingFileManager;
 import org.eclipse.aether.internal.impl.LocalPathComposer;
 import org.eclipse.aether.internal.impl.LocalPathPrefixComposerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
@@ -128,6 +129,7 @@ import org.eclipse.aether.internal.impl.filter.FilteringPipelineRepositoryConnec
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.filter.PrefixesLockingInhibitorFactory;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
+import org.eclipse.aether.internal.impl.named.DefaultNamedLockFactorySelector;
 import org.eclipse.aether.internal.impl.offline.OfflinePipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.resolution.TrustedChecksumsArtifactResolverPostProcessor;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
@@ -245,7 +247,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
     }
 
     protected TrackingFileManager createTrackingFileManager() {
-        return new DefaultTrackingFileManager();
+        return new LegacyTrackingFileManager();
     }
 
     private LocalPathComposer localPathComposer;
@@ -419,6 +421,20 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return result;
     }
 
+    private NamedLockFactorySelector namedLockFactorySelector;
+
+    public final NamedLockFactorySelector getNamedLockFactorySelector() {
+        checkClosed();
+        if (namedLockFactorySelector == null) {
+            namedLockFactorySelector = createNamedLockFactorySelector();
+        }
+        return namedLockFactorySelector;
+    }
+
+    protected NamedLockFactorySelector createNamedLockFactorySelector() {
+        return new DefaultNamedLockFactorySelector(getNamedLockFactories(), getRepositorySystemLifecycle());
+    }
+
     private NamedLockFactoryAdapterFactory namedLockFactoryAdapterFactory;
 
     public final NamedLockFactoryAdapterFactory getNamedLockFactoryAdapterFactory() {
@@ -431,10 +447,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
 
     protected NamedLockFactoryAdapterFactory createNamedLockFactoryAdapterFactory() {
         return new NamedLockFactoryAdapterFactoryImpl(
-                getNamedLockFactories(),
-                getNameMappers(),
-                getLockingInhibitorFactories(),
-                getRepositorySystemLifecycle());
+                getNamedLockFactorySelector(), getNameMappers(), getLockingInhibitorFactories());
     }
 
     private SyncContextFactory syncContextFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ under the License.
     <plexusInterpolationVersion>1.29</plexusInterpolationVersion>
     <plexusTestingVersion>2.1.0</plexusTestingVersion>
     <plexusXmlVersion>4.1.1</plexusXmlVersion>
-    <resolverVersion>2.0.16</resolverVersion>
+    <resolverVersion>2.0.17</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
     <sisuVersion>1.0.0</sisuVersion>
     <slf4jVersion>2.0.17</slf4jVersion>


### PR DESCRIPTION
It requires some new internals in object graph, so the suppliers needs change. Also, legacy goes to legacy.