### PR TITLE
Filter dependencies with uninterpolated expressions from CollectRequest

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -103,13 +103,7 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
 
         if (project.getDependencyArtifacts() == null) {
             for (Dependency dependency : project.getDependencies()) {
-                if (dependency.getGroupId() == null
-                        || dependency.getGroupId().isEmpty()
-                        || dependency.getArtifactId() == null
-                        || dependency.getArtifactId().isEmpty()
-                        || dependency.getVersion() == null
-                        || dependency.getVersion().isEmpty()) {
-                    // guard against case where best-effort resolution for invalid models is requested
+                if (isInvalidDependency(dependency)) {
                     continue;
                 }
                 collect.addDependency(RepositoryUtils.toDependency(dependency, stereotypes));
@@ -147,6 +141,10 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
         DependencyManagement depMgmt = project.getDependencyManagement();
         if (depMgmt != null) {
             for (Dependency dependency : depMgmt.getDependencies()) {
+                if (isInvalidDependency(dependency)) {
+                    logger.debug("Filtered managed dependency with uninterpolated expression: {}", dependency);
+                    continue;
+                }
                 collect.addManagedDependency(RepositoryUtils.toDependency(dependency, stereotypes));
             }
         }
@@ -206,5 +204,22 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
                 result.setResolutionErrors(node.getDependency(), ar.getExceptions());
             }
         }
+    }
+
+    private static boolean isInvalidDependency(Dependency dependency) {
+        return isNullOrEmpty(dependency.getGroupId())
+                || isNullOrEmpty(dependency.getArtifactId())
+                || isNullOrEmpty(dependency.getVersion())
+                || containsPlaceholder(dependency.getGroupId())
+                || containsPlaceholder(dependency.getArtifactId())
+                || containsPlaceholder(dependency.getVersion());
+    }
+
+    private static boolean isNullOrEmpty(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    private static boolean containsPlaceholder(String value) {
+        return value != null && value.contains("${");
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
@@ -147,11 +147,15 @@ public class DefaultDependencyResolver implements DependencyResolver {
                         .getResolutionScope(request.getPathScope().id())
                         .orElseThrow();
             }
+            List<org.eclipse.aether.graph.Dependency> aetherDeps =
+                    filterUninterpolated(session.toDependencies(dependencies, false));
+            List<org.eclipse.aether.graph.Dependency> aetherManagedDeps =
+                    filterUninterpolated(session.toDependencies(managedDependencies, true));
             CollectRequest collectRequest = new CollectRequest()
                     .setRootArtifact(rootArtifact != null ? session.toArtifact(rootArtifact) : null)
                     .setRoot(root != null ? session.toDependency(root, false) : null)
-                    .setDependencies(session.toDependencies(dependencies, false))
-                    .setManagedDependencies(session.toDependencies(managedDependencies, true))
+                    .setDependencies(aetherDeps)
+                    .setManagedDependencies(aetherManagedDeps)
                     .setRepositories(session.toResolvingRepositories(remoteRepositories))
                     .setRequestContext(trace.context())
                     .setTrace(trace.trace());
@@ -276,8 +280,47 @@ public class DefaultDependencyResolver implements DependencyResolver {
         return new DependencyResolverException("Cannot read module information of " + path, cause);
     }
 
+    static List<org.eclipse.aether.graph.Dependency> filterUninterpolated(
+            List<org.eclipse.aether.graph.Dependency> dependencies) {
+        if (dependencies == null || dependencies.isEmpty()) {
+            return dependencies;
+        }
+        return dependencies.stream()
+                .filter(dep -> {
+                    if (dep == null || dep.getArtifact() == null) {
+                        return true;
+                    }
+                    org.eclipse.aether.artifact.Artifact a = dep.getArtifact();
+                    return !containsPlaceholder(a.getGroupId())
+                            && !containsPlaceholder(a.getArtifactId())
+                            && !containsPlaceholder(a.getVersion());
+                })
+                .collect(Collectors.toList());
+    }
+
+    static boolean containsPlaceholder(String value) {
+        return value != null && value.contains("${");
+    }
+
     private static boolean containsUnresolvedExpression(String value) {
         return value != null && value.contains("${") && value.contains("}");
+    }
+
+    private static String findUnresolvedExpression(List<org.eclipse.aether.graph.Dependency> dependencies) {
+        for (org.eclipse.aether.graph.Dependency dep : dependencies) {
+            if (dep != null && dep.getArtifact() != null) {
+                org.eclipse.aether.artifact.Artifact artifact = dep.getArtifact();
+                String groupId = artifact.getGroupId();
+                String artifactId = artifact.getArtifactId();
+                String version = artifact.getVersion();
+                if (containsUnresolvedExpression(groupId)
+                        || containsUnresolvedExpression(artifactId)
+                        || containsUnresolvedExpression(version)) {
+                    return groupId + ":" + artifactId + ":" + version;
+                }
+            }
+        }
+        return null;
     }
 
     private static String enhanceCollectionError(DependencyCollectionException e, CollectRequest request) {
@@ -307,27 +350,16 @@ public class DefaultDependencyResolver implements DependencyResolver {
                 }
             }
 
-            for (org.eclipse.aether.graph.Dependency dep : request.getDependencies()) {
-                if (dep != null && dep.getArtifact() != null) {
-                    org.eclipse.aether.artifact.Artifact artifact = dep.getArtifact();
-                    String groupId = artifact.getGroupId();
-                    String artifactId = artifact.getArtifactId();
-                    String version = artifact.getVersion();
-
-                    if (containsUnresolvedExpression(groupId)
-                            || containsUnresolvedExpression(artifactId)
-                            || containsUnresolvedExpression(version)) {
-                        enhanced.append(" due to unresolved expression(s) in dependency: ")
-                                .append(groupId)
-                                .append(":")
-                                .append(artifactId)
-                                .append(":")
-                                .append(version)
-                                .append(".\n")
-                                .append("Please check that all properties are defined in your POM or settings.xml.");
-                        return enhanced.toString();
-                    }
-                }
+            String found = findUnresolvedExpression(request.getDependencies());
+            if (found == null) {
+                found = findUnresolvedExpression(request.getManagedDependencies());
+            }
+            if (found != null) {
+                enhanced.append(" due to unresolved expression(s) in dependency: ")
+                        .append(found)
+                        .append(".\n")
+                        .append("Please check that all properties are defined in your POM or settings.xml.");
+                return enhanced.toString();
             }
         }
         return e.getMessage();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultDependencyResolverTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultDependencyResolverTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultDependencyResolverTest {
+
+    @Test
+    void testFilterUninterpolatedRemovesPlaceholderVersion() {
+        List<Dependency> deps = new ArrayList<>();
+        deps.add(new Dependency(new DefaultArtifact("g", "a", "jar", "${unresolved}"), "compile"));
+        deps.add(new Dependency(new DefaultArtifact("g", "b", "jar", "1.0"), "compile"));
+
+        List<Dependency> result = DefaultDependencyResolver.filterUninterpolated(deps);
+
+        assertEquals(1, result.size());
+        assertEquals("b", result.get(0).getArtifact().getArtifactId());
+    }
+
+    @Test
+    void testFilterUninterpolatedRemovesPlaceholderGroupId() {
+        List<Dependency> deps = new ArrayList<>();
+        deps.add(new Dependency(new DefaultArtifact("${group}", "a", "jar", "1.0"), "compile"));
+        deps.add(new Dependency(new DefaultArtifact("g", "b", "jar", "1.0"), "compile"));
+
+        List<Dependency> result = DefaultDependencyResolver.filterUninterpolated(deps);
+
+        assertEquals(1, result.size());
+        assertEquals("b", result.get(0).getArtifact().getArtifactId());
+    }
+
+    @Test
+    void testFilterUninterpolatedRemovesPlaceholderArtifactId() {
+        List<Dependency> deps = new ArrayList<>();
+        deps.add(new Dependency(new DefaultArtifact("g", "${art}", "jar", "1.0"), "compile"));
+        deps.add(new Dependency(new DefaultArtifact("g", "b", "jar", "1.0"), "compile"));
+
+        List<Dependency> result = DefaultDependencyResolver.filterUninterpolated(deps);
+
+        assertEquals(1, result.size());
+        assertEquals("b", result.get(0).getArtifact().getArtifactId());
+    }
+
+    @Test
+    void testFilterUninterpolatedKeepsValidDeps() {
+        List<Dependency> deps = new ArrayList<>();
+        deps.add(new Dependency(new DefaultArtifact("g", "a", "jar", "1.0"), "compile"));
+        deps.add(new Dependency(new DefaultArtifact("g", "b", "jar", "2.0"), "test"));
+
+        List<Dependency> result = DefaultDependencyResolver.filterUninterpolated(deps);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testFilterUninterpolatedHandlesNull() {
+        assertNull(DefaultDependencyResolver.filterUninterpolated(null));
+    }
+
+    @Test
+    void testFilterUninterpolatedHandlesEmpty() {
+        List<Dependency> empty = new ArrayList<>();
+        List<Dependency> result = DefaultDependencyResolver.filterUninterpolated(empty);
+        assertSame(empty, result);
+    }
+
+    @Test
+    void testContainsPlaceholder() {
+        assertTrue(DefaultDependencyResolver.containsPlaceholder("${foo}"));
+        assertTrue(DefaultDependencyResolver.containsPlaceholder("prefix-${foo}"));
+        assertTrue(DefaultDependencyResolver.containsPlaceholder("${foo}-suffix"));
+        assertFalse(DefaultDependencyResolver.containsPlaceholder("no-placeholder"));
+        assertFalse(DefaultDependencyResolver.containsPlaceholder(""));
+        assertFalse(DefaultDependencyResolver.containsPlaceholder(null));
+    }
+}


### PR DESCRIPTION
## Summary
- Filter dependencies and managed dependencies with uninterpolated `${...}` property expressions before passing them to `CollectRequest`, preventing `MavenValidator` from rejecting the entire request with "Invalid Collect Request"
- Apply filtering in both `DefaultProjectDependenciesResolver` (Maven 3 compat path) and `DefaultDependencyResolver` (Maven 4 API path), consistent with what `DefaultArtifactDescriptorReader` already does for transitive dependencies
- Improve error enhancement in `DefaultDependencyResolver.enhanceCollectionError()` to also check managed dependencies for unresolved expressions

## Test plan
- [x] Unit tests for `filterUninterpolated()` covering placeholder in version/groupId/artifactId, valid deps pass-through, null and empty input, `containsPlaceholder` edge cases
- [x] All `maven-impl` tests pass (475 tests)
- [x] All `maven-core` tests pass (549 tests, 1 pre-existing skip)
- [ ] Verify with affected projects (causeway-app-helloworld, activemq-openwire, mina-sshd, etc.)

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)