### PR TITLE
Filter transitive dependencies with uninterpolated expressions

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
@@ -350,12 +350,20 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         }
 
         for (org.apache.maven.api.model.Dependency dependency : model.getDependencies()) {
+            if (hasUninterpolatedExpression(dependency)) {
+                logger.debug("Filtered dependency with uninterpolated expression: {}", dependency);
+                continue;
+            }
             result.addDependency(convert(dependency, stereotypes));
         }
 
         DependencyManagement dependencyManagement = model.getDependencyManagement();
         if (dependencyManagement != null) {
             for (org.apache.maven.api.model.Dependency dependency : dependencyManagement.getDependencies()) {
+                if (hasUninterpolatedExpression(dependency)) {
+                    logger.debug("Filtered managed dependency with uninterpolated expression: {}", dependency);
+                    continue;
+                }
                 result.addManagedDependency(convert(dependency, stereotypes));
             }
         }
@@ -420,6 +428,16 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
 
     private Exclusion convert(org.apache.maven.api.model.Exclusion exclusion) {
         return new Exclusion(exclusion.getGroupId(), exclusion.getArtifactId(), "*", "*");
+    }
+
+    private static boolean hasUninterpolatedExpression(org.apache.maven.api.model.Dependency dependency) {
+        return containsPlaceholder(dependency.getGroupId())
+                || containsPlaceholder(dependency.getArtifactId())
+                || containsPlaceholder(dependency.getVersion());
+    }
+
+    private static boolean containsPlaceholder(String value) {
+        return value != null && value.contains("${");
     }
 
     private void setArtifactProperties(ArtifactDescriptorResult result, Model model) {


### PR DESCRIPTION
## Summary

- Filter out transitive dependencies and managed dependencies with uninterpolated `${...}` expressions in `DefaultArtifactDescriptorReader.populateResult()` before they reach the resolver/validator
- Follows the same pattern used for transitive repositories with uninterpolated IDs/URLs (commit 9332ad3d55, PR #12050)
- Fixes builds that fail with `IllegalArgumentException: Not fully interpolated dependency` when a transitive POM contains dependencies with undefined property expressions (e.g., `org.osgi:osgi.core:jar:${osgi.version}`)

## Context

Maven 4's `MavenValidator.validateDependency()` rejects dependencies with uninterpolated property expressions. This is correct for the project's own POMs (caught during model validation), but transitive dependency POMs from Maven Central may contain managed dependencies with expressions that are not resolvable outside their original build context. These should be silently filtered rather than causing a build failure.

This is the resolver-side complement to #12083 (mvnup fix for project-local POMs with undefined property expressions).

## Test plan

- [x] `mvn test -B -pl impl/maven-impl` — 462 tests pass
- [x] `mvn test -B -pl compat/maven-resolver-provider` — 27 tests pass
- [ ] Verify with causeway-app-simpleapp (transitive `org.osgi:osgi.core:jar:${osgi.version}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)