### PR TITLE
Use request properties consistently for CI-friendly version interpolation

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -303,8 +303,8 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         request.session(iSession);
         request.source(src);
         request.locationTracking(false);
-        request.systemProperties(session.getSystemProperties());
-        request.userProperties(session.getUserProperties());
+        request.systemProperties(iSession.getSystemProperties());
+        request.userProperties(iSession.getUserProperties());
         request.lifecycleBindingsInjector(lifecycleBindingsInjector::injectLifecycleBindings);
         ModelBuilder.ModelBuilderSession mbSession =
                 iSession.getData().get(SessionData.key(ModelBuilder.ModelBuilderSession.class));

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -734,8 +734,10 @@ public class DefaultModelBuilder implements ModelBuilder {
                 logger.debug("Profile activation failure details", e);
             }
 
-            // User properties override everything
-            properties.putAll(session.getEffectiveProperties());
+            // System and user properties override everything (use request properties
+            // to ensure consistency with model interpolation, which also uses request properties)
+            properties.putAll(request.getSystemProperties());
+            properties.putAll(request.getUserProperties());
 
             return properties;
         }
@@ -1678,12 +1680,14 @@ public class DefaultModelBuilder implements ModelBuilder {
                         .profiles(map(model.getProfiles(), this::interpolateRepository, callback))
                         .distributionManagement(interpolateRepository(model.getDistributionManagement(), callback))
                         .build();
-                // Override model properties with user properties
-                Map<String, String> newProps = merge(model.getProperties(), session.getUserProperties());
+                // Override model properties with user properties (use request properties
+                // to ensure consistency with model interpolation)
+                Map<String, String> userProps = request.getUserProperties();
+                Map<String, String> newProps = merge(model.getProperties(), userProps);
                 if (newProps != null) {
                     model = model.withProperties(newProps);
                 }
-                model = model.withProfiles(merge(model.getProfiles(), session.getUserProperties()));
+                model = model.withProfiles(merge(model.getProfiles(), userProps));
             }
 
             for (var transformer : transformers) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -215,6 +215,69 @@ class DefaultModelBuilderTest {
     }
 
     @Test
+    public void testCiFriendlyDependencyVersionInterpolation() {
+        // Test that ${revision} in dependency versions is interpolated using model properties
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(getPom("ci-friendly-deps")))
+                .build();
+        ModelBuilderResult result = builder.newSession().build(request);
+        assertNotNull(result);
+        Model effective = result.getEffectiveModel();
+        assertEquals("1.0.0-SNAPSHOT", effective.getVersion());
+        assertEquals(1, effective.getDependencies().size());
+        assertEquals(
+                "1.0.0-SNAPSHOT",
+                effective.getDependencies().get(0).getVersion(),
+                "${revision} in dependency version should be interpolated");
+        assertNotNull(effective.getDistributionManagement());
+        assertEquals(
+                "releases-1.0.0-SNAPSHOT",
+                effective.getDistributionManagement().getRepository().getId(),
+                "${revision} in distributionManagement repository id should be interpolated");
+    }
+
+    @Test
+    public void testCiFriendlyDependencyVersionWithUserProperties() {
+        // Test that ${revision} in dependency versions is interpolated using user properties override
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .userProperties(Map.of("revision", "2.0.0"))
+                .source(Sources.buildSource(getPom("ci-friendly-deps")))
+                .build();
+        ModelBuilderResult result = builder.newSession().build(request);
+        assertNotNull(result);
+        Model effective = result.getEffectiveModel();
+        assertEquals("2.0.0", effective.getVersion());
+        assertEquals(1, effective.getDependencies().size());
+        assertEquals(
+                "2.0.0",
+                effective.getDependencies().get(0).getVersion(),
+                "${revision} in dependency version should be interpolated with user property");
+    }
+
+    @Test
+    public void testCiFriendlyDependencyVersionWithUserPropertiesOnly() {
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .userProperties(Map.of("revision", "3.0.0"))
+                .source(Sources.buildSource(getPom("ci-friendly-deps-no-prop")))
+                .build();
+        ModelBuilderResult result = builder.newSession().build(request);
+        assertNotNull(result);
+        Model effective = result.getEffectiveModel();
+        assertEquals("3.0.0", effective.getVersion(), "project version should use user property");
+        assertEquals(1, effective.getDependencies().size());
+        assertEquals(
+                "3.0.0",
+                effective.getDependencies().get(0).getVersion(),
+                "${revision} in dependency version should be interpolated with user-only property");
+    }
+
+    @Test
     public void testMissingDependencyGroupIdInference() throws Exception {
         // Test that dependencies with missing groupId but present version are inferred correctly in model 4.1.0
 

--- a/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-deps-no-prop.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-deps-no-prop.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>ci-friendly-deps-no-prop</artifactId>
+  <version>${revision}</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.test</groupId>
+      <artifactId>some-dep</artifactId>
+      <version>${revision}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-deps.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-deps.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>ci-friendly-deps</artifactId>
+  <version>${revision}</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <revision>1.0.0-SNAPSHOT</revision>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.test</groupId>
+      <artifactId>some-dep</artifactId>
+      <version>${revision}</version>
+    </dependency>
+  </dependencies>
+
+  <distributionManagement>
+    <repository>
+      <id>releases-${revision}</id>
+      <url>https://repo.example.com/releases</url>
+    </repository>
+  </distributionManagement>
+</project>


### PR DESCRIPTION
## Summary

- Fix inconsistent property source in `DefaultModelBuilder` that caused `${revision}` to not be properly interpolated in dependency versions and distributionManagement when user properties differ between the `ModelBuilderRequest` and the `Session`
- Fix `DefaultConsumerPomBuilder` to use API Session properties instead of `RepositorySystemSession` properties for consumer POM model building
- Add tests for CI-friendly `${revision}` interpolation in dependency versions with model properties, user property overrides, and user-property-only scenarios

## Context

The model builder used `session.getEffectiveProperties()` / `session.getUserProperties()` for CI-friendly version replacement and model property merging, while model interpolation used `request.getUserProperties()`. These can diverge when a `ModelBuilderRequest` is created with custom user properties. The fix makes all property lookups use request properties consistently.

## Test plan

- [x] `DefaultModelBuilderTest` — 3 new tests for `${revision}` in dependency versions and distributionManagement
- [x] `DefaultModelBuilderTest` — all 9 tests pass
- [x] `maven-impl` — all 471 tests pass
- [x] `maven-core` — all 546 tests pass (1 pre-existing skip)
- [x] `maven-compat` — all 160 tests pass (7 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)