### PR TITLE
Bump default maven-dependency-plugin to 3.11.0

### DIFF
--- a/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -79,7 +79,7 @@ under the License.
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.11.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
### Summary

Bumps the Maven 3.9.x Super POM default for `maven-dependency-plugin` from `3.7.0` to `3.11.0`.

### Rationale

The current default resolves short-prefix invocations such as `mvn dependency:add` to `maven-dependency-plugin:3.7.0`. Newer dependency plugin goals, including `dependency:add`, require a newer plugin version, so updating the Super POM default allows the short-form invocation to work without requiring users to spell out the fully qualified plugin coordinate.

### Testing

- `git diff --check`
- `mvn -q -pl maven-model-builder -am -DskipTests package`

### Checklist

- [x] My pull request addresses just one issue, without pulling in other changes.
- [x] I wrote a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request has a meaningful subject line and body.
- [x] I ran `mvn verify` or an appropriate targeted build.
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004.