### PR TITLE
Handle missing package metadata in model ids

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/plugin/DefaultReportingConverter.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/plugin/DefaultReportingConverter.java
@@ -51,12 +51,17 @@ public class DefaultReportingConverter implements ReportingConverter {
     private final InputLocation location;
 
     {
-        String modelId = "org.apache.maven:maven-model-builder:"
-                + this.getClass().getPackage().getImplementationVersion() + ":reporting-converter";
+        String modelId =
+                "org.apache.maven:maven-model-builder:" + getImplementationVersion(getClass()) + ":reporting-converter";
         InputSource inputSource = new InputSource();
         inputSource.setModelId(modelId);
         location = new InputLocation(-1, -1, inputSource);
         location.setLocation(0, location);
+    }
+
+    static String getImplementationVersion(Class<?> clazz) {
+        Package packageInfo = clazz.getPackage();
+        return packageInfo != null ? packageInfo.getImplementationVersion() : null;
     }
 
     @Override

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/superpom/DefaultSuperPomProvider.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/superpom/DefaultSuperPomProvider.java
@@ -70,8 +70,8 @@ public class DefaultSuperPomProvider implements SuperPomProvider {
                 Map<String, Object> options = new HashMap<>();
                 options.put("xml:4.0.0", "xml:4.0.0");
 
-                String modelId = "org.apache.maven:maven-model-builder:"
-                        + this.getClass().getPackage().getImplementationVersion() + ":super-pom";
+                String modelId =
+                        "org.apache.maven:maven-model-builder:" + getImplementationVersion(getClass()) + ":super-pom";
                 InputSource inputSource = new InputSource();
                 inputSource.setModelId(modelId);
                 inputSource.setLocation(getClass().getResource(resource).toExternalForm());
@@ -87,5 +87,10 @@ public class DefaultSuperPomProvider implements SuperPomProvider {
         }
 
         return superModel;
+    }
+
+    static String getImplementationVersion(Class<?> clazz) {
+        Package packageInfo = clazz.getPackage();
+        return packageInfo != null ? packageInfo.getImplementationVersion() : null;
     }
 }

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/plugin/DefaultReportingConverterTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/plugin/DefaultReportingConverterTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DefaultReportingConverterTest {
+
+    @Test
+    void returnsNullImplementationVersionWhenClassHasNoPackage() {
+        assertNull(DefaultReportingConverter.getImplementationVersion(int.class));
+    }
+}

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/superpom/DefaultSuperPomProviderTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/superpom/DefaultSuperPomProviderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.superpom;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DefaultSuperPomProviderTest {
+
+    @Test
+    void returnsNullImplementationVersionWhenClassHasNoPackage() {
+        assertNull(DefaultSuperPomProvider.getImplementationVersion(int.class));
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -88,7 +88,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
     private static final String MAVEN_PLUGINS = "org.apache.maven.plugins:";
 
     public static final String DEFAULT_LIFECYCLE_MODELID = "org.apache.maven:maven-core:"
-            + DefaultLifecycleRegistry.class.getPackage().getImplementationVersion()
+            + getImplementationVersion(DefaultLifecycleRegistry.class)
             + ":default-lifecycle-bindings";
 
     public static final InputLocation DEFAULT_LIFECYCLE_INPUT_LOCATION =
@@ -120,6 +120,11 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
                 }
             });
         }
+    }
+
+    static String getImplementationVersion(Class<?> clazz) {
+        Package packageInfo = clazz.getPackage();
+        return packageInfo != null ? packageInfo.getImplementationVersion() : null;
     }
 
     @Override

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultLifecycleRegistryTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultLifecycleRegistryTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.internal.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DefaultLifecycleRegistryTest {
+
+    @Test
+    void returnsNullImplementationVersionWhenClassHasNoPackage() {
+        assertNull(DefaultLifecycleRegistry.getImplementationVersion(int.class));
+    }
+}

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSuperPomProvider.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSuperPomProvider.java
@@ -62,8 +62,8 @@ public class DefaultSuperPomProvider implements SuperPomProvider {
                     + ", please verify the integrity of your Maven installation");
         }
         try (InputStream is = url.openStream()) {
-            String modelId = "org.apache.maven:maven-api-impl:"
-                    + this.getClass().getPackage().getImplementationVersion() + ":super-pom-" + version;
+            String modelId =
+                    "org.apache.maven:maven-api-impl:" + getImplementationVersion(getClass()) + ":super-pom-" + version;
             return modelProcessor.read(XmlReaderRequest.builder()
                     .modelId(modelId)
                     .location(url.toExternalForm())
@@ -76,5 +76,10 @@ public class DefaultSuperPomProvider implements SuperPomProvider {
                             + ", please verify the integrity of your Maven installation",
                     e);
         }
+    }
+
+    static String getImplementationVersion(Class<?> clazz) {
+        Package packageInfo = clazz.getPackage();
+        return packageInfo != null ? packageInfo.getImplementationVersion() : null;
     }
 }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSuperPomProviderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSuperPomProviderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DefaultSuperPomProviderTest {
+
+    @Test
+    void returnsNullImplementationVersionWhenClassHasNoPackage() {
+        assertNull(DefaultSuperPomProvider.getImplementationVersion(int.class));
+    }
+}


### PR DESCRIPTION
Fixes #8403.

This avoids NullPointerException when Maven code builds internal model ids in environments where Class#getPackage() returns null, while preserving the previous model id contents when package metadata exists but the implementation version is absent. The fallback is applied to the remaining implementation-version based model ids in the current codebase.

Validation:
- mvn -B -am -pl compat/maven-model-builder,impl/maven-impl,impl/maven-core -Dtest=DefaultReportingConverterTest,DefaultSuperPomProviderTest,DefaultLifecycleRegistryTest -Dsurefire.failIfNoSpecifiedTests=false test