### PR TITLE
[Backport 4.0.x] [#12288] Add -P !profile deactivation regression guard (#12298)

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.File;
 
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -67,6 +68,42 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
     @Test
     public void testActiveProfilesList() throws Exception {
         runAndAssertCustomPrefix("settings-active-profiles-list.xml");
+    }
+
+    @Test
+    public void testActiveByDefaultDeactivatedViaCli() throws Exception {
+        File testDir = extractResources("/settings-profile-aether-properties");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.setLogFileName("log-deactivation.txt");
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.settings.profile.aether");
+
+        // Sibling tests in this class install under the same custom prefix; clear it to
+        // avoid false positives if those tests ran first.
+        File customPrefixSubtree = new File(verifier.getLocalRepository(), "it-custom-prefix");
+        FileUtils.deleteDirectory(customPrefixSubtree);
+
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings-active-by-default.xml");
+        verifier.addCliArgument("-P!aether-split-via-settings");
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        File localRepo = new File(verifier.getLocalRepository());
+        String gavRelativePath = "org/apache/maven/its/settings/profile/aether/test-artifact/1.0/test-artifact-1.0.pom";
+        File flatLayout = new File(localRepo, gavRelativePath);
+        File customPrefix = new File(localRepo, "it-custom-prefix/" + gavRelativePath);
+
+        assertTrue(
+                flatLayout.exists(),
+                "Expected artifact at flat layout (profile deactivated via -P !), but not found at " + flatLayout);
+
+        assertFalse(
+                customPrefix.exists(),
+                "Found artifact at custom prefix " + customPrefix + " — deactivation via -P ! was ignored.");
     }
 
     private void runAndAssertCustomPrefix(String settingsFile) throws Exception {


### PR DESCRIPTION
Backport of #12298 to `maven-4.0.x`.

Cherry-pick of 22f9a0ee08 — adds a regression guard IT for `-P !profile` deactivation of `activeByDefault` profiles.

Fixes #12288