### PR TITLE
[maven-4.0.x] Fix #11920: skip expression validation for profile repository URLs

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -618,39 +618,43 @@ public class DefaultModelValidator implements ModelValidator {
         }
 
         if (validationLevel > VALIDATION_LEVEL_MINIMAL) {
-            validateRawRepositories(problems, m.getRepositories(), "repositories.repository.", EMPTY, validationLevel);
+            validateRawRepositories(
+                    problems, m.getRepositories(), "repositories.repository.", EMPTY, validationLevel, false);
 
             validateRawRepositories(
                     problems,
                     m.getPluginRepositories(),
                     "pluginRepositories.pluginRepository.",
                     EMPTY,
-                    validationLevel);
+                    validationLevel,
+                    false);
 
             for (Profile profile : m.getProfiles()) {
                 String prefix = "profiles.profile[" + profile.getId() + "].";
 
                 validateRawRepositories(
-                        problems, profile.getRepositories(), prefix, "repositories.repository.", validationLevel);
+                        problems, profile.getRepositories(), prefix, "repositories.repository.", validationLevel, true);
 
                 validateRawRepositories(
                         problems,
                         profile.getPluginRepositories(),
                         prefix,
                         "pluginRepositories.pluginRepository.",
-                        validationLevel);
+                        validationLevel,
+                        true);
             }
 
             DistributionManagement distMgmt = m.getDistributionManagement();
             if (distMgmt != null) {
                 validateRawRepository(
-                        problems, distMgmt.getRepository(), "distributionManagement.repository.", "", true);
+                        problems, distMgmt.getRepository(), "distributionManagement.repository.", "", true, false);
                 validateRawRepository(
                         problems,
                         distMgmt.getSnapshotRepository(),
                         "distributionManagement.snapshotRepository.",
                         "",
-                        true);
+                        true,
+                        false);
             }
         }
     }
@@ -1483,11 +1487,12 @@ public class DefaultModelValidator implements ModelValidator {
             List<Repository> repositories,
             String prefix,
             String prefix2,
-            int validationLevel) {
+            int validationLevel,
+            boolean skipExpressionCheck) {
         Map<String, Repository> index = new HashMap<>();
 
         for (Repository repository : repositories) {
-            validateRawRepository(problems, repository, prefix, prefix2, false);
+            validateRawRepository(problems, repository, prefix, prefix2, false, skipExpressionCheck);
 
             String key = repository.getId();
 
@@ -1516,23 +1521,25 @@ public class DefaultModelValidator implements ModelValidator {
             Repository repository,
             String prefix,
             String prefix2,
-            boolean allowEmptyUrl) {
+            boolean allowEmptyUrl,
+            boolean skipExpressionCheck) {
         if (repository == null) {
             return;
         }
         if (validateStringNotEmpty(
                 prefix, prefix2, "id", problems, Severity.ERROR, Version.V20, repository.getId(), null, repository)) {
-            // Check for uninterpolated expressions in ID - these should have been interpolated by now
-            Matcher matcher = EXPRESSION_NAME_PATTERN.matcher(repository.getId());
-            if (matcher.find()) {
-                addViolation(
-                        problems,
-                        Severity.ERROR,
-                        Version.V40,
-                        prefix + prefix2 + "[" + repository.getId() + "].id",
-                        null,
-                        "contains an uninterpolated expression.",
-                        repository);
+            if (!skipExpressionCheck) {
+                Matcher matcher = EXPRESSION_NAME_PATTERN.matcher(repository.getId());
+                if (matcher.find()) {
+                    addViolation(
+                            problems,
+                            Severity.ERROR,
+                            Version.V40,
+                            prefix + prefix2 + "[" + repository.getId() + "].id",
+                            null,
+                            "contains an uninterpolated expression.",
+                            repository);
+                }
             }
         }
 
@@ -1547,17 +1554,18 @@ public class DefaultModelValidator implements ModelValidator {
                         repository.getUrl(),
                         null,
                         repository)) {
-            // Check for uninterpolated expressions in URL - these should have been interpolated by now
-            Matcher matcher = EXPRESSION_NAME_PATTERN.matcher(repository.getUrl());
-            if (matcher.find()) {
-                addViolation(
-                        problems,
-                        Severity.ERROR,
-                        Version.V40,
-                        prefix + prefix2 + "[" + repository.getId() + "].url",
-                        null,
-                        "contains an uninterpolated expression.",
-                        repository);
+            if (!skipExpressionCheck) {
+                Matcher matcher = EXPRESSION_NAME_PATTERN.matcher(repository.getUrl());
+                if (matcher.find()) {
+                    addViolation(
+                            problems,
+                            Severity.ERROR,
+                            Version.V40,
+                            prefix + prefix2 + "[" + repository.getId() + "].url",
+                            null,
+                            "contains an uninterpolated expression.",
+                            repository);
+                }
             }
         }
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -911,6 +911,12 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void profileWithPropertyInRepositoryUrl() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/profile-with-property-in-repository-url.xml");
+        assertViolations(result, 0, 0, 0);
+    }
+
+    @Test
     void profileActivationWithAllowedExpression() throws Exception {
         SimpleProblemCollector result = validateRaw(
                 "raw-model/profile-activation-file-with-allowed-expressions.xml",

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/profile-with-property-in-repository-url.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/profile-with-property-in-repository-url.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.validation</groupId>
+  <artifactId>project</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <profiles>
+    <profile>
+      <id>maven-mirror</id>
+      <activation>
+        <property><name>env.MAVEN_MIRROR_URL</name></property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>maven-mirror</id>
+          <url>${env.MAVEN_MIRROR_URL}</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <id>snapshots-and-staging</id>
+      <properties>
+        <asf.staging>https://repository.apache.org/content/groups/staging/</asf.staging>
+        <asf.snapshots>https://repository.apache.org/content/repositories/snapshots/</asf.snapshots>
+      </properties>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>ASF-Staging</id>
+          <url>${asf.staging}</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>ASF-Snapshots</id>
+          <url>${asf.snapshots}</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
## Summary

Backport of #12047 to maven-4.0.x.

- Skip uninterpolated expression validation for repository URLs and IDs inside profiles during raw model validation
- Profile properties are injected after raw model validation, so expressions like `${asf.staging}` or `${env.MAVEN_MIRROR_URL}` defined in profile properties/activation cannot be resolved at this stage
- Top-level repositories and distribution management repositories continue to be validated

Closes #11920

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_