### PR TITLE
[maven-4.0.x] Fix #12085: regression tests for version inheritance from remote parent

### DIFF
--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -587,4 +587,43 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
         // The modules list should be empty since we explicitly defined an empty <modules /> element
         assertTrue(parent.getModel().getDelegate().getModules().isEmpty());
     }
+
+    @Test
+    void testVersionInheritedFromRemoteParent() throws Exception {
+        File f1 = getTestFile("src/test/resources/projects/parent-version-inherited-from-remote/pom.xml");
+        MavenProject project = getProject(f1);
+
+        assertNotNull(project, "project should not be null");
+        assertEquals("1.0", project.getVersion(), "version should be inherited from remote parent");
+        assertNotNull(project.getArtifact(), "project artifact should not be null");
+        assertEquals("1.0", project.getArtifact().getVersion(), "artifact version should match inherited version");
+        assertEquals("org.different.group", project.getGroupId(), "groupId should be from child POM");
+        assertEquals("child-project", project.getArtifactId(), "artifactId should be from child POM");
+    }
+
+    @Test
+    void testVersionInheritedFromRemoteParentMultiModule() throws Exception {
+        File pom = getTestFile("src/test/resources/projects/parent-version-inherited-from-remote-multimodule/pom.xml");
+        ProjectBuildingRequest configuration = newBuildingRequest();
+        InternalSession internalSession = InternalSession.from(configuration.getRepositorySession());
+        InternalMavenSession mavenSession = InternalMavenSession.from(internalSession);
+        mavenSession
+                .getMavenSession()
+                .getRequest()
+                .setRootDirectory(pom.toPath().getParent());
+
+        List<ProjectBuildingResult> results = projectBuilder.build(List.of(pom), true, configuration);
+        assertEquals(2, results.size());
+
+        MavenProject child = results.stream()
+                .map(ProjectBuildingResult::getProject)
+                .filter(p -> "child-project".equals(p.getArtifactId()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(child, "child project should be found");
+        assertEquals("1.0", child.getVersion(), "version should be inherited from remote parent");
+        assertNotNull(child.getArtifact(), "child project artifact should not be null");
+        assertEquals("1.0", child.getArtifact().getVersion(), "artifact version should match inherited version");
+        assertEquals("org.different.group", child.getGroupId(), "groupId should be from child POM");
+    }
 }

--- a/impl/maven-core/src/test/remote-repo/org/test/parent-pom/1.0/parent-pom-1.0.pom
+++ b/impl/maven-core/src/test/remote-repo/org/test/parent-pom/1.0/parent-pom-1.0.pom
@@ -1,0 +1,31 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.test</groupId>
+  <artifactId>parent-pom</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <repositories>
+    <repository>
+      <id>staging</id>
+      <url>https://repository.example.org/staging</url>
+    </repository>
+  </repositories>
+
+  <profiles>
+    <profile>
+      <id>nightly</id>
+      <activation>
+        <property>
+          <name>nightly</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>${uninterpolatedRepoId}</id>
+          <url>file://${SNAPSHOTS_PATH}</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+</project>

--- a/impl/maven-core/src/test/resources/projects/parent-version-inherited-from-remote-multimodule/child/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/parent-version-inherited-from-remote-multimodule/child/pom.xml
@@ -1,0 +1,12 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.test</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.0</version>
+    <relativePath/>
+  </parent>
+  <groupId>org.different.group</groupId>
+  <artifactId>child-project</artifactId>
+  <!-- no version - inherited from remote parent -->
+</project>

--- a/impl/maven-core/src/test/resources/projects/parent-version-inherited-from-remote-multimodule/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/parent-version-inherited-from-remote-multimodule/pom.xml
@@ -1,0 +1,10 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.test.aggregator</groupId>
+  <artifactId>aggregator</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>child</module>
+  </modules>
+</project>

--- a/impl/maven-core/src/test/resources/projects/parent-version-inherited-from-remote/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/parent-version-inherited-from-remote/pom.xml
@@ -1,0 +1,12 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.test</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.0</version>
+    <relativePath/>
+  </parent>
+  <groupId>org.different.group</groupId>
+  <artifactId>child-project</artifactId>
+  <!-- no version - inherited from parent -->
+</project>


### PR DESCRIPTION
Backport of #12090 to `maven-4.0.x`.

Adds regression tests for version inheritance from remote parent POMs, covering both single-module and multi-module scenarios.

_Claude Code on behalf of Guillaume Nodet_