### PR TITLE
[4.0.x] [MNG-6772] Re-enable integration test for nested import scope repository override

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Test;
  * The test confirms that the dominant repository definition (child) wins while resolving the import POMs.
  *
  */
-@Disabled // This IT has been disabled until it is decided how the solution shall look like
 public class MavenITmng6772NestedImportScopeRepositoryOverride extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng6772NestedImportScopeRepositoryOverride() {


### PR DESCRIPTION
Cherry-pick of #11826