### PR TITLE
Downgrade plexus-classworlds from 2.11.0 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ under the License.
     <assertjVersion>3.27.7</assertjVersion>
     <asmVersion>9.9.1</asmVersion>
     <byteBuddyVersion>1.18.8</byteBuddyVersion>
-    <classWorldsVersion>2.11.0</classWorldsVersion>
+    <classWorldsVersion>2.9.0</classWorldsVersion>
     <commonsCliVersion>1.11.0</commonsCliVersion>
     <guiceVersion>5.1.0</guiceVersion>
     <guavaVersion>33.6.0-jre</guavaVersion>


### PR DESCRIPTION
## Summary

- Downgrade plexus-classworlds from 2.11.0 to 2.9.0 to fix all integration test failures on ubuntu-latest

## Root Cause

Classworlds 2.11.0 introduced a bug in `ConfigurationParser.loadGlob()` ([commit 4f4cfe64](https://github.com/codehaus-plexus/plexus-classworlds/commit/4f4cfe64d1)) where an automated code cleanup incorrectly changed `&&` to `||` in the glob file filter. This causes `load maven-*.jar` in `m2.conf` to match **all** `.jar` files instead of only those starting with `maven-`.

On Linux ext4, `File.listFiles()` returns non-deterministic ordering (inode hash order). After a recent GitHub Actions runner image update (`ubuntu24/20260513.135`), `org.eclipse.sisu.plexus-1.0.0.jar` loads before `maven-embedder-4.0.0-SNAPSHOT.jar`, causing Sisu's `PlexusXmlBeanConverter` (without XmlNode handling) to win the class collision. This breaks lifecycle configuration injection for any component using `XmlNode` fields (e.g., `LifecycleMojo.configuration`).

This is the root cause of all 5 backport PR failures (#12071, #12070, #12073, #12077, #12079) — they are all innocent bystanders.

Upstream fix: https://github.com/codehaus-plexus/plexus-classworlds/pull/147

Once classworlds ships a fix (2.11.1+), we can upgrade again.

_Claude Code on behalf of Guillaume Nodet_