### PR TITLE
Fix NPE in DefaultModelBuilder when POM resolved from repository (backport to 4.0.x)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1400,7 +1400,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             // path correctly if it was not set in the input model
             if (inputModel.getParent() != null && inputModel.getParent().getRelativePath() == null) {
                 String relPath;
-                if (parentModel.getPomFile() != null && isBuildRequest()) {
+                if (isBuildRequest() && parentModel.getPomFile() != null && inputModel.getPomFile() != null) {
                     relPath = inputModel
                             .getPomFile()
                             .getParent()

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -323,6 +323,31 @@ class DefaultModelBuilderTest {
     }
 
     /**
+     * Verify that building a model from a resolved source (null pomFile) does not throw
+     * a NullPointerException. This simulates the scenario from GH-11919 where the
+     * cyclonedx-maven-plugin resolves a dependency POM from the repository, which
+     * produces a ModelSource whose {@code getPath()} returns {@code null}.
+     */
+    @Test
+    public void testResolvedSourceWithNullPomFile() {
+        Path pomPath = getPom("resolved-dependency");
+        // resolvedSource returns null for getPath(), simulating a dependency POM
+        // resolved from a remote repository (not a local project build)
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.CONSUMER_DEPENDENCY)
+                .source(Sources.resolvedSource(pomPath, "org.example:resolved-dep:1.0.0"))
+                .build();
+        ModelBuilderResult result = builder.newSession().build(request);
+        assertNotNull(result);
+        assertNotNull(result.getEffectiveModel());
+        assertNull(result.getEffectiveModel().getPomFile(), "pomFile should be null for resolved sources");
+        assertEquals("org.example", result.getEffectiveModel().getGroupId());
+        assertEquals("resolved-dep", result.getEffectiveModel().getArtifactId());
+        assertEquals("1.0.0", result.getEffectiveModel().getVersion());
+    }
+
+    /**
      * Verifies that when a BUILD_CONSUMER derived session is created with explicit
      * repositories, those repositories are propagated to the derived session's
      * {@code repositories} and {@code externalRepositories}.

--- a/impl/maven-impl/src/test/resources/poms/factory/resolved-dependency.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/resolved-dependency.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.example</groupId>
+    <artifactId>resolved-dep</artifactId>
+    <version>1.0.0</version>
+</project>


### PR DESCRIPTION
Backport of #11922 to maven-4.0.x.

Fix NullPointerException in readEffectiveModel() when inputModel has no local POM file (e.g. dependency POM resolved from a remote repository).

Fixes #11919