### PR TITLE
[maven-4.0.x] Fix #12075: skip expression validation for distributionManagement repository IDs

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -647,14 +647,14 @@ public class DefaultModelValidator implements ModelValidator {
             DistributionManagement distMgmt = m.getDistributionManagement();
             if (distMgmt != null) {
                 validateRawRepository(
-                        problems, distMgmt.getRepository(), "distributionManagement.repository.", "", true, false);
+                        problems, distMgmt.getRepository(), "distributionManagement.repository.", "", true, true);
                 validateRawRepository(
                         problems,
                         distMgmt.getSnapshotRepository(),
                         "distributionManagement.snapshotRepository.",
                         "",
                         true,
-                        false);
+                        true);
             }
         }
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -896,18 +896,23 @@ class DefaultModelValidatorTest {
     void repositoryWithUninterpolatedId() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/repository-with-uninterpolated-id.xml");
         // Uninterpolated expressions in repository IDs should cause validation errors
-        assertViolations(result, 0, 3, 0);
+        // distributionManagement repositories skip expression check since parent properties
+        // may not be available at file model validation stage
+        assertViolations(result, 0, 2, 0);
 
-        // Check that all three repository ID validation errors are present
+        // Check that repository ID validation errors are present for repositories and pluginRepositories
         assertTrue(result.getErrors().stream()
                 .anyMatch(error -> error.contains("repositories.repository.[${repository.id}].id")
                         && error.contains("contains an uninterpolated expression")));
         assertTrue(result.getErrors().stream()
                 .anyMatch(error -> error.contains("pluginRepositories.pluginRepository.[${plugin.repository.id}].id")
                         && error.contains("contains an uninterpolated expression")));
-        assertTrue(result.getErrors().stream()
-                .anyMatch(error -> error.contains("distributionManagement.repository.[${staging.repository.id}].id")
-                        && error.contains("contains an uninterpolated expression")));
+    }
+
+    @Test
+    void distributionManagementWithChainedPropertyInId() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/dm-with-chained-property-in-id.xml");
+        assertViolations(result, 0, 0, 0);
     }
 
     @Test

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/dm-with-chained-property-in-id.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/dm-with-chained-property-in-id.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.validation</groupId>
+  <artifactId>project</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <distMgmtStagingId>${distMgmtReleasesId}</distMgmtStagingId>
+    <distMgmtSnapshotsId>${distMgmtReleasesId}</distMgmtSnapshotsId>
+  </properties>
+
+  <distributionManagement>
+    <repository>
+      <id>${distMgmtStagingId}</id>
+      <url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>${distMgmtSnapshotsId}</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+</project>


### PR DESCRIPTION
Backport of #12076 to `maven-4.0.x`.

Fixes #12075: nested property interpolation in `distributionManagement` repository IDs fails validation in Maven 4. Skips expression validation for distributionManagement repository IDs, similar to the fix for profile repository URLs in #12047.

_Claude Code on behalf of Guillaume Nodet_