### PR TITLE
[maven-4.0.x] Fix mvnup to replace deprecated ${basedir} in repository URLs

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
@@ -466,12 +466,14 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
             Element urlElement = repository.child("url").orElse(null);
             if (urlElement != null) {
                 String url = urlElement.textContent().trim();
-                if (url.contains("${")) {
-                    // Allow repository URL interpolation; do not disable.
-                    // Keep a gentle warning to help users notice unresolved placeholders at build time.
+                String fixedUrl =
+                        url.replace("${basedir}", "${project.basedir}").replace("${pom.basedir}", "${project.basedir}");
+                if (!fixedUrl.equals(url)) {
+                    urlElement.textContent(fixedUrl);
                     String repositoryId = repository.childText("id");
-                    context.info("Detected interpolated expression in " + elementType + " URL (id: " + repositoryId
-                            + "): " + url);
+                    context.detail("Fixed: replaced deprecated expression in " + elementType + " URL (id: "
+                            + repositoryId + "): " + url + " → " + fixedUrl);
+                    fixed = true;
                 }
             }
         }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategyTest.java
@@ -282,6 +282,203 @@ class CompatibilityFixStrategyTest {
     }
 
     @Nested
+    @DisplayName("Repository Expression Fixes")
+    class RepositoryExpressionFixesTests {
+
+        @Test
+        @DisplayName("should replace ${basedir} with ${project.basedir} in repository URLs")
+        void shouldReplaceBasedirInRepositoryUrls() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <repositories>
+                        <repository>
+                            <id>local-repo</id>
+                            <url>file://${basedir}/internal-repository</url>
+                        </repository>
+                    </repositories>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed basedir expression");
+
+            Element root = document.root();
+            Element repositories = DomUtils.findChildElement(root, "repositories");
+            Element repository = DomUtils.findChildElement(repositories, "repository");
+            Element url = DomUtils.findChildElement(repository, "url");
+            assertEquals(
+                    "file://${project.basedir}/internal-repository",
+                    url.textContent().trim(),
+                    "Should have replaced ${basedir} with ${project.basedir}");
+        }
+
+        @Test
+        @DisplayName("should replace ${pom.basedir} with ${project.basedir} in repository URLs")
+        void shouldReplacePomBasedirInRepositoryUrls() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <repositories>
+                        <repository>
+                            <id>local-repo</id>
+                            <url>file://${pom.basedir}/lib</url>
+                        </repository>
+                    </repositories>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed pom.basedir expression");
+
+            Element root = document.root();
+            Element repositories = DomUtils.findChildElement(root, "repositories");
+            Element repository = DomUtils.findChildElement(repositories, "repository");
+            Element url = DomUtils.findChildElement(repository, "url");
+            assertEquals(
+                    "file://${project.basedir}/lib",
+                    url.textContent().trim(),
+                    "Should have replaced ${pom.basedir} with ${project.basedir}");
+        }
+
+        @Test
+        @DisplayName("should replace ${basedir} in pluginRepository URLs")
+        void shouldReplaceBasedirInPluginRepositoryUrls() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <pluginRepositories>
+                        <pluginRepository>
+                            <id>local-plugins</id>
+                            <url>file://${basedir}/plugin-repo</url>
+                        </pluginRepository>
+                    </pluginRepositories>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed basedir in pluginRepository");
+
+            Element root = document.root();
+            Element pluginRepositories = DomUtils.findChildElement(root, "pluginRepositories");
+            Element pluginRepository = DomUtils.findChildElement(pluginRepositories, "pluginRepository");
+            Element url = DomUtils.findChildElement(pluginRepository, "url");
+            assertEquals(
+                    "file://${project.basedir}/plugin-repo",
+                    url.textContent().trim(),
+                    "Should have replaced ${basedir} with ${project.basedir}");
+        }
+
+        @Test
+        @DisplayName("should replace ${basedir} in profile repository URLs")
+        void shouldReplaceBasedirInProfileRepositoryUrls() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <profiles>
+                        <profile>
+                            <id>local</id>
+                            <repositories>
+                                <repository>
+                                    <id>local-repo</id>
+                                    <url>file://${basedir}/repo</url>
+                                </repository>
+                            </repositories>
+                        </profile>
+                    </profiles>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed basedir in profile repository");
+
+            Element root = document.root();
+            Element profiles = DomUtils.findChildElement(root, "profiles");
+            Element profile = DomUtils.findChildElement(profiles, "profile");
+            Element repositories = DomUtils.findChildElement(profile, "repositories");
+            Element repository = DomUtils.findChildElement(repositories, "repository");
+            Element url = DomUtils.findChildElement(repository, "url");
+            assertEquals(
+                    "file://${project.basedir}/repo",
+                    url.textContent().trim(),
+                    "Should have replaced ${basedir} with ${project.basedir}");
+        }
+
+        @Test
+        @DisplayName("should not modify repository URLs without deprecated expressions")
+        void shouldNotModifyUrlsWithoutDeprecatedExpressions() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <repositories>
+                        <repository>
+                            <id>central</id>
+                            <url>https://repo.maven.apache.org/maven2</url>
+                        </repository>
+                        <repository>
+                            <id>local-repo</id>
+                            <url>file://${project.basedir}/repo</url>
+                        </repository>
+                    </repositories>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not have modified any POMs");
+        }
+    }
+
+    @Nested
     @DisplayName("Strategy Description")
     class StrategyDescriptionTests {
 


### PR DESCRIPTION
## Summary

Backport of #12105 to maven-4.0.x.

- Fix `CompatibilityFixStrategy.fixRepositoryExpressions()` to replace deprecated `${basedir}` and `${pom.basedir}` with the canonical `${project.basedir}` form in repository and pluginRepository URL elements (including inside profiles)
- Previously the method only logged a warning but never performed the replacement
- Add 5 tests covering repositories, pluginRepositories, profiles, and the no-op case

## Context

Maven 4 introduced `MavenValidator` ([MNG-8677](https://issues.apache.org/jira/browse/MNG-8677), [PR #2158](https://github.com/apache/maven/pull/2158)) which validates that repository URLs are fully interpolated. When a POM uses `${basedir}` in a repository URL (e.g. `file://${basedir}/internal-repository`), this can fail validation since `${basedir}` is a deprecated form that may not be interpolated in all contexts (notably during transitive dependency resolution).

The `pom.` prefix was deprecated in favor of `project.` ([MNG-7244](https://issues.apache.org/jira/browse/MNG-7244)), and prefixless expressions were dropped ([MNG-7404](https://issues.apache.org/jira/browse/MNG-7404)).

See: https://github.com/gnodet/maven4-testing/issues/13299

## Test plan

- [x] All existing `CompatibilityFixStrategyTest` tests pass
- [x] New tests verify `${basedir}` → `${project.basedir}` replacement in repository, pluginRepository, and profile repository URLs
- [x] New test verifies no modification when URLs already use `${project.basedir}` or contain no expressions


_Claude Code on behalf of Guillaume Nodet_