### PR TITLE
[Backport 4.0.x] Document deprecation rationale for Artifact version constants

### DIFF
--- a/compat/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
+++ b/compat/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java
@@ -37,9 +37,19 @@ import org.apache.maven.artifact.versioning.VersionRange;
  */
 public interface Artifact extends Comparable<Artifact> {
 
+    /**
+     * @deprecated The use of the {@code RELEASE} version is discouraged because it results
+     * in non-reproducible builds and exposes projects to supply chain attacks.
+     * Use explicit versions instead.
+     */
     @Deprecated(since = "4.0.0")
     String RELEASE_VERSION = "RELEASE";
 
+    /**
+     * @deprecated The use of the {@code LATEST} version is discouraged because it results
+     * in non-reproducible builds and exposes projects to supply chain attacks.
+     * Use explicit versions instead.
+     */
     @Deprecated(since = "4.0.0")
     String LATEST_VERSION = "LATEST";
 


### PR DESCRIPTION
Backport of #11584 to `maven-4.0.x`.

Adds Javadoc explaining why `RELEASE` and `LATEST` version constants in `Artifact` are deprecated (non-reproducible builds) and documents recommended alternatives.

Documentation-only change — no behavioral or API changes.

Cherry-picked from 4bffb2a6bc9f025d2674e2becee74cb0c69c68b5.