### PR TITLE
Fix mvnup effective model analysis for CI-friendly parent versions

### DIFF
--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.cling.invoker.mvnup.goals;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -776,8 +778,6 @@ class PluginUpgradeStrategyTest {
             // org.apache:apache:23 defines maven-enforcer-plugin:1.4.1 in pluginManagement.
             // A child POM that inherits from this parent should get pluginManagement overrides
             // added by mvnup for plugins that need Maven 4 compatibility upgrades.
-            // Uses an absolute path because the effective model analysis path resolution
-            // requires it to match between phases.
             String pomXml = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -793,20 +793,35 @@ class PluginUpgradeStrategyTest {
                 </project>
                 """;
 
-            Document document = Document.of(pomXml);
-            Path pomPath = Paths.get("/project/pom.xml").toAbsolutePath();
-            Map<Path, Document> pomMap = Map.of(pomPath, document);
+            Path tempDir = Files.createTempDirectory("mvnup-test-");
+            try {
+                Files.createDirectories(tempDir.resolve(".mvn"));
+                Path pomPath = tempDir.resolve("pom.xml");
+                Files.writeString(pomPath, pomXml);
 
-            UpgradeContext context = createMockContext();
-            UpgradeResult result = strategy.doApply(context, pomMap);
+                Document document = Document.of(pomXml);
+                Map<Path, Document> pomMap = Map.of(pomPath, document);
 
-            assertTrue(result.success(), "Strategy should succeed");
-            assertTrue(result.modifiedCount() > 0, "Should have added plugin management for inherited plugins");
+                UpgradeContext context = createMockContext();
+                UpgradeResult result = strategy.doApply(context, pomMap);
 
-            String xml = DomUtils.toXml(document);
-            assertTrue(
-                    xml.contains("<artifactId>maven-enforcer-plugin</artifactId>"),
-                    "Should add pluginManagement for maven-enforcer-plugin inherited from parent");
+                assertTrue(result.success(), "Strategy should succeed");
+                assertTrue(result.modifiedCount() > 0, "Should have added plugin management for inherited plugins");
+
+                String xml = DomUtils.toXml(document);
+                assertTrue(
+                        xml.contains("<artifactId>maven-enforcer-plugin</artifactId>"),
+                        "Should add pluginManagement for maven-enforcer-plugin inherited from parent");
+            } finally {
+                try (var walk = Files.walk(tempDir)) {
+                    walk.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                        try {
+                            Files.delete(p);
+                        } catch (IOException ignored) {
+                        }
+                    });
+                }
+            }
         }
 
         @Test

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1598,8 +1598,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                             pomPath = modelProcessor.locateExistingPom(pomPath);
                         }
                         if (pomPath != null && Files.isRegularFile(pomPath)) {
-                            if (rootDirectoryFromSession
-                                    && !isParentWithinRootDirectory(pomPath, rootDirectory)) {
+                            if (rootDirectoryFromSession && !isParentWithinRootDirectory(pomPath, rootDirectory)) {
                                 add(
                                         Severity.FATAL,
                                         Version.BASE,

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1502,12 +1502,14 @@ public class DefaultModelBuilder implements ModelBuilder {
             ModelSource modelSource = request.getSource();
             Model model;
             Path rootDirectory;
+            boolean rootDirectoryFromSession = false;
             setSource(modelSource.getLocation());
             logger.debug("Reading file model from " + modelSource.getLocation());
             try {
                 boolean strict = isBuildRequest();
                 try {
                     rootDirectory = request.getSession().getRootDirectory();
+                    rootDirectoryFromSession = true;
                 } catch (IllegalStateException ignore) {
                     rootDirectory = modelSource.getPath();
                     while (rootDirectory != null && !Files.isDirectory(rootDirectory)) {
@@ -1586,7 +1588,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                     String artifactId = parent.getArtifactId();
                     String version = parent.getVersion();
                     String path = parent.getRelativePath();
-                    if ((groupId == null || artifactId == null || version == null)
+                    boolean versionContainsExpression = version != null && version.contains("${");
+                    if ((groupId == null || artifactId == null || version == null || versionContainsExpression)
                             && (path == null || !path.isEmpty())) {
                         Path pomFile = model.getPomFile();
                         Path relativePath = Paths.get(path != null ? path : "..");
@@ -1595,8 +1598,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                             pomPath = modelProcessor.locateExistingPom(pomPath);
                         }
                         if (pomPath != null && Files.isRegularFile(pomPath)) {
-                            // Check if parent POM is above the root directory
-                            if (!isParentWithinRootDirectory(pomPath, rootDirectory)) {
+                            if (rootDirectoryFromSession
+                                    && !isParentWithinRootDirectory(pomPath, rootDirectory)) {
                                 add(
                                         Severity.FATAL,
                                         Version.BASE,
@@ -1614,7 +1617,9 @@ public class DefaultModelBuilder implements ModelBuilder {
                             String parentVersion = getVersion(parentModel);
                             if ((groupId == null || groupId.equals(parentGroupId))
                                     && (artifactId == null || artifactId.equals(parentArtifactId))
-                                    && (version == null || version.equals(parentVersion))) {
+                                    && (version == null
+                                            || version.equals(parentVersion)
+                                            || versionContainsExpression)) {
                                 model = model.withParent(parent.with()
                                         .groupId(parentGroupId)
                                         .artifactId(parentArtifactId)

--- a/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-version.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/ci-friendly-version.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>ci-friendly-version-test</artifactId>
+    <version>${revision}</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+</project>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12184CIFriendlyParentVersionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12184CIFriendlyParentVersionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for <a href="https://github.com/apache/maven/issues/12184">#12184</a>.
+ * Verifies that CI-friendly {@code ${revision}} in parent version works in Maven 4
+ * native mode (without maven3Personality) for model version 4.0.0 projects.
+ */
+class MavenITgh12184CIFriendlyParentVersionTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a multi-module project with {@code ${revision}} in parent version
+     * builds successfully when the property is defined in the parent POM properties.
+     */
+    @Test
+    void testCiFriendlyParentVersionFromProperties() throws Exception {
+        File testDir = extractResources("/gh-12184-ci-friendly-parent-version");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+
+    /**
+     * Verify that a multi-module project with {@code ${revision}} in parent version
+     * builds successfully when the property is overridden via command line.
+     */
+    @Test
+    void testCiFriendlyParentVersionFromCli() throws Exception {
+        File testDir = extractResources("/gh-12184-ci-friendly-parent-version");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.addCliArgument("-Drevision=2.0.0");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12184-ci-friendly-parent-version/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12184-ci-friendly-parent-version/child/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12184</groupId>
+    <artifactId>ci-friendly-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>ci-friendly-child</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12184-ci-friendly-parent-version/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12184-ci-friendly-parent-version/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12184</groupId>
+  <artifactId>ci-friendly-parent</artifactId>
+  <version>${revision}</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child</module>
+  </modules>
+
+  <properties>
+    <revision>1.0.0-SNAPSHOT</revision>
+  </properties>
+</project>


### PR DESCRIPTION
## Summary
- **Eliminate temp directory** in `PluginUpgradeStrategy` — build effective models from original file paths instead of copying POMs to a temp directory that lacked `.mvn` for root detection
- **Fix `DefaultModelBuilder.doReadFileModel()`** to handle `${revision}` parent versions: enter parent resolution block for expression versions, skip `isParentWithinRootDirectory` when root directory is a fallback guess, and accept parent version match when version contains an expression
- Add unit test, integration test, and fix existing `PluginUpgradeStrategyTest`

Fixes the "Parent POM is located above the root directory" error that occurred in `mvnup apply` for all CI-friendly projects using `${revision}` (bigtop-manager, guacamole-client, hbase-connectors, logging-log4j-samples).

## Test plan
- [x] `DefaultModelBuilderTest` — 7 tests pass (including new `testCiFriendlyVersion`)
- [x] `PluginUpgradeStrategyTest` — 27 tests pass (including fixed `shouldDetectInheritedPluginsFromRemoteParent`)
- [x] `MavenITgh12184CIFriendlyParentVersionTest` — 2 ITs pass (property from POM, property from CLI)
- [x] Existing CI-friendly ITs pass (`MavenITgh11196CIFriendlyProfilesTest`, `MavenITmng8744CIFriendlyTest`)
- [x] `mvnup apply` on all 4 affected projects produces no "parent above root" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)