### PR TITLE
Fix domtrip API breakage after 1.5.1 upgrade

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/AbstractUpgradeGoal.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/AbstractUpgradeGoal.java
@@ -310,7 +310,7 @@ public abstract class AbstractUpgradeGoal implements Goal {
             boolean modified = false;
             boolean needsNisseCompat = false;
 
-            List<Element> extensions = root.children("extension").toList();
+            List<Element> extensions = root.childElements("extension").toList();
             List<Element> toRemove = new ArrayList<>();
 
             for (Element ext : extensions) {


### PR DESCRIPTION
## Summary
- Fix compilation failure introduced by the domtrip 0.4.1 → 1.5.1 upgrade (#12131)
- The `children(String)` method on `ContainerNode` was renamed to `childElements(String)` on `Element` in domtrip 1.5.1
- Single one-line fix in `AbstractUpgradeGoal.java`

## Test plan
- [x] `mvn compile` passes in `impl/maven-cli`
- [x] `AbstractUpgradeGoalTest` passes
- [ ] CI should go green

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)