### PR TITLE
Fix Source targetPath incorrectly aligned to project basedir

### DIFF
--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectBuilderTest.java
@@ -996,4 +996,99 @@ class ProjectBuilderTest extends AbstractCoreMavenComponentTestCase {
                 testJavaRoots.get(0).module().orElse(null),
                 "Test source root should be for com.example.dup module");
     }
+
+    @Test
+    void testSourceTargetPathRemainsRelative() throws Exception {
+        File pom = getProject("source-target-path");
+
+        MavenSession mavenSession = createMavenSession(null);
+        ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
+        configuration.setRepositorySession(mavenSession.getRepositorySession());
+
+        ProjectBuildingResult result = getContainer()
+                .lookup(org.apache.maven.project.ProjectBuilder.class)
+                .build(pom, configuration);
+
+        MavenProject project = result.getProject();
+
+        // Verify main resources have relative targetPath preserved
+        List<SourceRoot> mainResources = project.getEnabledSourceRoots(ProjectScope.MAIN, Language.RESOURCES)
+                .toList();
+        assertEquals(1, mainResources.size());
+        assertTrue(mainResources.get(0).targetPath().isPresent());
+        assertEquals(Path.of(".grammar"), mainResources.get(0).targetPath().get());
+
+        // Verify test resources have relative targetPath preserved
+        List<SourceRoot> testResources = project.getEnabledSourceRoots(ProjectScope.TEST, Language.RESOURCES)
+                .toList();
+        assertEquals(1, testResources.size());
+        assertTrue(testResources.get(0).targetPath().isPresent());
+        assertEquals(Path.of("META-INF/test"), testResources.get(0).targetPath().get());
+
+        // Verify the compat layer also returns relative targetPath
+        List<org.apache.maven.model.Resource> resources = project.getResources();
+        assertEquals(1, resources.size());
+        assertEquals(".grammar", resources.get(0).getTargetPath());
+
+        List<org.apache.maven.model.Resource> testResourceList = project.getTestResources();
+        assertEquals(1, testResourceList.size());
+        assertEquals(
+                "META-INF" + File.separator + "test", testResourceList.get(0).getTargetPath());
+    }
+
+    @Test
+    void testResourceTargetPathRemainsRelativeInCompatLayer() throws Exception {
+        File pom = getProject("resource-target-path");
+
+        MavenSession mavenSession = createMavenSession(null);
+        ProjectBuildingRequest configuration = new DefaultProjectBuildingRequest();
+        configuration.setRepositorySession(mavenSession.getRepositorySession());
+
+        ProjectBuildingResult result = getContainer()
+                .lookup(org.apache.maven.project.ProjectBuilder.class)
+                .build(pom, configuration);
+
+        MavenProject project = result.getProject();
+
+        // Verify main resources via SourceRoot API
+        List<SourceRoot> mainResources = project.getEnabledSourceRoots(ProjectScope.MAIN, Language.RESOURCES)
+                .toList();
+        assertEquals(1, mainResources.size());
+        assertTrue(mainResources.get(0).targetPath().isPresent());
+        assertFalse(
+                mainResources.get(0).targetPath().get().isAbsolute(),
+                "SourceRoot targetPath must be relative, got: "
+                        + mainResources.get(0).targetPath().get());
+        assertEquals(
+                Path.of("META-INF/tags/rdc"), mainResources.get(0).targetPath().get());
+
+        // Verify test resources via SourceRoot API
+        List<SourceRoot> testResources = project.getEnabledSourceRoots(ProjectScope.TEST, Language.RESOURCES)
+                .toList();
+        assertEquals(1, testResources.size());
+        assertTrue(testResources.get(0).targetPath().isPresent());
+        assertFalse(
+                testResources.get(0).targetPath().get().isAbsolute(),
+                "SourceRoot targetPath must be relative, got: "
+                        + testResources.get(0).targetPath().get());
+        assertEquals(
+                Path.of("org/apache/maven/messages"),
+                testResources.get(0).targetPath().get());
+
+        // Verify compat layer: MavenProject.getResources() must return relative targetPath
+        List<org.apache.maven.model.Resource> resources = project.getResources();
+        assertEquals(1, resources.size());
+        assertEquals(
+                "META-INF" + File.separator + "tags" + File.separator + "rdc",
+                resources.get(0).getTargetPath(),
+                "Resource targetPath from getResources() must remain relative");
+
+        // Verify compat layer: MavenProject.getTestResources() must return relative targetPath
+        List<org.apache.maven.model.Resource> testResourceList = project.getTestResources();
+        assertEquals(1, testResourceList.size());
+        assertEquals(
+                "org" + File.separator + "apache" + File.separator + "maven" + File.separator + "messages",
+                testResourceList.get(0).getTargetPath(),
+                "Test resource targetPath from getTestResources() must remain relative");
+    }
 }

--- a/impl/maven-core/src/test/projects/project-builder/resource-target-path/pom.xml
+++ b/impl/maven-core/src/test/projects/project-builder/resource-target-path/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng</groupId>
+  <artifactId>resource-target-path-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Resource TargetPath Compat Test</name>
+  <description>Test that targetPath in legacy resource elements remains relative through the compat layer</description>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <targetPath>META-INF/tags/rdc</targetPath>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <targetPath>org/apache/maven/messages</targetPath>
+      </testResource>
+    </testResources>
+  </build>
+</project>

