### PR TITLE
Upgrade plugin dependencies (extra-enforcer-rules) in mvnup

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -64,6 +64,8 @@ import org.eclipse.aether.transport.jdk.JdkTransporterFactory;
 
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.ARTIFACT_ID;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.BUILD;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.DEPENDENCIES;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.DEPENDENCY;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.GROUP_ID;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PARENT;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGIN;
@@ -99,6 +101,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     "maven-remote-resources-plugin",
                     "3.0.0",
                     MAVEN_4_COMPATIBILITY_REASON));
+
+    private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
+            "org.codehaus.mojo",
+            "extra-enforcer-rules",
+            "1.4",
+            "Versions before 1.4 use a removed DependencyGraphBuilder API incompatible with Maven 4"));
 
     private Session session;
 
@@ -262,6 +270,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         return pluginsElement
                 .children(PLUGIN)
                 .map(pluginElement -> {
+                    boolean upgraded = false;
                     String groupId = getChildText(pluginElement, GROUP_ID);
                     String artifactId = getChildText(pluginElement, ARTIFACT_ID);
 
@@ -275,10 +284,13 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                         PluginUpgradeInfo upgrade = pluginUpgrades.get(pluginKey);
 
                         if (upgrade != null) {
-                            return upgradePluginVersion(pluginElement, upgrade, pomDocument, sectionName, context);
+                            upgraded = upgradePluginVersion(pluginElement, upgrade, pomDocument, sectionName, context);
                         }
                     }
-                    return false;
+
+                    upgraded |= upgradePluginDependencies(pluginElement, pomDocument, sectionName, context);
+
+                    return upgraded;
                 })
                 .reduce(false, Boolean::logicalOr);
     }
@@ -368,6 +380,46 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         }
 
         return false;
+    }
+
+    /**
+     * Upgrades plugin dependencies (e.g., extra-enforcer-rules inside maven-enforcer-plugin).
+     */
+    private boolean upgradePluginDependencies(
+            Element pluginElement, Document pomDocument, String sectionName, UpgradeContext context) {
+        Element dependenciesElement = pluginElement.child(DEPENDENCIES).orElse(null);
+        if (dependenciesElement == null) {
+            return false;
+        }
+
+        Map<String, PluginUpgradeInfo> depUpgrades = getPluginDependencyUpgradesMap();
+
+        return dependenciesElement
+                .children(DEPENDENCY)
+                .map(depElement -> {
+                    String groupId = getChildText(depElement, GROUP_ID);
+                    String artifactId = getChildText(depElement, ARTIFACT_ID);
+
+                    if (groupId != null && artifactId != null) {
+                        String depKey = groupId + ":" + artifactId;
+                        PluginUpgradeInfo upgrade = depUpgrades.get(depKey);
+
+                        if (upgrade != null) {
+                            return upgradePluginVersion(
+                                    depElement, upgrade, pomDocument, sectionName + "/plugin/dependencies", context);
+                        }
+                    }
+                    return false;
+                })
+                .reduce(false, Boolean::logicalOr);
+    }
+
+    private Map<String, PluginUpgradeInfo> getPluginDependencyUpgradesMap() {
+        return PLUGIN_DEPENDENCY_UPGRADES.stream()
+                .collect(Collectors.toMap(
+                        upgrade -> upgrade.groupId() + ":" + upgrade.artifactId(),
+                        upgrade ->
+                                new PluginUpgradeInfo(upgrade.groupId(), upgrade.artifactId(), upgrade.minVersion())));
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -418,6 +418,93 @@ class PluginUpgradeStrategyTest {
     }
 
     @Nested
+    @DisplayName("Plugin Dependency Upgrades")
+    class PluginDependencyUpgradeTests {
+
+        @Test
+        @DisplayName("should upgrade extra-enforcer-rules dependency when below minimum")
+        void shouldUpgradeExtraEnforcerRulesDependency() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.5.0</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>extra-enforcer-rules</artifactId>
+                                        <version>1.0-beta-4</version>
+                                    </dependency>
+                                </dependencies>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Plugin dependency upgrade should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have upgraded extra-enforcer-rules");
+
+            String xml = document.toXml();
+            assertTrue(xml.contains("<version>1.4</version>"), "extra-enforcer-rules should be upgraded to 1.4");
+            assertFalse(xml.contains("1.0-beta-4"), "Old version should be gone");
+        }
+
+        @Test
+        @DisplayName("should not upgrade extra-enforcer-rules when version is already sufficient")
+        void shouldNotUpgradeExtraEnforcerRulesWhenSufficient() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.5.0</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>extra-enforcer-rules</artifactId>
+                                        <version>1.8.0</version>
+                                    </dependency>
+                                </dependencies>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            strategy.doApply(context, pomMap);
+
+            String xml = document.toXml();
+            assertTrue(xml.contains("1.8.0"), "Version 1.8.0 should be preserved");
+        }
+    }
+
+    @Nested
     @DisplayName("Plugin Management")
     class PluginManagementTests {
 


### PR DESCRIPTION
## Summary

- Adds support for upgrading plugin dependencies (not just plugin versions) in `mvnup`
- Specifically upgrades `org.codehaus.mojo:extra-enforcer-rules` to minimum version 1.4 for Maven 4 compatibility

## Problem

`extra-enforcer-rules` versions before 1.4 use `DependencyGraphBuilder.buildDependencyGraph(MavenProject, ArtifactFilter)` — a method removed in Maven 4. This causes `NoSuchMethodError` at runtime when rules like `BanCircularDependencies` are executed.

Found during maven4-testing across ~960 Apache repositories (e.g., [rocketmq](https://github.com/gnodet/maven4-testing/issues/10554) uses `extra-enforcer-rules:1.0-beta-4`).

Version 1.4 switched to `buildDependencyGraph(ProjectBuildingRequest, ArtifactFilter)` which is compatible with Maven 4.

## Changes

- `PluginUpgradeStrategy`: Added `PLUGIN_DEPENDENCY_UPGRADES` list and `upgradePluginDependencies()` method that checks `<dependencies>` inside `<plugin>` elements
- Reuses existing `upgradePluginVersion()` for version comparison and property handling
- Added 2 tests for the new functionality

## Test plan

- [x] Existing tests pass (19/19)
- [x] New tests pass (2 new, 21 total)
  - Upgrades `extra-enforcer-rules:1.0-beta-4` to `1.4`
  - Preserves `extra-enforcer-rules:1.8.0` (already sufficient)

_Claude Code on behalf of Guillaume Nodet_