### PR TITLE
Move testing classes from org.apache.maven.api to org.apache.maven.testing

### DIFF
--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/di/MavenDIExtension.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/di/MavenDIExtension.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.di.testing;
+package org.apache.maven.testing.di;
 
 import java.io.File;
 import java.util.Optional;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/di/MavenDITest.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/di/MavenDITest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.di.testing;
+package org.apache.maven.testing.di;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/Basedir.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/Basedir.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/InjectMojo.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/InjectMojo.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoExtension.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoExtension.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -52,7 +52,6 @@ import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Priority;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
-import org.apache.maven.api.di.testing.MavenDIExtension;
 import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.ConfigurationContainer;
 import org.apache.maven.api.model.Model;
@@ -62,12 +61,6 @@ import org.apache.maven.api.plugin.Mojo;
 import org.apache.maven.api.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.api.plugin.descriptor.Parameter;
 import org.apache.maven.api.plugin.descriptor.PluginDescriptor;
-import org.apache.maven.api.plugin.testing.stubs.MojoExecutionStub;
-import org.apache.maven.api.plugin.testing.stubs.PluginStub;
-import org.apache.maven.api.plugin.testing.stubs.ProducedArtifactStub;
-import org.apache.maven.api.plugin.testing.stubs.ProjectStub;
-import org.apache.maven.api.plugin.testing.stubs.RepositorySystemSupplier;
-import org.apache.maven.api.plugin.testing.stubs.SessionMock;
 import org.apache.maven.api.services.ArtifactDeployer;
 import org.apache.maven.api.services.ArtifactFactory;
 import org.apache.maven.api.services.ArtifactInstaller;
@@ -95,6 +88,13 @@ import org.apache.maven.model.v4.MavenMerger;
 import org.apache.maven.model.v4.MavenStaxReader;
 import org.apache.maven.plugin.PluginParameterExpressionEvaluatorV4;
 import org.apache.maven.plugin.descriptor.io.PluginDescriptorStaxReader;
+import org.apache.maven.testing.di.MavenDIExtension;
+import org.apache.maven.testing.plugin.stubs.MojoExecutionStub;
+import org.apache.maven.testing.plugin.stubs.PluginStub;
+import org.apache.maven.testing.plugin.stubs.ProducedArtifactStub;
+import org.apache.maven.testing.plugin.stubs.ProjectStub;
+import org.apache.maven.testing.plugin.stubs.RepositorySystemSupplier;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.component.configurator.expression.TypeAwareExpressionEvaluator;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoParameter.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoParameter.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoParameters.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoParameters.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoTest.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/SecDispatcherProvider.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/SecDispatcherProvider.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.util.Map;
 

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/ArtifactStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/ArtifactStub.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.util.Objects;
 

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/LookupStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/LookupStub.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.util.List;
 import java.util.Map;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/MojoExecutionStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/MojoExecutionStub.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.util.Optional;
 

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/PluginStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/PluginStub.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.util.Collections;
 import java.util.List;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/ProducedArtifactStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/ProducedArtifactStub.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import org.apache.maven.api.ProducedArtifact;
 

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/ProjectStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/ProjectStub.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.nio.file.Path;
 import java.util.Arrays;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/RepositorySystemSupplier.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/RepositorySystemSupplier.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/SessionMock.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/SessionMock.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.net.URI;
 import java.nio.file.Path;

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/SessionStub.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/SessionStub.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing.stubs;
+package org.apache.maven.testing.plugin.stubs;
 
 import java.nio.file.Path;
 import java.time.Instant;

--- a/impl/maven-testing/src/test/java/org/apache/maven/testing/di/SimpleDITest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/testing/di/SimpleDITest.java
@@ -16,18 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.di.testing;
+package org.apache.maven.testing.di;
 
 import java.io.File;
 
 import org.apache.maven.api.Session;
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Provides;
-import org.apache.maven.api.plugin.testing.stubs.SessionMock;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import static org.apache.maven.api.di.testing.MavenDIExtension.getBasedir;
+import static org.apache.maven.testing.di.MavenDIExtension.getBasedir;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;

--- a/impl/maven-testing/src/test/java/org/apache/maven/testing/plugin/ExpressionEvaluatorTest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/testing/plugin/ExpressionEvaluatorTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -30,8 +30,8 @@ import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.plugin.MojoException;
 import org.apache.maven.api.plugin.annotations.Mojo;
-import org.apache.maven.api.plugin.testing.stubs.ProjectStub;
-import org.apache.maven.api.plugin.testing.stubs.SessionMock;
+import org.apache.maven.testing.plugin.stubs.ProjectStub;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/impl/maven-testing/src/test/java/org/apache/maven/testing/plugin/MojoExtensionModelTest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/testing/plugin/MojoExtensionModelTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/impl/maven-testing/src/test/java/org/apache/maven/testing/plugin/MojoRealSessionTest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/testing/plugin/MojoRealSessionTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.api.plugin.testing;
+package org.apache.maven.testing.plugin;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,8 +25,8 @@ import org.apache.maven.api.Session;
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
-import org.apache.maven.api.plugin.testing.stubs.SessionMock;
 import org.apache.maven.impl.standalone.ApiRunner;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/impl/maven-testing/src/test/resources/META-INF/maven/org.apache.maven.api.di.Inject
