### PR TITLE
Resolver 2018

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -344,23 +344,37 @@ public final class Constants {
     public static final String MAVEN_RELOCATIONS_ENTRIES = "maven.relocations.entries";
 
     /**
-     * User property for version filter expression used in session, applied to resolving ranges: a semicolon separated
-     * list of filters to apply. By default, no version filter is applied (like in Maven 3).
+     * Builds <code>org.eclipse.aether.collection.VersionFilter</code> instances out of input expression string.
+     * <br/>
+     * Expression is a semicolon separated list of filters to apply. By default, no version filter is applied (like in Maven 3).
      * <br/>
      * Supported filters:
      * <ul>
-     *     <li>"h" or "h(num)" - highest version or top list of highest ones filter</li>
-     *     <li>"l" or "l(num)" - lowest version or bottom list of lowest ones filter</li>
-     *     <li>"s" - contextual snapshot filter</li>
-     *     <li>"ns" - unconditional snapshot filter (no snapshots selected from ranges)</li>
-     *     <li>"e(G:A:V)" - predicate filter (leaves out G:A:V from range, if hit, V can be range)</li>
+     *     <li><code>"s"</code> - contextual snapshot filter (project version decides are snapshots allowed or not)</li>
+     *     <li><code>"nosnapshot"</code> - unconditional snapshot filter (no snapshot versions selected from ranges)</li>
+     *     <li><code>"norelease"</code> - unconditional release filter (no release versions selected from ranges)</li>
+     *     <li><code>"nopreview"</code> - unconditional preview filter (no preview versions selected from ranges)</li>
+     *     <li><code>"noprerelease"</code> - unconditional pre-release filter (no preview and rc/cr versions selected from ranges)</li>
+     *     <li><code>"noqualifier"</code> - unconditional any-qualifier filter (no version with any qualifier selected from ranges)</li>
+     *     <li><code>"h"</code> (shorthand of <code>h(1)</code>) or <code>"h(num)"</code> - highest N version (based on version ordering)</li>
+     *     <li><code>"l"</code> (shorthand of <code>l(1)</code>) or <code>"l(num)"</code> - lowest N version (based on version ordering)</li>
+     *     <li><code>"e(V)"</code> - exclusion filter (excludes versions matching V version constraint)</li>
+     *     <li><code>"i(V)"</code> - inclusion filter (includes versions matching V version constraint)</li>
      * </ul>
-     * Example filter expression: <code>"h(5);s;e(org.foo:bar:1)</code> will cause: ranges are filtered for "top 5" (instead
-     * full range), snapshots are banned if root project is not a snapshot, and if range for <code>org.foo:bar</code> is
-     * being processed, version 1 is omitted. Value in this property builds
-     * <code>org.eclipse.aether.collection.VersionFilter</code> instance.
+     * Every filter expression may have "scope" applied, in form of <code>@G[:A]</code>. Presence of "scope" narrows the
+     * application of filter to given G or G:A.
+     * <br/>
+     * In case of multiple "similar" rule scopes, user should enlist rules from "most specific" to "least specific".
+     * <br/>
+     * Example filter expression: <code>"h(5);s;e(1)@org.foo:bar"</code> will cause:
+     * <ul>
+     *     <li>ranges are filtered for "top 5" (instead of full range)</li>
+     *     <li>snapshots are banned if root project is not a snapshot</li>
+     *     <li>if range for <code>org.foo:bar</code> is being processed, version 1 is omitted</li>
+     * </ul>
+     * Values in this property builds <code>org.eclipse.aether.collection.VersionFilter</code> instance.
      *
-     * @since 4.0.0
+     * @since 3.10.0
      */
     @Config
     public static final String MAVEN_VERSION_FILTER = "maven.session.versionFilter";

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/legacy/DefaultUpdateCheckManagerTest.java
@@ -30,7 +30,7 @@ import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
 import org.apache.maven.artifact.repository.metadata.RepositoryMetadata;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
-import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
+import org.eclipse.aether.internal.impl.LegacyTrackingFileManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +59,7 @@ class DefaultUpdateCheckManagerTest extends AbstractArtifactComponentTestCase {
         super.setUp();
 
         updateCheckManager = new DefaultUpdateCheckManager(
-                new ConsoleLogger(Logger.LEVEL_DEBUG, "test"), new DefaultTrackingFileManager());
+                new ConsoleLogger(Logger.LEVEL_DEBUG, "test"), new LegacyTrackingFileManager());
     }
 
     @Test

