### PR TITLE
[ISSUE-10329] Document behaviour of UrlNormalizer (backport)

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/path/UrlNormalizer.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/path/UrlNormalizer.java
@@ -19,8 +19,14 @@
 package org.apache.maven.model.path;
 
 /**
- * Normalizes a URL to remove the ugly parent references "../" that got potentially inserted by URL adjustment during
- * model inheritance.
+ * Simplifies URLs by removing parent directory references ("/../") and collapsing path segments.
+ * This performs purely string-based normalization without full URL parsing or validation.
+ *
+ * <p>The normalization process iteratively removes "/../" segments by eliminating the preceding path segment,
+ * effectively resolving relative path traversals.
+ *
+ * <p>This does not guarantee that the resulting URL is valid or reachable; it simply
+ * produces a more canonical representation of the input string.
  *
  * @author Benjamin Bentmann
  */

--- a/maven-model-builder/src/test/java/org/apache/maven/model/path/DefaultUrlNormalizerTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/path/DefaultUrlNormalizerTest.java
@@ -78,4 +78,20 @@ public class DefaultUrlNormalizerTest {
     public void leadingParentDirectoryNotRemovedFromRelativeUriReference() {
         assertEquals("../", normalize("../"));
     }
+
+    @Test
+    public void testMultipleParentRefsInRelativePath() {
+        assertEquals("b", normalize("a/../b"));
+        assertEquals("b/d", normalize("a/../b/c/../d"));
+        assertEquals("b/c/d", normalize("a/../b/c/d"));
+        assertEquals("b/c", normalize("a/../b/c"));
+        assertEquals("b/", normalize("a/../b/c/../"));
+    }
+
+    @Test
+    public void testPreservationOfEncodedAndMalformedUrls() {
+        assertEquals("https://example.com/a%20b/c%20d", normalize("https://example.com/a%20b/c%20d"));
+        assertEquals("https://example.com/a b/c d", normalize("https://example.com/a b/c d"));
+        assertEquals("ht!tps:/bad_url", normalize("ht!tps:/bad_url"));
+    }
 }


### PR DESCRIPTION
## Summary

Backport of #12293 to `maven-3.10.x`.

- Enhanced Javadoc on `UrlNormalizer` interface explaining its string-based URL normalization behavior
- Additional test cases for `DefaultUrlNormalizerTest` covering relative path traversals, encoded spaces, and malformed URLs

Closes #10329 (backport)

_Fully automatic review from Claude Code_