### PR TITLE
Filter transitive repositories with uninterpolated IDs

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -552,7 +552,9 @@ public class DefaultModelBuilder implements ModelBuilder {
                     // filter out transitive invalid repositories
                     // this should be safe because invalid repo coming from build POMs
                     // have been rejected earlier during validation
-                    .filter(repo -> repo.getUrl() != null && !repo.getUrl().contains("${"))
+                    .filter(repo -> repo.getUrl() != null
+                            && !repo.getUrl().contains("${")
+                            && (repo.getId() == null || !repo.getId().contains("${")))
                     .map(session::createRemoteRepository)
                     .toList();
             if (replace) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -107,12 +107,16 @@ class DefaultModelBuilderTest {
                         Repository.newBuilder()
                                 .id("third")
                                 .url("${thirdParentRepo}")
+                                .build(),
+                        Repository.newBuilder()
+                                .id("${uninterpolatedRepoId}")
+                                .url("https://valid.url")
                                 .build()))
                 .build();
 
         state.mergeRepositories(model, false);
 
-        // after merge
+        // after merge: "second" filtered (uninterpolated URL), "${uninterpolatedRepoId}" filtered (uninterpolated ID)
         repositories = (List<RemoteRepository>) repositoriesField.get(state);
         assertEquals(3, repositories.size());
         assertEquals("first", repositories.get(0).getId());


### PR DESCRIPTION
## Summary

- Extend the transitive repository filter in `mergeRepositories` to also exclude repositories whose ID contains uninterpolated expressions (`${...}`), not just URLs
- Add test coverage for repositories with uninterpolated IDs but valid URLs

Fixes #12049

## Context

The existing filter (added in #11357) already excluded transitive repositories with uninterpolated URLs. However, when a transitive dependency POM contained an expression like `${eclipseP2RepoId}` as a repository **ID** with a valid URL, it passed the filter and later caused `MavenValidator.validateRemoteRepository` to throw `IllegalArgumentException`, failing the build.

The consuming project has no control over third-party POM content, so these invalid repositories should be silently skipped (they can't be useful in the consuming project's context anyway).

## Test plan

- [x] Extended `testMergeRepositories` to verify repositories with uninterpolated IDs are filtered
- [x] CI passes

_Claude Code on behalf of Guillaume Nodet_