### PR TITLE
[maven-4.0.x] Upgrade plugin dependencies (extra-enforcer-rules) in mvnup

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -64,6 +64,8 @@ import org.eclipse.aether.transport.jdk.JdkTransporterFactory;
 
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.ARTIFACT_ID;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.BUILD;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.DEPENDENCIES;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.DEPENDENCY;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.GROUP_ID;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PARENT;
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGIN;
@@ -99,6 +101,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     "maven-remote-resources-plugin",
                     "3.0.0",
                     MAVEN_4_COMPATIBILITY_REASON));
+
+    private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
+            "org.codehaus.mojo",
+            "extra-enforcer-rules",
+            "1.4",
+            "Versions before 1.4 use a removed DependencyGraphBuilder API incompatible with Maven 4"));
 
     private Session session;
 
@@ -262,6 +270,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         return pluginsElement
                 .children(PLUGIN)
                 .map(pluginElement -> {
+                    boolean upgraded = false;
                     String groupId = getChildText(pluginElement, GROUP_ID);
                     String artifactId = getChildText(pluginElement, ARTIFACT_ID);
 
@@ -275,10 +284,13 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                         PluginUpgradeInfo upgrade = pluginUpgrades.get(pluginKey);
 
                         if (upgrade != null) {
-                            return upgradePluginVersion(pluginElement, upgrade, pomDocument, sectionName, context);
+                            upgraded = upgradePluginVersion(pluginElement, upgrade, pomDocument, sectionName, context);
                         }
                     }
-                    return false;
+
+                    upgraded |= upgradePluginDependencies(pluginElement, pomDocument, sectionName, context);
+
+                    return upgraded;
                 })
                 .reduce(false, Boolean::logicalOr);
     }
@@ -368,6 +380,46 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         }
 
         return false;
+    }
+
+    /**
+     * Upgrades plugin dependencies (e.g., extra-enforcer-rules inside maven-enforcer-plugin).
+     */
+    private boolean upgradePluginDependencies(
+            Element pluginElement, Document pomDocument, String sectionName, UpgradeContext context) {
+        Element dependenciesElement = pluginElement.child(DEPENDENCIES).orElse(null);
+        if (dependenciesElement == null) {
+            return false;
+        }
+
+        Map<String, PluginUpgradeInfo> depUpgrades = getPluginDependencyUpgradesMap();
+
+        return dependenciesElement
+                .children(DEPENDENCY)
+                .map(depElement -> {
+                    String groupId = getChildText(depElement, GROUP_ID);
+                    String artifactId = getChildText(depElement, ARTIFACT_ID);
+
+                    if (groupId != null && artifactId != null) {
+                        String depKey = groupId + ":" + artifactId;
+                        PluginUpgradeInfo upgrade = depUpgrades.get(depKey);
+
+                        if (upgrade != null) {
+                            return upgradePluginVersion(
+                                    depElement, upgrade, pomDocument, sectionName + "/plugin/dependencies", context);
+                        }
+                    }
+                    return false;
+                })
+                .reduce(false, Boolean::logicalOr);
+    }
+
+    private Map<String, PluginUpgradeInfo> getPluginDependencyUpgradesMap() {
+        return PLUGIN_DEPENDENCY_UPGRADES.stream()
+                .collect(Collectors.toMap(
+                        upgrade -> upgrade.groupId() + ":" + upgrade.artifactId(),
+                        upgrade ->
+                                new PluginUpgradeInfo(upgrade.groupId(), upgrade.artifactId(), upgrade.minVersion())));
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -458,6 +458,93 @@ class PluginUpgradeStrategyTest {
     }
 
     @Nested
+    @DisplayName("Plugin Dependency Upgrades")
+    class PluginDependencyUpgradeTests {
+
+        @Test
+        @DisplayName("should upgrade extra-enforcer-rules dependency when below minimum")
+        void shouldUpgradeExtraEnforcerRulesDependency() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.5.0</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>extra-enforcer-rules</artifactId>
+                                        <version>1.0-beta-4</version>
+                                    </dependency>
+                                </dependencies>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Plugin dependency upgrade should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have upgraded extra-enforcer-rules");
+
+            String xml = document.toXml();
+            assertTrue(xml.contains("<version>1.4</version>"), "extra-enforcer-rules should be upgraded to 1.4");
+            assertFalse(xml.contains("1.0-beta-4"), "Old version should be gone");
+        }
+
+        @Test
+        @DisplayName("should not upgrade extra-enforcer-rules when version is already sufficient")
+        void shouldNotUpgradeExtraEnforcerRulesWhenSufficient() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.5.0</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>extra-enforcer-rules</artifactId>
+                                        <version>1.8.0</version>
+                                    </dependency>
+                                </dependencies>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            strategy.doApply(context, pomMap);
+
+            String xml = document.toXml();
+            assertTrue(xml.contains("1.8.0"), "Version 1.8.0 should be preserved");
+        }
+    }
+
+    @Nested
     @DisplayName("Plugin Management")
     class PluginManagementTests {
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -209,21 +209,20 @@ class PluginUpgradeStrategyTest {
                 </project>
                 """;
 
-            Document document = saxBuilder.build(new StringReader(pomXml));
+            Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
 
             UpgradeContext context = createMockContext();
-            UpgradeResult result = strategy.apply(context, pomMap);
+            UpgradeResult result = strategy.doApply(context, pomMap);
 
             assertTrue(result.success(), "Plugin upgrade should succeed");
             assertTrue(result.modifiedCount() > 0, "Should have upgraded 3.0.0-M1 to 3.0.0");
 
-            Element root = document.getRootElement();
-            Namespace namespace = root.getNamespace();
-            Element build = root.getChild("build", namespace);
-            Element plugins = build.getChild("plugins", namespace);
-            Element plugin = plugins.getChild("plugin", namespace);
-            String version = plugin.getChildText("version", namespace);
+            Editor editor = new Editor(document);
+            Element root = editor.root();
+            String version = root.path("build", "plugins", "plugin", "version")
+                    .map(Element::textContentTrimmed)
+                    .orElse(null);
             assertEquals("3.0.0", version, "3.0.0-M1 should be upgraded to 3.0.0");
         }
 


### PR DESCRIPTION
## Summary

Backport of #12051 (merged to master) — adds extra-enforcer-rules to mvnup plugin dependency handling.

Cherry-picked from the squash-merge commit on master onto the current maven-4.0.x branch (post-domtrip migration #12082).

Replaces #12071 which had conflicts after the domtrip migration.

_Claude Code on behalf of Guillaume Nodet_