### PR TITLE
[#12288] Add -P !profile deactivation regression guard

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
@@ -107,10 +107,11 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
         if (!path.exists()) {
             return;
         }
-        Files.walk(path.toPath())
-                .sorted(Comparator.reverseOrder())
-                .map(java.nio.file.Path::toFile)
-                .forEach(File::delete);
+        try (var paths = Files.walk(path.toPath())) {
+            paths.sorted(Comparator.reverseOrder())
+                    .map(java.nio.file.Path::toFile)
+                    .forEach(File::delete);
+        }
     }
 
     private void runAndAssertCustomPrefix(String settingsFile) throws Exception {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
@@ -101,7 +101,6 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
                 customPrefix.exists(),
                 "Found artifact at custom prefix " + customPrefix + " — deactivation via -P ! was ignored.");
     }
-    }
 
     private void runAndAssertCustomPrefix(String settingsFile) throws Exception {
         File testDir = extractResources("/settings-profile-aether-properties");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
@@ -19,6 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.util.Comparator;
 
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +65,52 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
     @Test
     public void testActiveProfilesList() throws Exception {
         runAndAssertCustomPrefix("settings-active-profiles-list.xml");
+    }
+
+    @Test
+    public void testActiveByDefaultDeactivatedViaCli() throws Exception {
+        File testDir = extractResources("/settings-profile-aether-properties");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.setLogFileName("log-deactivation.txt");
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.settings.profile.aether");
+
+        // Sibling tests in this class install under the same custom prefix; clear it to
+        // avoid false positives if those tests ran first.
+        File customPrefixSubtree = new File(verifier.getLocalRepository(), "it-custom-prefix");
+        deleteRecursivelyIfExists(customPrefixSubtree);
+
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings-active-by-default.xml");
+        verifier.addCliArgument("-P!aether-split-via-settings");
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        File localRepo = new File(verifier.getLocalRepository());
+        String gavRelativePath = "org/apache/maven/its/settings/profile/aether/test-artifact/1.0/test-artifact-1.0.pom";
+        File flatLayout = new File(localRepo, gavRelativePath);
+        File customPrefix = new File(localRepo, "it-custom-prefix/" + gavRelativePath);
+
+        assertTrue(
+                flatLayout.exists(),
+                "Expected artifact at flat layout (profile deactivated via -P !), but not found at " + flatLayout);
+
+        assertFalse(
+                customPrefix.exists(),
+                "Found artifact at custom prefix " + customPrefix + " — deactivation via -P ! was ignored.");
+    }
+
+    private static void deleteRecursivelyIfExists(File path) throws Exception {
+        if (!path.exists()) {
+            return;
+        }
+        Files.walk(path.toPath())
+                .sorted(Comparator.reverseOrder())
+                .map(java.nio.file.Path::toFile)
+                .forEach(File::delete);
     }
 
     private void runAndAssertCustomPrefix(String settingsFile) throws Exception {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
@@ -19,9 +19,8 @@
 package org.apache.maven.it;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.util.Comparator;
 
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -80,7 +79,7 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
         // Sibling tests in this class install under the same custom prefix; clear it to
         // avoid false positives if those tests ran first.
         File customPrefixSubtree = new File(verifier.getLocalRepository(), "it-custom-prefix");
-        deleteRecursivelyIfExists(customPrefixSubtree);
+        FileUtils.deleteDirectory(customPrefixSubtree);
 
         verifier.addCliArgument("--settings");
         verifier.addCliArgument("settings-active-by-default.xml");
@@ -102,16 +101,6 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
                 customPrefix.exists(),
                 "Found artifact at custom prefix " + customPrefix + " — deactivation via -P ! was ignored.");
     }
-
-    private static void deleteRecursivelyIfExists(File path) throws Exception {
-        if (!path.exists()) {
-            return;
-        }
-        try (var paths = Files.walk(path.toPath())) {
-            paths.sorted(Comparator.reverseOrder())
-                    .map(java.nio.file.Path::toFile)
-                    .forEach(File::delete);
-        }
     }
 
     private void runAndAssertCustomPrefix(String settingsFile) throws Exception {


### PR DESCRIPTION
Hypersedes #12297 (which superseded #12291).

Starts from the head of #12297 and adds one additional integration
test, `testActiveByDefaultDeactivatedViaCli`, that guards the
`-P !profileId` deactivation path introduced in @gnodet's commit
"Address review feedback: fix activeByDefault deactivation and rename
IT". The fix logic itself is unchanged from #12297; this PR adds the
regression test to lock it in.

## What's new vs #12297

* `testActiveByDefaultDeactivatedViaCli` — runs `mvn install` with
  `-P!aether-split-via-settings` and asserts the artifact lands at the
  flat layout (not under the custom prefix), confirming the
  `inactiveProfileId` guard works end-to-end.
* `deleteRecursivelyIfExists` private helper — clears any stale
  `it-custom-prefix/` subtree before the deactivation run, so the
  assertion is robust against test-execution order with sibling tests
  installing under that same prefix.

## Verification

* Patched build: 3/3 ITs green.
* Without the deactivation guard in the fix (i.e. vanilla master):
  `testActiveByDefaultProfile` is RED — the bug — and the deactivation
  test trivially passes because the profile is silently dropped anyway.
  So the new test specifically guards the fix-introduced deactivation
  logic, not a pre-existing path.

Happy to fold the extra test into #12297 instead if you'd prefer to
keep it on a single PR; just say the word.
