### PR TITLE
Fix #11798: Preserve profile activation during consumer POM generation

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1135,7 +1135,16 @@ public class DefaultModelBuilder implements ModelBuilder {
             }
 
             try {
-                ModelBuilderSessionState derived = derive(candidateSource);
+                ModelBuilderSessionState derived;
+                if (request.getRequestType() == ModelBuilderRequest.RequestType.BUILD_CONSUMER) {
+                    ModelBuilderRequest parentRequest = ModelBuilderRequest.builder(request)
+                            .requestType(ModelBuilderRequest.RequestType.CONSUMER_PARENT)
+                            .source(candidateSource)
+                            .build();
+                    derived = derive(parentRequest);
+                } else {
+                    derived = derive(candidateSource);
+                }
 
                 // Check GA match BEFORE readAsParentModel() which recursively resolves
                 // the candidate's parent chain and can trigger false cycle detection (GH-12074).

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11798ConsumerPomProfileActivationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11798ConsumerPomProfileActivationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify that consumer POM generation preserves profile activation for locally-resolved parent POMs.
+ * When a parent POM defines properties inside a profile with property-based activation,
+ * those properties must be resolved during BUILD_CONSUMER so that BOM imports using
+ * those properties do not fail with "Invalid Version Range Request".
+ *
+ * @see <a href="https://github.com/apache/maven/issues/11798">GH-11798</a>
+ */
+class MavenITgh11798ConsumerPomProfileActivationTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void testConsumerPomResolvesParentProfileProperties() throws Exception {
+        Path basedir = extractResources("/gh-11798-consumer-pom-profile-activation").toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/child/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <modelVersion>4.1.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh11798</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>child</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh11798</groupId>
+        <artifactId>test-bom</artifactId>
+        <version>${dep.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <modelVersion>4.1.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh11798</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child</module>
+  </modules>
+
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <checksumPolicy>ignore</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>local-test-repo</id>
+      <url>file://${project.rootDirectory}/repo</url>
+    </repository>
+  </repositories>
+
+  <profiles>
+    <profile>
+      <id>default-versions</id>
+      <activation>
+        <property>
+          <name>!skipDefaultVersions</name>
+        </property>
+      </activation>
+      <properties>
+        <dep.version>1.0</dep.version>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/repo/org/apache/maven/its/gh11798/test-bom/1.0/test-bom-1.0.pom
+++ b/its/core-it-suite/src/test/resources/gh-11798-consumer-pom-profile-activation/repo/org/apache/maven/its/gh11798/test-bom/1.0/test-bom-1.0.pom
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.its.gh11798</groupId>
+    <artifactId>test-bom</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+</project>


### PR DESCRIPTION
## Summary

- When `readParentLocally()` resolves a parent POM during `BUILD_CONSUMER`, it now uses `CONSUMER_PARENT` request type (which allows profile activation) instead of inheriting `BUILD_CONSUMER` (which suppresses it)
- This matches the existing behavior of `resolveAndReadParentExternally()` and ensures that properties defined inside profiles with property-based activation are correctly resolved for locally-resolved parent POMs
- Adds integration test verifying BOM imports using profile-defined properties work during consumer POM generation

## Test plan

- [ ] Integration test `MavenITgh11798ConsumerPomProfileActivationTest` passes: parent POM defines `dep.version` in a profile with property-based activation, child imports a BOM using `${dep.version}`, `install` succeeds
- [ ] Existing integration tests pass (no regression in profile activation or consumer POM generation)

Fixes #11798

🤖 Generated with [Claude Code](https://claude.com/claude-code)