### PR TITLE
Fix #12086: filter transitive repos and deps with uninterpolated expressions

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
@@ -121,6 +121,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         Model model = loadPom(session, request, result);
         if (model != null) {
             populateResult(InternalSession.from(session), result, model);
+            filterUninterpolated(result);
         }
 
         return result;
@@ -434,6 +435,36 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         return containsPlaceholder(dependency.getGroupId())
                 || containsPlaceholder(dependency.getArtifactId())
                 || containsPlaceholder(dependency.getVersion());
+    }
+
+    private void filterUninterpolated(ArtifactDescriptorResult result) {
+        result.getRepositories().removeIf(repo -> {
+            if (containsPlaceholder(repo.getId()) || containsPlaceholder(repo.getUrl())) {
+                logger.debug("Filtered repository with uninterpolated expression: {}", repo);
+                return true;
+            }
+            return false;
+        });
+        result.getDependencies().removeIf(dep -> {
+            if (hasUninterpolatedExpression(dep.getArtifact())) {
+                logger.debug("Filtered dependency with uninterpolated expression: {}", dep);
+                return true;
+            }
+            return false;
+        });
+        result.getManagedDependencies().removeIf(dep -> {
+            if (hasUninterpolatedExpression(dep.getArtifact())) {
+                logger.debug("Filtered managed dependency with uninterpolated expression: {}", dep);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private static boolean hasUninterpolatedExpression(Artifact artifact) {
+        return containsPlaceholder(artifact.getGroupId())
+                || containsPlaceholder(artifact.getArtifactId())
+                || containsPlaceholder(artifact.getVersion());
     }
 
     private static boolean containsPlaceholder(String value) {


### PR DESCRIPTION
## Summary

- Filter out repositories with uninterpolated IDs or URLs from `ArtifactDescriptorResult` after `populateResult()` in `DefaultArtifactDescriptorReader`
- Also filter dependencies and managed dependencies with uninterpolated groupId/artifactId/version
- Defense-in-depth on top of the `mergeRepositories` filter in `DefaultModelBuilder` (PR #12050), catching entries that reach the artifact descriptor reader through any code path

Fixes #12086

## Test plan

- [x] `mvn test` passes in `impl/maven-impl`
- [x] `mvn test` passes in `compat/maven-resolver-provider`
- [ ] Verify with `apache/opennlp-sandbox` build (the reproducer from the issue)