--- a/impl/maven-core/src/test/projects/project-builder/source-target-path/pom.xml
+++ b/impl/maven-core/src/test/projects/project-builder/source-target-path/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng</groupId>
+  <artifactId>source-target-path-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Source TargetPath Test</name>
+  <description>Test that targetPath in source elements remains relative to output directory</description>
+
+  <build>
+    <sources>
+      <source>
+        <lang>resources</lang>
+        <directory>src/main/resources</directory>
+        <targetPath>.grammar</targetPath>
+      </source>
+      <source>
+        <lang>resources</lang>
+        <scope>test</scope>
+        <directory>src/test/resources</directory>
+        <targetPath>META-INF/test</targetPath>
+      </source>
+    </sources>
+  </build>
+</project>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelPathTranslator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelPathTranslator.java
@@ -134,11 +134,9 @@ public class DefaultModelPathTranslator implements ModelPathTranslator {
             if (newDir != oldDir) {
                 source = source.withDirectory(newDir);
             }
-            oldDir = source.getTargetPath();
-            newDir = alignToBaseDirectory(oldDir, basedir);
-            if (newDir != oldDir) {
-                source = source.withTargetPath(newDir);
-            }
+            // Note: targetPath is intentionally NOT aligned to basedir.
+            // It is relative to the output directory (target/classes or target/test-classes),
+            // not to the project base directory. See maven.mdo Source.targetPath documentation.
         }
         return source;
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelPathTranslatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelPathTranslatorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl.model;
+
+import java.nio.file.Path;
+
+import org.apache.maven.api.model.Build;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.model.Resource;
+import org.apache.maven.api.model.Source;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultModelPathTranslatorTest {
+
+    private DefaultModelPathTranslator translator;
+    private Path basedir;
+
+    @BeforeEach
+    void setUp() {
+        translator = new DefaultModelPathTranslator(new DefaultPathTranslator());
+        basedir = Path.of("/home/user/myproject").toAbsolutePath();
+    }
+
+    @Test
+    void sourceDirectoryIsAlignedToBasedir() {
+        Source source = Source.newBuilder().directory("src/main/java").build();
+        Model model = Model.newBuilder()
+                .build(Build.newBuilder().sources(java.util.List.of(source)).build())
+                .build();
+
+        Model result = translator.alignToBaseDirectory(model, basedir, null);
+
+        String dir = result.getBuild().getSources().get(0).getDirectory();
+        assertTrue(Path.of(dir).isAbsolute(), "directory should be absolute after alignment");
+        assertTrue(Path.of(dir).endsWith(Path.of("src/main/java")), "directory should end with original path");
+    }
+
+    @Test
+    void sourceTargetPathIsNotAlignedToBasedir() {
+        Source source = Source.newBuilder()
+                .directory("src/main/resources")
+                .targetPath("META-INF/resources")
+                .build();
+        Model model = Model.newBuilder()
+                .build(Build.newBuilder().sources(java.util.List.of(source)).build())
+                .build();
+
+        Model result = translator.alignToBaseDirectory(model, basedir, null);
+
+        String targetPath = result.getBuild().getSources().get(0).getTargetPath();
+        assertEquals("META-INF/resources", targetPath, "targetPath should remain relative");
+    }
+
+    @Test
+    void sourceTargetPathDotPrefixRemainsRelative() {
+        Source source = Source.newBuilder()
+                .directory("src/main/resources")
+                .targetPath(".grammar")
+                .build();
+        Model model = Model.newBuilder()
+                .build(Build.newBuilder().sources(java.util.List.of(source)).build())
+                .build();
+
+        Model result = translator.alignToBaseDirectory(model, basedir, null);
+
+        String targetPath = result.getBuild().getSources().get(0).getTargetPath();
+        assertEquals(".grammar", targetPath, "dot-prefixed targetPath should remain relative");
+    }
+
+    @Test
+    void resourceDirectoryIsAlignedButTargetPathIsNot() {
+        Resource resource = Resource.newBuilder()
+                .directory("src/main/resources")
+                .targetPath("custom-output")
+                .build();
+        Model model = Model.newBuilder()
+                .build(Build.newBuilder().resources(java.util.List.of(resource)).build())
+                .build();
+
+        Model result = translator.alignToBaseDirectory(model, basedir, null);
+
+        Resource aligned = result.getBuild().getResources().get(0);
+        assertTrue(
+                Path.of(aligned.getDirectory()).isAbsolute(), "resource directory should be absolute after alignment");
+        assertEquals("custom-output", aligned.getTargetPath(), "resource targetPath should remain relative");
+    }
+}


### PR DESCRIPTION
## Summary

- `DefaultModelPathTranslator.alignToBaseDirectory(Source)` was incorrectly resolving `Source.targetPath` against the project basedir, turning a relative path like `.grammar` into an absolute path like `/path/to/project/.grammar`
- This caused the maven-resources-plugin to write files to incorrect absolute locations instead of relative to the output directory (`target/classes`)
- Removed the targetPath alignment from `Source` path translation, matching the existing behavior for `Resource.targetPath` (which is correctly not aligned)

## Test plan

- [x] New `DefaultModelPathTranslatorTest` — verifies Source targetPath is NOT aligned while directory IS aligned
- [x] New `ProjectBuilderTest#testSourceTargetPathRemainsRelative` — full model builder integration test with `.grammar` and `META-INF/test` targetPaths, verifying both SourceRoot API and compat Resource API
- [x] Existing `PomConstructionTest#testTargetPathResourceRegression` — still passes
- [x] Existing `ResourceIncludeTest` (10 tests) — still passes
- [x] Existing `DefaultSourceRootTest` (13 tests) — still passes
- [x] Full test suite for `maven-impl` and `maven-core` (547 tests) — all pass

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)