### PR TITLE
[4.0.x] Deps: Maven Executor 1.0.0 released; use it

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -265,7 +265,7 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.executor</groupId>
         <artifactId>maven-executor</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Move off from SNAPSHOT.
