### PR TITLE
[maven-4.0.x] Upgrade plugin dependencies (extra-enforcer-rules) in mvnup

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
@@ -99,6 +100,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     "maven-remote-resources-plugin",
                     "3.0.0",
                     MAVEN_4_COMPATIBILITY_REASON));
+
+    private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
+            "org.codehaus.mojo",
+            "extra-enforcer-rules",
+            "1.4",
+            "Versions before 1.4 use a removed DependencyGraphBuilder API incompatible with Maven 4"));
 
     private Session session;
 
@@ -281,6 +288,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     }
                 }
             }
+
+            hasUpgrades |= upgradePluginDependencies(pluginElement, namespace, pomDocument, sectionName, context);
         }
 
         return hasUpgrades;
@@ -371,6 +380,57 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         }
 
         return false;
+    }
+
+    /**
+     * Upgrades plugin dependencies (e.g., extra-enforcer-rules inside maven-enforcer-plugin).
+     */
+    private boolean upgradePluginDependencies(
+            Element pluginElement,
+            Namespace namespace,
+            Document pomDocument,
+            String sectionName,
+            UpgradeContext context) {
+        Element dependenciesElement = pluginElement.getChild("dependencies", namespace);
+        if (dependenciesElement == null) {
+            return false;
+        }
+
+        Map<String, PluginUpgradeInfo> depUpgrades = getPluginDependencyUpgradesMap();
+        boolean hasUpgrades = false;
+
+        List<Element> depElements = dependenciesElement.getChildren("dependency", namespace);
+        for (Element depElement : depElements) {
+            String groupId = getChildText(depElement, GROUP_ID, namespace);
+            String artifactId = getChildText(depElement, ARTIFACT_ID, namespace);
+
+            if (groupId != null && artifactId != null) {
+                String depKey = groupId + ":" + artifactId;
+                PluginUpgradeInfo upgrade = depUpgrades.get(depKey);
+
+                if (upgrade != null) {
+                    if (upgradePluginVersion(
+                            depElement,
+                            namespace,
+                            upgrade,
+                            pomDocument,
+                            sectionName + "/plugin/dependencies",
+                            context)) {
+                        hasUpgrades = true;
+                    }
+                }
+            }
+        }
+
+        return hasUpgrades;
+    }
+
+    private Map<String, PluginUpgradeInfo> getPluginDependencyUpgradesMap() {
+        return PLUGIN_DEPENDENCY_UPGRADES.stream()
+                .collect(Collectors.toMap(
+                        upgrade -> upgrade.groupId() + ":" + upgrade.artifactId(),
+                        upgrade ->
+                                new PluginUpgradeInfo(upgrade.groupId(), upgrade.artifactId(), upgrade.minVersion())));
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -429,6 +429,93 @@ class PluginUpgradeStrategyTest {
     }
 
     @Nested
+    @DisplayName("Plugin Dependency Upgrades")
+    class PluginDependencyUpgradeTests {
+
+        @Test
+        @DisplayName("should upgrade extra-enforcer-rules dependency when below minimum")
+        void shouldUpgradeExtraEnforcerRulesDependency() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.5.0</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>extra-enforcer-rules</artifactId>
+                                        <version>1.0-beta-4</version>
+                                    </dependency>
+                                </dependencies>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = saxBuilder.build(new StringReader(pomXml));
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Plugin dependency upgrade should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have upgraded extra-enforcer-rules");
+
+            String xml = new XMLOutputter().outputString(document);
+            assertTrue(xml.contains("<version>1.4</version>"), "extra-enforcer-rules should be upgraded to 1.4");
+            assertFalse(xml.contains("1.0-beta-4"), "Old version should be gone");
+        }
+
+        @Test
+        @DisplayName("should not upgrade extra-enforcer-rules when version is already sufficient")
+        void shouldNotUpgradeExtraEnforcerRulesWhenSufficient() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.5.0</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>extra-enforcer-rules</artifactId>
+                                        <version>1.8.0</version>
+                                    </dependency>
+                                </dependencies>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = saxBuilder.build(new StringReader(pomXml));
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            strategy.doApply(context, pomMap);
+
+            String xml = new XMLOutputter().outputString(document);
+            assertTrue(xml.contains("1.8.0"), "Version 1.8.0 should be preserved");
+        }
+    }
+
+    @Nested
     @DisplayName("Plugin Management")
     class PluginManagementTests {
 


### PR DESCRIPTION
Backport of #12051 to `maven-4.0.x`.

## Summary

Adds support for upgrading plugin dependencies in `mvnup`, specifically `org.codehaus.mojo:extra-enforcer-rules` to minimum version 1.4 for Maven 4 compatibility.

## Problem

`extra-enforcer-rules` versions before 1.4 use `DependencyGraphBuilder.buildDependencyGraph(MavenProject, ArtifactFilter)` — a method removed in Maven 4. This causes `NoSuchMethodError` at runtime when rules like `BanCircularDependencies` are executed.

Found during maven4-testing across ~960 Apache repositories (e.g., rocketmq uses `extra-enforcer-rules:1.0-beta-4`).

## Changes

- `PluginUpgradeStrategy`: Added `PLUGIN_DEPENDENCY_UPGRADES` list and `upgradePluginDependencies()` method
- Added 2 tests for plugin dependency upgrades

_Claude Code on behalf of Guillaume Nodet_