### PR TITLE
Backport: Maven 3.10.x fixed plugin resolution

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
@@ -20,8 +20,10 @@ package org.apache.maven.plugin.prefix.internal;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -102,16 +104,20 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
                         LinkedHashMap::new,
                         Collectors.mapping(Plugin::getArtifactId, Collectors.toSet())));
         request.getPluginGroups().forEach(g -> candidates.put(g, null));
-        PluginPrefixResult result = resolveFromRepository(request, candidates);
-
-        // If we haven't been able to resolve the plugin from the repository,
-        // as a last resort, we go through all declared plugins, load them
+        PluginPrefixResult result = null;
+        // First, we go through all declared plugins, load them
         // one by one, and try to find a matching prefix.
-        if (result == null && build != null) {
-            result = resolveFromProject(request, build.getPlugins());
-            if (result == null && management != null) {
-                result = resolveFromProject(request, management.getPlugins());
-            }
+        if (build != null) {
+            result = resolveFromProject(
+                    request,
+                    build.getPlugins(),
+                    management != null ? management.getPlugins() : Collections.emptyList());
+        }
+
+        // Second, we go use G level metadata to discover prefix
+        // This order allows user managed clashing prefixes (they can declare them in POM)
+        if (result == null) {
+            result = resolveFromRepository(request, candidates);
         }
 
         if (result == null) {
@@ -129,7 +135,30 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
         return result;
     }
 
-    private PluginPrefixResult resolveFromProject(PluginPrefixRequest request, List<Plugin> plugins) {
+    private PluginPrefixResult resolveFromProject(
+            PluginPrefixRequest request, List<Plugin> plugins, List<Plugin> pluginMgmt) {
+        if (plugins.isEmpty() && pluginMgmt.isEmpty()) {
+            return null;
+        }
+        PluginPrefixResult result = null;
+        // try optimistically; first if A contains prefix?
+        Set<Plugin> candidates = new LinkedHashSet<>();
+        Stream.concat(plugins.stream(), pluginMgmt.stream())
+                .filter(p -> p.getArtifactId().contains(request.getPrefix()))
+                .forEach(candidates::add);
+        if (!candidates.isEmpty()) {
+            result = doResolveFromProject(request, candidates);
+        }
+        // if no luck; try the rest
+        if (result == null) {
+            Set<Plugin> remainder = new LinkedHashSet<>(plugins);
+            remainder.removeAll(candidates);
+            result = doResolveFromProject(request, remainder);
+        }
+        return result;
+    }
+
+    private PluginPrefixResult doResolveFromProject(PluginPrefixRequest request, Collection<Plugin> plugins) {
         for (Plugin plugin : plugins) {
             try {
                 PluginDescriptor pluginDescriptor =


### PR DESCRIPTION
It puts user again in charge (as it should be), prefer POM defined plugins over remote repository metadata discovered ones.

Backport of 0691e55823aaf452fea94259a30b1b7ca8c85b18

Fixes #12019
Fixes #11905
