### PR TITLE
[#12288] Pass settings.xml profile properties to LRM

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -433,9 +433,15 @@ public class DefaultRepositorySystemSessionFactory implements RepositorySystemSe
         HashSet<String> activeProfileId =
                 new HashSet<>(request.getProfileActivation().getRequiredActiveProfileIds());
         activeProfileId.addAll(request.getProfileActivation().getOptionalActiveProfileIds());
+        // Also include profiles activated via settings.xml <activeProfiles> so that their
+        // properties (notably aether.* configuration) reach the resolver session config in
+        // time for LocalRepositoryManager initialization.
+        activeProfileId.addAll(request.getActiveProfiles());
 
         return request.getProfiles().stream()
-                .filter(profile -> activeProfileId.contains(profile.getId()))
+                .filter(profile -> activeProfileId.contains(profile.getId())
+                        || (profile.getActivation() != null
+                                && profile.getActivation().isActiveByDefault()))
                 .map(ModelBase::getProperties)
                 .flatMap(properties -> properties.entrySet().stream())
                 .filter(e -> e.getValue() != null)

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITSettingsProfileAetherPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITSettingsProfileAetherPropertiesTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests proving that {@code aether.*} properties declared in the
+ * {@code <properties>} block of a {@code settings.xml} profile are honored
+ * by the resolver at local repository manager initialization, regardless of
+ * which settings.xml-only activation channel was used.
+ *
+ * <p>Two activation channels are covered:
+ * <ul>
+ *   <li>{@code <activation><activeByDefault>true</activeByDefault></activation>}
+ *       on the profile itself;</li>
+ *   <li>{@code <activeProfiles><activeProfile>...</activeProfile></activeProfiles>}
+ *       at the top of {@code settings.xml}.</li>
+ * </ul>
+ *
+ * <p>In both cases the same profile sets:
+ * <pre>
+ *   aether.enhancedLocalRepository.split       = true
+ *   aether.enhancedLocalRepository.localPrefix = it-custom-prefix
+ * </pre>
+ * and the test asserts that {@code mvn install} writes the installed pom
+ * under {@code <localRepo>/it-custom-prefix/&lt;groupId-path&gt;/...} rather
+ * than the flat or default-split layout.
+ *
+ * <p>The same properties on the same profile work correctly when the
+ * profile is activated via {@code -P <id>} on the CLI; only the
+ * settings.xml activation channels fail, which is what these tests guard
+ * against.
+ */
+public class MavenITSettingsProfileAetherPropertiesTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    public void testActiveByDefaultProfile() throws Exception {
+        runAndAssertCustomPrefix("settings-active-by-default.xml");
+    }
+
+    @Test
+    public void testActiveProfilesList() throws Exception {
+        runAndAssertCustomPrefix("settings-active-profiles-list.xml");
+    }
+
+    private void runAndAssertCustomPrefix(String settingsFile) throws Exception {
+        File testDir = extractResources("/settings-profile-aether-properties");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.settings.profile.aether");
+
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument(settingsFile);
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        File localRepo = new File(verifier.getLocalRepository());
+        String gavRelativePath = "org/apache/maven/its/settings/profile/aether/test-artifact/1.0/test-artifact-1.0.pom";
+
+        File expectedAtCustomPrefix = new File(localRepo, "it-custom-prefix/" + gavRelativePath);
+        File flatLayout = new File(localRepo, gavRelativePath);
+        File defaultSplitPrefix = new File(localRepo, "installed/" + gavRelativePath);
+
+        assertTrue(
+                expectedAtCustomPrefix.exists(),
+                "Expected install to use custom localPrefix 'it-custom-prefix' from "
+                        + settingsFile
+                        + ", but artifact not found at "
+                        + expectedAtCustomPrefix);
+
+        assertFalse(
+                flatLayout.exists(),
+                "Found artifact at flat layout "
+                        + flatLayout
+                        + " — indicates the settings.xml profile properties did not reach the resolver"
+                        + " session config in time for LRM init.");
+
+        assertFalse(
+                defaultSplitPrefix.exists(),
+                "Found artifact at default split-LRM prefix "
+                        + defaultSplitPrefix
+                        + " — indicates split=true was honored but localPrefix was silently dropped.");
+    }
+}

