### PR TITLE
Add deprecation Javadoc to XmlNode constants and methods (backport #11576)

### DIFF
--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/XmlNode.java
@@ -54,12 +54,21 @@ import org.apache.maven.api.annotations.ThreadSafe;
 @Immutable
 public interface XmlNode {
 
+    /**
+     * @deprecated Use {@link XmlService#CHILDREN_COMBINATION_MODE_ATTRIBUTE} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String CHILDREN_COMBINATION_MODE_ATTRIBUTE = XmlService.CHILDREN_COMBINATION_MODE_ATTRIBUTE;
 
+    /**
+     * @deprecated Use {@link XmlService#CHILDREN_COMBINATION_MERGE} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String CHILDREN_COMBINATION_MERGE = XmlService.CHILDREN_COMBINATION_MERGE;
 
+    /**
+     * @deprecated Use {@link XmlService#CHILDREN_COMBINATION_APPEND} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String CHILDREN_COMBINATION_APPEND = XmlService.CHILDREN_COMBINATION_APPEND;
 
@@ -67,24 +76,40 @@ public interface XmlNode {
      * This default mode for combining children DOMs during merge means that where element names match, the process will
      * try to merge the element data, rather than putting the dominant and recessive elements (which share the same
      * element name) as siblings in the resulting DOM.
+     *
+     * @deprecated Use {@link XmlService#DEFAULT_CHILDREN_COMBINATION_MODE} instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String DEFAULT_CHILDREN_COMBINATION_MODE = XmlService.DEFAULT_CHILDREN_COMBINATION_MODE;
 
+    /**
+     * @deprecated Use {@link XmlService#SELF_COMBINATION_MODE_ATTRIBUTE} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String SELF_COMBINATION_MODE_ATTRIBUTE = XmlService.SELF_COMBINATION_MODE_ATTRIBUTE;
 
+    /**
+     * @deprecated Use {@link XmlService#SELF_COMBINATION_OVERRIDE} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String SELF_COMBINATION_OVERRIDE = XmlService.SELF_COMBINATION_OVERRIDE;
 
+    /**
+     * @deprecated Use {@link XmlService#SELF_COMBINATION_MERGE} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String SELF_COMBINATION_MERGE = XmlService.SELF_COMBINATION_MERGE;
 
+    /**
+     * @deprecated Use {@link XmlService#SELF_COMBINATION_REMOVE} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String SELF_COMBINATION_REMOVE = XmlService.SELF_COMBINATION_REMOVE;
 
     /**
      * In case of complex XML structures, combining can be done based on id.
+     *
+     * @deprecated Use {@link XmlService#ID_COMBINATION_MODE_ATTRIBUTE} instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String ID_COMBINATION_MODE_ATTRIBUTE = XmlService.ID_COMBINATION_MODE_ATTRIBUTE;
@@ -92,6 +117,8 @@ public interface XmlNode {
     /**
      * In case of complex XML structures, combining can be done based on keys.
      * This is a comma separated list of attribute names.
+     *
+     * @deprecated Use {@link XmlService#KEYS_COMBINATION_MODE_ATTRIBUTE} instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String KEYS_COMBINATION_MODE_ATTRIBUTE = XmlService.KEYS_COMBINATION_MODE_ATTRIBUTE;
@@ -101,6 +128,8 @@ public interface XmlNode {
      * try to merge the element attributes and values, rather than overriding the recessive element completely with the
      * dominant one. This means that wherever the dominant element doesn't provide the value or a particular attribute,
      * that value or attribute will be set from the recessive DOM node.
+     *
+     * @deprecated Use {@link XmlService#DEFAULT_SELF_COMBINATION_MODE} instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     String DEFAULT_SELF_COMBINATION_MODE = XmlService.DEFAULT_SELF_COMBINATION_MODE;
@@ -199,55 +228,81 @@ public interface XmlNode {
     @Nullable
     Object inputLocation();
 
-    // Deprecated methods that delegate to new ones
+    /**
+     * @deprecated Use {@link #name()} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nonnull
     default String getName() {
         return name();
     }
 
+    /**
+     * @deprecated Use {@link #namespaceUri()} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nonnull
     default String getNamespaceUri() {
         return namespaceUri();
     }
 
+    /**
+     * @deprecated Use {@link #prefix()} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nonnull
     default String getPrefix() {
         return prefix();
     }
 
+    /**
+     * @deprecated Use {@link #value()} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nullable
     default String getValue() {
         return value();
     }
 
+    /**
+     * @deprecated Use {@link #attributes()} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nonnull
     default Map<String, String> getAttributes() {
         return attributes();
     }
 
+    /**
+     * @deprecated Use {@link #attribute(String)} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nullable
     default String getAttribute(@Nonnull String name) {
         return attribute(name);
     }
 
+    /**
+     * @deprecated Use {@link #children()} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nonnull
     default List<XmlNode> getChildren() {
         return children();
     }
 
+    /**
+     * @deprecated Use {@link #child(String)} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nullable
     default XmlNode getChild(String name) {
         return child(name);
     }
 
+    /**
+     * @deprecated Use {@link #inputLocation()} instead.
+     */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nullable
     default Object getInputLocation() {
@@ -255,7 +310,7 @@ public interface XmlNode {
     }
 
     /**
-     * @deprecated use {@link XmlService#merge(XmlNode, XmlNode, Boolean)} instead
+     * @deprecated Use {@link XmlService#merge(XmlNode, XmlNode, Boolean)} instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     default XmlNode merge(@Nullable XmlNode source) {
@@ -263,7 +318,7 @@ public interface XmlNode {
     }
 
     /**
-     * @deprecated use {@link XmlService#merge(XmlNode, XmlNode, Boolean)} instead
+     * @deprecated Use {@link XmlService#merge(XmlNode, XmlNode, Boolean)} instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     default XmlNode merge(@Nullable XmlNode source, @Nullable Boolean childMergeOverride) {
@@ -279,7 +334,8 @@ public interface XmlNode {
      * @param recessive if {@code null}, nothing will happen
      * @return the merged node
      *
-     * @deprecated use {@link XmlService#merge(XmlNode, XmlNode, Boolean)} instead
+     * @deprecated Use {@link XmlService#merge(XmlNode, XmlNode, Boolean)}
+     * with an appropriate {@code childMergeOverride} value instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     @Nullable


### PR DESCRIPTION
Backport of #11576 to maven-4.0.x.

Add `@deprecated` Javadoc comments to all deprecated constants and methods
in `XmlNode` that were missing replacement guidance. Each tag now points to the
corresponding `XmlService` constant or the new-style method name.

No functional behavior is changed.