### PR TITLE
[Backport master] Add deprecated property replacement (${version} → ${project.version}) to mvnup (#12304)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
@@ -147,6 +147,7 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
                 hasIssues |= fixDuplicateDependencies(pomDocument, context);
                 hasIssues |= fixDuplicatePlugins(pomDocument, context);
                 hasIssues |= fixUnsupportedRepositoryExpressions(pomDocument, context);
+                hasIssues |= fixDeprecatedPropertyExpressions(pomDocument, context);
                 hasIssues |= fixIncorrectParentRelativePaths(pomDocument, pomPath, pomMap, context);
                 hasIssues |= fixUndefinedPropertyExpressions(pomDocument, allDefinedProperties, context);
                 hasIssues |= fixUndefinedPropertyExpressionsInRepositories(pomDocument, allDefinedProperties, context);
@@ -758,6 +759,46 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
         }
 
         return fixed;
+    }
+
+    /**
+     * Fixes deprecated Maven 2/3 shorthand property expressions throughout the POM.
+     * Replaces ${version}, ${groupId}, and ${artifactId} with their ${project.*} equivalents,
+     * which are the only forms supported in Maven 4.
+     */
+    private boolean fixDeprecatedPropertyExpressions(Document pomDocument, UpgradeContext context) {
+        return fixDeprecatedPropertyExpressionsInElement(pomDocument.root(), context);
+    }
+
+    private boolean fixDeprecatedPropertyExpressionsInElement(Element element, UpgradeContext context) {
+        boolean fixed = false;
+
+        List<Element> children = element.childElements().toList();
+
+        if (children.isEmpty()) {
+            String text = element.textContent();
+            if (text != null && !text.isEmpty()) {
+                String fixedText = replaceDeprecatedExpressions(text);
+                if (!fixedText.equals(text)) {
+                    element.textContent(fixedText);
+                    context.detail("Fixed: replaced deprecated property expression in <" + element.name() + ">: "
+                            + text.trim() + " → " + fixedText.trim());
+                    fixed = true;
+                }
+            }
+        } else {
+            for (Element child : children) {
+                fixed |= fixDeprecatedPropertyExpressionsInElement(child, context);
+            }
+        }
+
+        return fixed;
+    }
+
+    private static String replaceDeprecatedExpressions(String text) {
+        return text.replace("${version}", "${project.version}")
+                .replace("${groupId}", "${project.groupId}")
+                .replace("${artifactId}", "${project.artifactId}");
     }
 
     private Path findParentPomInMap(

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategyTest.java
@@ -1633,6 +1633,203 @@ class CompatibilityFixStrategyTest {
     }
 
     @Nested
+    @DisplayName("Deprecated Property Expression Fixes")
+    class DeprecatedPropertyExpressionFixesTests {
+
+        @Test
+        @DisplayName("should replace ${version} with ${project.version} in dependency version")
+        void shouldReplaceVersionExpression() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>test</groupId>
+                                <artifactId>test-dep</artifactId>
+                                <version>${version}</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-jar-plugin</artifactId>
+                                <version>${version}</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed deprecated ${version}");
+
+            String xml = DomUtils.toXml(document);
+            assertFalse(xml.contains("${version}"), "Should not contain deprecated ${version}");
+            assertTrue(xml.contains("${project.version}"), "Should contain ${project.version}");
+        }
+
+        @Test
+        @DisplayName("should replace ${groupId} and ${artifactId} expressions")
+        void shouldReplaceGroupIdAndArtifactIdExpressions() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>my-project</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>${groupId}</groupId>
+                            <artifactId>my-lib</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.example</groupId>
+                            <artifactId>${artifactId}-core</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed deprecated expressions");
+
+            String xml = DomUtils.toXml(document);
+            assertFalse(xml.contains("${groupId}"), "Should not contain deprecated ${groupId}");
+            assertFalse(xml.contains("${artifactId}"), "Should not contain deprecated ${artifactId}");
+            assertTrue(xml.contains("${project.groupId}"), "Should contain ${project.groupId}");
+            assertTrue(xml.contains("${project.artifactId}"), "Should contain ${project.artifactId}");
+        }
+
+        @Test
+        @DisplayName("should replace all three deprecated expressions in one POM")
+        void shouldReplaceAllThreeDeprecatedExpressions() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>my-project</artifactId>
+                    <version>2.0.0</version>
+                    <properties>
+                        <selfCoords>${groupId}:${artifactId}:${version}</selfCoords>
+                    </properties>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed deprecated expressions");
+
+            String xml = DomUtils.toXml(document);
+            assertFalse(xml.contains("${version}"), "Should not contain ${version}");
+            assertFalse(xml.contains("${groupId}"), "Should not contain ${groupId}");
+            assertFalse(xml.contains("${artifactId}"), "Should not contain ${artifactId}");
+            assertTrue(xml.contains("${project.version}"), "Should contain ${project.version}");
+            assertTrue(xml.contains("${project.groupId}"), "Should contain ${project.groupId}");
+            assertTrue(xml.contains("${project.artifactId}"), "Should contain ${project.artifactId}");
+        }
+
+        @Test
+        @DisplayName("should not modify POMs without deprecated expressions")
+        void shouldNotModifyPomsWithoutDeprecatedExpressions() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>my-project</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-lib</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not have modified POM without deprecated expressions");
+        }
+
+        @Test
+        @DisplayName("should replace deprecated expressions in plugin configuration")
+        void shouldReplaceDeprecatedExpressionsInPluginConfiguration() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>my-project</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-jar-plugin</artifactId>
+                                <configuration>
+                                    <archive>
+                                        <manifestEntries>
+                                            <Implementation-Version>${version}</Implementation-Version>
+                                        </manifestEntries>
+                                    </archive>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Compatibility fix should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have fixed deprecated ${version} in plugin config");
+
+            String xml = DomUtils.toXml(document);
+            assertFalse(xml.contains("${version}"), "Should not contain deprecated ${version}");
+            assertTrue(xml.contains("${project.version}"), "Should contain ${project.version}");
+        }
+    }
+
+    @Nested
     @DisplayName("Strategy Description")
     class StrategyDescriptionTests {
 


### PR DESCRIPTION
Cherry-pick of #12308 from `maven-4.0.x` to `master`.

Adds support for replacing the deprecated `${version}` property expression (which is no longer an alias for `${project.version}` in Maven 4) in the mvnup compatibility fix strategy.

Fixes #12304