### PR TITLE
[maven-4.0.x] Use maven-api Version for mvnup plugin version comparison

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -381,33 +381,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         if (currentVersion == null || minVersion == null) {
             return false;
         }
-
-        // Remove any qualifiers like -SNAPSHOT, -alpha, etc. for comparison
-        String cleanCurrent = currentVersion.split("-")[0];
-        String cleanMin = minVersion.split("-")[0];
-
-        try {
-            String[] currentParts = cleanCurrent.split("\\.");
-            String[] minParts = cleanMin.split("\\.");
-
-            int maxLength = Math.max(currentParts.length, minParts.length);
-
-            for (int i = 0; i < maxLength; i++) {
-                int currentPart = i < currentParts.length ? Integer.parseInt(currentParts[i]) : 0;
-                int minPart = i < minParts.length ? Integer.parseInt(minParts[i]) : 0;
-
-                if (currentPart < minPart) {
-                    return true;
-                } else if (currentPart > minPart) {
-                    return false;
-                }
-            }
-
-            return false; // Versions are equal
-        } catch (NumberFormatException e) {
-            // Fallback to string comparison if parsing fails
-            return currentVersion.compareTo(minVersion) < 0;
-        }
+        return getSession().parseVersion(currentVersion).compareTo(getSession().parseVersion(minVersion)) < 0;
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -196,6 +196,46 @@ class PluginUpgradeStrategyTest {
         }
 
         @Test
+        @DisplayName("should upgrade milestone version below release minimum")
+        void shouldUpgradeMilestoneVersionBelowRelease() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.0.0-M1</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = saxBuilder.build(new StringReader(pomXml));
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.apply(context, pomMap);
+
+            assertTrue(result.success(), "Plugin upgrade should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have upgraded 3.0.0-M1 to 3.0.0");
+
+            Element root = document.getRootElement();
+            Namespace namespace = root.getNamespace();
+            Element build = root.getChild("build", namespace);
+            Element plugins = build.getChild("plugins", namespace);
+            Element plugin = plugins.getChild("plugin", namespace);
+            String version = plugin.getChildText("version", namespace);
+            assertEquals("3.0.0", version, "3.0.0-M1 should be upgraded to 3.0.0");
+        }
+
+        @Test
         @DisplayName("should upgrade plugin in pluginManagement")
         void shouldUpgradePluginInPluginManagement() throws Exception {
             String pomXml = """


### PR DESCRIPTION
## Summary

Backport of #12072 to `maven-4.0.x`.

Replace the hand-rolled version comparison in `PluginUpgradeStrategy.isVersionBelow()` with `Session.parseVersion()` from maven-api, which correctly handles milestone/pre-release qualifiers.

## Problem

The previous implementation stripped qualifiers before comparison:
```java
String cleanCurrent = currentVersion.split("-")[0]; // "3.0.0-M1" → "3.0.0"
```

This caused `isVersionBelow("3.0.0-M1", "3.0.0")` to return `false` — mvnup thought `3.0.0-M1` was already sufficient when it's actually a pre-release below `3.0.0`.

This affected 19 projects in maven4-testing (16 flink-connectors + 3 sling projects) using `maven-enforcer-plugin:3.0.0-M1`, which is incompatible with Maven 4.

## Fix

Use `Session.parseVersion()` from maven-api which returns a `Comparable<Version>` that correctly handles all version qualifier semantics:
- `3.0.0-M1 < 3.0.0` ✓
- `3.0.0-alpha-1 < 3.0.0` ✓
- `3.0.0-RC1 < 3.0.0` ✓
- `3.0.0-SNAPSHOT < 3.0.0` ✓

## Test plan

- [x] All existing tests pass (22/22)
- [x] New test: `shouldUpgradeMilestoneVersionBelowRelease` — verifies `3.0.0-M1` is upgraded to `3.0.0`

_Claude Code on behalf of Guillaume Nodet_