### PR TITLE
[maven-4.0.x] Fix #12306: normalize targetPath in DefaultSourceRoot

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -108,7 +108,12 @@ public record DefaultSourceRoot(
         this.includes = (includes != null) ? List.copyOf(includes) : List.of();
         this.excludes = (excludes != null) ? List.copyOf(excludes) : List.of();
         this.stringFiltering = stringFiltering;
-        this.targetPathOrNull = (targetPathOrNull != null) ? targetPathOrNull.normalize() : null;
+        if (targetPathOrNull != null) {
+            Path normalized = targetPathOrNull.normalize();
+            this.targetPathOrNull = normalized.toString().isEmpty() ? null : normalized;
+        } else {
+            this.targetPathOrNull = null;
+        }
         this.enabled = enabled;
     }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSourceRootTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSourceRootTest.java
@@ -229,6 +229,34 @@ public class DefaultSourceRootTest {
         assertFalse(targetPath.isPresent(), "targetPath should be empty for empty string");
     }
 
+    /** GH-12306: {@code targetPath="."} normalizes to an empty path and must be treated as absent. */
+    @Test
+    void testHandlesDotTargetPathFromResource() {
+        Resource resource = Resource.newBuilder()
+                .directory("src/main/resources")
+                .targetPath(".")
+                .build();
+
+        DefaultSourceRoot sourceRoot = new DefaultSourceRoot(Path.of("myproject"), ProjectScope.MAIN, resource);
+
+        assertFalse(sourceRoot.targetPath().isPresent(), "targetPath \".\" should be treated as absent");
+    }
+
+    /** GH-12306: {@code targetPath="./subdir"} normalizes to {@code "subdir"} and must be preserved. */
+    @Test
+    void testHandlesDotRelativeTargetPathFromResource() {
+        Resource resource = Resource.newBuilder()
+                .directory("src/main/resources")
+                .targetPath("./subdir")
+                .build();
+
+        DefaultSourceRoot sourceRoot = new DefaultSourceRoot(Path.of("myproject"), ProjectScope.MAIN, resource);
+
+        assertTrue(
+                sourceRoot.targetPath().isPresent(), "targetPath \"./subdir\" should be present after normalization");
+        assertEquals(Path.of("subdir"), sourceRoot.targetPath().orElseThrow());
+    }
+
     /*MNG-11062*/
     @Test
     void testHandlesPropertyPlaceholderInTargetPath() {


### PR DESCRIPTION
## Problem

When a resource is declared with `<targetPath>.</targetPath>`, Maven 4 throws a `NoSuchFileException`. Closes #12306.

## Root Cause

In `DefaultSourceRoot`'s canonical constructor, the incoming `targetPathOrNull` was normalized via `Path.normalize()` and stored as-is. On JDK 21 (Linux), `Path.of(".").normalize()` returns a `Path` whose `toString()` is `""` (empty string) but whose `getNameCount()` is `1`. This empty-string path was then passed to plugins, which concatenated it into an absolute path like `/org/apache/…`, bypassing the output directory entirely and causing `NoSuchFileException`.

## Fix

After normalizing the target path, treat any path whose `toString()` is empty (which includes `"."` after normalization) the same as a null/absent target path. This preserves the Maven 3.x behavior where `<targetPath>.</targetPath>` is equivalent to not specifying a `targetPath`.

## Changes

- `impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java` — normalize-and-nullify logic
- `impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSourceRootTest.java` — two new tests:
  - `testHandlesDotTargetPathFromResource` — verifies `"."` is treated as absent
  - `testHandlesDotRelativeTargetPathFromResource` — verifies `"./subdir"` normalizes to `"subdir"` and is preserved

## Test plan

- [ ] `mvn -pl impl/maven-impl -am clean test -DskipITs -Drat.skip=true` passes (453 tests, 0 failures)
- [ ] New tests `testHandlesDotTargetPathFromResource` and `testHandlesDotRelativeTargetPathFromResource` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)