+++ b/impl/maven-testing/src/test/resources/META-INF/maven/org.apache.maven.api.di.Inject
@@ -16,4 +16,4 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-org.apache.maven.api.plugin.testing.ExpressionEvaluatorTest$ExpressionEvaluatorMojo
+org.apache.maven.testing.plugin.ExpressionEvaluatorTest$ExpressionEvaluatorMojo

--- a/impl/maven-testing/src/test/resources/META-INF/maven/plugin.xml
+++ b/impl/maven-testing/src/test/resources/META-INF/maven/plugin.xml
@@ -73,7 +73,7 @@ under the License.
         </parameter>
         <parameter>
           <name>beanParam</name>
-          <type>org.apache.maven.api.plugin.testing.ExpressionEvaluatorTest$TestBean</type>
+          <type>org.apache.maven.testing.plugin.ExpressionEvaluatorTest$TestBean</type>
         </parameter>
         <parameter>
           <name>intValue</name>

--- a/its/core-it-suite/src/test/resources/gh-11055-di-service-injection/src/test/java/com/gitlab/tkslaw/ditests/InjectServiceMojoTests.java
+++ b/its/core-it-suite/src/test/resources/gh-11055-di-service-injection/src/test/java/com/gitlab/tkslaw/ditests/InjectServiceMojoTests.java
@@ -18,8 +18,8 @@
  */
 package com.gitlab.tkslaw.ditests;
 
-import org.apache.maven.api.plugin.testing.InjectMojo;
-import org.apache.maven.api.plugin.testing.MojoTest;
+import org.apache.maven.testing.plugin.InjectMojo;
+import org.apache.maven.testing.plugin.MojoTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/resources/gh-11055-di-service-injection/src/test/java/com/gitlab/tkslaw/ditests/TestProviders.java
+++ b/its/core-it-suite/src/test/resources/gh-11055-di-service-injection/src/test/java/com/gitlab/tkslaw/ditests/TestProviders.java
@@ -24,7 +24,7 @@ import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Priority;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
-import org.apache.maven.api.plugin.testing.stubs.SessionMock;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.apache.maven.api.services.DependencyResolver;
 import org.apache.maven.api.services.OsService;
 import org.apache.maven.api.services.ToolchainManager;
@@ -33,7 +33,7 @@ import org.apache.maven.impl.InternalSession;
 import org.apache.maven.impl.model.DefaultOsService;
 import org.mockito.Mockito;
 
-import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
+import static org.apache.maven.testing.plugin.MojoExtension.getBasedir;
 
 @Named
 public class TestProviders {

--- a/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/pom.xml
@@ -31,31 +31,9 @@ under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javaVersion>17</javaVersion>
-    <guiceVersion>6.0.0</guiceVersion>
-    <mavenVersion>4.0.0-beta-5</mavenVersion>
+    <mavenVersion>4.1.0-SNAPSHOT</mavenVersion>
     <mavenPluginPluginVersion>4.0.0-beta-1</mavenPluginPluginVersion>
-    <mavenPluginTestingVersion>4.0.0-beta-2</mavenPluginTestingVersion>
-    <mavenResolverVersion>2.0.2</mavenResolverVersion>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>5.13.4</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-bom</artifactId>
-        <version>5.20.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -70,59 +48,13 @@ under the License.
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-api-meta</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
+      <artifactId>maven-testing</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-api</artifactId>
-      <version>${mavenResolverVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-api-impl</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>${guiceVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-testing</groupId>
-      <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>${mavenPluginTestingVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/src/test/java/org/apache/maven/plugins/HelloMojoTest.java
+++ b/its/core-it-suite/src/test/resources/mng-8525-maven-di-plugin/src/test/java/org/apache/maven/plugins/HelloMojoTest.java
@@ -22,9 +22,9 @@ import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Priority;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
-import org.apache.maven.api.plugin.testing.InjectMojo;
-import org.apache.maven.api.plugin.testing.MojoParameter;
-import org.apache.maven.api.plugin.testing.MojoTest;
+import org.apache.maven.testing.plugin.InjectMojo;
+import org.apache.maven.testing.plugin.MojoParameter;
+import org.apache.maven.testing.plugin.MojoTest;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 


### PR DESCRIPTION
Move testing classes from `org.apache.maven.api.{di,plugin}.testing` to `org.apache.maven.testing.{di,plugin}`.

### Migration

| Old package | New package |
|---|---|
| `org.apache.maven.api.di.testing` | `org.apache.maven.testing.di` |
| `org.apache.maven.api.plugin.testing` | `org.apache.maven.testing.plugin` |
| `org.apache.maven.api.plugin.testing.stubs` | `org.apache.maven.testing.plugin.stubs` |

These classes are public-facing test utilities for Maven plugin developers (not API, not impl internals), so `org.apache.maven.testing` is the appropriate package.

Old classes are removed on master. See companion PR #12277 for 4.0.x deprecation.