### PR TITLE
Feat: Maven 3.10.x super POM

### DIFF
--- a/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/PomConstructionTest.java
@@ -1243,7 +1243,7 @@ public class PomConstructionTest {
     @Test
     public void testPropertiesNoDuplication() throws Exception {
         PomTestWrapper pom = buildPom("properties-no-duplication/sub");
-        assertEquals(1, ((Properties) pom.getValue("properties")).size());
+        assertEquals(4, ((Properties) pom.getValue("properties")).size());
         assertEquals("child", pom.getValue("properties/pomProfile"));
     }
 
@@ -1367,7 +1367,7 @@ public class PomConstructionTest {
         assertEquals(1, ((List<?>) pom.getValue("modules")).size());
         assertEquals("sub", pom.getValue("modules[1]"));
 
-        assertEquals(1, ((Map<?, ?>) pom.getValue("properties")).size());
+        assertEquals(4, ((Map<?, ?>) pom.getValue("properties")).size());
         assertEquals("project-property", pom.getValue("properties[1]/itProperty"));
 
         assertEquals(1, ((List<?>) pom.getValue("dependencyManagement/dependencies")).size());

--- a/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -23,6 +23,13 @@ under the License.
 <project>
   <modelVersion>4.0.0</modelVersion>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!-- Fixed date for reproducible build -->
+    <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
+  </properties>
+
   <repositories>
     <repository>
       <id>central</id>


### PR DESCRIPTION
Add entries from Maven 4 model 4.0.0 superpom, that are in essence sane defaults.

Needs IT change: https://github.com/apache/maven-integration-testing/pull/426