### PR TITLE
document modelVersion supported values (backport of #11810)

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -92,7 +92,8 @@
           <name>modelVersion</name>
           <version>4.0.0+</version>
           <required>true</required>
-          <description>Declares to which version of project descriptor this POM conforms.</description>
+          <description>Declares which version of the project descriptor this POM conforms to:
+            {@code 4.0.0} for Maven 3, {@code 4.1.0} or {@code 4.2.0} for Maven 4.</description>
           <type>String</type>
         </field>
 


### PR DESCRIPTION
## Summary
- Backport of #11810 from `maven-4.0.x` to `master`
- Documents the supported `modelVersion` values: `4.0.0` for Maven 3, `4.1.0` or `4.2.0` for Maven 4
- Fixes grammar: adds missing "the", removes double preposition

_Claude Code on behalf of Guillaume Nodet_