### PR TITLE
[maven-4.0.x] Fix #12306: normalize targetPath in DefaultSourceRoot

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSourceRoot.java
@@ -108,7 +108,12 @@ public record DefaultSourceRoot(
         this.includes = (includes != null) ? List.copyOf(includes) : List.of();
         this.excludes = (excludes != null) ? List.copyOf(excludes) : List.of();
         this.stringFiltering = stringFiltering;
-        this.targetPathOrNull = (targetPathOrNull != null) ? targetPathOrNull.normalize() : null;
+        if (targetPathOrNull != null) {
+            Path normalized = targetPathOrNull.normalize();
+            this.targetPathOrNull = normalized.toString().isEmpty() ? null : normalized;
+        } else {
+            this.targetPathOrNull = null;
+        }
         this.enabled = enabled;
     }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSourceRootTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSourceRootTest.java
@@ -229,6 +229,34 @@ public class DefaultSourceRootTest {
         assertFalse(targetPath.isPresent(), "targetPath should be empty for empty string");
     }
 
+    /** GH-12306: {@code targetPath="."} normalizes to an empty path and must be treated as absent. */
+    @Test
+    void testHandlesDotTargetPathFromResource() {
+        Resource resource = Resource.newBuilder()
+                .directory("src/main/resources")
+                .targetPath(".")
+                .build();
+
+        DefaultSourceRoot sourceRoot = new DefaultSourceRoot(Path.of("myproject"), ProjectScope.MAIN, resource);
+
+        assertFalse(sourceRoot.targetPath().isPresent(), "targetPath \".\" should be treated as absent");
+    }
+
+    /** GH-12306: {@code targetPath="./subdir"} normalizes to {@code "subdir"} and must be preserved. */
+    @Test
+    void testHandlesDotRelativeTargetPathFromResource() {
+        Resource resource = Resource.newBuilder()
+                .directory("src/main/resources")
+                .targetPath("./subdir")
+                .build();
+
+        DefaultSourceRoot sourceRoot = new DefaultSourceRoot(Path.of("myproject"), ProjectScope.MAIN, resource);
+
+        assertTrue(
+                sourceRoot.targetPath().isPresent(), "targetPath \"./subdir\" should be present after normalization");
+        assertEquals(Path.of("subdir"), sourceRoot.targetPath().orElseThrow());
+    }
+
     /*MNG-11062*/
     @Test
     void testHandlesPropertyPlaceholderInTargetPath() {


### PR DESCRIPTION
## Problem\n\n`Path.of(\".\").normalize()` returns an empty path, which causes `NoSuchFileException` when Maven tries to copy resources with `targetPath=\".\"`.\n\n## Fix\n\nNormalize `targetPath` in `DefaultSourceRoot` so that `\".\"` becomes absent (`null`) and `\"./subdir\"` becomes `\"subdir\"`. This matches the behavior users expect — a targetPath of `\".\"` means \"copy to the output root\", which is the default when no targetPath is set.\n\n- Adds normalization logic in `DefaultSourceRoot`\n- Adds unit tests for `\".\"` and `\"./subdir\"` targetPath behavior\n\nSplit out from #12308 as suggested by Copilot review.\n\nFixes #12306\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)