### PR TITLE
Fix site lifecycle reactor dependency resolution

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -217,11 +218,41 @@ class ReactorReader implements MavenWorkspaceReader {
             if (projectHasOutputFromPreviousSession || projectCompiledDuringThisSession) {
                 return outputDirectory;
             }
+
+            if (hasSiteLifecyclePhase(project) && "jar".equals(artifact.getExtension()) && "jar".equals(type)) {
+                return ensureEmptyArtifactFile(artifact);
+            }
         }
 
         // The fall-through indicates that the artifact cannot be found;
         // for instance if package produced nothing or classifier problems.
         return null;
+    }
+
+    private File ensureEmptyArtifactFile(final Artifact artifact) {
+        Path target = getArtifactPath(artifact);
+        synchronized (this) {
+            if (Files.isRegularFile(target)) {
+                return target.toFile();
+            }
+            try {
+                Files.createDirectories(target.getParent());
+                try (JarOutputStream ignored = new JarOutputStream(Files.newOutputStream(target))) {
+                    // create an empty jar for site reports that inspect reactor artifacts before package
+                }
+                return target.toFile();
+            } catch (IOException e) {
+                LOGGER.warn("Unable to create empty reactor artifact for '{}'.", artifact, e);
+                return null;
+            }
+        }
+    }
+
+    private boolean hasSiteLifecyclePhase(MavenProject project) {
+        return project.hasLifecyclePhase("pre-site")
+                || project.hasLifecyclePhase("site")
+                || project.hasLifecyclePhase("post-site")
+                || project.hasLifecyclePhase("site-deploy");
     }
 
     private boolean isPackagedArtifactUpToDate(MavenProject project, File packagedArtifactFile) {

--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -81,6 +81,8 @@ class ReactorReader implements MavenWorkspaceReader {
     private Map<String, Map<String, Map<String, MavenProject>>> projects;
     private Map<String, Map<String, Map<String, MavenProject>>> allProjects;
     private Path projectLocalRepository;
+    private Path emptyArtifactRepository;
+    private final ConcurrentHashMap<Path, File> emptyArtifactCache = new ConcurrentHashMap<>();
     // projectId -> Deque<lifecycle>
     private final Map<String, Deque<String>> lifecycles = new ConcurrentHashMap<>();
 
@@ -219,7 +221,7 @@ class ReactorReader implements MavenWorkspaceReader {
                 return outputDirectory;
             }
 
-            if (hasSiteLifecyclePhase(project) && "jar".equals(artifact.getExtension()) && "jar".equals(type)) {
+            if (isSiteGoalRequested() && "jar".equals(artifact.getExtension()) && "jar".equals(type)) {
                 return ensureEmptyArtifactFile(artifact);
             }
         }
@@ -230,29 +232,35 @@ class ReactorReader implements MavenWorkspaceReader {
     }
 
     private File ensureEmptyArtifactFile(final Artifact artifact) {
-        Path target = getArtifactPath(artifact);
-        synchronized (this) {
-            if (Files.isRegularFile(target)) {
-                return target.toFile();
+        Path target = getEmptyArtifactPath(artifact);
+        return emptyArtifactCache.computeIfAbsent(target, path -> {
+            if (Files.isRegularFile(path)) {
+                return path.toFile();
             }
             try {
-                Files.createDirectories(target.getParent());
-                try (JarOutputStream ignored = new JarOutputStream(Files.newOutputStream(target))) {
+                Files.createDirectories(path.getParent());
+                try (JarOutputStream ignored = new JarOutputStream(Files.newOutputStream(path))) {
                     // create an empty jar for site reports that inspect reactor artifacts before package
                 }
-                return target.toFile();
+                return path.toFile();
             } catch (IOException e) {
                 LOGGER.warn("Unable to create empty reactor artifact for '{}'.", artifact, e);
                 return null;
             }
-        }
+        });
     }
 
-    private boolean hasSiteLifecyclePhase(MavenProject project) {
-        return project.hasLifecyclePhase("pre-site")
-                || project.hasLifecyclePhase("site")
-                || project.hasLifecyclePhase("post-site")
-                || project.hasLifecyclePhase("site-deploy");
+    private boolean isSiteGoalRequested() {
+        return session.getGoals().stream().anyMatch(ReactorReader::isSiteGoal);
+    }
+
+    private static boolean isSiteGoal(String goal) {
+        return "pre-site".equals(goal)
+                || "site".equals(goal)
+                || "post-site".equals(goal)
+                || "site-deploy".equals(goal)
+                || goal.endsWith(":site")
+                || goal.endsWith(":site-deploy");
     }
 
     private boolean isPackagedArtifactUpToDate(MavenProject project, File packagedArtifactFile) {
@@ -516,12 +524,26 @@ class ReactorReader implements MavenWorkspaceReader {
         String version = artifact.getBaseVersion();
         String classifier = artifact.getClassifier();
         String extension = artifact.getExtension();
-        return getArtifactPath(groupId, artifactId, version, classifier, extension);
+        return getArtifactPath(getProjectLocalRepo(), groupId, artifactId, version, classifier, extension);
     }
 
     private Path getArtifactPath(
             String groupId, String artifactId, String version, String classifier, String extension) {
-        Path repo = getProjectLocalRepo();
+        return getArtifactPath(getProjectLocalRepo(), groupId, artifactId, version, classifier, extension);
+    }
+
+    private Path getEmptyArtifactPath(Artifact artifact) {
+        return getArtifactPath(
+                getEmptyArtifactRepo(),
+                artifact.getGroupId(),
+                artifact.getArtifactId(),
+                artifact.getBaseVersion(),
+                artifact.getClassifier(),
+                artifact.getExtension());
+    }
+
+    private Path getArtifactPath(
+            Path repo, String groupId, String artifactId, String version, String classifier, String extension) {
         return repo.resolve(groupId)
                 .resolve(artifactId)
                 .resolve(version)
@@ -531,6 +553,13 @@ class ReactorReader implements MavenWorkspaceReader {
                         + (classifier != null && !classifier.isEmpty() ? "-" + classifier : "")
                         + '.'
                         + extension);
+    }
+
+    private Path getEmptyArtifactRepo() {
+        if (emptyArtifactRepository == null) {
+            emptyArtifactRepository = getProjectLocalRepo().resolveSibling("reactor-empty-artifacts");
+        }
+        return emptyArtifactRepository;
     }
 
     private Path getProjectLocalRepo() {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12064SiteReactorDependenciesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12064SiteReactorDependenciesTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/12064">GH-12064</a>.
+ */
+class MavenITgh12064SiteReactorDependenciesTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void testSiteLifecycleResolvesReactorDependencies() throws Exception {
+        File testDir = extractResources("/gh-12064-site-reactor-dependencies");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("producer/target");
+        verifier.deleteDirectory("consumer/target");
+        verifier.deleteArtifacts("org.apache.maven.its.gh12064");
+        verifier.addCliArgument("site");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        verifier.verifyFilePresent("consumer/target/site/dependencies.html");
+        assertFalse(new File(testDir, "producer/target/classes").exists(), "site must not require compile first");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12064SiteReactorDependenciesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12064SiteReactorDependenciesTest.java
@@ -44,5 +44,12 @@ class MavenITgh12064SiteReactorDependenciesTest extends AbstractMavenIntegration
 
         verifier.verifyFilePresent("consumer/target/site/dependencies.html");
         assertFalse(new File(testDir, "producer/target/classes").exists(), "site must not require compile first");
+        assertFalse(
+                new File(
+                                testDir,
+                                "target/project-local-repo/org.apache.maven.its.gh12064/producer/1.0-SNAPSHOT/"
+                                        + "producer-1.0-SNAPSHOT.jar")
+                        .exists(),
+                "site must not leave synthetic artifacts in the project-local-repo");
     }
 }

--- a/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/consumer/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/consumer/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12064</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>consumer</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.gh12064</groupId>
+      <artifactId>producer</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/consumer/src/main/java/org/apache/maven/its/gh12064/Consumer.java
+++ b/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/consumer/src/main/java/org/apache/maven/its/gh12064/Consumer.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.gh12064;
+
+public class Consumer {
+    public String message() {
+        return Producer.message();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.gh12064</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>producer</module>
+    <module>consumer</module>
+  </modules>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/producer/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/producer/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12064</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>producer</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/producer/src/main/java/org/apache/maven/its/gh12064/Producer.java
+++ b/its/core-it-suite/src/test/resources/gh-12064-site-reactor-dependencies/producer/src/main/java/org/apache/maven/its/gh12064/Producer.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.gh12064;
+
+public class Producer {
+    public static String message() {
+        return "producer";
+    }
+}


### PR DESCRIPTION
Fixes #12064

This updates Maven's reactor workspace resolution for site lifecycle builds so reports can resolve reactor JAR dependencies even when the producer module has not been compiled or packaged first.

The change keeps compile/default lifecycle behavior unchanged and adds an integration test covering a multi-module site build where a consumer module depends on a producer module. The test verifies that mvn site succeeds without running compile explicitly and without producing producer/target/classes.

This should be a candidate for backport to maven-3.10.x.