### PR TITLE
Fix mvnup: use effective model to resolve properties from remote parents

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
@@ -125,6 +125,7 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
         Set<Path> errorPoms = new HashSet<>();
 
         Set<String> allDefinedProperties = collectAllDefinedProperties(pomMap);
+        allDefinedProperties.addAll(collectEffectiveProperties(context, pomMap));
 
         for (Map.Entry<Path, Document> entry : pomMap.entrySet()) {
             Path pomPath = entry.getKey();
@@ -373,6 +374,19 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
                         .forEach(profile -> profile.childElement(PROPERTIES)
                                 .ifPresent(propsElement ->
                                         propsElement.childElements().forEach(child -> properties.add(child.name())))));
+    }
+
+    private Set<String> collectEffectiveProperties(UpgradeContext context, Map<Path, Document> pomMap) {
+        Set<String> properties = new HashSet<>();
+        for (Path pomPath : pomMap.keySet()) {
+            try {
+                org.apache.maven.api.model.Model effectiveModel = buildEffectiveModel(pomPath);
+                properties.addAll(effectiveModel.getProperties().keySet());
+            } catch (Exception e) {
+                context.debug("Failed to build effective model for " + pomPath + ": " + e.getMessage());
+            }
+        }
+        return properties;
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategyTest.java
@@ -919,6 +919,132 @@ class CompatibilityFixStrategyTest {
                     deps.childElements("dependency").count(),
                     "Dependency should not be commented out when property is inherited from grandparent");
         }
+
+        @Test
+        @DisplayName("should not comment out when property is defined in external parent not in reactor")
+        void shouldNotCommentOutWhenPropertyFromExternalParentNotInReactor() throws Exception {
+            String externalParentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>external-parent</artifactId>
+                    <version>1.0.0</version>
+                    <packaging>pom</packaging>
+                    <properties>
+                        <oak.version>1.62.0</oak.version>
+                    </properties>
+                </project>
+                """;
+
+            String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>external-parent</artifactId>
+                        <version>1.0.0</version>
+                        <relativePath>../external/pom.xml</relativePath>
+                    </parent>
+                    <artifactId>child</artifactId>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.jackrabbit</groupId>
+                                <artifactId>oak-core</artifactId>
+                                <version>${oak.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """;
+
+            Path externalDir = Files.createDirectories(tempDir.resolve("external"));
+            Path externalParentPath = externalDir.resolve("pom.xml");
+            Path childDir = Files.createDirectories(tempDir.resolve("child"));
+            Path childPomPath = childDir.resolve("pom.xml");
+
+            Files.writeString(externalParentPath, externalParentPom);
+            Files.writeString(childPomPath, childPom);
+
+            Document childDoc = Document.of(childPom);
+            Map<Path, Document> pomMap = Map.of(childPomPath, childDoc);
+
+            UpgradeContext context = createMockContext(childDir);
+            strategy.doApply(context, pomMap);
+
+            Element root = childDoc.root();
+            Element depMgmt = DomUtils.findChildElement(root, "dependencyManagement");
+            Element deps = DomUtils.findChildElement(depMgmt, "dependencies");
+            assertEquals(
+                    1,
+                    deps.childElements("dependency").count(),
+                    "Managed dependency should not be commented out when property is inherited from external parent");
+        }
+
+        @Test
+        @DisplayName("should comment out when property is truly undefined even in effective model")
+        void shouldCommentOutWhenPropertyTrulyUndefinedInEffectiveModel() throws Exception {
+            String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+            String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0.0</version>
+                        <relativePath>../pom.xml</relativePath>
+                    </parent>
+                    <artifactId>child</artifactId>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.google.guava</groupId>
+                                <artifactId>guava</artifactId>
+                                <version>${truly.undefined.prop}</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """;
+
+            Path parentPath = tempDir.resolve("pom.xml");
+            Path childDir = Files.createDirectories(tempDir.resolve("child"));
+            Path childPomPath = childDir.resolve("pom.xml");
+
+            Files.writeString(parentPath, parentPom);
+            Files.writeString(childPomPath, childPom);
+
+            Document childDoc = Document.of(childPom);
+            Map<Path, Document> pomMap = Map.of(childPomPath, childDoc);
+
+            UpgradeContext context = createMockContext(childDir);
+            strategy.doApply(context, pomMap);
+
+            String xml = DomUtils.toXml(childDoc);
+            assertTrue(xml.contains("mvnup: commented out"), "Should contain comment-out marker");
+            assertTrue(xml.contains("truly.undefined.prop"), "Should mention the undefined property");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

- Fix `CompatibilityFixStrategy` incorrectly commenting out `dependencyManagement` entries whose versions use properties inherited from remote parent POMs (e.g., `${oak.version}` from `sling-parent`, `${version}` from a published parent)
- The existing static analysis only scanned reactor POMs for property definitions, missing properties from remote parents
- Now uses the `buildEffectiveModel` infrastructure (already available in `AbstractUpgradeStrategy`) to resolve properties from the full parent chain before deciding a property is "undefined"

Fixes https://github.com/gnodet/maven4-testing/issues/13383
Fixes https://github.com/gnodet/maven4-testing/issues/13374

## Test plan

- [x] New test: property from external parent not in reactor is correctly recognized as defined
- [x] New test: truly undefined property (not in any parent) is still correctly commented out
- [x] All 24 existing `CompatibilityFixStrategyTest` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)