### PR TITLE
Fix ConditionParser to handle newlines before && operator

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
@@ -129,8 +129,8 @@ public class ConditionParser {
                 }
                 quoteType = c;
                 sb.append(c);
-            } else if (c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '(' || c == ')' || c == ',' || c == '+'
-                    || c == '>' || c == '<' || c == '=' || c == '!' || c == '&') {
+            } else if (Character.isWhitespace(c) || c == '(' || c == ')' || c == ',' || c == '+'
+                    || c == '>' || c == '<' || c == '=' || c == '!' || c == '&' || c == '|') {
                 if (!sb.isEmpty()) {
                     tokens.add(sb.toString());
                     sb.setLength(0);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
@@ -129,17 +129,20 @@ public class ConditionParser {
                 }
                 quoteType = c;
                 sb.append(c);
-            } else if (c == ' ' || c == '(' || c == ')' || c == ',' || c == '+' || c == '>' || c == '<' || c == '='
-                    || c == '!') {
+            } else if (c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '(' || c == ')' || c == ',' || c == '+'
+                    || c == '>' || c == '<' || c == '=' || c == '!' || c == '&') {
                 if (!sb.isEmpty()) {
                     tokens.add(sb.toString());
                     sb.setLength(0);
                 }
-                if (c != ' ') {
-                    if ((c == '>' || c == '<' || c == '=' || c == '!')
+                if (c != ' ' && c != '\n' && c != '\r' && c != '\t') {
+                    if ((c == '>' || c == '<' || c == '=' || c == '!' || c == '&')
                             && i + 1 < expression.length()
                             && expression.charAt(i + 1) == '=') {
                         tokens.add(c + "=");
+                        i++; // Skip the next character
+                    } else if (c == '&' && i + 1 < expression.length() && expression.charAt(i + 1) == '&') {
+                        tokens.add("&&");
                         i++; // Skip the next character
                     } else {
                         tokens.add(String.valueOf(c));

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
@@ -135,7 +135,7 @@ public class ConditionParser {
                     tokens.add(sb.toString());
                     sb.setLength(0);
                 }
-                if (c != ' ' && c != '\n' && c != '\r' && c != '\t') {
+                if (!Character.isWhitespace(c)) {
                     if ((c == '>' || c == '<' || c == '=' || c == '!' || c == '&')
                             && i + 1 < expression.length()
                             && expression.charAt(i + 1) == '=') {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
@@ -129,20 +129,32 @@ public class ConditionParser {
                 }
                 quoteType = c;
                 sb.append(c);
-            } else if (Character.isWhitespace(c) || c == '(' || c == ')' || c == ',' || c == '+'
-                    || c == '>' || c == '<' || c == '=' || c == '!' || c == '&' || c == '|') {
+            } else if (Character.isWhitespace(c)
+                    || c == '('
+                    || c == ')'
+                    || c == ','
+                    || c == '+'
+                    || c == '>'
+                    || c == '<'
+                    || c == '='
+                    || c == '!'
+                    || c == '&'
+                    || c == '|') {
                 if (!sb.isEmpty()) {
                     tokens.add(sb.toString());
                     sb.setLength(0);
                 }
                 if (!Character.isWhitespace(c)) {
-                    if ((c == '>' || c == '<' || c == '=' || c == '!' || c == '&')
+                    if ((c == '>' || c == '<' || c == '=' || c == '!')
                             && i + 1 < expression.length()
                             && expression.charAt(i + 1) == '=') {
                         tokens.add(c + "=");
                         i++; // Skip the next character
                     } else if (c == '&' && i + 1 < expression.length() && expression.charAt(i + 1) == '&') {
                         tokens.add("&&");
+                        i++; // Skip the next character
+                    } else if (c == '|' && i + 1 < expression.length() && expression.charAt(i + 1) == '|') {
+                        tokens.add("||");
                         i++; // Skip the next character
                     } else {
                         tokens.add(String.valueOf(c));

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
@@ -263,6 +263,32 @@ class ConditionParserTest {
     }
 
     @Test
+    void testAmpersandAmpersandTokenizerMultiline() {
+        // Regression test for https://github.com/apache/maven/issues/11882
+        // The && operator was not being tokenized correctly when a line break appeared before it.
+        // Uses ${os.name} and ${os.arch} which work reliably in the test environment.
+        // ${os.name} == 'windows' && ${os.arch} == 'amd64' evaluates to true.
+
+        // Case 1: Basic && without line breaks (baseline - always worked)
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64' && ${os.name} == 'windows'"));
+
+        // Case 2: Line break BEFORE && - this was the bug from issue #11882
+        // In the issue, CDATA content had a line break before &&:
+        // <condition><![CDATA[exists( '.profile-2' )\n&& missing( '.profile-1' )]]></condition>
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64'\n&& ${os.name} == 'windows'"));
+
+        // Case 3: Line break AFTER &&
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64' &&\n${os.name} == 'windows'"));
+
+        // Case 4: Line breaks on both sides
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64'\n&&\n${os.name} == 'windows'"));
+
+        // Case 5: Multiple && with line break before first && (like bad-profile-2d in issue)
+        assertTrue(
+                (Boolean) parser.parse("${os.arch} == 'amd64'\n&& ${os.name} == 'windows' && ${os.name} == 'windows'"));
+    }
+
+    @Test
     void testNestedPropertyAlias() {
         functions.put("property", args -> {
             if (args.get(0).equals("project.rootDirectory")) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
@@ -266,8 +266,7 @@ class ConditionParserTest {
     void testAmpersandAmpersandTokenizerMultiline() {
         // Regression test for https://github.com/apache/maven/issues/11882
         // The && operator was not being tokenized correctly when a line break appeared before it.
-        // Uses ${os.name} and ${os.arch} which work reliably in the test environment.
-        // ${os.name} == 'windows' && ${os.arch} == 'amd64' evaluates to true.
+        // Uses ${os.name} and ${os.arch} which are set to 'windows' and 'amd64' in the mock context.
 
         // Case 1: Basic && without line breaks (baseline - always worked)
         assertTrue((Boolean) parser.parse("${os.arch} == 'amd64' && ${os.name} == 'windows'"));

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
@@ -288,6 +288,29 @@ class ConditionParserTest {
     }
 
     @Test
+    void testPipePipeTokenizerMultiline() {
+        // Regression test for https://github.com/apache/maven/issues/11882
+        // The || operator was not being tokenized correctly when a line break appeared before it.
+        // Uses ${os.name} which is set to 'windows' in the mock context.
+
+        // Case 1: Basic || without line breaks (baseline)
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64' || ${os.name} == 'windows'"));
+
+        // Case 2: Line break BEFORE ||
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64'\n|| ${os.name} == 'windows'"));
+
+        // Case 3: Line break AFTER ||
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64' ||\n${os.name} == 'windows'"));
+
+        // Case 4: Line breaks on both sides
+        assertTrue((Boolean) parser.parse("${os.arch} == 'amd64'\n||\n${os.name} == 'windows'"));
+
+        // Case 5: Mixed && and || with line breaks
+        assertTrue(
+                (Boolean) parser.parse("${os.arch} == 'amd64'\n&& ${os.name} == 'windows' || ${os.name} == 'windows'"));
+    }
+
+    @Test
     void testNestedPropertyAlias() {
         functions.put("property", args -> {
             if (args.get(0).equals("project.rootDirectory")) {


### PR DESCRIPTION
Fix for https://github.com/apache/maven/issues/11882

The tokenize() method only treated space as whitespace, so newlines became standalone tokens. When a line break appeared before &&, the operator was parsed as two separate & tokens instead of one &&.

Added \n, \r, \t to whitespace handling and properly tokenize && as a single operator token regardless of surrounding whitespace.