### PR TITLE
Move repository expression validation from raw to effective model

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -668,7 +668,7 @@ public class DefaultModelValidator implements ModelValidator {
 
         if (validationLevel > VALIDATION_LEVEL_MINIMAL) {
             validateRawRepositories(
-                    problems, model.getRepositories(), "repositories.repository.", EMPTY, validationLevel, false);
+                    problems, model.getRepositories(), "repositories.repository.", EMPTY, validationLevel, true);
 
             validateRawRepositories(
                     problems,
@@ -676,7 +676,7 @@ public class DefaultModelValidator implements ModelValidator {
                     "pluginRepositories.pluginRepository.",
                     EMPTY,
                     validationLevel,
-                    false);
+                    true);
 
             for (Profile profile : model.getProfiles()) {
                 String prefix = "profiles.profile[" + profile.getId() + "].";
@@ -1676,6 +1676,28 @@ public class DefaultModelValidator implements ModelValidator {
                     null,
                     repository,
                     ILLEGAL_REPO_ID_CHARS);
+
+            if (hasExpression(repository.getId())) {
+                addViolation(
+                        problems,
+                        Severity.ERROR,
+                        Version.V40,
+                        prefix + "[" + repository.getId() + "].id",
+                        null,
+                        "contains an uninterpolated expression.",
+                        repository);
+            }
+
+            if (hasExpression(repository.getUrl())) {
+                addViolation(
+                        problems,
+                        Severity.ERROR,
+                        Version.V40,
+                        prefix + "[" + repository.getId() + "].url",
+                        null,
+                        "contains an uninterpolated expression.",
+                        repository);
+            }
 
             if ("local".equals(repository.getId())) {
                 addViolation(

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -913,33 +913,52 @@ class DefaultModelValidatorTest {
     @Test
     void repositoryWithBasedirExpression() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/repository-with-basedir-expression.xml");
-        // This test runs on raw model without interpolation, so all expressions appear uninterpolated
-        // In the real flow, supported expressions would be interpolated before validation
-        assertViolations(result, 0, 3, 0);
+        // Raw validation no longer checks for uninterpolated expressions in repositories
+        // because parent properties are not available at this stage
+        assertViolations(result, 0, 0, 0);
     }
 
     @Test
     void repositoryWithUnsupportedExpression() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/repository-with-unsupported-expression.xml");
-        // Unsupported expressions should cause validation errors
-        assertViolations(result, 0, 1, 0);
+        // Raw validation no longer checks for uninterpolated expressions in repositories
+        assertViolations(result, 0, 0, 0);
     }
 
     @Test
     void repositoryWithUninterpolatedId() throws Exception {
         SimpleProblemCollector result = validateRaw("raw-model/repository-with-uninterpolated-id.xml");
-        // Uninterpolated expressions in repository IDs should cause validation errors
-        // distributionManagement repositories skip expression check since parent properties
-        // may not be available at file model validation stage
-        assertViolations(result, 0, 2, 0);
+        // Raw validation no longer checks for uninterpolated expressions in repositories
+        // because parent properties are not available at this stage
+        assertViolations(result, 0, 0, 0);
+    }
 
-        // Check that repository ID validation errors are present for repositories and pluginRepositories
+    @Test
+    void effectiveRepositoryWithUninterpolatedId() throws Exception {
+        SimpleProblemCollector result = validate("raw-model/repository-with-uninterpolated-id.xml");
+        // After full interpolation, remaining expressions in repository IDs/URLs are errors
+        // All three repository types (repositories, pluginRepositories, distributionManagement) are checked
+        assertViolations(result, 0, 3, 0);
+
         assertTrue(result.getErrors().stream()
                 .anyMatch(error -> error.contains("repositories.repository.[${repository.id}].id")
                         && error.contains("contains an uninterpolated expression")));
         assertTrue(result.getErrors().stream()
                 .anyMatch(error -> error.contains("pluginRepositories.pluginRepository.[${plugin.repository.id}].id")
                         && error.contains("contains an uninterpolated expression")));
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains("distributionManagement.repository.[${staging.repository.id}].id")
+                        && error.contains("contains an uninterpolated expression")));
+    }
+
+    @Test
+    void effectiveRepositoryWithUninterpolatedUrl() throws Exception {
+        SimpleProblemCollector result = validate("raw-model/repository-with-unsupported-expression.xml");
+        // After full interpolation, remaining expressions in repository URLs are errors
+        assertViolations(result, 0, 1, 0);
+
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains(".url") && error.contains("contains an uninterpolated expression")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Skip uninterpolated expression checks for root-level repositories during raw model validation, because parent POM properties are not yet available at that stage
- Add the same expression checks to effective model validation (`validate20EffectiveRepository`), where parent properties have been merged and full interpolation is complete
- Truly unresolvable expressions are still caught as errors, but after all property sources have been resolved

## Context

Raw model validation runs before the parent POM is read (`doReadRawModel` → `validateRawModel` happens before `readEffectiveModel` → `readParent`). This means properties defined in parent POMs (e.g., `${eclipseP2RepoId}`) are not available during raw validation, causing false positives.

Profile and distributionManagement repositories already skipped expression checks for the same reason. This change extends that to root-level `repositories` and `pluginRepositories`.

Fixes: MNG-15012, MNG-14390, MNG-10104, MNG-13299, MNG-14733

## Test plan

- [x] Updated raw validation tests to reflect skipped expression checks
- [x] Added effective model validation tests to verify unresolvable expressions are still caught
- [x] All 470 maven-impl tests pass


_Generated with Claude Code_