### PR TITLE
[maven-4.0.x] Backport bug fixes from master to maven-4.0.x

### DIFF
--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -355,6 +355,10 @@ class DefaultModelValidatorTest {
         assertViolations(result, 0, 0, 2);
 
         assertTrue(result.getWarnings().get(0).contains("test:f"));
+        // Check that the import scope error message is more helpful
+        assertTrue(result.getWarnings()
+                .get(0)
+                .contains("has scope 'import'. The 'import' scope is only valid in <dependencyManagement> sections"));
 
         assertTrue(result.getWarnings().get(1).contains("test:g"));
     }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
@@ -66,4 +66,17 @@ class ModelTest {
     void testToStringNullSafe() {
         assertNotNull(new Model().toString());
     }
+
+    @Test
+    void testPropertiesClear() {
+        // Test for issue #11552: NullPointerException when clearing properties
+        Model model = new Model();
+        model.addProperty("key1", "value1");
+        model.addProperty("key2", "value2");
+        assertEquals(2, model.getProperties().size());
+
+        // This should not throw NullPointerException
+        model.getProperties().clear();
+        assertEquals(0, model.getProperties().size());
+    }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -46,7 +46,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.maven.ProjectCycleException;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.api.ArtifactCoordinates;
 import org.apache.maven.api.Language;
@@ -504,10 +503,14 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                         .findAny()
                         .orElse(null);
                 if (cycle != null) {
-                    throw new RuntimeException(new ProjectCycleException(
+                    final CycleDetectedException cde = (CycleDetectedException) cycle.getException();
+                    throw new ProjectBuildingException(
+                            null,
                             "The projects in the reactor contain a cyclic reference: " + cycle.getMessage(),
-                            (CycleDetectedException) cycle.getException()));
+                            null,
+                            cde);
                 }
+
                 throw new ProjectBuildingException(results);
             }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
@@ -21,6 +21,8 @@ package org.apache.maven.project;
 import java.io.File;
 import java.util.List;
 
