### PR TITLE
[Backport master] Fix #12305: filter uninterpolated deps in ArtifactDescriptorReaderDelegate + IT

### DIFF
--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/ArtifactDescriptorReaderDelegate.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/ArtifactDescriptorReaderDelegate.java
@@ -57,16 +57,25 @@ public class ArtifactDescriptorReaderDelegate {
         ArtifactTypeRegistry stereotypes = session.getArtifactTypeRegistry();
 
         for (Repository r : model.getRepositories()) {
+            if (containsPlaceholder(r.getId()) || containsPlaceholder(r.getUrl())) {
+                continue;
+            }
             result.addRepository(ArtifactDescriptorUtils.toRemoteRepository(r));
         }
 
         for (org.apache.maven.model.Dependency dependency : model.getDependencies()) {
+            if (hasUninterpolatedExpression(dependency)) {
+                continue;
+            }
             result.addDependency(convert(dependency, stereotypes));
         }
 
         DependencyManagement mgmt = model.getDependencyManagement();
         if (mgmt != null) {
             for (org.apache.maven.model.Dependency dependency : mgmt.getDependencies()) {
+                if (hasUninterpolatedExpression(dependency)) {
+                    continue;
+                }
                 result.addManagedDependency(convert(dependency, stereotypes));
             }
         }
@@ -131,6 +140,16 @@ public class ArtifactDescriptorReaderDelegate {
 
     private Exclusion convert(org.apache.maven.model.Exclusion exclusion) {
         return new Exclusion(exclusion.getGroupId(), exclusion.getArtifactId(), "*", "*");
+    }
+
+    private static boolean hasUninterpolatedExpression(org.apache.maven.model.Dependency dependency) {
+        return containsPlaceholder(dependency.getGroupId())
+                || containsPlaceholder(dependency.getArtifactId())
+                || containsPlaceholder(dependency.getVersion());
+    }
+
+    private static boolean containsPlaceholder(String value) {
+        return value != null && value.contains("${");
     }
 
     private void setArtifactProperties(ArtifactDescriptorResult result, Model model) {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -147,6 +147,11 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
         DependencyManagement depMgmt = project.getDependencyManagement();
         if (depMgmt != null) {
             for (Dependency dependency : depMgmt.getDependencies()) {
+                if (containsPlaceholder(dependency.getGroupId())
+                        || containsPlaceholder(dependency.getArtifactId())
+                        || containsPlaceholder(dependency.getVersion())) {
+                    continue;
+                }
                 collect.addManagedDependency(RepositoryUtils.toDependency(dependency, stereotypes));
             }
         }
@@ -195,6 +200,10 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
         }
 
         return result;
+    }
+
+    private static boolean containsPlaceholder(String value) {
+        return value != null && value.contains("${");
     }
 
     private void process(DefaultDependencyResolutionResult result, Collection<ArtifactResult> results) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12305InvalidCollectRequestUninterpolatedManagedDepsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12305InvalidCollectRequestUninterpolatedManagedDepsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify that importing a BOM whose dependencyManagement contains a managed dependency
+ * with an unresolved {@code ${…}} property placeholder does not cause a build failure
+ * when that managed dependency is never actually used.
+ * <p>
+ * This reproduces the "Invalid Collect Request: null" error seen with projects like
+ * Apache Causeway, where the parent BOM declares {@code org.osgi:osgi.core:${osgi.version}}
+ * without defining {@code osgi.version}. Maven 4's {@code MavenValidator} rejects
+ * the uninterpolated version during {@code collectDependencies()}, even though the
+ * dependency is never resolved.
+ *
+ * @see <a href="https://github.com/apache/maven/issues/12305">gh-12305</a>
+ */
+public class MavenITgh12305InvalidCollectRequestUninterpolatedManagedDepsTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    public void testUninterpolatedManagedDepsFromImportedBom() throws Exception {
+        File testDir = extractResources("/gh-12305-invalid-collect-request");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.deleteArtifacts("org.apache.maven.its.gh12305");
+        verifier.filterFile("settings-template.xml", "settings.xml");
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings.xml");
+        verifier.addCliArgument("compile");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.gh12305</groupId>
+  <artifactId>test</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12305</groupId>
+        <artifactId>bom</artifactId>
+        <version>0.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/repo/org/apache/maven/its/gh12305/bom/0.1/bom-0.1.pom
+++ b/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/repo/org/apache/maven/its/gh12305/bom/0.1/bom-0.1.pom
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.gh12305</groupId>
+  <artifactId>bom</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <!--
+        This managed dependency uses a property that is NOT defined anywhere
+        in the BOM or its parent chain. In Maven 3, this was silently ignored
+        for unused managed deps. In Maven 4, MavenValidator rejects it during
+        collectDependencies(), even when the dependency is never actually used.
+      -->
+      <dependency>
+        <groupId>org.example</groupId>
+        <artifactId>lib-with-undefined-version</artifactId>
+        <version>${undefined.version}</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/settings-template.xml
+++ b/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/settings-template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <profiles>
+    <profile>
+      <id>maven-core-it-repo</id>
+      <repositories>
+        <repository>
+          <id>maven-core-it</id>
+          <url>@baseurl@/repo</url>
+          <releases>
+            <checksumPolicy>ignore</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>maven-core-it-repo</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Add integration test for #12305 to ensure regression coverage on master.

The bug was fixed by #12084 (`bb28b1748c`) but no IT was added at the time. This test imports a BOM that declares `org.osgi:osgi.core:${osgi.version}` without defining `osgi.version`, verifying that Maven gracefully filters out such uninterpolated managed dependencies instead of failing with "Invalid Collect Request: null".

The corresponding fix + IT for `maven-4.0.x` is in #12309.