--- a/its/core-it-suite/src/test/resources/settings-profile-aether-properties/pom.xml
+++ b/its/core-it-suite/src/test/resources/settings-profile-aether-properties/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.settings.profile.aether</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: Settings Profile Aether Properties</name>
+  <description>
+    Minimal project for proving that aether.enhancedLocalRepository.*
+    properties set in an active-by-default settings.xml profile are honored
+    by the resolver at local repository manager initialization.
+  </description>
+</project>

--- a/its/core-it-suite/src/test/resources/settings-profile-aether-properties/settings-active-by-default.xml
+++ b/its/core-it-suite/src/test/resources/settings-profile-aether-properties/settings-active-by-default.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <profiles>
+    <profile>
+      <id>aether-split-via-settings</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <aether.enhancedLocalRepository.split>true</aether.enhancedLocalRepository.split>
+        <aether.enhancedLocalRepository.localPrefix>it-custom-prefix</aether.enhancedLocalRepository.localPrefix>
+      </properties>
+    </profile>
+  </profiles>
+</settings>

--- a/its/core-it-suite/src/test/resources/settings-profile-aether-properties/settings-active-profiles-list.xml
+++ b/its/core-it-suite/src/test/resources/settings-profile-aether-properties/settings-active-profiles-list.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <activeProfiles>
+    <activeProfile>aether-split-via-settings</activeProfile>
+  </activeProfiles>
+  <profiles>
+    <profile>
+      <id>aether-split-via-settings</id>
+      <properties>
+        <aether.enhancedLocalRepository.split>true</aether.enhancedLocalRepository.split>
+        <aether.enhancedLocalRepository.localPrefix>it-custom-prefix</aether.enhancedLocalRepository.localPrefix>
+      </properties>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
Fixes #12288.

Profiles activated through `settings.xml` (`<activeProfiles>` or
`<activation><activeByDefault>true</activeByDefault>`) had their
`<properties>` block dropped before the resolver session was built, so
`aether.*` configuration declared in such a profile silently failed.
The same `<properties>` on the same `<profile>` worked when activated
via CLI `-P`.

## Changes

1. Two ITs in `core-it-suite` covering both settings.xml activation
   channels — `testActiveByDefaultProfile` (red on master) and
   `testActiveProfilesList` (green on master, regression guard).
2. `DefaultRepositorySystemSessionFactory#getPropertiesFromRequestedProfiles`
   extended to also consider `request.getActiveProfiles()` and
   `<activeByDefault>true</activeByDefault>` profiles.

Locally verified against the `core-it-suite`:
- master + new ITs: 1 of 2 fail (`testActiveByDefaultProfile`)
- master + new ITs + fix: 2 of 2 pass

## Scope

Only the profile's `<properties>` block is affected — other profile
content (`<plugins>`, `<dependencies>`, `<repositories>`, …) flows
through its existing channels unchanged.

Limitation: this does not re-implement the full `DefaultProfileSelector`
semantics (e.g. `activeByDefault` deactivation when other profiles of
the same source are active). For the property-propagation use case in
scope of #12288 this is sufficient; injecting `ProfileSelector` here
would be a larger refactor in a session-build hot path and is left to a
follow-up if needed.

## Affected versions

Reproduces on Maven 4.x master and on Maven 3.9.16; backport candidate.

## Test plan

- [x] `mvn install` on `apache-maven` from the branch builds cleanly
- [x] `mvn verify -Prun-its -DmavenDistro=… -Dit.test=MavenITSettingsProfileAetherPropertiesTest` on the patched dist: both ITs green
- [x] Same command on vanilla master dist: `testActiveByDefaultProfile` red, `testActiveProfilesList` green
- [ ] `core-it-suite` full run (not done locally — CI takes it from here)
