### PR TITLE
Fix #11973: Restore backward-compatible DefaultToolchain constructor

### DIFF
--- a/compat/maven-compat/src/main/java/org/apache/maven/toolchain/DefaultToolchain.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/toolchain/DefaultToolchain.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 
 import org.apache.maven.toolchain.model.ToolchainModel;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default abstract toolchain implementation, to be used as base class for any toolchain implementation
@@ -66,6 +67,27 @@ implements Toolchain, ToolchainPrivate {
     protected DefaultToolchain(ToolchainModel model, String type, Logger logger) {
         this(model, logger);
         this.type = type;
+    }
+
+    /**
+     * @param model the model, must not be {@code null}
+     * @param logger the logger (ignored, an SLF4J logger is used instead)
+     * @deprecated Use {@link #DefaultToolchain(ToolchainModel, Logger)} with an SLF4J logger instead.
+     */
+    @Deprecated(since = "4.0.0")
+    protected DefaultToolchain(ToolchainModel model, org.codehaus.plexus.logging.Logger logger) {
+        this(model, LoggerFactory.getLogger(DefaultToolchain.class));
+    }
+
+    /**
+     * @param model the model, must not be {@code null}
+     * @param type the type
+     * @param logger the logger (ignored, an SLF4J logger is used instead)
+     * @deprecated Use {@link #DefaultToolchain(ToolchainModel, String, Logger)} with an SLF4J logger instead.
+     */
+    @Deprecated(since = "4.0.0")
+    protected DefaultToolchain(ToolchainModel model, String type, org.codehaus.plexus.logging.Logger logger) {
+        this(model, type, LoggerFactory.getLogger(DefaultToolchain.class));
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes #11973

Custom toolchain implementations compiled against Maven 3.x call `DefaultToolchain(ToolchainModel, String, org.codehaus.plexus.logging.Logger)`, which was removed when Maven 4 switched to SLF4J. This causes `NoSuchMethodError` at runtime.

This PR adds two deprecated backward-compatible constructors that accept the old Plexus `Logger` parameter and delegate to the existing SLF4J-based constructors.

See also: https://github.com/apache/maven-toolchains-plugin/pull/152

## Test plan

- [x] `mvn install -DskipTests` builds successfully
- [x] Run maven-toolchains-plugin ITs with custom toolchain (`use-custom-toolchain`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)