### PR TITLE
Add XmlService classloader fallback for ServiceLoader discovery

### DIFF
--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlService.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlService.java
@@ -239,8 +239,15 @@ public abstract class XmlService {
 
     /** Holder class for lazy initialization of the default instance */
     private static final class Holder {
-        static final XmlService INSTANCE = ServiceLoader.load(XmlService.class)
+        static final XmlService INSTANCE = ServiceLoader.load(XmlService.class, XmlService.class.getClassLoader())
                 .findFirst()
+                .or(() -> {
+                    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+                    return contextClassLoader != null
+                            ? ServiceLoader.load(XmlService.class, contextClassLoader)
+                                    .findFirst()
+                            : java.util.Optional.empty();
+                })
                 .orElseThrow(() -> new IllegalStateException("No XmlService implementation found"));
 
         private Holder() {}

--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlService.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlService.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 import org.apache.maven.api.annotations.Nonnull;
@@ -246,7 +247,7 @@ public abstract class XmlService {
                     return contextClassLoader != null
                             ? ServiceLoader.load(XmlService.class, contextClassLoader)
                                     .findFirst()
-                            : java.util.Optional.empty();
+                            : Optional.empty();
                 })
                 .orElseThrow(() -> new IllegalStateException("No XmlService implementation found"));
 

--- a/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlServiceLoadingTest.java
+++ b/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/XmlServiceLoadingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.internal.xml;
+
+import java.io.StringReader;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.apache.maven.api.xml.XmlNode;
+import org.apache.maven.api.xml.XmlService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class XmlServiceLoadingTest {
+
+    @Test
+    void testServiceLoaderFallbackWhenContextClassLoaderCannotSeeProvider() throws Exception {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        try (URLClassLoader contextClassLoader = new URLClassLoader(new URL[0], null)) {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            XmlNode node = XmlService.read(new StringReader("<configuration/>"));
+            assertEquals("configuration", node.name());
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracted from #11742 (by @arturobernalg) to keep the classloader fix separate from the namespace-preservation fix (#11715).

When the thread context classloader cannot see the `XmlService` provider (e.g. in isolated plugin classloaders), the `ServiceLoader.load(XmlService.class)` call fails with `IllegalStateException("No XmlService implementation found")`.

This change:
- Tries `XmlService.class.getClassLoader()` first — this is the core realm classloader which always sees the provider
- Falls back to the TCCL if the class's own classloader doesn't find it
- The order (class CL → TCCL) is intentional: `XmlService` lives in the API module, and its classloader reliably sees the `impl/maven-xml` provider through Maven's core realm. The TCCL may be a plugin classrealm or an isolated classloader that cannot.

## Test plan

- [x] `XmlServiceLoadingTest` verifies discovery works when TCCL is an empty `URLClassLoader` that cannot see the provider

_Claude Code on behalf of Guillaume Nodet_

Co-authored-by: Arturo Bernal <abernal@apache.org>