### PR TITLE
Fix #11885: Disable ANSI colors when stdout is piped on JDK 22+ (backport)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -342,7 +342,7 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
             context.coloredOutput = context.coloredOutput != null ? context.coloredOutput : false;
             context.closeables.add(out::flush);
         } else {
-            builder.systemOutput(TerminalBuilder.SystemOutput.ForcedSysOut);
+            builder.systemOutput(TerminalBuilder.SystemOutput.SysOut);
         }
         if (context.coloredOutput != null) {
             builder.color(context.coloredOutput);
@@ -354,12 +354,10 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
      */
     protected final void doConfigureWithTerminal(C context, Terminal terminal) {
         context.terminal = terminal;
-        // tricky thing: align what JLine3 detected and Maven thinks:
+        // Align Maven's color setting with JLine's terminal detection:
         // if embedded, we default to context.coloredOutput=false unless overridden (see above)
-        // if not embedded, JLine3 may detect redirection and will create dumb terminal.
+        // if not embedded, JLine detects redirection via SysOut and will create dumb terminal.
         // To align Maven with outcomes, we set here color enabled based on these premises.
-        // Note: Maven3 suffers from similar thing: if you do `mvn3 foo > log.txt`, the output will
-        // not be not colored (good), but Maven will print out "Message scheme: color".
         MessageUtils.setColorEnabled(
                 context.coloredOutput != null ? context.coloredOutput : !Terminal.TYPE_DUMB.equals(terminal.getType()));
 


### PR DESCRIPTION
Backport of #11887 to `maven-4.0.x`.

## Summary

- Change `ForcedSysOut` to `SysOut` in JLine's `TerminalBuilder` configuration so that JLine properly checks whether stdout is a TTY before creating a system terminal
- On JDK 22+ with the FFM provider, `ForcedSysOut` caused ANSI escape codes in piped output because stdin being a TTY was enough to create a non-dumb terminal

Fixes #11885

_Claude Code on behalf of Guillaume Nodet_