### PR TITLE
Fix mvnup version normalization and artifact ID for plugin upgrades

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -67,9 +67,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
 
     private static final List<PluginUpgrade> PLUGIN_UPGRADES = List.of(
             new PluginUpgrade(
-                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-compiler-plugin", "3.2.0", MAVEN_4_COMPATIBILITY_REASON),
-            new PluginUpgrade(
-                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-exec-plugin", "3.2.0", MAVEN_4_COMPATIBILITY_REASON),
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-compiler-plugin", "3.2", MAVEN_4_COMPATIBILITY_REASON),
+            new PluginUpgrade("org.codehaus.mojo", "exec-maven-plugin", "3.2.0", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade(
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.5.0", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade("org.codehaus.mojo", "flatten-maven-plugin", "1.2.7", MAVEN_4_COMPATIBILITY_REASON),

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -521,8 +521,8 @@ class PluginUpgradeStrategyTest {
                     <build>
                         <plugins>
                             <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-exec-plugin</artifactId>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>exec-maven-plugin</artifactId>
                                 <!-- No version - inherited from parent or pluginManagement -->
                             </plugin>
                         </plugins>
@@ -553,8 +553,8 @@ class PluginUpgradeStrategyTest {
                     <build>
                         <plugins>
                             <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-exec-plugin</artifactId>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>exec-maven-plugin</artifactId>
                                 <version>${exec.plugin.version}</version>
                             </plugin>
                         </plugins>
@@ -737,7 +737,7 @@ class PluginUpgradeStrategyTest {
             boolean hasCompilerPlugin =
                     upgrades.stream().anyMatch(upgrade -> "maven-compiler-plugin".equals(upgrade.artifactId()));
             boolean hasExecPlugin =
-                    upgrades.stream().anyMatch(upgrade -> "maven-exec-plugin".equals(upgrade.artifactId()));
+                    upgrades.stream().anyMatch(upgrade -> "exec-maven-plugin".equals(upgrade.artifactId()));
             boolean hasSurefirePlugin =
                     upgrades.stream().anyMatch(upgrade -> "maven-surefire-plugin".equals(upgrade.artifactId()));
             boolean hasFailsafePlugin =
@@ -746,7 +746,7 @@ class PluginUpgradeStrategyTest {
                     upgrades.stream().anyMatch(upgrade -> "maven-surefire-report-plugin".equals(upgrade.artifactId()));
 
             assertTrue(hasCompilerPlugin, "Should include maven-compiler-plugin upgrade");
-            assertTrue(hasExecPlugin, "Should include maven-exec-plugin upgrade");
+            assertTrue(hasExecPlugin, "Should include exec-maven-plugin upgrade");
             assertTrue(hasSurefirePlugin, "Should include maven-surefire-plugin upgrade");
             assertTrue(hasFailsafePlugin, "Should include maven-failsafe-plugin upgrade");
             assertTrue(hasSurefireReportPlugin, "Should include maven-surefire-report-plugin upgrade");


### PR DESCRIPTION
## Summary
- Fix maven-compiler-plugin minimum version from `3.2.0` to `3.2` — version 3.2.0 does not exist on Maven Central, causing resolution failures (e.g. servicemix4-bundles, synapse)
- Fix exec-maven-plugin entry in `PLUGIN_UPGRADES` to use the correct groupId (`org.codehaus.mojo`) and artifactId (`exec-maven-plugin`) — was incorrectly listed as `org.apache.maven.plugins:maven-exec-plugin`, inconsistent with `getPluginUpgradesMap()`

## Test plan
- [x] `PluginUpgradeStrategyTest` — all 27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)