### PR TITLE
Fix @since annotation for XmlService.newXMLInputFactory()

### DIFF
--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlService.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlService.java
@@ -109,7 +109,7 @@ public abstract class XmlService {
      * The returned factory has DTD support and external entity resolution disabled.
      *
      * @return a hardened XMLInputFactory
-     * @since 4.1.0
+     * @since 4.0.0-rc-6
      */
     public static XMLInputFactory newXMLInputFactory() {
         XMLInputFactory factory = XMLInputFactory.newFactory();


### PR DESCRIPTION
The `newXMLInputFactory()` method is being backported to 4.0.x (#12269), so the `@since` tag should be `4.0.0-rc-6`, not `4.1.0`.

Follow-up to #12256.