+import org.apache.maven.model.building.ModelProblem;
+
 /**
  */
 public class ProjectBuildingException extends Exception {
@@ -59,7 +61,7 @@ public class ProjectBuildingException extends Exception {
     }
 
     public ProjectBuildingException(List<ProjectBuildingResult> results) {
-        super("Some problems were encountered while processing the POMs");
+        super(createMessage(results));
         this.projectId = "";
         this.results = results;
     }
@@ -95,6 +97,86 @@ public class ProjectBuildingException extends Exception {
         if (pomFile != null) {
             buffer.append(" at ").append(pomFile.getAbsolutePath());
         }
+        return buffer.toString();
+    }
+
+    private static String createMessage(List<ProjectBuildingResult> results) {
+        if (results == null || results.isEmpty()) {
+            return "Some problems were encountered while processing the POMs";
+        }
+
+        long totalProblems = 0;
+        long errorProblems = 0;
+
+        for (ProjectBuildingResult result : results) {
+            List<ModelProblem> problems = result.getProblems();
+            totalProblems += problems.size();
+
+            for (ModelProblem problem : problems) {
+                if (problem.getSeverity() != ModelProblem.Severity.WARNING) {
+                    errorProblems++;
+                }
+            }
+        }
+
+        StringBuilder buffer = new StringBuilder(1024);
+        buffer.append(totalProblems);
+        buffer.append(totalProblems == 1 ? " problem was " : " problems were ");
+        buffer.append("encountered while processing the POMs");
+
+        if (errorProblems > 0) {
+            buffer.append(" (")
+                    .append(errorProblems)
+                    .append(" ")
+                    .append(errorProblems > 1 ? "errors" : "error")
+                    .append(")");
+        }
+
+        buffer.append(":\n");
+
+        for (ProjectBuildingResult result : results) {
+            if (!result.getProblems().isEmpty()) {
+                String projectInfo = result.getProjectId();
+                if (projectInfo.trim().isEmpty()) {
+                    projectInfo =
+                            result.getPomFile() != null ? result.getPomFile().getName() : "unknown project";
+                }
+
+                buffer.append("\n[").append(projectInfo).append("]\n");
+
+                for (ModelProblem problem : result.getProblems()) {
+                    if (errorProblems > 0 && problem.getSeverity() == ModelProblem.Severity.WARNING) {
+                        continue;
+                    }
+
+                    buffer.append("  [").append(problem.getSeverity()).append("] ");
+                    buffer.append(problem.getMessage());
+
+                    String location = "";
+                    if (!problem.getSource().trim().isEmpty()) {
+                        location = problem.getSource();
+                    }
+                    if (problem.getLineNumber() > 0) {
+                        if (!location.isEmpty()) {
+                            location += ", ";
+                        }
+                        location += "line " + problem.getLineNumber();
+                    }
+                    if (problem.getColumnNumber() > 0) {
+                        if (!location.isEmpty()) {
+                            location += ", ";
+                        }
+                        location += "column " + problem.getColumnNumber();
+                    }
+
+                    if (!location.isEmpty()) {
+                        buffer.append(" @ ").append(location);
+                    }
+                    buffer.append("\n");
+                }
+            }
+        }
+
         return buffer.toString();
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuildingExceptionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuildingExceptionTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.project;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.model.building.DefaultModelProblem;
+import org.apache.maven.model.building.ModelProblem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for {@link ProjectBuildingException} message generation.
+ */
+@SuppressWarnings("deprecation")
+class ProjectBuildingExceptionTest {
+
+    @Test
+    void testDetailedExceptionMessageWithMultipleProblems() {
+        List<ProjectBuildingResult> results = new ArrayList<>();
+
+        List<ModelProblem> problems1 = new ArrayList<>();
+        Collections.addAll(
+                problems1,
+                new DefaultModelProblem(
+                        "Missing required dependency",
+                        ModelProblem.Severity.ERROR,
+                        null,
+                        "pom.xml",
+                        25,
+                        10,
+                        null,
+                        null),
+                new DefaultModelProblem(
+                        "Invalid version format", ModelProblem.Severity.ERROR, null, "pom.xml", 30, 5, null, null));
+        DefaultProjectBuildingResult result1 =
+                new DefaultProjectBuildingResult("com.example:project1:1.0", new File("project1/pom.xml"), problems1);
+        results.add(result1);
+
+        List<ModelProblem> problems2 = new ArrayList<>();
+        Collections.addAll(
+                problems2,
+                new DefaultModelProblem(
+                        "Deprecated plugin usage", ModelProblem.Severity.WARNING, null, "pom.xml", 15, 3, null, null));
+        DefaultProjectBuildingResult result2 =
+                new DefaultProjectBuildingResult("com.example:project2:1.0", new File("project2/pom.xml"), problems2);
+        results.add(result2);
+
+        ProjectBuildingException exception = new ProjectBuildingException(results);
+        String message = exception.getMessage();
+
+        assertTrue(
+                message.contains("3 problems were encountered while processing the POMs (2 errors)"),
+                "Message should contain problem count and error count");
+
+        assertTrue(message.contains("[com.example:project1:1.0]"), "Message should contain project1 identifier");
+
+        assertTrue(message.contains("[com.example:project2:1.0]"), "Message should contain project2 identifier");
+
+        assertTrue(
+                message.contains("[ERROR] Missing required dependency @ pom.xml, line 25, column 10"),
+                "Message should contain error details with location");
+
+        assertTrue(
+                message.contains("[ERROR] Invalid version format @ pom.xml, line 30, column 5"),
+                "Message should contain second error details");
+
+        assertTrue(
+                !message.contains("[WARNING]") || message.contains("[WARNING] Deprecated plugin usage"),
+                "Warnings should be filtered when errors are present or shown if explicitly included");
+    }
+
+    @Test
+    void testExceptionMessageWithOnlyWarnings() {
+        List<ProjectBuildingResult> results = new ArrayList<>();
+
+        List<ModelProblem> problems = new ArrayList<>();
+        Collections.addAll(
+                problems,
+                new DefaultModelProblem(
+                        "Deprecated feature used", ModelProblem.Severity.WARNING, null, "pom.xml", 10, 1, null, null));
+        DefaultProjectBuildingResult result =
+                new DefaultProjectBuildingResult("com.example:project:1.0", new File("project/pom.xml"), problems);
+        results.add(result);
+
+        ProjectBuildingException exception = new ProjectBuildingException(results);
+        String message = exception.getMessage();
+
+        assertTrue(
+                message.contains("1 problem was encountered while processing the POMs"),
+                "Message should use singular form for single problem");
+
+        assertTrue(
+                message.contains("[WARNING] Deprecated feature used"),
+                "Message should contain warning when no errors are present");
+
+        assertTrue(
+                !message.contains("(") || !message.contains("error"),
+                "Message should not contain error count when there are no errors");
+    }
+
+    @Test
+    void testExceptionMessageWithEmptyResults() {
+        List<ProjectBuildingResult> results = Collections.emptyList();
+
+        ProjectBuildingException exception = new ProjectBuildingException(results);
+        String message = exception.getMessage();
+
+        assertEquals(
+                "Some problems were encountered while processing the POMs",
+                message,
+                "Empty results should fall back to generic message");
+    }
+
+    @Test
+    void testExceptionMessageWithNullResults() {
+        ProjectBuildingException exception = new ProjectBuildingException((List<ProjectBuildingResult>) null);
+        String message = exception.getMessage();
+
+        assertEquals(
+                "Some problems were encountered while processing the POMs",
+                message,
+                "Null results should fall back to generic message");
+    }
+
+    @Test
+    void testExceptionMessageWithUnknownProject() {
+        List<ProjectBuildingResult> results = new ArrayList<>();
+
+        List<ModelProblem> problems = new ArrayList<>();
+        Collections.addAll(
+                problems,
+                new DefaultModelProblem("Some error", ModelProblem.Severity.ERROR, null, "unknown", 1, 1, null, null));
+        DefaultProjectBuildingResult result = new DefaultProjectBuildingResult(null, null, problems);
+        results.add(result);
+
+        ProjectBuildingException exception = new ProjectBuildingException(results);
+        String message = exception.getMessage();
+
+        assertTrue(message.contains("[unknown project]"), "Message should handle unknown project gracefully");
+    }
+}

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -372,7 +372,7 @@ public class DefaultModelValidator implements ModelValidator {
         } else if (validationLevel >= ModelValidator.VALIDATION_LEVEL_MAVEN_2_0) {
             validateStringNotEmpty("modelVersion", problems, Severity.ERROR, Version.V20, m.getModelVersion(), m);
 
-            validateModelVersion(problems, m.getModelVersion(), m, ModelBuilder.KNOWN_MODEL_VERSIONS);
+            validateModelVersion(s, problems, m.getModelVersion(), m, ModelBuilder.KNOWN_MODEL_VERSIONS);
 
             Set<String> modules = new HashSet<>();
             for (int i = 0, n = m.getModules().size(); i < n; i++) {
@@ -2025,19 +2025,23 @@ public class DefaultModelValidator implements ModelValidator {
 
     @SuppressWarnings("checkstyle:parameternumber")
     private boolean validateModelVersion(
-            ModelProblemCollector problems, String string, InputLocationTracker tracker, List<String> validVersions) {
-        if (string == null || string.isEmpty()) {
+            Session session,
+            ModelProblemCollector problems,
+            String requestedModel,
+            InputLocationTracker tracker,
+            List<String> validVersions) {
+        if (requestedModel == null || requestedModel.isEmpty()) {
             return true;
         }
 
-        if (validVersions.contains(string)) {
+        if (validVersions.contains(requestedModel)) {
             return true;
         }
 
         boolean newerThanAll = true;
         boolean olderThanAll = true;
         for (String validValue : validVersions) {
-            final int comparison = compareModelVersions(validValue, string);
+            final int comparison = compareModelVersions(validValue, requestedModel);
             newerThanAll = newerThanAll && comparison < 0;
             olderThanAll = olderThanAll && comparison > 0;
         }
@@ -2049,8 +2053,10 @@ public class DefaultModelValidator implements ModelValidator {
                     Version.V20,
                     "modelVersion",
                     null,
-                    "of '" + string + "' is newer than the versions supported by this version of Maven: "
-                            + validVersions + ". Building this project requires a newer version of Maven.",
+                    "of '" + requestedModel + "' is newer than the versions supported by this Maven version ("
+                            + getMavenVersionString(session)
+                            + "). Supported modelVersions are: " + validVersions
+                            + ". Building this project requires a newer version of Maven.",
                     tracker);
 
         } else if (olderThanAll) {
@@ -2061,8 +2067,10 @@ public class DefaultModelValidator implements ModelValidator {
                     Version.V20,
                     "modelVersion",
                     null,
-                    "of '" + string + "' is older than the versions supported by this version of Maven: "
-                            + validVersions + ". Building this project requires an older version of Maven.",
+                    "of '" + requestedModel + "' is older than the versions supported by this Maven version ("
+                            + getMavenVersionString(session)
+                            + "). Supported modelVersions are: " + validVersions
+                            + ". Building this project requires an older version of Maven.",
                     tracker);
 
         } else {
@@ -2072,11 +2080,20 @@ public class DefaultModelValidator implements ModelValidator {
                     Version.V20,
                     "modelVersion",
                     null,
-                    "must be one of " + validVersions + " but is '" + string + "'.",
+                    "must be one of " + validVersions + " but is '" + requestedModel + "'.",
                     tracker);
         }
 
         return false;
+    }
+
+    private String getMavenVersionString(Session session) {
+        try {
+            return session.getMavenVersion().toString();
+        } catch (Exception e) {
+            // Fallback for test contexts where RuntimeInformation might not be available
+            return "unknown";
+        }
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1238,12 +1238,12 @@ public class DefaultModelValidator implements ModelValidator {
                             d);
 
                     /*
-                     * TODO Extensions like Flex Mojos use custom scopes like "merged", "internal", "external", etc. In
-                     * order to don't break backward-compat with those, only warn but don't error out.
+                     * Extensions like Flex Mojos use custom scopes like "merged", "internal", "external", etc. In
+                     * order to not break backward-compat with those, only warn but don't error out.
                      */
                     ScopeManager scopeManager =
                             InternalSession.from(s).getSession().getScopeManager();
-                    validateEnum(
+                    validateDependencyScope(
                             prefix,
                             "scope",
                             problems,
@@ -1255,7 +1255,8 @@ public class DefaultModelValidator implements ModelValidator {
                             scopeManager.getDependencyScopeUniverse().stream()
                                     .map(DependencyScope::getId)
                                     .distinct()
-                                    .toArray(String[]::new));
+                                    .toArray(String[]::new),
+                            false);
 
                     validateEffectiveModelAgainstDependency(prefix, problems, m, d);
                 } else {
@@ -1265,7 +1266,7 @@ public class DefaultModelValidator implements ModelValidator {
                             .map(DependencyScope::getId)
                             .collect(Collectors.toCollection(HashSet::new));
                     scopes.add("import");
-                    validateEnum(
+                    validateDependencyScope(
                             prefix,
                             "scope",
                             problems,
@@ -1274,7 +1275,8 @@ public class DefaultModelValidator implements ModelValidator {
                             d.getScope(),
                             SourceHint.dependencyManagementKey(d),
                             d,
-                            scopes.toArray(new String[0]));
+                            scopes.toArray(new String[0]),
+                            true);
                 }
             }
         }
@@ -2019,6 +2021,52 @@ public class DefaultModelValidator implements ModelValidator {
                 sourceHint,
                 "must be one of " + values + " but is '" + string + "'.",
                 tracker);
+
+        return false;
+    }
+
+    @SuppressWarnings("checkstyle:parameternumber")
+    private boolean validateDependencyScope(
+            String prefix,
+            String fieldName,
+            ModelProblemCollector problems,
+            Severity severity,
+            Version version,
+            String scope,
+            @Nullable SourceHint sourceHint,
+            InputLocationTracker tracker,
+            String[] validScopes,
+            boolean isDependencyManagement) {
+        if (scope == null || scope.isEmpty()) {
+            return true;
+        }
+
+        List<String> values = Arrays.asList(validScopes);
+
+        if (values.contains(scope)) {
+            return true;
+        }
+
+        // Provide a more helpful error message for the 'import' scope
+        if ("import".equals(scope) && !isDependencyManagement) {
+            addViolation(
+                    problems,
+                    severity,
+                    version,
+                    prefix + fieldName,
+                    sourceHint,
+                    "has scope 'import'. The 'import' scope is only valid in <dependencyManagement> sections.",
+                    tracker);
+        } else {
+            addViolation(
+                    problems,
+                    severity,
+                    version,
+                    prefix + fieldName,
+                    sourceHint,
+                    "must be one of " + values + " but is '" + scope + "'.",
+                    tracker);
+        }
 
         return false;
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -412,6 +412,10 @@ class DefaultModelValidatorTest {
         assertViolations(result, 0, 0, 2);
 
         assertTrue(result.getWarnings().get(0).contains("groupId='test', artifactId='f'"));
+        // Check that the import scope error message is more helpful
+        assertTrue(result.getWarnings()
+                .get(0)
+                .contains("has scope 'import'. The 'import' scope is only valid in <dependencyManagement> sections"));
 
         assertTrue(result.getWarnings().get(1).contains("groupId='test', artifactId='g'"));
     }

--- a/src/mdo/java/WrapperProperties.java
+++ b/src/mdo/java/WrapperProperties.java
@@ -379,6 +379,12 @@ class WrapperProperties extends Properties {
         }
 
         @Override
+        public synchronized void clear() {
+            keyOrder.clear();
+            super.clear();
+        }
+
+        @Override
         public synchronized void forEach(BiConsumer<? super Object, ? super Object> action) {
             entrySet().forEach(e -> action.accept(e.getKey(), e.getValue()));
         }

--- a/src/mdo/model-v3.vm
+++ b/src/mdo/model-v3.vm
@@ -204,7 +204,11 @@ public class ${class.name}
         }
       #elseif( $field.type == "java.util.Properties" )
         LinkedHashMap<String, String> map = new LinkedHashMap<>();
-        ${field.name}.forEach((key, value) -> map.put(key.toString(), value.toString()));
+        ${field.name}.forEach((key, value) -> {
+            if (value != null) {
+                map.put(key.toString(), value.toString());
+            }
+        });
         if (!Objects.equals(map, getDelegate().get${cap}())) {
             update(getDelegate().with${cap}(map));
         }


### PR DESCRIPTION
## Summary

Backport 5 bug fixes from master that are applicable to the maven-4.0.x branch:

1. **Add Maven version to error message when rejecting model versions** (#10921) — helps users understand which Maven version they need when a model version is rejected.
2. **Improve ProjectBuildingException error messages with detailed problem reporting** (#10975) — clearer error messages with detailed problem information.
3. **Improve dependency scope validation error messages for import scope** (#10991) — better error messages when import scope is misused, distinguishing between dependency and dependency management contexts.
4. **Throw ProjectBuildingException for reactor cycles** (#11091, fixes #10950) — wraps `CycleDetectedException` in `ProjectBuildingException` instead of `RuntimeException`, providing meaningful error output.
5. **Fix NullPointerException when clearing project properties** (fixes #11552) — `OrderedProperties.clear()` now also clears the `keyOrder` list to prevent inconsistent state.

## Test plan

- [x] Compilation verified (`mvn install -pl impl/maven-impl,impl/maven-core -DskipTests -am`)
- [x] All 527 tests pass (`mvn test -pl impl/maven-impl,impl/maven-core` — 0 failures, 0 errors)
- [ ] Full CI validation

_Claude Code on behalf of Guillaume Nodet_