### PR TITLE
Fix mvnup recommending non-existent maven-enforcer-plugin:3.5.2

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -71,10 +71,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             new PluginUpgrade(
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-exec-plugin", "3.2.0", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade(
-                    DEFAULT_MAVEN_PLUGIN_GROUP_ID,
-                    "maven-enforcer-plugin",
-                    "3.5.2",
-                    "Versions before 3.5.2 use removed PluginParameterExpressionEvaluator API incompatible with Maven 4"),
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.5.0", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade("org.codehaus.mojo", "flatten-maven-plugin", "1.2.7", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade(
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-shade-plugin", "3.5.0", MAVEN_4_COMPATIBILITY_REASON),
@@ -243,7 +240,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 new PluginUpgradeInfo("org.codehaus.mojo", "exec-maven-plugin", "3.2.0"));
         upgrades.put(
                 DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-enforcer-plugin",
-                new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.5.2"));
+                new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.5.0"));
         upgrades.put(
                 "org.codehaus.mojo:flatten-maven-plugin",
                 new PluginUpgradeInfo("org.codehaus.mojo", "flatten-maven-plugin", "1.2.7"));

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -216,14 +216,14 @@ class PluginUpgradeStrategyTest {
             UpgradeResult result = strategy.doApply(context, pomMap);
 
             assertTrue(result.success(), "Plugin upgrade should succeed");
-            assertTrue(result.modifiedCount() > 0, "Should have upgraded 3.0.0-M1 to 3.5.2");
+            assertTrue(result.modifiedCount() > 0, "Should have upgraded 3.0.0-M1 to 3.5.0");
 
             Editor editor = new Editor(document);
             String version = editor.root()
                     .path("build", "plugins", "plugin", "version")
                     .map(Element::textContentTrimmed)
                     .orElse(null);
-            assertEquals("3.5.2", version, "3.0.0-M1 should be upgraded to 3.5.2");
+            assertEquals("3.5.0", version, "3.0.0-M1 should be upgraded to 3.5.0");
         }
 
         @Test
@@ -265,7 +265,7 @@ class PluginUpgradeStrategyTest {
             String version = root.path("build", "pluginManagement", "plugins", "plugin", "version")
                     .map(Element::textContentTrimmed)
                     .orElse(null);
-            assertEquals("3.5.2", version);
+            assertEquals("3.5.0", version);
         }
 
         @Test


### PR DESCRIPTION
## Summary

- Fixed `PluginUpgradeStrategy` recommending `maven-enforcer-plugin:3.5.2`, a version that was never released to Maven Central (versions go 3.5.0 → 3.6.0)
- The `3.5.2` version was confused with `maven-surefire-plugin`, which does have a 3.5.2 release
- Changed the recommended minimum to `3.5.0`, which exists and includes the necessary Maven 4 compatibility changes (plexus-utils 4.0.0 bump)

## Test plan

- [x] All 27 `PluginUpgradeStrategyTest` tests pass
- [ ] Verify `mvnup apply` no longer recommends non-existent enforcer plugin version

🤖 Generated with [Claude Code](https://claude.com/claude-code)