### PR TITLE
Fix MavenITConsumerPomBomFromSettingsRepoTest missing super constructor call

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITConsumerPomBomFromSettingsRepoTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITConsumerPomBomFromSettingsRepoTest.java
@@ -45,6 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class MavenITConsumerPomBomFromSettingsRepoTest extends AbstractMavenIntegrationTestCase {
 
+    MavenITConsumerPomBomFromSettingsRepoTest() {
+        super("[4.0.0-rc-1,)");
+    }
+
     /**
      * Verifies that consumer POM flattening works when the BOM is only available
      * from a repository defined in a settings.xml profile.


### PR DESCRIPTION
## Summary

- Add missing `super("[4.0.0-rc-1,)")` constructor call to `MavenITConsumerPomBomFromSettingsRepoTest`, fixing a compilation error on `maven-4.0.x` where `AbstractMavenIntegrationTestCase` has no no-arg constructor.
- The test was backported in #11767 without the constructor that all sibling IT test classes use.

## Test plan

- [x] Verified `its/core-it-suite` compiles successfully with `mvn compile test-compile`

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)