### PR TITLE
Bump scala-maven-plugin upgrade target from 4.9.2 to 4.9.5

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -92,8 +92,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             new PluginUpgrade(
                     "net.alchim31.maven",
                     "scala-maven-plugin",
-                    "4.9.2",
-                    "Versions before 4.9.2 call add() on immutable lists returned by Maven 4 API"),
+                    "4.9.5",
+                    "Versions before 4.9.5 call add() on immutable lists returned by Maven 4 API"),
             new PluginUpgrade(
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID,
                     "maven-resources-plugin",
@@ -261,7 +261,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-surefire-report-plugin", "3.5.2"));
         upgrades.put(
                 "net.alchim31.maven:scala-maven-plugin",
-                new PluginUpgradeInfo("net.alchim31.maven", "scala-maven-plugin", "4.9.2"));
+                new PluginUpgradeInfo("net.alchim31.maven", "scala-maven-plugin", "4.9.5"));
         upgrades.put(
                 DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-resources-plugin",
                 new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-resources-plugin", "3.3.1"));


### PR DESCRIPTION
## Summary
- Bump the scala-maven-plugin version target in mvnup from 4.9.2 to 4.9.5
- Versions 4.9.3 and 4.9.4 were tagged but never published to Maven Central; 4.9.5 is the first release containing the fix for [davidB/scala-maven-plugin@e6d922e](https://github.com/davidB/scala-maven-plugin/commit/e6d922eb) which resolves `UnsupportedOperationException` when running with Maven 4 (the plugin called `add()` on immutable lists returned by Maven 4 API)

## Test plan
- [ ] Verify mvnup recommends 4.9.5 for scala-maven-plugin
- [ ] Verify 4.9.5 is available on Maven Central

_Claude Code on behalf of Guillaume Nodet_