--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -217,7 +217,7 @@ public class DefaultMaven implements Maven {
             session.setSession(defaultSessionFactory.newSession(session));
 
             sessionScope.seed(MavenSession.class, session);
-            sessionScope.seed(RepositorySystemSession.class, closeableSession);
+            sessionScope.seed(RepositorySystemSession.class, closeableSession); // fixed in Maven 3.10.x
             sessionScope.seed(Session.class, session.getSession());
             sessionScope.seed(InternalMavenSession.class, InternalMavenSession.from(session.getSession()));
 

--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -217,6 +217,7 @@ public class DefaultMaven implements Maven {
             session.setSession(defaultSessionFactory.newSession(session));
 
             sessionScope.seed(MavenSession.class, session);
+            sessionScope.seed(RepositorySystemSession.class, closeableSession);
             sessionScope.seed(Session.class, session.getSession());
             sessionScope.seed(InternalMavenSession.class, InternalMavenSession.from(session.getSession()));
 

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.maven.api.Constants;
@@ -54,17 +53,9 @@ import org.eclipse.aether.RepositoryListener;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.collection.VersionFilter;
+import org.eclipse.aether.collection.VersionFilterBuilder;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
-import org.eclipse.aether.util.graph.version.ChainedVersionFilter;
-import org.eclipse.aether.util.graph.version.ContextualSnapshotVersionFilter;
-import org.eclipse.aether.util.graph.version.HighestVersionFilter;
-import org.eclipse.aether.util.graph.version.LowestVersionFilter;
-import org.eclipse.aether.util.graph.version.PredicateVersionFilter;
-import org.eclipse.aether.util.graph.version.SnapshotVersionFilter;
 import org.eclipse.aether.util.listener.ChainedRepositoryListener;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.eclipse.aether.util.repository.ChainedLocalRepositoryManager;
@@ -74,8 +65,7 @@ import org.eclipse.aether.util.repository.DefaultProxySelector;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
 import org.eclipse.aether.util.repository.SimpleResolutionErrorPolicy;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
-import org.eclipse.aether.version.Version;
-import org.eclipse.aether.version.VersionRange;
+import org.eclipse.aether.version.VersionConstraint;
 import org.eclipse.aether.version.VersionScheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +121,8 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
 
     private final Map<String, RepositorySystemSessionExtender> sessionExtenders;
 
+    private final VersionFilterBuilder versionFilterBuilder;
+
     @SuppressWarnings("checkstyle:ParameterNumber")
     @Inject
     DefaultRepositorySystemSessionFactory(
@@ -139,13 +131,15 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
             RuntimeInformation runtimeInformation,
             TypeRegistry typeRegistry,
             VersionScheme versionScheme,
-            Map<String, RepositorySystemSessionExtender> sessionExtenders) {
+            Map<String, RepositorySystemSessionExtender> sessionExtenders,
+            VersionFilterBuilder versionFilterBuilder) {
         this.repoSystem = repoSystem;
         this.eventSpyDispatcher = eventSpyDispatcher;
         this.runtimeInformation = runtimeInformation;
         this.typeRegistry = typeRegistry;
         this.versionScheme = versionScheme;
         this.sessionExtenders = sessionExtenders;
+        this.versionFilterBuilder = versionFilterBuilder;
     }
 
     @Deprecated
@@ -194,10 +188,9 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
         sessionBuilder.setArtifactDescriptorPolicy(new SimpleArtifactDescriptorPolicy(
                 request.isIgnoreMissingArtifactDescriptor(), request.isIgnoreInvalidArtifactDescriptor()));
 
-        VersionFilter versionFilter = buildVersionFilter(mergedProps.get(Constants.MAVEN_VERSION_FILTER));
-        if (versionFilter != null) {
-            sessionBuilder.setVersionFilter(versionFilter);
-        }
+        versionFilterBuilder
+                .buildVersionFilter(mergedProps.get(Constants.MAVEN_VERSION_FILTER), this::parseVersionConstraint)
+                .ifPresent(sessionBuilder::setVersionFilter);
 
         DefaultMirrorSelector mirrorSelector = new DefaultMirrorSelector();
         for (Mirror mirror : request.getMirrors()) {
@@ -405,6 +398,14 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
         return sessionBuilder;
     }
 
+    private VersionConstraint parseVersionConstraint(String spec) {
+        try {
+            return versionScheme.parseVersionConstraint(spec);
+        } catch (InvalidVersionSpecificationException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
     private Path resolve(String string) {
         if (string.startsWith("~/") || string.startsWith("~\\")) {
             // resolve based on $HOME
@@ -415,74 +416,6 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
         } else {
             // resolve based on $CWD
             return Paths.get(string).normalize().toAbsolutePath();
-        }
-    }
-
-    private VersionFilter buildVersionFilter(String filterExpression) {
-        ArrayList<VersionFilter> filters = new ArrayList<>();
-        if (filterExpression != null) {
-            List<String> expressions = Arrays.stream(filterExpression.split(";"))
-                    .filter(s -> s != null && !s.trim().isEmpty())
-                    .toList();
-            for (String expression : expressions) {
-                if ("h".equals(expression)) {
-                    filters.add(new HighestVersionFilter());
-                } else if (expression.startsWith("h(") && expression.endsWith(")")) {
-                    int num = Integer.parseInt(expression.substring(2, expression.length() - 1));
-                    filters.add(new HighestVersionFilter(num));
-                } else if ("l".equals(expression)) {
-                    filters.add(new LowestVersionFilter());
-                } else if (expression.startsWith("l(") && expression.endsWith(")")) {
-                    int num = Integer.parseInt(expression.substring(2, expression.length() - 1));
-                    filters.add(new LowestVersionFilter(num));
-                } else if ("s".equals(expression)) {
-                    filters.add(new ContextualSnapshotVersionFilter());
-                } else if ("ns".equals(expression)) {
-                    filters.add(new SnapshotVersionFilter());
-                } else if (expression.startsWith("e(") && expression.endsWith(")")) {
-                    Artifact artifact = new DefaultArtifact(expression.substring(2, expression.length() - 1));
-                    VersionRange versionRange =
-                            artifact.getVersion().contains(",") ? parseVersionRange(artifact.getVersion()) : null;
-                    Predicate<Artifact> predicate = a -> {
-                        if (artifact.getGroupId().equals(a.getGroupId())
-                                && artifact.getArtifactId().equals(a.getArtifactId())) {
-                            if (versionRange != null) {
-                                Version v = parseVersion(a.getVersion());
-                                return !versionRange.containsVersion(v);
-                            } else {
-                                return !artifact.getVersion().equals(a.getVersion());
-                            }
-                        }
-                        return true;
-                    };
-                    filters.add(new PredicateVersionFilter(predicate));
-                } else {
-                    throw new IllegalArgumentException("Unsupported filter expression: " + expression);
-                }
-            }
-        }
-        if (filters.isEmpty()) {
-            return null;
-        } else if (filters.size() == 1) {
-            return filters.get(0);
-        } else {
-            return ChainedVersionFilter.newInstance(filters);
-        }
-    }
-
-    private Version parseVersion(String spec) {
-        try {
-            return versionScheme.parseVersion(spec);
-        } catch (InvalidVersionSpecificationException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private VersionRange parseVersionRange(String spec) {
-        try {
-            return versionScheme.parseVersionRange(spec);
-        } catch (InvalidVersionSpecificationException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -44,6 +44,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.collection.VersionFilterBuilder;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -237,6 +238,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
 
         try {
             DefaultRepositorySystemSession pluginSession = new DefaultRepositorySystemSession(session);
+            pluginSession.setConfigProperty(VersionFilterBuilder.VERSION_FILTER_SUPPRESSED, Boolean.TRUE.toString());
             pluginSession.setDependencySelector(session.getDependencySelector());
             pluginSession.setDependencyGraphTransformer(session.getDependencyGraphTransformer());
 

--- a/impl/maven-core/src/main/java/org/apache/maven/session/scope/internal/SessionScopeModule.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/session/scope/internal/SessionScopeModule.java
@@ -26,6 +26,7 @@ import org.apache.maven.SessionScoped;
 import org.apache.maven.api.Session;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.internal.impl.InternalMavenSession;
+import org.eclipse.aether.RepositorySystemSession;
 
 /**
  * SessionScopeModule
@@ -51,6 +52,9 @@ public class SessionScopeModule extends AbstractModule {
 
         bind(MavenSession.class)
                 .toProvider(SessionScope.seededKeyProvider(MavenSession.class))
+                .in(scope);
+        bind(RepositorySystemSession.class)
+                .toProvider(SessionScope.seededKeyProvider(RepositorySystemSession.class))
                 .in(scope);
         bind(Session.class)
                 .toProvider(SessionScope.seededKeyProvider(Session.class))

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactoryTest.java
@@ -40,19 +40,13 @@ import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.ConfigurationProperties;
-import org.eclipse.aether.collection.VersionFilter;
+import org.eclipse.aether.collection.VersionFilterBuilder;
 import org.eclipse.aether.repository.RepositoryPolicy;
-import org.eclipse.aether.util.graph.version.ChainedVersionFilter;
-import org.eclipse.aether.util.graph.version.ContextualSnapshotVersionFilter;
-import org.eclipse.aether.util.graph.version.HighestVersionFilter;
-import org.eclipse.aether.util.graph.version.LowestVersionFilter;
-import org.eclipse.aether.util.graph.version.PredicateVersionFilter;
 import org.eclipse.aether.version.VersionScheme;
 import org.junit.jupiter.api.Test;
 
 import static org.codehaus.plexus.testing.PlexusExtension.getBasedir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
@@ -80,6 +74,9 @@ public class DefaultRepositorySystemSessionFactoryTest {
     @Inject
     protected VersionScheme versionScheme;
 
+    @Inject
+    protected VersionFilterBuilder versionFilterBuilder;
+
     @Test
     void isNoSnapshotUpdatesTest() throws InvalidRepositoryException {
         DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
@@ -88,7 +85,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepository(getLocalRepository());
@@ -110,7 +108,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepository(getLocalRepository());
@@ -144,7 +143,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         PlexusConfiguration plexusConfiguration = (PlexusConfiguration) systemSessionFactory
                 .newRepositorySession(request)
@@ -186,7 +186,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         Map<String, String> headers = (Map<String, String>) systemSessionFactory
                 .newRepositorySession(request)
@@ -222,7 +223,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         int connectionTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -262,7 +264,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         int connectionTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -296,7 +299,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         int requestTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -336,7 +340,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         int requestTimeout = (Integer) systemSessionFactory
                 .newRepositorySession(request)
@@ -353,7 +358,8 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 information,
                 defaultTypeRegistry,
                 versionScheme,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                versionFilterBuilder);
 
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepository(getLocalRepository());
@@ -388,64 +394,6 @@ public class DefaultRepositorySystemSessionFactoryTest {
                 "Unknown resolver transport 'illegal'. Supported transports are: wagon, apache, jdk, auto",
                 exception.getMessage());
         properties.remove("maven.resolver.transport");
-    }
-
-    @Test
-    void versionFilteringTest() throws InvalidRepositoryException {
-        DefaultRepositorySystemSessionFactory systemSessionFactory = new DefaultRepositorySystemSessionFactory(
-                aetherRepositorySystem,
-                eventSpyDispatcher,
-                information,
-                defaultTypeRegistry,
-                versionScheme,
-                Collections.emptyMap());
-
-        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
-        request.setLocalRepository(getLocalRepository());
-
-        VersionFilter versionFilter;
-
-        // single one
-        request.getUserProperties().put("maven.session.versionFilter", "s");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(ContextualSnapshotVersionFilter.class, versionFilter);
-
-        request.getUserProperties().put("maven.session.versionFilter", "h");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(HighestVersionFilter.class, versionFilter);
-
-        request.getUserProperties().put("maven.session.versionFilter", "h(5)");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(HighestVersionFilter.class, versionFilter);
-
-        request.getUserProperties().put("maven.session.versionFilter", "l");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(LowestVersionFilter.class, versionFilter);
-
-        request.getUserProperties().put("maven.session.versionFilter", "l(5)");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(LowestVersionFilter.class, versionFilter);
-
-        request.getUserProperties().put("maven.session.versionFilter", "e(g:a:v)");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(PredicateVersionFilter.class, versionFilter);
-
-        request.getUserProperties().put("maven.session.versionFilter", "e(g:a:[1,2])");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(PredicateVersionFilter.class, versionFilter);
-
-        // chained
-        request.getUserProperties().put("maven.session.versionFilter", "h(5);s;e(org.foo:bar:1)");
-        versionFilter = systemSessionFactory.newRepositorySession(request).getVersionFilter();
-        assertNotNull(versionFilter);
-        assertInstanceOf(ChainedVersionFilter.class, versionFilter);
     }
 
     protected ArtifactRepository getLocalRepository() throws InvalidRepositoryException {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
@@ -37,6 +37,7 @@ import org.eclipse.aether.impl.Installer;
 import org.eclipse.aether.impl.LocalRepositoryProvider;
 import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.MetadataResolver;
+import org.eclipse.aether.impl.NamedLockFactorySelector;
 import org.eclipse.aether.impl.OfflineController;
 import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -68,7 +69,6 @@ import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemValidator;
-import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.DefaultTransporterProvider;
 import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
@@ -78,6 +78,7 @@ import org.eclipse.aether.internal.impl.LocalPathPrefixComposerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.TrackingFileManager;
+import org.eclipse.aether.internal.impl.TrackingFileManagerSupplier;
 import org.eclipse.aether.internal.impl.checksum.DefaultChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
 import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
@@ -95,6 +96,7 @@ import org.eclipse.aether.internal.impl.filter.FilteringPipelineRepositoryConnec
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.filter.PrefixesLockingInhibitorFactory;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
+import org.eclipse.aether.internal.impl.named.DefaultNamedLockFactorySelector;
 import org.eclipse.aether.internal.impl.offline.OfflinePipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
@@ -188,8 +190,8 @@ public class RepositorySystemSupplier {
 
     @Singleton
     @Provides
-    static TrackingFileManager newTrackingFileManager() {
-        return new DefaultTrackingFileManager();
+    static TrackingFileManager newTrackingFileManager(NamedLockFactorySelector namedLockFactorySelector) {
+        return new TrackingFileManagerSupplier(namedLockFactorySelector).get();
     }
 
     @Singleton
@@ -378,12 +380,18 @@ public class RepositorySystemSupplier {
 
     @Singleton
     @Provides
+    static NamedLockFactorySelector newNamedLockFactorySelector(
+            Map<String, NamedLockFactory> factories, RepositorySystemLifecycle lifecycle) {
+        return new DefaultNamedLockFactorySelector(factories, lifecycle);
+    }
+
+    @Singleton
+    @Provides
     static NamedLockFactoryAdapterFactory newNamedLockFactoryAdapterFactory(
-            Map<String, NamedLockFactory> factories,
+            NamedLockFactorySelector namedLockFactorySelector,
             Map<String, NameMapper> nameMappers,
-            Map<String, LockingInhibitorFactory> lockingInhibitorFactories,
-            RepositorySystemLifecycle lifecycle) {
-        return new NamedLockFactoryAdapterFactoryImpl(factories, nameMappers, lockingInhibitorFactories, lifecycle);
+            Map<String, LockingInhibitorFactory> lockingInhibitorFactories) {
+        return new NamedLockFactoryAdapterFactoryImpl(namedLockFactorySelector, nameMappers, lockingInhibitorFactories);
     }
 
     @Singleton

--- a/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/RepositorySystemSupplier.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/api/plugin/testing/stubs/RepositorySystemSupplier.java
@@ -70,6 +70,7 @@ import org.eclipse.aether.impl.Installer;
 import org.eclipse.aether.impl.LocalRepositoryProvider;
 import org.eclipse.aether.impl.MetadataGeneratorFactory;
 import org.eclipse.aether.impl.MetadataResolver;
+import org.eclipse.aether.impl.NamedLockFactorySelector;
 import org.eclipse.aether.impl.OfflineController;
 import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -101,7 +102,6 @@ import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystemValidator;
-import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.DefaultTransporterProvider;
 import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
@@ -111,6 +111,7 @@ import org.eclipse.aether.internal.impl.LocalPathPrefixComposerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.TrackingFileManager;
+import org.eclipse.aether.internal.impl.TrackingFileManagerSupplier;
 import org.eclipse.aether.internal.impl.checksum.DefaultChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
 import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
@@ -128,6 +129,7 @@ import org.eclipse.aether.internal.impl.filter.FilteringPipelineRepositoryConnec
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.filter.PrefixesLockingInhibitorFactory;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
+import org.eclipse.aether.internal.impl.named.DefaultNamedLockFactorySelector;
 import org.eclipse.aether.internal.impl.offline.OfflinePipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.resolution.TrustedChecksumsArtifactResolverPostProcessor;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
@@ -245,7 +247,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
     }
 
     protected TrackingFileManager createTrackingFileManager() {
-        return new DefaultTrackingFileManager();
+        return new TrackingFileManagerSupplier(getNamedLockFactorySelector()).get();
     }
 
     private LocalPathComposer localPathComposer;
@@ -429,12 +431,23 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return namedLockFactoryAdapterFactory;
     }
 
+    private NamedLockFactorySelector namedLockFactorySelector;
+
+    public final NamedLockFactorySelector getNamedLockFactorySelector() {
+        checkClosed();
+        if (namedLockFactorySelector == null) {
+            namedLockFactorySelector = createNamedLockFactorySelector();
+        }
+        return namedLockFactorySelector;
+    }
+
+    protected NamedLockFactorySelector createNamedLockFactorySelector() {
+        return new DefaultNamedLockFactorySelector(getNamedLockFactories(), getRepositorySystemLifecycle());
+    }
+
     protected NamedLockFactoryAdapterFactory createNamedLockFactoryAdapterFactory() {
         return new NamedLockFactoryAdapterFactoryImpl(
-                getNamedLockFactories(),
-                getNameMappers(),
-                getLockingInhibitorFactories(),
-                getRepositorySystemLifecycle());
+                getNamedLockFactorySelector(), getNameMappers(), getLockingInhibitorFactories());
     }
 
     private SyncContextFactory syncContextFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ under the License.
     <plexusInterpolationVersion>1.29</plexusInterpolationVersion>
     <plexusTestingVersion>2.1.0</plexusTestingVersion>
     <plexusXmlVersion>4.1.1</plexusXmlVersion>
-    <resolverVersion>2.0.16</resolverVersion>
+    <resolverVersion>2.0.18</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
     <sisuVersion>1.0.0</sisuVersion>
     <slf4jVersion>2.0.18</slf4jVersion>


### PR DESCRIPTION
Bumps `resolverVersion` from 2.0.16 to 2.0.18. Also some related changes.

Changes:
* updates Resolver to 2.0.18
* dropped any existing filter building, is happening now in new component in Resolver 2.0.18 (same as in Maven 3.10.x)
* user configured filter is NOT applied to plugin resolution
* Legacy code uses `LegacyTrackingFileManager` the rest `TrackingFileManagerSupplier`
* Expose `RepositorySystemSession` as session scoped, same as Maven 3.10.x (in fact, Maven 3.9.x did seed it, but Module by mistake never exposed it -- this is one of changes in Maven 3.10.x)