### PR TITLE
[backport maven-4.0.x] Fix logging setup/teardown order

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -311,11 +311,6 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
 
     protected final void createTerminal(C context) {
         if (context.terminal == null) {
-            // Create the build log appender; also sets MavenSimpleLogger sink
-            ProjectBuildLogAppender projectBuildLogAppender =
-                    new ProjectBuildLogAppender(determineBuildEventListener(context));
-            context.closeables.add(projectBuildLogAppender);
-
             MessageUtils.systemInstall(
                     builder -> doCreateTerminal(context, builder),
                     terminal -> doConfigureWithTerminal(context, terminal));
@@ -323,6 +318,11 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
             context.terminal = MessageUtils.getTerminal();
             context.closeables.add(MessageUtils::systemUninstall);
             MessageUtils.registerShutdownHook(); // safety belt
+
+            // Create the build log appender; also sets MavenSimpleLogger sink
+            ProjectBuildLogAppender projectBuildLogAppender =
+                    new ProjectBuildLogAppender(determineBuildEventListener(context));
+            context.closeables.add(projectBuildLogAppender);
         } else {
             doConfigureWithTerminal(context, context.terminal);
         }


### PR DESCRIPTION
## Backport of #11901

Cherry-pick of #11901 onto `maven-4.0.x`.

**Original PR:** #11901 - Fix logging setup/teardown order
**Original author:** @oehme
**Target branch:** `maven-4.0.x`

### Original description

Reorder ProjectBuildLogAppender registration in LookupInvoker so that it is added to the closeables list after the terminal setup. Since closeables are closed in reverse order (LIFO), this ensures the log sink is deregistered before the terminal is torn down, preventing StackOverflowErrors during shutdown.

Relates to https://github.com/apache/maven/issues/11498