### PR TITLE
[maven-4.0.x] Filter transitive repositories with uninterpolated IDs (#12049)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -541,7 +541,9 @@ public class DefaultModelBuilder implements ModelBuilder {
                     // filter out transitive invalid repositories
                     // this should be safe because invalid repo coming from build POMs
                     // have been rejected earlier during validation
-                    .filter(repo -> repo.getUrl() != null && !repo.getUrl().contains("${"))
+                    .filter(repo -> repo.getUrl() != null
+                            && !repo.getUrl().contains("${")
+                            && (repo.getId() == null || !repo.getId().contains("${")))
                     .map(session::createRemoteRepository)
                     .toList();
             if (replace) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -107,12 +107,16 @@ class DefaultModelBuilderTest {
                         Repository.newBuilder()
                                 .id("third")
                                 .url("${thirdParentRepo}")
+                                .build(),
+                        Repository.newBuilder()
+                                .id("${uninterpolatedRepoId}")
+                                .url("https://valid.url")
                                 .build()))
                 .build();
 
         state.mergeRepositories(model, false);
 
-        // after merge
+        // after merge: "second" filtered (uninterpolated URL), "${uninterpolatedRepoId}" filtered (uninterpolated ID)
         repositories = (List<RemoteRepository>) repositoriesField.get(state);
         assertEquals(3, repositories.size());
         assertEquals("first", repositories.get(0).getId());


### PR DESCRIPTION
## Summary

Backport of #12050 to `maven-4.0.x`.

- Extend the transitive repository filter in `mergeRepositories` to also exclude repositories whose ID contains uninterpolated expressions (`${...}`), not just URLs
- Add test coverage for repositories with uninterpolated IDs but valid URLs

Fixes #12049

_Claude Code on behalf of Guillaume Nodet_