### PR TITLE
Ensure `MavenProject#getPluginManagement` never returns null

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -751,6 +751,10 @@ public class MavenProject implements Cloneable {
             pluginMgmt = build.getPluginManagement();
         }
 
+        if (pluginMgmt == null) {
+            pluginMgmt = new PluginManagement();
+        }
+
         return pluginMgmt;
     }
 

--- a/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/MavenProjectTest.java
@@ -214,6 +214,13 @@ public class MavenProjectTest extends AbstractMavenProjectTestCase {
         assertEquals(1, project.getCompileSourceRoots().size());
     }
 
+    @Test
+    public void pluginManagementShouldReturnNotNull() {
+        MavenProject project = new MavenProject();
+
+        assertNotNull(project.getPluginManagement());
+    }
+
     private void assertNoNulls(List<String> elements) {
         assertFalse(elements.contains(null));
     }


### PR DESCRIPTION
When we have `pluginManagement` in Super POM - MavenProject#getPluginManagement never returns null, should be the same after removing `pluginManagement`.

It can break the plugin which can assume that it is not null.

---

<!--
Please open pull requests against one of the following branches:

- master — default target for all changes (new features + bug fixes).  
  If the change should also go to maven-4.0.x, request a backport in the PR.

- maven-3.10.x — target for 3.x changes (new features + bug fixes).  
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.

Backports are typically handled by maintainers; 
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
