### PR TITLE
Avoid final logger injection in EventSpyDispatcher

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/eventspy/internal/EventSpyDispatcher.java
+++ b/maven-core/src/main/java/org/apache/maven/eventspy/internal/EventSpyDispatcher.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 @Named
 public class EventSpyDispatcher {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventSpyDispatcher.class);
 
     private final List<EventSpy> eventSpies;
 
@@ -107,10 +107,10 @@ public class EventSpyDispatcher {
     private void logError(String action, Throwable e, EventSpy spy) {
         String msg = "Failed to " + action + " spy " + spy.getClass().getName() + ": " + e.getMessage();
 
-        if (logger.isDebugEnabled()) {
-            logger.warn(msg, e);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.warn(msg, e);
         } else {
-            logger.warn(msg);
+            LOGGER.warn(msg);
         }
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/eventspy/internal/EventSpyDispatcherTest.java
+++ b/maven-core/src/test/java/org/apache/maven/eventspy/internal/EventSpyDispatcherTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.eventspy.internal;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class EventSpyDispatcherTest {
+
+    @Test
+    void doesNotExposeFinalInstanceLoggerFieldForInjection() {
+        boolean hasFinalInstanceLogger = Arrays.stream(EventSpyDispatcher.class.getDeclaredFields())
+                .filter(field -> Logger.class.equals(field.getType()))
+                .anyMatch(field -> !Modifier.isStatic(field.getModifiers()) && Modifier.isFinal(field.getModifiers()));
+
+        assertFalse(hasFinalInstanceLogger);
+    }
+}


### PR DESCRIPTION
Fixes #12115

This changes EventSpyDispatcher to use a static logger so Sisu does not mutate a final instance logger field reflectively on newer JDKs. It also adds a small regression test that guards against reintroducing a final instance Logger field.

Validation:
- mvn -B -pl maven-core -Dtest=EventSpyDispatcherTest test
- mvn -B -pl maven-core test