### PR TITLE
Backport #11742: Fix #11715: preserve 4.1.0 namespace/schema in help:effective-pom

### DIFF
--- a/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
+++ b/compat/maven-model/src/main/java/org/apache/maven/model/io/xpp3/MavenXpp3Writer.java
@@ -26,6 +26,7 @@ import java.io.Writer;
 
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.v4.MavenModelVersion;
 import org.apache.maven.model.v4.MavenStaxWriter;
 
 /**
@@ -33,6 +34,10 @@ import org.apache.maven.model.v4.MavenStaxWriter;
  */
 @Deprecated
 public class MavenXpp3Writer {
+    private static final String NAMESPACE_FORMAT = "http://maven.apache.org/POM/%s";
+
+    private static final String SCHEMA_LOCATION_FORMAT = "https://maven.apache.org/xsd/maven-%s.xsd";
+
     // --------------------------/
     // - Class/Member Variables -/
     // --------------------------/
@@ -79,6 +84,7 @@ public class MavenXpp3Writer {
      */
     public void write(Writer writer, Model model) throws IOException {
         try {
+            configureDelegate(model);
             delegate.write(writer, model.getDelegate());
         } catch (XMLStreamException e) {
             throw new IOException(e);
@@ -94,9 +100,19 @@ public class MavenXpp3Writer {
      */
     public void write(OutputStream stream, Model model) throws IOException {
         try {
+            configureDelegate(model);
             delegate.write(stream, model.getDelegate());
         } catch (XMLStreamException e) {
             throw new IOException(e);
         }
     } // -- void write( OutputStream, Model )
+
+    private void configureDelegate(Model model) {
+        String version = model.getModelVersion();
+        if (version == null || version.isBlank()) {
+            version = new MavenModelVersion().getModelVersion(model.getDelegate());
+        }
+        delegate.setNamespace(String.format(NAMESPACE_FORMAT, version));
+        delegate.setSchemaLocation(String.format(SCHEMA_LOCATION_FORMAT, version));
+    }
 }

--- a/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
+++ b/compat/maven-model/src/test/java/org/apache/maven/model/ModelTest.java
@@ -18,12 +18,16 @@
  */
 package org.apache.maven.model;
 
+import java.io.StringWriter;
+
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@code Model}.
@@ -65,6 +69,43 @@ class ModelTest {
     @Test
     void testToStringNullSafe() {
         assertNotNull(new Model().toString());
+    }
+
+    @Test
+    void testWriteUsesMinimumModelVersionNamespace() throws Exception {
+        Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
+                .modelVersion("4.1.0")
+                .root(true)
+                .groupId("g")
+                .artifactId("a")
+                .version("1")
+                .build());
+
+        StringWriter output = new StringWriter();
+        new MavenXpp3Writer().write(output, model);
+
+        String xml = output.toString();
+        assertTrue(xml.contains("xmlns=\"http://maven.apache.org/POM/4.1.0\""));
+        assertTrue(
+                xml.contains(
+                        "xsi:schemaLocation=\"http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd\""));
+    }
+
+    @Test
+    void testWriteDefaultsTo400Namespace() throws Exception {
+        Model model = new Model();
+        model.setGroupId("g");
+        model.setArtifactId("a");
+        model.setVersion("1");
+
+        StringWriter output = new StringWriter();
+        new MavenXpp3Writer().write(output, model);
+
+        String xml = output.toString();
+        assertTrue(xml.contains("xmlns=\"http://maven.apache.org/POM/4.0.0\""));
+        assertTrue(
+                xml.contains(
+                        "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\""));
     }
 
     @Test

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11715EffectivePomNamespaceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11715EffectivePomNamespaceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/11715">GH-11715</a>.
+ *
+ * Verifies that help:effective-pom preserves the 4.1.0 root namespace/schema for a 4.1.0 POM.
+ *
+ * @since 4.0.0-rc-5
+ */
+class MavenITgh11715EffectivePomNamespaceTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh11715EffectivePomNamespaceTest() {
+        super("[4.0.0-rc-1,)");
+    }
+
+    @Test
+    void testIt() throws Exception {
+        Path basedir = extractResources("/gh-11715").getAbsoluteFile().toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("help:effective-pom");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        verifier.verifyTextInLog("<modelVersion>4.1.0</modelVersion>");
+        verifier.verifyTextInLog("<project xmlns=\"http://maven.apache.org/POM/4.1.0\"");
+        verifier.verifyTextInLog(
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd\"");
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-11715/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11715/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.1.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+  <groupId>org.apache.maven.its.gh11715</groupId>
+  <artifactId>effective-pom-namespace</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+</project>


### PR DESCRIPTION
Backport of #11742 to 4.0.x branch.