### PR TITLE
Fix #12045: warn when effective model analysis fails for inherited plugins

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -565,7 +565,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 }
 
             } catch (Exception e) {
-                context.debug("Failed to analyze effective model for " + originalPomPath + ": " + e.getMessage());
+                context.warning("Failed to analyze effective model for " + originalPomPath + ": " + e.getMessage());
             }
         }
 

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -38,6 +38,7 @@ import org.apache.maven.api.cli.mvnup.UpgradeOptions;
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Priority;
+import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
 import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.Model;
@@ -55,10 +56,9 @@ import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
 import org.apache.maven.impl.standalone.ApiRunner;
 import org.codehaus.plexus.components.secdispatcher.Dispatcher;
 import org.codehaus.plexus.components.secdispatcher.internal.dispatchers.LegacyDispatcher;
-import org.eclipse.aether.internal.impl.DefaultPathProcessor;
-import org.eclipse.aether.internal.impl.DefaultTransporterProvider;
-import org.eclipse.aether.internal.impl.transport.http.DefaultChecksumExtractor;
-import org.eclipse.aether.spi.connector.transport.TransporterProvider;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.jdk.JdkTransporterFactory;
 
@@ -438,15 +438,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     private Session createMaven4Session() {
         Session session = ApiRunner.createSession(injector -> {
             injector.bindInstance(Dispatcher.class, new LegacyDispatcher());
-
-            injector.bindInstance(
-                    TransporterProvider.class,
-                    new DefaultTransporterProvider(Map.of(
-                            "https",
-                            new JdkTransporterFactory(
-                                    new DefaultChecksumExtractor(Map.of()), new DefaultPathProcessor()),
-                            "file",
-                            new FileTransporterFactory())));
+            injector.bindImplicit(TransporterFactoryConfig.class);
         });
 
         // Configure repositories
@@ -878,6 +870,26 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             this.groupId = groupId;
             this.artifactId = artifactId;
             this.minVersion = minVersion;
+        }
+    }
+
+    /**
+     * DI configuration that registers transporter factories for the standalone Maven session.
+     * Uses {@code @Provides} methods so the factories are properly registered as named beans
+     * and feed into the {@code Map<String, TransporterFactory>} used by the TransporterProvider.
+     */
+    static class TransporterFactoryConfig {
+        @Provides
+        @Named(JdkTransporterFactory.NAME)
+        static TransporterFactory jdkTransporterFactory(
+                ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
+            return new JdkTransporterFactory(checksumExtractor, pathProcessor);
+        }
+
+        @Provides
+        @Named(FileTransporterFactory.NAME)
+        static TransporterFactory fileTransporterFactory() {
+            return new FileTransporterFactory();
         }
     }
 }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -38,7 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -514,6 +517,43 @@ class PluginUpgradeStrategyTest {
     @Nested
     @DisplayName("Error Handling")
     class ErrorHandlingTests {
+
+        @Test
+        @DisplayName("should warn when effective model analysis fails for POM with remote parent")
+        void shouldWarnWhenEffectiveModelAnalysisFailsForRemoteParent() throws Exception {
+            // POM inherits from a remote parent that cannot be resolved in test environment.
+            // This simulates the scenario where plugins are inherited from remote parent POMs
+            // (e.g., org.apache:apache:23 defining maven-enforcer-plugin:1.4.1).
+            // The effective model analysis should warn (not silently swallow) the failure.
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.apache</groupId>
+                        <artifactId>apache</artifactId>
+                        <version>23</version>
+                    </parent>
+                    <artifactId>test-child</artifactId>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            // Strategy should complete successfully even when effective model analysis fails
+            assertNotNull(result, "Result should not be null");
+            assertTrue(result.success(), "Strategy should succeed even when effective model analysis fails");
+            assertTrue(result.processedPoms().contains(Paths.get("pom.xml")), "POM should be marked as processed");
+
+            // The warning should have been logged (not silently swallowed at debug level)
+            // Verify through the mock logger that warn was called
+            verify(context.logger, atLeastOnce())
+                    .warn(argThat(msg -> msg.contains("Failed to analyze effective model")));
+        }
 
         @Test
         @DisplayName("should handle malformed POM gracefully")

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -515,6 +515,50 @@ class PluginUpgradeStrategyTest {
     }
 
     @Nested
+    @DisplayName("Inherited Plugin Detection")
+    class InheritedPluginDetectionTests {
+
+        @Test
+        @DisplayName("should detect inherited plugins from remote parent POM and add pluginManagement")
+        void shouldDetectInheritedPluginsFromRemoteParent() throws Exception {
+            // org.apache:apache:23 defines maven-enforcer-plugin:1.4.1 in pluginManagement.
+            // A child POM that inherits from this parent should get pluginManagement overrides
+            // added by mvnup for plugins that need Maven 4 compatibility upgrades.
+            // Uses an absolute path because the effective model analysis path resolution
+            // requires it to match between phases.
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.apache</groupId>
+                        <artifactId>apache</artifactId>
+                        <version>23</version>
+                    </parent>
+                    <groupId>org.example</groupId>
+                    <artifactId>test-child</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Path pomPath = Paths.get("/project/pom.xml").toAbsolutePath();
+            Map<Path, Document> pomMap = Map.of(pomPath, document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have added plugin management for inherited plugins");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(
+                    xml.contains("<artifactId>maven-enforcer-plugin</artifactId>"),
+                    "Should add pluginManagement for maven-enforcer-plugin inherited from parent");
+        }
+    }
+
+    @Nested
     @DisplayName("Error Handling")
     class ErrorHandlingTests {
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -519,20 +519,18 @@ class PluginUpgradeStrategyTest {
     class ErrorHandlingTests {
 
         @Test
-        @DisplayName("should warn when effective model analysis fails for POM with remote parent")
-        void shouldWarnWhenEffectiveModelAnalysisFailsForRemoteParent() throws Exception {
-            // POM inherits from a remote parent that cannot be resolved in test environment.
-            // This simulates the scenario where plugins are inherited from remote parent POMs
-            // (e.g., org.apache:apache:23 defining maven-enforcer-plugin:1.4.1).
+        @DisplayName("should warn when effective model analysis fails for POM with unresolvable remote parent")
+        void shouldWarnWhenEffectiveModelAnalysisFailsForUnresolvableRemoteParent() throws Exception {
+            // POM inherits from a remote parent that does not exist.
             // The effective model analysis should warn (not silently swallow) the failure.
             String pomXml = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <project xmlns="http://maven.apache.org/POM/4.0.0">
                     <modelVersion>4.0.0</modelVersion>
                     <parent>
-                        <groupId>org.apache</groupId>
-                        <artifactId>apache</artifactId>
-                        <version>23</version>
+                        <groupId>com.nonexistent.test</groupId>
+                        <artifactId>nonexistent-parent</artifactId>
+                        <version>1.0.0</version>
                     </parent>
                     <artifactId>test-child</artifactId>
                 </project>
@@ -550,7 +548,6 @@ class PluginUpgradeStrategyTest {
             assertTrue(result.processedPoms().contains(Paths.get("pom.xml")), "POM should be marked as processed");
 
             // The warning should have been logged (not silently swallowed at debug level)
-            // Verify through the mock logger that warn was called
             verify(context.logger, atLeastOnce())
                     .warn(argThat(msg -> msg.contains("Failed to analyze effective model")));
         }


### PR DESCRIPTION
## Summary

- Change log level from `debug` to `warning` when effective model analysis fails in `PluginUpgradeStrategy`, so users are informed when plugins inherited from remote parent POMs cannot be detected for upgrade
- Fix standalone session transport configuration: register transporter factories via `@Provides` methods so they properly feed into the DI `Map<String, TransporterFactory>`. The previous approach of binding `TransporterProvider` directly was overridden by the `@Provides` method in `RepositorySystemSupplier` which received an empty factory map, leaving no HTTP transport available
- Add test verifying the warning is emitted when effective model analysis fails for a POM with an unresolvable remote parent

### Before

`mvnup apply` on [accumulo-wikisearch](https://github.com/apache/accumulo-wikisearch) silently reports "No plugin upgrades needed" for all 4 POMs, despite inheriting `maven-enforcer-plugin:1.4.1` from `org.apache:apache:23`.

### After

`mvnup apply` correctly detects and adds `pluginManagement` entries for 3 inherited plugins that need Maven 4 compatibility upgrades:
- `maven-enforcer-plugin` → `3.0.0`
- `maven-remote-resources-plugin` → `3.0.0`
- `maven-shade-plugin` → `3.5.0`

Closes #12045

## Test plan

- [x] Existing `PluginUpgradeStrategyTest` tests pass (20 tests)
- [x] New test verifies warning is logged when effective model analysis fails for unresolvable parent
- [x] Manual test against [accumulo-wikisearch](https://github.com/apache/accumulo-wikisearch) confirms inherited plugins are now detected and upgraded

_Claude Code on behalf of Guillaume Nodet_