### PR TITLE
[Backport 4.0.x] Update lifecycles reference to point to LifecycleRegistry

### DIFF
--- a/impl/maven-core/src/site/apt/lifecycles.apt.vm
+++ b/impl/maven-core/src/site/apt/lifecycles.apt.vm
@@ -25,7 +25,7 @@
 
 Lifecycles Reference
 
-  Maven defines 3 lifecycles in {{{./apidocs/org/apache/maven/lifecycle/providers/package-summary.html}<<<org.apache.maven.lifecycle.providers>>>}} package:
+  Maven defines 3 lifecycles, which are registered in {{{./apidocs/org/apache/maven/api/services/LifecycleRegistry.html}<<<LifecycleRegistry>>>}}:
 
 %{toc|fromDepth=2}
 


### PR DESCRIPTION
Backport of #12260 to `maven-4.0.x`.

Updates `lifecycles.apt.vm` to point to `LifecycleRegistry` in the aggregated Javadoc instead of the old `org.apache.maven.lifecycle.providers` package reference.

Cherry-picked from f254df73af3a0e549a3d090152221135f4b434e4.