### PR TITLE
[maven-4.0.x] Filter transitive dependencies with uninterpolated expressions

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
@@ -334,6 +334,13 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
     }
 
     private void filterUninterpolatedDependencies(ArtifactDescriptorResult result) {
+        result.getRepositories().removeIf(repo -> {
+            if (containsPlaceholder(repo.getId()) || containsPlaceholder(repo.getUrl())) {
+                logger.debug("Filtered repository with uninterpolated expression: {}", repo);
+                return true;
+            }
+            return false;
+        });
         result.getDependencies().removeIf(dep -> {
             if (hasUninterpolatedExpression(dep.getArtifact())) {
                 logger.debug("Filtered dependency with uninterpolated expression: {}", dep);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
@@ -113,6 +113,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
             }
 
             delegate.populateResult(InternalSession.from(session), result, model);
+            filterUninterpolatedDependencies(result);
         }
 
         return result;
@@ -330,5 +331,32 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
             return ArtifactDescriptorPolicy.STRICT;
         }
         return policy.getPolicy(session, new ArtifactDescriptorPolicyRequest(a, request.getRequestContext()));
+    }
+
+    private void filterUninterpolatedDependencies(ArtifactDescriptorResult result) {
+        result.getDependencies().removeIf(dep -> {
+            if (hasUninterpolatedExpression(dep.getArtifact())) {
+                logger.debug("Filtered dependency with uninterpolated expression: {}", dep);
+                return true;
+            }
+            return false;
+        });
+        result.getManagedDependencies().removeIf(dep -> {
+            if (hasUninterpolatedExpression(dep.getArtifact())) {
+                logger.debug("Filtered managed dependency with uninterpolated expression: {}", dep);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private static boolean hasUninterpolatedExpression(Artifact artifact) {
+        return containsPlaceholder(artifact.getGroupId())
+                || containsPlaceholder(artifact.getArtifactId())
+                || containsPlaceholder(artifact.getVersion());
+    }
+
+    private static boolean containsPlaceholder(String value) {
+        return value != null && value.contains("${");
     }
 }


### PR DESCRIPTION
Backport of #12084 to `maven-4.0.x`.

Filters out transitive dependencies that contain uninterpolated `${...}` expressions in their coordinates, preventing build failures caused by unresolved property references in transitive dependency POMs.

_Claude Code on behalf of Guillaume Nodet_