### PR TITLE
Fix deadlocks in request cache (unstable hashCode, re-entrant self-deadlock, mutable properties)

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilderRequest.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/ModelBuilderRequest.java
@@ -332,8 +332,8 @@ public interface ModelBuilderRequest extends RepositoryAwareRequest {
                 this.activeProfileIds = activeProfileIds != null ? List.copyOf(activeProfileIds) : List.of();
                 this.inactiveProfileIds = inactiveProfileIds != null ? List.copyOf(inactiveProfileIds) : List.of();
                 this.systemProperties =
-                        systemProperties != null ? Map.copyOf(systemProperties) : session.getSystemProperties();
-                this.userProperties = userProperties != null ? Map.copyOf(userProperties) : session.getUserProperties();
+                        Map.copyOf(systemProperties != null ? systemProperties : session.getSystemProperties());
+                this.userProperties = Map.copyOf(userProperties != null ? userProperties : session.getUserProperties());
                 this.repositoryMerging = repositoryMerging;
                 this.repositories = repositories != null ? List.copyOf(validate(repositories)) : null;
                 this.lifecycleBindingsInjector = lifecycleBindingsInjector;

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/AbstractRequestCache.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/AbstractRequestCache.java
@@ -60,7 +60,14 @@ public abstract class AbstractRequestCache implements RequestCache {
     @SuppressWarnings("all")
     public <REQ extends Request<?>, REP extends Result<REQ>> REP request(REQ req, Function<REQ, REP> supplier) {
         CachingSupplier<REQ, REP> cs = doCache(req, supplier);
-        return cs.apply(req);
+        try {
+            return cs.apply(req);
+        } catch (CachingSupplier.CyclicCacheAccessException e) {
+            // Re-entrant access from the same thread (e.g., a batch requests() computation
+            // triggered a singular request() that found the same cached entry). Compute
+            // directly with the caller's supplier to break the cycle.
+            return supplier.apply(req);
+        }
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/AbstractRequestCache.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/AbstractRequestCache.java
@@ -19,7 +19,7 @@
 package org.apache.maven.impl.cache;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -85,7 +85,7 @@ public abstract class AbstractRequestCache implements RequestCache {
     @SuppressWarnings("unchecked")
     public <REQ extends Request<?>, REP extends Result<REQ>> List<REP> requests(
             List<REQ> reqs, Function<List<REQ>, List<REP>> supplier) {
-        final Map<REQ, Object> nonCachedResults = new HashMap<>();
+        final Map<REQ, Object> nonCachedResults = new IdentityHashMap<>();
         List<RequestResult<REQ, REP>> allResults = new ArrayList<>(reqs.size());
 
         Function<REQ, REP> individualSupplier = req -> {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/CachingSupplier.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/CachingSupplier.java
@@ -30,6 +30,8 @@ import java.util.function.Function;
 public class CachingSupplier<REQ, REP> implements Function<REQ, REP> {
     protected final Function<REQ, REP> supplier;
     protected volatile Object value;
+    // Guarded by synchronized(this) — tracks which thread is currently computing
+    private Thread computingThread;
 
     public CachingSupplier(Function<REQ, REP> supplier) {
         this.supplier = supplier;
@@ -46,10 +48,18 @@ public class CachingSupplier<REQ, REP> implements Function<REQ, REP> {
         if ((v = value) == null) {
             synchronized (this) {
                 if ((v = value) == null) {
+                    if (computingThread == Thread.currentThread()) {
+                        throw new CyclicCacheAccessException();
+                    }
+                    computingThread = Thread.currentThread();
                     try {
                         v = value = supplier.apply(req);
+                    } catch (CyclicCacheAccessException e) {
+                        throw e;
                     } catch (Exception e) {
                         v = value = new AltRes(e);
+                    } finally {
+                        computingThread = null;
                     }
                 }
             }
@@ -58,6 +68,16 @@ public class CachingSupplier<REQ, REP> implements Function<REQ, REP> {
             DefaultRequestCache.uncheckedThrow(altRes.throwable);
         }
         return (REP) v;
+    }
+
+    /**
+     * Thrown when a re-entrant call is detected on the same thread that is already
+     * computing this supplier's value. Prevents self-deadlock when a batch
+     * {@code requests()} computation triggers a singular {@code request()} that
+     * finds the same CachingSupplier in the cache.
+     */
+    public static class CyclicCacheAccessException extends RuntimeException {
+        CyclicCacheAccessException() {}
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes two deadlock vectors and one root-cause mutability bug in the Maven 4 request cache layer, responsible for ~80 timeout failures in [Maven 4 compatibility testing](https://github.com/gnodet/maven4-testing/issues/9934) (projects using `maven-remote-resources-plugin` hang indefinitely).

## Root Cause Analysis

The hang occurs during parent POM resolution triggered by the remote-resources-plugin's lazy `getProjects()` call, which enters the compat resolver → `projectBuilder.build()` → Maven 4 `ArtifactResolver` → request cache. Two independent deadlock vectors exist:

### 1. Unstable `hashCode()` in `nonCachedResults` HashMap

`AbstractRequestCache.requests()` uses a local `HashMap` to coordinate batch results. The batch supplier puts results via `put()`, and the `individualSupplier` lambda retrieves them via `containsKey()`.

`ResolverRequest` is a Java record whose `hashCode()` transitively includes `RequestTrace.data` → `ModelBuilderRequest` → `systemProperties`. When `systemProperties` is null in the builder, `DefaultModelBuilderRequest` stores a **live view** of `session.getSystemProperties()` (backed by `java.util.Properties`) instead of a snapshot. If `System.setProperty()` is called between `put()` and `containsKey()`, the hash changes, the entry is stored in one bucket but looked up in another, and `containsKey()` returns `false` — the thread waits forever.

### 2. Re-entrant self-deadlock via `CachingSupplier`

When `requests()` stores `CachingSupplier` instances wrapping `individualSupplier` in the shared session cache, a re-entrant call **from the same thread** during batch computation can self-deadlock:

1. `requests([req])` → `doCache(req, individualSupplier)` creates `CachingSupplier` CS in cache
2. Batch executes under `synchronized(nonCachedResults)`
3. Batch computation triggers model building → parent POM resolution → `request(req)` → finds CS in cache
4. `cs.apply(req)` → `synchronized(cs)` is re-entrant (same thread) → `value` is null → calls `individualSupplier`
5. `individualSupplier` → `synchronized(nonCachedResults)` (re-entrant) → `containsKey(req)` → false (batch not done) → `wait()` → releases `nonCachedResults` monitor
6. **DEADLOCK**: the thread is blocked in `wait()`, but it is also the thread running the batch — `notifyAll()` only fires after the batch returns, which can never happen

## Fix (3 commits)

### Commit 1: `IdentityHashMap` for `nonCachedResults`

Switch from `HashMap` to `IdentityHashMap` in `AbstractRequestCache.requests()`. Since the code always uses the same object references for `put()` and `containsKey()` within a single `requests()` call, identity-based lookup is correct and immune to any `hashCode()` instability. This is a defense-in-depth measure: `RequestTrace.data` is typed as `Object` with no immutability guarantee, so any mutable data in the trace chain could trigger the same issue.

### Commit 2: Re-entrant self-deadlock detection in `CachingSupplier`

Track the computing thread in `CachingSupplier`. When `apply()` detects re-entrant access from the same thread (the thread that is already computing the value), it throws `CyclicCacheAccessException`. `AbstractRequestCache.request()` catches this and falls back to computing directly with the caller's original supplier, bypassing the cache for that one call. The outer batch computation continues normally and sets the cached value for future callers.

### Commit 3: Snapshot system/user properties in `ModelBuilderRequest`

`DefaultModelBuilderRequest` constructor used `session.getSystemProperties()` directly when `systemProperties` was null, storing a live view backed by `java.util.Properties`. Now always wraps in `Map.copyOf()` regardless of the source, ensuring the stored map is a true immutable snapshot. Same fix applied to `userProperties`.

## Test plan

- [x] Reproduced locally: `httpcomponents-stylecheck` hangs indefinitely with Maven 4
- [x] Verified fix: same project builds in 1.6s after the changes
- [x] Maven's own build (`mvn verify -DskipTests`) passes
- [x] Existing `AbstractRequestCacheTest` passes

_Claude Code on behalf of Guillaume Nodet_