### PR TITLE
Upgrade domtrip from 1.5.1 to 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ under the License.
     <byteBuddyVersion>1.18.8</byteBuddyVersion>
     <classWorldsVersion>2.12.0</classWorldsVersion>
     <commonsCliVersion>1.11.0</commonsCliVersion>
-    <domtripVersion>1.5.1</domtripVersion>
+    <domtripVersion>1.5.2</domtripVersion>
     <guiceVersion>5.1.0</guiceVersion>
     <guavaVersion>33.6.0-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>


### PR DESCRIPTION
## Summary
- Upgrade domtrip from 1.5.1 to 1.5.2
- Fixes blank line idempotency in `addBlankLineBefore`/`addBlankLineAfter` ([domtrip PR #238](https://github.com/maveniverse/domtrip/pull/238))
- Without this fix, repeated `mvnup` runs accumulate duplicate blank lines, causing Spotless formatting check failures

## Test plan
- [ ] Verify mvnup runs are idempotent (no accumulating blank lines)
- [ ] Run Spotless check after mvnup on a project that uses it

_Claude Code on behalf of Guillaume Nodet_