### PR TITLE
[maven-4.0.x] fix: propagate addResource() to model Build for Maven 3 compat

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -772,11 +772,13 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     sourceContext.handleResourceConfiguration(ProjectScope.TEST);
                 }
 
-                // Sync model Build resources from sources set so that
-                // project.getBuild().getResources() is consistent with project.getResources().
-                // This is needed for Maven 3 plugin compatibility, since some plugins
-                // (e.g. maven-source-plugin) access resources via project.getBuild().getResources().
-                project.syncBuildResources();
+                // When resources are defined via <sources> (4.1.0 model), sync them to
+                // the model's Build so project.getBuild().getResources() is consistent.
+                // For legacy <resources>, the model already has the correct resources.
+                if (sourceContext.hasSources(Language.RESOURCES, ProjectScope.MAIN)
+                        || sourceContext.hasSources(Language.RESOURCES, ProjectScope.TEST)) {
+                    project.syncBuildResources();
+                }
             }
 
             project.setActiveProfiles(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -771,6 +771,12 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     sourceContext.handleResourceConfiguration(ProjectScope.MAIN);
                     sourceContext.handleResourceConfiguration(ProjectScope.TEST);
                 }
+
+                // Sync model Build resources from sources set so that
+                // project.getBuild().getResources() is consistent with project.getResources().
+                // This is needed for Maven 3 plugin compatibility, since some plugins
+                // (e.g. maven-source-plugin) access resources via project.getBuild().getResources().
+                project.syncBuildResources();
             }
 
             project.setActiveProfiles(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -848,16 +848,21 @@ public class MavenProject implements Cloneable {
     }
 
     /**
-     * @deprecated {@link Resource} is replaced by {@link SourceRoot}.
+     * Syncs {@code Build.resources/testResources} from the {@code sources} set
+     * for Maven 3 plugin compatibility (e.g. when resources come from {@code <sources>}).
      */
+    void syncBuildResources() {
+        getModelBuild().setResources(new java.util.ArrayList<>(getResources()));
+        getModelBuild().setTestResources(new java.util.ArrayList<>(getTestResources()));
+    }
+
+    /** @deprecated {@link Resource} is replaced by {@link SourceRoot}. */
     @Deprecated(since = "4.0.0")
     public void addResource(Resource resource) {
         addResource(ProjectScope.MAIN, resource);
     }
 
-    /**
-     * @deprecated {@link Resource} is replaced by {@link SourceRoot}.
-     */
+    /** @deprecated {@link Resource} is replaced by {@link SourceRoot}. */
     @Deprecated(since = "4.0.0")
     public void addTestResource(Resource testResource) {
         addResource(ProjectScope.TEST, testResource);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -838,6 +838,13 @@ public class MavenProject implements Cloneable {
 
     private void addResource(ProjectScope scope, Resource resource) {
         addSourceRoot(new DefaultSourceRoot(getBaseDirectory(), scope, resource.getDelegate()));
+        // Also update the model's Build to maintain compatibility with code that
+        // accesses resources via project.getBuild().getResources()
+        if (scope == ProjectScope.MAIN) {
+            getModelBuild().addResource(resource);
+        } else {
+            getModelBuild().addTestResource(resource);
+        }
     }
 
     /**

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ResourceIncludeTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ResourceIncludeTest.java
@@ -281,4 +281,62 @@ class ResourceIncludeTest {
                 placeholderResult.getTargetPath(),
                 "Property placeholder in targetPath should be preserved");
     }
+
+    /**
+     * Verifies that resources added via {@code project.addResource()} or
+     * {@code project.getResources().add()} are visible through both
+     * {@code project.getResources()} and {@code project.getBuild().getResources()}.
+     * This is important for Maven 3 compatibility, since plugins may access
+     * resources through either path.
+     *
+     * @see <a href="https://github.com/apache/maven-source-plugin/pull/281">maven-source-plugin#281</a>
+     */
+    @Test
+    void testAddResourceVisibleViaBuildGetResources() {
+        // Initial state: one resource in sources, none added dynamically
+        assertEquals(1, project.getResources().size());
+        int initialBuildResources = project.getBuild().getResources().size();
+
+        // Add a resource dynamically (simulating what maven-remote-resources-plugin does)
+        Resource dynamicResource = new Resource();
+        dynamicResource.setDirectory("target/maven-shared-archive-resources");
+        project.addResource(dynamicResource);
+
+        // Verify visible via project.getResources()
+        List<Resource> projectResources = project.getResources();
+        assertEquals(2, projectResources.size(), "Dynamic resource should be visible via project.getResources()");
+
+        // Verify ALSO visible via project.getBuild().getResources()
+        List<Resource> buildResources = project.getBuild().getResources();
+        assertEquals(
+                initialBuildResources + 1,
+                buildResources.size(),
+                "Dynamic resource should also be visible via project.getBuild().getResources()");
+
+        boolean found =
+                buildResources.stream().anyMatch(r -> r.getDirectory().contains("maven-shared-archive-resources"));
+        assertTrue(found, "getBuild().getResources() should contain the dynamically added resource");
+    }
+
+    /**
+     * Same as above but using {@code project.getResources().add()} path.
+     */
+    @Test
+    void testAddResourceViaListVisibleViaBuildGetResources() {
+        int initialBuildResources = project.getBuild().getResources().size();
+
+        Resource dynamicResource = new Resource();
+        dynamicResource.setDirectory("target/maven-shared-archive-resources");
+        project.getResources().add(dynamicResource);
+
+        List<Resource> buildResources = project.getBuild().getResources();
+        assertEquals(
+                initialBuildResources + 1,
+                buildResources.size(),
+                "Resource added via getResources().add() should be visible via getBuild().getResources()");
+
+        boolean found =
+                buildResources.stream().anyMatch(r -> r.getDirectory().contains("maven-shared-archive-resources"));
+        assertTrue(found, "getBuild().getResources() should contain the resource added via getResources().add()");
+    }
 }


### PR DESCRIPTION
Backport of #11868 to `maven-4.0.x`.

Propagate `addResource()` / `addTestResource()` calls on the model `Build` object to the underlying `Sources` set for Maven 3 compatibility. Also ensures `Build.resources` is properly synced from the `Sources` set for `<sources>` projects.

_Claude Code on behalf of Guillaume Nodet_