### PR TITLE
disable dtd and external entities in stax xml parsers

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/root/DefaultRootLocator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/root/DefaultRootLocator.java
@@ -43,7 +43,7 @@ public class DefaultRootLocator implements RootLocator {
         // we're too early to use the modelProcessor ...
         Path pom = dir.resolve("pom.xml");
         try (InputStream is = Files.newInputStream(pom)) {
-            XMLStreamReader parser = XMLInputFactory.newFactory().createXMLStreamReader(is);
+            XMLStreamReader parser = newInputFactory().createXMLStreamReader(is);
             if (parser.nextTag() == XMLStreamReader.START_ELEMENT
                     && parser.getLocalName().equals("project")) {
                 for (int i = 0; i < parser.getAttributeCount(); i++) {
@@ -60,5 +60,12 @@ public class DefaultRootLocator implements RootLocator {
             // displayed to the user, so just bail out and return false.
         }
         return false;
+    }
+
+    private static XMLInputFactory newInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
     }
 }

--- a/compat/maven-plugin-api/src/main/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilder.java
+++ b/compat/maven-plugin-api/src/main/java/org/apache/maven/plugin/descriptor/PluginDescriptorBuilder.java
@@ -74,12 +74,12 @@ public class PluginDescriptorBuilder {
         try {
             BufferedReader br = new BufferedReader(reader, BUFFER_SIZE);
             br.mark(BUFFER_SIZE);
-            XMLStreamReader xsr = XMLInputFactory.newFactory().createXMLStreamReader(br);
+            XMLStreamReader xsr = newInputFactory().createXMLStreamReader(br);
             xsr.nextTag();
             String nsUri = xsr.getNamespaceURI();
             br.reset();
             if (PLUGIN_2_0_0.equals(nsUri)) {
-                xsr = XMLInputFactory.newFactory().createXMLStreamReader(br);
+                xsr = newInputFactory().createXMLStreamReader(br);
                 return new PluginDescriptor(new PluginDescriptorStaxReader().read(xsr, true));
             } else {
                 // Call buildConfiguration() for backward compatibility with subclasses that override it
@@ -98,11 +98,11 @@ public class PluginDescriptorBuilder {
     public PluginDescriptor build(ReaderSupplier readerSupplier, String source) throws PlexusConfigurationException {
         try (BufferedReader br = new BufferedReader(readerSupplier.open(), BUFFER_SIZE)) {
             br.mark(BUFFER_SIZE);
-            XMLStreamReader xsr = XMLInputFactory.newFactory().createXMLStreamReader(br);
+            XMLStreamReader xsr = newInputFactory().createXMLStreamReader(br);
             xsr.nextTag();
             String nsUri = xsr.getNamespaceURI();
             try (BufferedReader br2 = reset(readerSupplier, br)) {
-                xsr = XMLInputFactory.newFactory().createXMLStreamReader(br2);
+                xsr = newInputFactory().createXMLStreamReader(br2);
                 return build(source, nsUri, xsr);
             }
         } catch (XMLStreamException | IOException e) {
@@ -118,12 +118,12 @@ public class PluginDescriptorBuilder {
         try {
             BufferedInputStream bis = new BufferedInputStream(input, BUFFER_SIZE);
             bis.mark(BUFFER_SIZE);
-            XMLStreamReader xsr = XMLInputFactory.newFactory().createXMLStreamReader(bis);
+            XMLStreamReader xsr = newInputFactory().createXMLStreamReader(bis);
             xsr.nextTag();
             String nsUri = xsr.getNamespaceURI();
             bis.reset();
             if (PLUGIN_2_0_0.equals(nsUri)) {
-                xsr = XMLInputFactory.newFactory().createXMLStreamReader(bis);
+                xsr = newInputFactory().createXMLStreamReader(bis);
                 return new PluginDescriptor(new PluginDescriptorStaxReader().read(xsr, true));
             } else {
                 // Call buildConfiguration() for backward compatibility with subclasses that override it
@@ -142,11 +142,11 @@ public class PluginDescriptorBuilder {
     public PluginDescriptor build(StreamSupplier inputSupplier, String source) throws PlexusConfigurationException {
         try (BufferedInputStream bis = new BufferedInputStream(inputSupplier.open(), BUFFER_SIZE)) {
             bis.mark(BUFFER_SIZE);
-            XMLStreamReader xsr = XMLInputFactory.newFactory().createXMLStreamReader(bis);
+            XMLStreamReader xsr = newInputFactory().createXMLStreamReader(bis);
             xsr.nextTag();
             String nsUri = xsr.getNamespaceURI();
             try (BufferedInputStream bis2 = reset(inputSupplier, bis)) {
-                xsr = XMLInputFactory.newFactory().createXMLStreamReader(bis2);
+                xsr = newInputFactory().createXMLStreamReader(bis2);
                 return build(source, nsUri, xsr);
             }
         } catch (XMLStreamException | IOException e) {
@@ -504,7 +504,7 @@ public class PluginDescriptorBuilder {
 
     public PlexusConfiguration buildConfiguration(Reader configuration) throws PlexusConfigurationException {
         try {
-            XMLStreamReader reader = XMLInputFactory.newFactory().createXMLStreamReader(configuration);
+            XMLStreamReader reader = newInputFactory().createXMLStreamReader(configuration);
             return XmlPlexusConfiguration.toPlexusConfiguration(XmlService.read(reader));
         } catch (XMLStreamException e) {
             throw new PlexusConfigurationException(e.getMessage(), e);
@@ -513,10 +513,17 @@ public class PluginDescriptorBuilder {
 
     public PlexusConfiguration buildConfiguration(InputStream configuration) throws PlexusConfigurationException {
         try {
-            XMLStreamReader reader = XMLInputFactory.newFactory().createXMLStreamReader(configuration);
+            XMLStreamReader reader = newInputFactory().createXMLStreamReader(configuration);
             return XmlPlexusConfiguration.toPlexusConfiguration(XmlService.read(reader));
         } catch (XMLStreamException e) {
             throw new PlexusConfigurationException(e.getMessage(), e);
         }
+    }
+
+    private static XMLInputFactory newInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/ExtensionDescriptorBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ExtensionDescriptorBuilder.java
@@ -88,7 +88,7 @@ public class ExtensionDescriptorBuilder {
 
         XmlNode dom;
         try {
-            XMLStreamReader reader = XMLInputFactory.newFactory().createXMLStreamReader(is);
+            XMLStreamReader reader = newInputFactory().createXMLStreamReader(is);
             dom = XmlService.read(reader);
         } catch (XMLStreamException e) {
             throw new IOException(e.getMessage(), e);
@@ -123,5 +123,12 @@ public class ExtensionDescriptorBuilder {
         }
 
         return strings;
+    }
+
+    private static XMLInputFactory newInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ExtensionDescriptorBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ExtensionDescriptorBuilderTest.java
@@ -19,8 +19,11 @@
 package org.apache.maven.project;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.AfterEach;
@@ -28,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -79,5 +83,25 @@ class ExtensionDescriptorBuilderTest {
         assertNotNull(ed);
         assertEquals(Arrays.asList("a", "b", "c"), ed.getExportedPackages());
         assertEquals(Arrays.asList("x", "y", "z"), ed.getExportedArtifacts());
+    }
+
+    @Test
+    void testExternalEntityIsNotResolved() throws Exception {
+        Path secret = Files.createTempFile("extension-xxe", ".txt");
+        Files.writeString(secret, "TOPSECRET");
+        try {
+            String xml = "<?xml version='1.0'?>\n" + "<!DOCTYPE extension [ <!ENTITY xxe SYSTEM \""
+                    + secret.toUri() + "\"> ]>\n"
+                    + "<extension><exportedPackages><exportedPackage>&xxe;</exportedPackage></exportedPackages></extension>";
+
+            try {
+                ExtensionDescriptor ed = builder.build(toStream(xml));
+                assertFalse(ed.getExportedPackages().contains("TOPSECRET"));
+            } catch (IOException expected) {
+                // doctype / external entities rejected at parse time
+            }
+        } finally {
+            Files.deleteIfExists(secret);
+        }
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -194,6 +194,8 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
             XMLInputFactory factory = XMLInputFactory.newFactory();
             factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, true);
             factory.setProperty(XMLInputFactory.IS_COALESCING, true);
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             XML_INPUT_FACTORY = factory;
         }
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/rootlocator/PomXmlRootDetector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/rootlocator/PomXmlRootDetector.java
@@ -37,7 +37,7 @@ public class PomXmlRootDetector implements RootDetector {
         // we're too early to use the modelProcessor ...
         Path pom = dir.resolve("pom.xml");
         try (InputStream is = Files.newInputStream(pom)) {
-            XMLStreamReader parser = XMLInputFactory.newFactory().createXMLStreamReader(is);
+            XMLStreamReader parser = newInputFactory().createXMLStreamReader(is);
             if (parser.nextTag() == XMLStreamReader.START_ELEMENT
                     && parser.getLocalName().equals("project")) {
                 for (int i = 0; i < parser.getAttributeCount(); i++) {
@@ -54,5 +54,12 @@ public class PomXmlRootDetector implements RootDetector {
             // displayed to the user, so just bail out and return false.
         }
         return false;
+    }
+
+    private static XMLInputFactory newInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
     }
 }

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/DefaultXmlService.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/DefaultXmlService.java
@@ -53,7 +53,7 @@ public class DefaultXmlService extends XmlService {
     @Override
     public XmlNode doRead(InputStream input, @Nullable XmlService.InputLocationBuilder locationBuilder)
             throws XMLStreamException {
-        XMLStreamReader parser = XMLInputFactory.newFactory().createXMLStreamReader(input);
+        XMLStreamReader parser = newInputFactory().createXMLStreamReader(input);
         return doRead(parser, locationBuilder);
     }
 
@@ -61,8 +61,15 @@ public class DefaultXmlService extends XmlService {
     @Override
     public XmlNode doRead(Reader reader, @Nullable XmlService.InputLocationBuilder locationBuilder)
             throws XMLStreamException {
-        XMLStreamReader parser = XMLInputFactory.newFactory().createXMLStreamReader(reader);
+        XMLStreamReader parser = newInputFactory().createXMLStreamReader(reader);
         return doRead(parser, locationBuilder);
+    }
+
+    private static XMLInputFactory newInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
     }
 
     @Nonnull

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/XmlNodeStaxBuilder.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/XmlNodeStaxBuilder.java
@@ -40,13 +40,20 @@ public class XmlNodeStaxBuilder {
 
     public static XmlNode build(InputStream stream, InputLocationBuilderStax locationBuilder)
             throws XMLStreamException {
-        XMLStreamReader parser = XMLInputFactory.newFactory().createXMLStreamReader(stream);
+        XMLStreamReader parser = newInputFactory().createXMLStreamReader(stream);
         return build(parser, DEFAULT_TRIM, locationBuilder);
     }
 
     public static XmlNode build(Reader reader, InputLocationBuilderStax locationBuilder) throws XMLStreamException {
-        XMLStreamReader parser = XMLInputFactory.newFactory().createXMLStreamReader(reader);
+        XMLStreamReader parser = newInputFactory().createXMLStreamReader(reader);
         return build(parser, DEFAULT_TRIM, locationBuilder);
+    }
+
+    private static XMLInputFactory newInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
     }
 
     public static XmlNode build(XMLStreamReader parser) throws XMLStreamException {


### PR DESCRIPTION
**XXE via external entity resolution in the StAX XML parsers**

Maven's hand-written StAX readers build their parser with `XMLInputFactory.newFactory()`, and the Woodstox defaults resolve external entities. A `pom.xml`, `META-INF/maven/extension.xml` or `plugin.xml` read from a downloaded artifact can pull in `file://` or `http://` SYSTEM entities, which gives local file disclosure and SSRF while a build runs. `SUPPORT_DTD` and `IS_SUPPORTING_EXTERNAL_ENTITIES` are now turned off on every input factory used to read XML. None of Maven's own formats carry a DOCTYPE, so this only rejects hostile input.

The added test in `ExtensionDescriptorBuilderTest` leaks a temp file through an external entity in an extension descriptor; it fails on the current tree and passes with the factories hardened.

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [ ] Run `mvn verify` to make sure basic checks pass.
- [ ] You have run the [Core IT][core-its] successfully.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
