### PR TITLE
[maven-4.0.x] Upgrade more plugins in mvnup PluginUpgradeStrategy

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -92,7 +92,10 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             new PluginUpgrade(
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-exec-plugin", "3.2.0", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade(
-                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.0.0", MAVEN_4_COMPATIBILITY_REASON),
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID,
+                    "maven-enforcer-plugin",
+                    "3.5.2",
+                    "Versions before 3.5.2 use removed PluginParameterExpressionEvaluator API incompatible with Maven 4"),
             new PluginUpgrade("org.codehaus.mojo", "flatten-maven-plugin", "1.2.7", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade(
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-shade-plugin", "3.5.0", MAVEN_4_COMPATIBILITY_REASON),
@@ -109,7 +112,17 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID,
                     "maven-surefire-report-plugin",
                     "3.5.2",
-                    MAVEN_4_COMPATIBILITY_REASON));
+                    MAVEN_4_COMPATIBILITY_REASON),
+            new PluginUpgrade(
+                    "net.alchim31.maven",
+                    "scala-maven-plugin",
+                    "4.9.2",
+                    "Versions before 4.9.2 call add() on immutable lists returned by Maven 4 API"),
+            new PluginUpgrade(
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID,
+                    "maven-resources-plugin",
+                    "3.3.1",
+                    "Beta/RC versions compiled against different Maven 4 API signatures"));
 
     private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
             "org.codehaus.mojo",
@@ -253,7 +266,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 new PluginUpgradeInfo("org.codehaus.mojo", "exec-maven-plugin", "3.2.0"));
         upgrades.put(
                 DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-enforcer-plugin",
-                new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.0.0"));
+                new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.5.2"));
         upgrades.put(
                 "org.codehaus.mojo:flatten-maven-plugin",
                 new PluginUpgradeInfo("org.codehaus.mojo", "flatten-maven-plugin", "1.2.7"));
@@ -272,6 +285,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         upgrades.put(
                 DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-surefire-report-plugin",
                 new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-surefire-report-plugin", "3.5.2"));
+        upgrades.put(
+                "net.alchim31.maven:scala-maven-plugin",
+                new PluginUpgradeInfo("net.alchim31.maven", "scala-maven-plugin", "4.9.2"));
+        upgrades.put(
+                DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-resources-plugin",
+                new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-resources-plugin", "3.3.1"));
         return upgrades;
     }
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -216,14 +216,14 @@ class PluginUpgradeStrategyTest {
             UpgradeResult result = strategy.doApply(context, pomMap);
 
             assertTrue(result.success(), "Plugin upgrade should succeed");
-            assertTrue(result.modifiedCount() > 0, "Should have upgraded 3.0.0-M1 to 3.0.0");
+            assertTrue(result.modifiedCount() > 0, "Should have upgraded 3.0.0-M1 to 3.5.2");
 
             Editor editor = new Editor(document);
             Element root = editor.root();
             String version = root.path("build", "plugins", "plugin", "version")
                     .map(Element::textContentTrimmed)
                     .orElse(null);
-            assertEquals("3.0.0", version, "3.0.0-M1 should be upgraded to 3.0.0");
+            assertEquals("3.5.2", version, "3.0.0-M1 should be upgraded to 3.5.2");
         }
 
         @Test
@@ -265,7 +265,7 @@ class PluginUpgradeStrategyTest {
             String version = root.path("build", "pluginManagement", "plugins", "plugin", "version")
                     .map(Element::textContentTrimmed)
                     .orElse(null);
-            assertEquals("3.0.0", version);
+            assertEquals("3.5.2", version);
         }
 
         @Test


### PR DESCRIPTION
Backport of #12119 to `maven-4.0.x`.

Upgrades enforcer plugin minimum version and adds new plugin upgrades in PluginUpgradeStrategy.

_Claude Code on behalf of Guillaume Nodet_