### PR TITLE
Fix mvnup PLUGIN_UPGRADES for compiler and exec plugins

### DIFF
--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -746,7 +746,7 @@ class PluginUpgradeStrategyTest {
                     upgrades.stream().anyMatch(upgrade -> "maven-surefire-report-plugin".equals(upgrade.artifactId()));
 
             assertTrue(hasCompilerPlugin, "Should include maven-compiler-plugin upgrade");
-            assertTrue(hasExecPlugin, "Should include maven-exec-plugin upgrade");
+            assertTrue(hasExecPlugin, "Should include exec-maven-plugin upgrade");
             assertTrue(hasSurefirePlugin, "Should include maven-surefire-plugin upgrade");
             assertTrue(hasFailsafePlugin, "Should include maven-failsafe-plugin upgrade");
             assertTrue(hasSurefireReportPlugin, "Should include maven-surefire-report-plugin upgrade");


### PR DESCRIPTION
## Summary
- Fixed `maven-compiler-plugin` version from `3.2.0` to `3.2` in `PLUGIN_UPGRADES` — version 3.2.0 does not exist on Maven Central (confirmed via HTTP 404), causing build resolution failures in projects like servicemix4-bundles and synapse
- Fixed `exec-maven-plugin` entry: corrected groupId from `org.apache.maven.plugins` to `org.codehaus.mojo` and artifactId from `maven-exec-plugin` to `exec-maven-plugin`, making `PLUGIN_UPGRADES` consistent with `getPluginUpgradesMap()`

## Test plan
- [x] Verified `maven-compiler-plugin:3.2` exists on Maven Central (HTTP 200)
- [x] Verified `maven-compiler-plugin:3.2.0` does NOT exist on Maven Central (HTTP 404)
- [x] Verified `exec-maven-plugin:3.2.0` exists on Maven Central (HTTP 200)
- [x] Updated tests to match corrected artifact IDs
- [x] All 27 `PluginUpgradeStrategyTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)