### PR TITLE
Bump exec-maven-plugin target to 3.5.0 and fix PLUGIN_UPGRADES inconsistencies

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -67,9 +67,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
 
     private static final List<PluginUpgrade> PLUGIN_UPGRADES = List.of(
             new PluginUpgrade(
-                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-compiler-plugin", "3.2.0", MAVEN_4_COMPATIBILITY_REASON),
-            new PluginUpgrade(
-                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-exec-plugin", "3.2.0", MAVEN_4_COMPATIBILITY_REASON),
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-compiler-plugin", "3.2", MAVEN_4_COMPATIBILITY_REASON),
+            new PluginUpgrade("org.codehaus.mojo", "exec-maven-plugin", "3.5.0", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade(
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.5.0", MAVEN_4_COMPATIBILITY_REASON),
             new PluginUpgrade("org.codehaus.mojo", "flatten-maven-plugin", "1.2.7", MAVEN_4_COMPATIBILITY_REASON),
@@ -237,7 +236,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-compiler-plugin", "3.2"));
         upgrades.put(
                 "org.codehaus.mojo:exec-maven-plugin",
-                new PluginUpgradeInfo("org.codehaus.mojo", "exec-maven-plugin", "3.2.0"));
+                new PluginUpgradeInfo("org.codehaus.mojo", "exec-maven-plugin", "3.5.0"));
         upgrades.put(
                 DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-enforcer-plugin",
                 new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-enforcer-plugin", "3.5.0"));

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -521,8 +521,8 @@ class PluginUpgradeStrategyTest {
                     <build>
                         <plugins>
                             <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-exec-plugin</artifactId>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>exec-maven-plugin</artifactId>
                                 <!-- No version - inherited from parent or pluginManagement -->
                             </plugin>
                         </plugins>
@@ -553,8 +553,8 @@ class PluginUpgradeStrategyTest {
                     <build>
                         <plugins>
                             <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-exec-plugin</artifactId>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>exec-maven-plugin</artifactId>
                                 <version>${exec.plugin.version}</version>
                             </plugin>
                         </plugins>
@@ -737,7 +737,7 @@ class PluginUpgradeStrategyTest {
             boolean hasCompilerPlugin =
                     upgrades.stream().anyMatch(upgrade -> "maven-compiler-plugin".equals(upgrade.artifactId()));
             boolean hasExecPlugin =
-                    upgrades.stream().anyMatch(upgrade -> "maven-exec-plugin".equals(upgrade.artifactId()));
+                    upgrades.stream().anyMatch(upgrade -> "exec-maven-plugin".equals(upgrade.artifactId()));
             boolean hasSurefirePlugin =
                     upgrades.stream().anyMatch(upgrade -> "maven-surefire-plugin".equals(upgrade.artifactId()));
             boolean hasFailsafePlugin =


### PR DESCRIPTION
## Summary
- Bump exec-maven-plugin upgrade target from 3.2.0 to 3.5.0 — versions ≤3.1.0 call `MavenSession.getContainer()` which returns null in Maven 4 (Plexus container removed)
- Fix PLUGIN_UPGRADES list: exec-maven-plugin had wrong groupId (`org.apache.maven.plugins` → `org.codehaus.mojo`) and artifactId (`maven-exec-plugin` → `exec-maven-plugin`)
- Fix compiler-plugin min version: `3.2.0` → `3.2` (3.2.0 does not exist on Maven Central)

Fixes xalan-java build failure (exec-maven-plugin:3.1.0 getContainer() NPE).

## Test plan
- [x] All 27 PluginUpgradeStrategyTest tests pass

_Claude Code on behalf of Guillaume Nodet_