### PR TITLE
Fix Spotless config in its/core-it-suite to enforce formatting rules

### DIFF
--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -94,6 +94,7 @@ under the License.
     <core-it-support-version>2.1-SNAPSHOT</core-it-support-version>
 
     <version.palantirJavaFormat>2.90.0</version.palantirJavaFormat>
+    <version.maven-shared-resources>6</version.maven-shared-resources>
     <its.forkCount>0.75C</its.forkCount>
     <its.test />
   </properties>
@@ -423,7 +424,7 @@ under the License.
             <dependency>
               <groupId>org.apache.maven.shared</groupId>
               <artifactId>maven-shared-resources</artifactId>
-              <version>6</version>
+              <version>${version.maven-shared-resources}</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -381,28 +381,50 @@ under the License.
           <artifactId>spotless-maven-plugin</artifactId>
           <configuration>
             <java>
-              <includes>
+              <palantirJavaFormat>
+                <version>2.90.0</version>
+              </palantirJavaFormat>
+              <removeUnusedImports />
+              <importOrder>
+                <file>config/maven-eclipse-importorder.txt</file>
+              </importOrder>
+              <licenseHeader>
+                <file>config/maven-header-plain.txt</file>
+              </licenseHeader>
+              <includes combine.children="append">
                 <include>src/main/java/**/*.java</include>
                 <include>src/test/java/**/*.java</include>
                 <include>src/test/resources/**/src/main/java/**/*.java</include>
                 <include>src/test/resources/**/src/test/java/**/*.java</include>
               </includes>
-              <excludes>
+              <excludes combine.children="append">
                 <exclude>src/test/resources/mng-5208/project/sub-2/src/main/java/Bad.java</exclude>
               </excludes>
             </java>
             <pom>
-              <includes>
+              <sortPom>
+                <expandEmptyElements>false</expandEmptyElements>
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+                <quiet>true</quiet>
+              </sortPom>
+              <includes combine.children="append">
                 <include>pom.xml</include>
                 <include>src/test/resources/**/pom.xml</include>
               </includes>
-              <excludes>
+              <excludes combine.children="append">
                 <exclude>src/test/resources/mng-2254/latin-1/pom.xml</exclude>
                 <exclude>src/test/resources/mng-2362/latin-1/pom.xml</exclude>
                 <exclude>src/test/resources/mng-3839/pom.xml</exclude>
               </excludes>
             </pom>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.shared</groupId>
+              <artifactId>maven-shared-resources</artifactId>
+              <version>6</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -358,12 +358,12 @@ under the License.
       <artifactId>maven-it-plugin-plexus-lifecycle</artifactId>
       <version>${core-it-support-version}</version>
     </dependency>
-      <dependency>
-          <groupId>commons-jxpath</groupId>
-          <artifactId>commons-jxpath</artifactId>
-          <version>1.4.0</version>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>commons-jxpath</groupId>
+      <artifactId>commons-jxpath</artifactId>
+      <version>1.4.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -93,6 +93,7 @@ under the License.
     <!-- Support artifacts version - kept separate from Maven version -->
     <core-it-support-version>2.1-SNAPSHOT</core-it-support-version>
 
+    <version.palantirJavaFormat>2.90.0</version.palantirJavaFormat>
     <its.forkCount>0.75C</its.forkCount>
     <its.test />
   </properties>
@@ -382,7 +383,7 @@ under the License.
           <configuration>
             <java>
               <palantirJavaFormat>
-                <version>2.90.0</version>
+                <version>${version.palantirJavaFormat}</version>
               </palantirJavaFormat>
               <removeUnusedImports />
               <importOrder>
@@ -391,13 +392,13 @@ under the License.
               <licenseHeader>
                 <file>config/maven-header-plain.txt</file>
               </licenseHeader>
-              <includes combine.children="append">
+              <includes>
                 <include>src/main/java/**/*.java</include>
                 <include>src/test/java/**/*.java</include>
                 <include>src/test/resources/**/src/main/java/**/*.java</include>
                 <include>src/test/resources/**/src/test/java/**/*.java</include>
               </includes>
-              <excludes combine.children="append">
+              <excludes>
                 <exclude>src/test/resources/mng-5208/project/sub-2/src/main/java/Bad.java</exclude>
               </excludes>
             </java>
@@ -407,11 +408,11 @@ under the License.
                 <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
                 <quiet>true</quiet>
               </sortPom>
-              <includes combine.children="append">
+              <includes>
                 <include>pom.xml</include>
                 <include>src/test/resources/**/pom.xml</include>
               </includes>
-              <excludes combine.children="append">
+              <excludes>
                 <exclude>src/test/resources/mng-2254/latin-1/pom.xml</exclude>
                 <exclude>src/test/resources/mng-2362/latin-1/pom.xml</exclude>
                 <exclude>src/test/resources/mng-3839/pom.xml</exclude>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,9 +29,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/ItUtils.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/ItUtils.java
@@ -22,10 +22,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+
 import org.codehaus.plexus.util.FileUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0011DefaultVersionByDependencyManagementTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0011DefaultVersionByDependencyManagementTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0063SystemScopeDependencyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0063SystemScopeDependencyTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,7 +39,8 @@ public class MavenIT0063SystemScopeDependencyTest extends AbstractMavenIntegrati
         Verifier verifier = newVerifier(testDir);
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
-        verifier.getSystemProperties().setProperty("jre.home", testDir.resolve("jdk/jre").toString());
+        verifier.getSystemProperties()
+                .setProperty("jre.home", testDir.resolve("jdk/jre").toString());
         verifier.addCliArgument(
                 "org.apache.maven.its.plugins:maven-it-plugin-dependency-resolution:2.1-SNAPSHOT:compile");
         verifier.execute();
@@ -46,8 +48,6 @@ public class MavenIT0063SystemScopeDependencyTest extends AbstractMavenIntegrati
 
         List<String> lines = verifier.loadLines("target/compile.txt");
         assertEquals(2, lines.size());
-        ItUtils.assertCanonicalFileEquals(
-                testDir.resolve("jdk/lib/tools.jar"),
-                Path.of((String) lines.get(1)));
+        ItUtils.assertCanonicalFileEquals(testDir.resolve("jdk/lib/tools.jar"), Path.of((String) lines.get(1)));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0108SnapshotUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0108SnapshotUpdateTest.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -93,9 +94,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
     @Test
     public void testSnapshotUpdatedWithMetadata() throws Exception {
         Path metadata = repository.resolve("org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        Files.writeString(
-                metadata,
-                constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
+        Files.writeString(metadata, constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
 
         verifier.addCliArgument("package");
         verifier.execute();
@@ -106,8 +105,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
 
         Files.writeString(artifact, "updatedArtifact");
         metadata = repository.resolve("org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        Files.writeString(
-                metadata, constructMetadata("2", System.currentTimeMillis(), true));
+        Files.writeString(metadata, constructMetadata("2", System.currentTimeMillis(), true));
 
         verifier.addCliArgument("package");
         verifier.execute();
@@ -126,9 +124,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
         Files.createDirectories(localMetadata.getParent());
 
         Path metadata = repository.resolve("org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        Files.writeString(
-                metadata,
-                constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
+        Files.writeString(metadata, constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, true));
 
         verifier.addCliArgument("package");
         verifier.execute();
@@ -157,8 +153,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
         Files.writeString(
                 localMetadata,
                 constructLocalMetadata("org.apache.maven", "maven-core-it-support", cal.getTimeInMillis(), true));
-        Files.writeString(
-                metadata, constructMetadata("2", System.currentTimeMillis() - 2000, true));
+        Files.writeString(metadata, constructMetadata("2", System.currentTimeMillis() - 2000, true));
         Files.setLastModifiedTime(artifact, FileTime.fromMillis(System.currentTimeMillis()));
 
         verifier.addCliArgument("package");
@@ -172,9 +167,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
     @Test
     public void testSnapshotUpdatedWithMetadataUsingFileTimestamp() throws Exception {
         Path metadata = repository.resolve("org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        Files.writeString(
-                metadata,
-                constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, false));
+        Files.writeString(metadata, constructMetadata("1", System.currentTimeMillis() - TIME_OFFSET, false));
         Files.setLastModifiedTime(metadata, FileTime.fromMillis(System.currentTimeMillis() - TIME_OFFSET));
 
         verifier.addCliArgument("package");
@@ -186,8 +179,7 @@ public class MavenIT0108SnapshotUpdateTest extends AbstractMavenIntegrationTestC
 
         Files.writeString(artifact, "updatedArtifact");
         metadata = repository.resolve("org/apache/maven/maven-core-it-support/1.0-SNAPSHOT/maven-metadata.xml");
-        Files.writeString(
-                metadata, constructMetadata("2", System.currentTimeMillis(), false));
+        Files.writeString(metadata, constructMetadata("2", System.currentTimeMillis(), false));
 
         verifier.addCliArgument("package");
         verifier.execute();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0139InterpolationWithProjectPrefixTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0139InterpolationWithProjectPrefixTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0140InterpolationWithPomPrefixTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0140InterpolationWithPomPrefixTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0146InstallerSnapshotNaming.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0146InstallerSnapshotNaming.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Path;
 import java.util.Map;
+
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0199CyclicImportScopeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0199CyclicImportScopeTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenIT0199CyclicImportScopeTest extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITConsumerPomBomFromSettingsRepoTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITConsumerPomBomFromSettingsRepoTest.java
@@ -26,7 +26,6 @@ import org.apache.maven.api.model.Model;
 import org.apache.maven.model.v4.MavenStaxReader;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -100,8 +99,8 @@ class MavenITConsumerPomBomFromSettingsRepoTest extends AbstractMavenIntegration
                         && "2.0".equals(d.getVersion()));
         assertTrue(
                 hasLibA,
-                "Consumer POM should contain lib-a with version 2.0 resolved from the BOM. "
-                        + "Actual dependencies: " + consumerPomModel.getDependencies());
+                "Consumer POM should contain lib-a with version 2.0 resolved from the BOM. " + "Actual dependencies: "
+                        + consumerPomModel.getDependencies());
 
         // The BOM import should NOT appear in the consumer POM (it's been flattened)
         if (consumerPomModel.getDependencyManagement() != null) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITMissingNamespaceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITMissingNamespaceTest.java
@@ -23,8 +23,7 @@ import org.junit.jupiter.api.Test;
 
 public class MavenITMissingNamespaceTest extends AbstractMavenIntegrationTestCase {
 
-    public MavenITMissingNamespaceTest() {
-    }
+    public MavenITMissingNamespaceTest() {}
 
     /**
      * Test when project element does not have an xmlns attribute.

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITMissingNamespaceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITMissingNamespaceTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenITMissingNamespaceTest extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10937QuotedPipesInMavenOptsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10937QuotedPipesInMavenOptsTest.java
@@ -37,8 +37,7 @@ class MavenITgh10937QuotedPipesInMavenOptsTest extends AbstractMavenIntegrationT
      */
     @Test
     void testIt() throws Exception {
-        Path basedir =
-                extractResources("gh-10937-pipes-maven-opts");
+        Path basedir = extractResources("gh-10937-pipes-maven-opts");
 
         Verifier verifier = newVerifier(basedir);
         verifier.setEnvironmentVariable("MAVEN_OPTS", "-Dprop.maven-opts=\"foo|bar\"");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11140RepoInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11140RepoInterpolationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11181CoreExtensionsMetaVersionsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11181CoreExtensionsMetaVersionsTest.java
@@ -35,8 +35,8 @@ class MavenITgh11181CoreExtensionsMetaVersionsTest extends AbstractMavenIntegrat
      */
     @Test
     void pwMetaVersionIsInvalid() throws Exception {
-        Path testDir = extractResources("gh-11181-core-extensions-meta-versions")
-                .resolve("pw-metaversion-is-invalid");
+        Path testDir =
+                extractResources("gh-11181-core-extensions-meta-versions").resolve("pw-metaversion-is-invalid");
         Verifier verifier = newVerifier(testDir);
         verifier.setUserHomeDirectory(testDir.resolve("HOME"));
         verifier.setAutoclean(false);
@@ -55,8 +55,8 @@ class MavenITgh11181CoreExtensionsMetaVersionsTest extends AbstractMavenIntegrat
      */
     @Test
     void uwMetaVersionIsValid() throws Exception {
-        Path testDir = extractResources("gh-11181-core-extensions-meta-versions")
-                .resolve("uw-metaversion-is-valid");
+        Path testDir =
+                extractResources("gh-11181-core-extensions-meta-versions").resolve("uw-metaversion-is-valid");
         Verifier verifier = newVerifier(testDir);
         verifier.setUserHomeDirectory(testDir.resolve("HOME"));
         verifier.setHandleLocalRepoTail(false);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11280DuplicateDependencyConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11280DuplicateDependencyConsumerPomTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11314PluginInjectionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11314PluginInjectionTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11346DependencyManagementOverrideTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11346DependencyManagementOverrideTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import org.apache.maven.api.Constants;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11356InvalidTransitiveRepositoryTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11356InvalidTransitiveRepositoryTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11381ResourceTargetPathTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11381ResourceTargetPathTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11381ResourceTargetPathTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11381ResourceTargetPathTest.java
@@ -57,4 +57,3 @@ class MavenITgh11381ResourceTargetPathTest extends AbstractMavenIntegrationTestC
         verifier.verifyFileNotPresent("target-dir/subdir/another.yml");
     }
 }
-

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11384RecursiveVariableReferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11384RecursiveVariableReferenceTest.java
@@ -49,4 +49,3 @@ class MavenITgh11384RecursiveVariableReferenceTest extends AbstractMavenIntegrat
         verifier.verifyTextInLog("<url>https://github.com/slackapi/java-slack-sdk</url>");
     }
 }
-

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11399FlattenPluginParentCycleTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11399FlattenPluginParentCycleTest.java
@@ -57,4 +57,3 @@ class MavenITgh11399FlattenPluginParentCycleTest extends AbstractMavenIntegratio
         verifier.verifyFilePresent("target/.flattened-pom.xml");
     }
 }
-

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11399FlattenPluginParentCycleTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11399FlattenPluginParentCycleTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11409ProfileSourceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11409ProfileSourceTest.java
@@ -53,4 +53,3 @@ class MavenITgh11409ProfileSourceTest extends AbstractMavenIntegrationTestCase {
         verifier.verifyTextInLog("child-profile (source: test.gh11409:subproject:1.0-SNAPSHOT)");
     }
 }
-

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11427BomConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11427BomConsumerPomTest.java
@@ -115,8 +115,6 @@ class MavenITgh11427BomConsumerPomTest extends AbstractMavenIntegrationTestCase 
                 content.contains("<version>1.0.0-SNAPSHOT</version>") || content.contains("<version>${"),
                 "Consumer pom should have version for module dependency");
         assertTrue(
-                content.contains("<version>4.13.2</version>"),
-                "Consumer pom should have version for junit dependency");
+                content.contains("<version>4.13.2</version>"), "Consumer pom should have version for junit dependency");
     }
 }
-

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11456MixinsConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11456MixinsConsumerPomTest.java
@@ -122,4 +122,3 @@ class MavenITgh11456MixinsConsumerPomTest extends AbstractMavenIntegrationTestCa
                 "Mixins should be kept in consumer POM when preserveModelVersion is enabled");
     }
 }
-

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11485AtSignInJvmConfigTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11485AtSignInJvmConfigTest.java
@@ -37,8 +37,7 @@ public class MavenITgh11485AtSignInJvmConfigTest extends AbstractMavenIntegratio
         Path testDir = extractResources("/gh-11485-at-sign");
 
         Verifier verifier = newVerifier(testDir);
-        verifier.addCliArgument(
-                "-Dexpression.outputFile=" + testDir.resolve("target/pom.properties"));
+        verifier.addCliArgument("-Dexpression.outputFile=" + testDir.resolve("target/pom.properties"));
         verifier.setForkJvm(true); // custom .mvn/jvm.config
         // Enable debug logging for launcher script to diagnose jvm.config parsing issues
         verifier.setEnvironmentVariable("MAVEN_DEBUG_SCRIPT", "1");
@@ -63,8 +62,7 @@ public class MavenITgh11485AtSignInJvmConfigTest extends AbstractMavenIntegratio
         Path testDir = extractResources("/gh-11485-at-sign");
 
         Verifier verifier = newVerifier(testDir);
-        verifier.addCliArgument(
-                "-Dexpression.outputFile=" + testDir.resolve("target/pom.properties"));
+        verifier.addCliArgument("-Dexpression.outputFile=" + testDir.resolve("target/pom.properties"));
         verifier.setForkJvm(true); // custom .mvn/jvm.config
         // Pass a path with @ character via command line (simulating Jenkins workspace)
         String jenkinsPath = testDir.toString().replace('\\', '/') + "/jenkins.workspace/proj@2";

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11485AtSignInJvmConfigTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11485AtSignInJvmConfigTest.java
@@ -85,4 +85,3 @@ public class MavenITgh11485AtSignInJvmConfigTest extends AbstractMavenIntegratio
                 "Command-line value with @ character should be preserved");
     }
 }
-

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11772ConsumerPom410Test.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11772ConsumerPom410Test.java
@@ -55,15 +55,13 @@ class MavenITgh11772ConsumerPom410Test extends AbstractMavenIntegrationTestCase 
         verifier.verifyErrorFreeLog();
 
         // Verify parent consumer POM (main artifact) is 4.0.0
-        Path parentConsumerPom =
-                verifier.getArtifactPath(GROUP_ID, "parent", "1.0.0-SNAPSHOT", "pom");
+        Path parentConsumerPom = verifier.getArtifactPath(GROUP_ID, "parent", "1.0.0-SNAPSHOT", "pom");
         assertTrue(Files.exists(parentConsumerPom), "Parent consumer POM should exist");
         Model parentConsumer = readModel(parentConsumerPom);
         assertEquals("4.0.0", parentConsumer.getModelVersion(), "Parent consumer POM should be 4.0.0");
 
         // Verify parent build POM retains 4.1.0 features
-        Path parentBuildPom =
-                verifier.getArtifactPath(GROUP_ID, "parent", "1.0.0-SNAPSHOT", "pom", "build");
+        Path parentBuildPom = verifier.getArtifactPath(GROUP_ID, "parent", "1.0.0-SNAPSHOT", "pom", "build");
         assertTrue(Files.exists(parentBuildPom), "Parent build POM should exist");
         Model parentBuild = readModel(parentBuildPom);
         // Build POM should retain subprojects (4.1.0 feature)
@@ -71,8 +69,7 @@ class MavenITgh11772ConsumerPom410Test extends AbstractMavenIntegrationTestCase 
         assertTrue(!parentBuild.getSubprojects().isEmpty(), "Build POM should retain subprojects");
 
         // Verify child consumer POM is 4.0.0
-        Path childConsumerPom =
-                verifier.getArtifactPath(GROUP_ID, "child", "1.0.0-SNAPSHOT", "pom");
+        Path childConsumerPom = verifier.getArtifactPath(GROUP_ID, "child", "1.0.0-SNAPSHOT", "pom");
         assertTrue(Files.exists(childConsumerPom), "Child consumer POM should exist");
         Model childConsumer = readModel(childConsumerPom);
         assertEquals("4.0.0", childConsumer.getModelVersion(), "Child consumer POM should be 4.0.0");
@@ -83,8 +80,7 @@ class MavenITgh11772ConsumerPom410Test extends AbstractMavenIntegrationTestCase 
         assertEquals("parent", childConsumer.getParent().getArtifactId());
 
         // Verify child build POM exists
-        Path childBuildPom =
-                verifier.getArtifactPath(GROUP_ID, "child", "1.0.0-SNAPSHOT", "pom", "build");
+        Path childBuildPom = verifier.getArtifactPath(GROUP_ID, "child", "1.0.0-SNAPSHOT", "pom", "build");
         assertTrue(Files.exists(childBuildPom), "Child build POM should exist");
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh2532DuplicateDependencyEffectiveModelTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh2532DuplicateDependencyEffectiveModelTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh2576ItrNotHonoredTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh2576ItrNotHonoredTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -40,7 +41,8 @@ class MavenITgh2576ItrNotHonoredTest extends AbstractMavenIntegrationTestCase {
         verifier.deleteArtifacts("org.apache.maven.its.gh2576");
 
         verifier = newVerifier(testDir.resolve("parent"));
-        verifier.addCliArguments("install:install-file", "-Dfile=pom.xml", "-DpomFile=pom.xml", "-DlocalRepositoryPath=../repo/");
+        verifier.addCliArguments(
+                "install:install-file", "-Dfile=pom.xml", "-DpomFile=pom.xml", "-DlocalRepositoryPath=../repo/");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0294MergeGlobalAndUserSettingsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0294MergeGlobalAndUserSettingsTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 
-import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0479OverrideCentralRepoTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0479OverrideCentralRepoTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
@@ -160,8 +161,7 @@ public class MavenITmng0553SettingsAuthzEncryptionTest extends AbstractMavenInte
         // NOTE: The selection of the Turkish language for the JVM locale is essential part of the test
         verifier.setEnvironmentVariable(
                 "MAVEN_OPTS",
-                "-Dsettings.security=" + testDir.resolve("settings~security.xml")
-                        + " -Duser.language=tr");
+                "-Dsettings.security=" + testDir.resolve("settings~security.xml") + " -Duser.language=tr");
         verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0680ParentBasedirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0680ParentBasedirTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0768OfflineModeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0768OfflineModeTest.java
@@ -21,9 +21,9 @@ package org.apache.maven.it;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.nio.file.Path;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0828PluginConfigValuesInDebugTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0828PluginConfigValuesInDebugTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,10 +88,7 @@ public class MavenITmng0828PluginConfigValuesInDebugTest extends AbstractMavenIn
 
         // Map items order is not guaranteed, so only check begin of params ...
         checkLog(log, "[DEBUG]   (f) mapParam = {key");
-        checkLog(
-                log,
-                "[DEBUG]   (f) propertiesFile = "
-                        + testDir.resolve("target/plugin-config.properties"));
+        checkLog(log, "[DEBUG]   (f) propertiesFile = " + testDir.resolve("target/plugin-config.properties"));
 
         // Properties item order is not guaranteed, so only check begin of params ...
         checkLog(log, "[DEBUG]   (f) propertiesParam = {key");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1021EqualAttachmentBuildNumberTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1021EqualAttachmentBuildNumberTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,8 +78,7 @@ public class MavenITmng1021EqualAttachmentBuildNumberTest extends AbstractMavenI
 
     private String getSnapshotVersion(Path artifactDir) throws IOException {
         try (var stream = Files.list(artifactDir)) {
-            return stream
-                    .filter(Files::isRegularFile)
+            return stream.filter(Files::isRegularFile)
                     .map(Path::getFileName)
                     .map(Path::toString)
                     .filter(name -> name.endsWith(".pom"))
@@ -86,4 +86,5 @@ public class MavenITmng1021EqualAttachmentBuildNumberTest extends AbstractMavenI
                     .map(pomName -> pomName.substring("test-".length(), pomName.length() - ".pom".length()))
                     .orElseThrow(() -> new IllegalStateException("POM not found in " + artifactDir));
         }
-    }}
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng11133MixinsPrecedenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng11133MixinsPrecedenceTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1703PluginMgmtDepInheritanceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1703PluginMgmtDepInheritanceTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2006ChildPathAwareUrlInheritanceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2006ChildPathAwareUrlInheritanceTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2068ReactorRelativeParentsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2068ReactorRelativeParentsTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2136ActiveByDefaultProfileTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2136ActiveByDefaultProfileTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,8 +47,7 @@ public class MavenITmng2136ActiveByDefaultProfileTest extends AbstractMavenInteg
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
 
-        verifier.addCliArgument(
-                "-Dexpression.outputFile=" + testDir.resolve("target/expression.properties"));
+        verifier.addCliArgument("-Dexpression.outputFile=" + testDir.resolve("target/expression.properties"));
         verifier.addCliArgument("-Dexpression.expressions=project/properties");
         verifier.addCliArgument("--settings");
         verifier.addCliArgument("settings.xml");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2201PluginConfigInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2201PluginConfigInterpolationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,8 +51,7 @@ public class MavenITmng2201PluginConfigInterpolationTest extends AbstractMavenIn
         ItUtils.assertCanonicalFileEquals(testDir.resolve("target"), Path.of(props.getProperty("stringParam")));
         ItUtils.assertCanonicalFileEquals(
                 testDir.resolve("target"), Path.of(props.getProperty("propertiesParam.buildDir")));
-        ItUtils.assertCanonicalFileEquals(
-                testDir.resolve("target"), Path.of(props.getProperty("mapParam.buildDir")));
+        ItUtils.assertCanonicalFileEquals(testDir.resolve("target"), Path.of(props.getProperty("mapParam.buildDir")));
         assertEquals("4.0.0", props.getProperty("domParam.children.modelVersion.0.value"));
         assertEquals("org.apache.maven.its.it0104", props.getProperty("domParam.children.groupId.0.value"));
         assertEquals("1.0-SNAPSHOT", props.getProperty("domParam.children.version.0.value"));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2305MultipleProxiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2305MultipleProxiesTest.java
@@ -18,13 +18,15 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.NetworkConnector;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2339BadProjectInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2339BadProjectInterpolationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2362DeployedPomEncodingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2362DeployedPomEncodingTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2387InactiveProxyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2387InactiveProxyTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.net.InetAddress;
 import java.nio.file.Path;
 import java.util.Map;
+
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
@@ -68,7 +69,8 @@ public class MavenITmng2387InactiveProxyTest extends AbstractMavenIntegrationTes
         System.out.println("Bound server socket to the HTTP port " + port);
 
         resourceHandler = new ResourceHandler();
-        resourceHandler.setResourceBase(testDir.resolve("proxy").toAbsolutePath().toString());
+        resourceHandler.setResourceBase(
+                testDir.resolve("proxy").toAbsolutePath().toString());
 
         handlers = new HandlerList();
         handlers.setHandlers(new Handler[] {resourceHandler, new DefaultHandler()});

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2577SettingsXmlInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2577SettingsXmlInterpolationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2690MojoLoadingErrorsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2690MojoLoadingErrorsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2790LastUpdatedMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2790LastUpdatedMetadataTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,8 +59,7 @@ public class MavenITmng2790LastUpdatedMetadataTest extends AbstractMavenIntegrat
 
         Path metadataArtifactVersionFile =
                 verifier.getArtifactMetadataPath("org.apache.maven.its.mng2790", "project", "1.0-SNAPSHOT");
-        Path metadataArtifactFile =
-                verifier.getArtifactMetadataPath("org.apache.maven.its.mng2790", "project");
+        Path metadataArtifactFile = verifier.getArtifactMetadataPath("org.apache.maven.its.mng2790", "project");
 
         Date artifactVersionLastUpdated1 = getLastUpdated(metadataArtifactVersionFile);
         Date artifactLastUpdated1 = getLastUpdated(metadataArtifactFile);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2820PomCommentsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2820PomCommentsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2871PrePackageSubartifactResolutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2871PrePackageSubartifactResolutionTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,8 +51,6 @@ public class MavenITmng2871PrePackageSubartifactResolutionTest extends AbstractM
 
         List<String> compileClassPath = verifier.loadLines("consumer/target/compile.txt");
         assertEquals(2, compileClassPath.size());
-        ItUtils.assertCanonicalFileEquals(
-                testDir.resolve("ejbs/target/classes"),
-                Path.of(compileClassPath.get(1)));
+        ItUtils.assertCanonicalFileEquals(testDir.resolve("ejbs/target/classes"), Path.of(compileClassPath.get(1)));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2926PluginPrefixOrderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2926PluginPrefixOrderTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,12 +48,15 @@ public class MavenITmng2926PluginPrefixOrderTest extends AbstractMavenIntegratio
         verifier.deleteArtifacts("org.apache.maven.plugins", "mng-2926", "0.1");
         verifier.deleteArtifacts("org.apache.maven.plugins", "mng-2926", "0.1");
         Files.deleteIfExists(verifier.getArtifactMetadataPath(
-                        "org.apache.maven.plugins", null, null, "maven-metadata-maven-core-it.xml"));
-        Files.deleteIfExists(verifier.getArtifactMetadataPath("org.apache.maven.plugins", null, null, "resolver-status.properties"));
+                "org.apache.maven.plugins", null, null, "maven-metadata-maven-core-it.xml"));
+        Files.deleteIfExists(
+                verifier.getArtifactMetadataPath("org.apache.maven.plugins", null, null, "resolver-status.properties"));
         verifier.deleteArtifacts("org.codehaus.mojo", "mng-2926", "0.1");
         verifier.deleteArtifacts("org.codehaus.mojo", "mng-2926", "0.1");
-        Files.deleteIfExists(verifier.getArtifactMetadataPath("org.codehaus.mojo", null, null, "maven-metadata-maven-core-it.xml"));
-        Files.deleteIfExists(verifier.getArtifactMetadataPath("org.codehaus.mojo", null, null, "resolver-status.properties"));
+        Files.deleteIfExists(
+                verifier.getArtifactMetadataPath("org.codehaus.mojo", null, null, "maven-metadata-maven-core-it.xml"));
+        Files.deleteIfExists(
+                verifier.getArtifactMetadataPath("org.codehaus.mojo", null, null, "resolver-status.properties"));
 
         verifier = newVerifier(testDir);
         verifier.setAutoclean(false);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3023ReactorDependencyResolutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3023ReactorDependencyResolutionTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3038TransitiveDepManVersionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3038TransitiveDepManVersionTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3043BestEffortReactorResolutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3043BestEffortReactorResolutionTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3052DepRepoAggregationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3052DepRepoAggregationTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3183LoggingToFileTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3183LoggingToFileTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3372DirectInvocationOfPluginsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3372DirectInvocationOfPluginsTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3379ParallelArtifactDownloadsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3379ParallelArtifactDownloadsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3394POMPluginVersionDominanceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3394POMPluginVersionDominanceTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3396DependencyManagementForOverConstrainedRangesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3396DependencyManagementForOverConstrainedRangesTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,8 +28,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -240,9 +242,7 @@ public class MavenITmng3415JunkRepositoryMetadataTest extends AbstractMavenInteg
     private void assertMetadataMissing(Verifier verifier) {
         Path metadata = getMetadataFile(verifier);
 
-        assertFalse(
-                Files.exists(metadata),
-                "Metadata file should NOT be present in local repository: " + metadata);
+        assertFalse(Files.exists(metadata), "Metadata file should NOT be present in local repository: " + metadata);
     }
 
     private void setupDummyDependency(Verifier verifier, Path testDir, boolean resetUpdateInterval) throws IOException {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3441MetadataUpdatedFromDeploymentRepositoryTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3441MetadataUpdatedFromDeploymentRepositoryTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3461MirrorMatchingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3461MirrorMatchingTest.java
@@ -21,8 +21,8 @@ package org.apache.maven.it;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3475BaseAlignedDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3475BaseAlignedDirTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3503Xpp3ShadingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3503Xpp3ShadingTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3506ArtifactHandlersFromPluginsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3506ArtifactHandlersFromPluginsTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3599useHttpProxyForWebDAVMk2Test.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3599useHttpProxyForWebDAVMk2Test.java
@@ -18,11 +18,13 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3600DeploymentModeDefaultsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3600DeploymentModeDefaultsTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3607ClassLoadersUseValidUrlsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3607ClassLoadersUseValidUrlsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3642DynamicResourcesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3642DynamicResourcesTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3652UserAgentHeaderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3652UserAgentHeaderTest.java
@@ -18,12 +18,14 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3693PomFileBasedirChangeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3693PomFileBasedirChangeTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3710PollutedClonedPluginsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3710PollutedClonedPluginsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -65,7 +66,8 @@ public class MavenITmng3710PollutedClonedPluginsTest extends AbstractMavenIntegr
         assertTrue(Files.exists(midLevelTouchFile), "Mid-level touch file should have been created in projects tree.");
 
         Path childLevelTouchFile = projectsDir.resolve("middle/child/target/touch.txt");
-        assertTrue(Files.exists(childLevelTouchFile), "Child-level touch file should have been created in projects tree.");
+        assertTrue(
+                Files.exists(childLevelTouchFile), "Child-level touch file should have been created in projects tree.");
     }
 
     @Test

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3714ToolchainsCliOptionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3714ToolchainsCliOptionTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,7 +70,7 @@ public class MavenITmng3714ToolchainsCliOptionTest extends AbstractMavenIntegrat
         if (tool.endsWith(".exe")) {
             tool = tool.substring(0, tool.length() - 4);
         }
-        assertEquals(javaHome.resolve( "bin/javac"), Path.of(tool));
+        assertEquals(javaHome.resolve("bin/javac"), Path.of(tool));
 
         verifier.verifyFilePresent("target/tool.properties");
         Properties toolProps = verifier.loadProperties("target/tool.properties");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3716AggregatorForkingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3716AggregatorForkingTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3747PrefixedPathExpressionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3747PrefixedPathExpressionTest.java
@@ -50,8 +50,6 @@ public class MavenITmng3747PrefixedPathExpressionTest extends AbstractMavenInteg
         verifier.verifyErrorFreeLog();
 
         Properties props = verifier.loadProperties("target/config.properties");
-        assertEquals(
-                "path is: " + testDir.resolve("relative") + "/somepath",
-                props.getProperty("stringParam"));
+        assertEquals("path is: " + testDir.resolve("relative") + "/somepath", props.getProperty("stringParam"));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3775ConflictResolutionBacktrackingTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3775ConflictResolutionBacktrackingTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3822BasedirAlignedInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3822BasedirAlignedInterpolationTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3827PluginConfigTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3827PluginConfigTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3831PomInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3831PomInterpolationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3843PomInheritanceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3843PomInheritanceTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Properties;
 import java.util.TreeSet;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,7 +66,7 @@ class MavenITmng3843PomInheritanceTest extends AbstractMavenIntegrationTestCase 
         Properties props;
         Path basedir;
 
-        basedir = verifier.getBasedir().resolve( "test-1");
+        basedir = verifier.getBasedir().resolve("test-1");
         props = verifier.loadProperties("test-1/target/pom.properties");
         assertEquals("org.apache.maven.its.mng3843", props.getProperty("project.groupId"));
         assertEquals("test-1", props.getProperty("project.artifactId"));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3846PomInheritanceUrlAdjustmentTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3846PomInheritanceUrlAdjustmentTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3864PerExecPluginConfigTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3864PerExecPluginConfigTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3877BasedirAlignedModelTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3877BasedirAlignedModelTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3886ExecutionGoalsOrderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3886ExecutionGoalsOrderTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3892ReleaseDeploymentTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3892ReleaseDeploymentTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3904NestedBuildDirInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3904NestedBuildDirInterpolationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3925MergedPluginExecutionOrderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3925MergedPluginExecutionOrderTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,7 +59,7 @@ public class MavenITmng3925MergedPluginExecutionOrderTest extends AbstractMavenI
     private void testitMNG3925(String project) throws Exception {
         Path testDir = extractResources("mng-3925");
 
-        Verifier verifier = newVerifier(testDir.resolve(project).resolve( "sub"));
+        Verifier verifier = newVerifier(testDir.resolve(project).resolve("sub"));
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
         verifier.addCliArgument("validate");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3937MergedPluginExecutionGoalsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3937MergedPluginExecutionGoalsTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3944BasedirInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3944BasedirInterpolationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3951AbsolutePathsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3951AbsolutePathsTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -65,10 +66,8 @@ public class MavenITmng3951AbsolutePathsTest extends AbstractMavenIntegrationTes
         verifier.verifyFilePresent("target/path.properties");
         Properties props = verifier.loadProperties("target/path.properties");
 
-        ItUtils.assertCanonicalFileEquals(
-                testDir.resolve("tmp"), Path.of(props.getProperty("fileParams.0")));
-        ItUtils.assertCanonicalFileEquals(
-                getRoot(testDir).resolve("tmp"), Path.of(props.getProperty("fileParams.1")));
+        ItUtils.assertCanonicalFileEquals(testDir.resolve("tmp"), Path.of(props.getProperty("fileParams.0")));
+        ItUtils.assertCanonicalFileEquals(getRoot(testDir).resolve("tmp"), Path.of(props.getProperty("fileParams.1")));
         ItUtils.assertCanonicalFileEquals(repoDir, Path.of(props.getProperty("stringParams.0")));
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3955EffectiveSettingsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3955EffectiveSettingsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4233ReactorResolutionForManuallyCreatedArtifactTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4233ReactorResolutionForManuallyCreatedArtifactTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
@@ -158,7 +158,7 @@ public class MavenITmng4235HttpAuthDeploymentChecksumsTest extends AbstractMaven
     }
 
     private void assertHash(Verifier verifier, String dataFile, String hashExt, String algo) throws Exception {
-        String actualHash = ItUtils.calcHash(verifier.getBasedir().resolve( dataFile), algo);
+        String actualHash = ItUtils.calcHash(verifier.getBasedir().resolve(dataFile), algo);
 
         String expectedHash = verifier.loadLines(dataFile + hashExt).get(0).trim();
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4238ArtifactHandlerExtensionUsageTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4238ArtifactHandlerExtensionUsageTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4269BadReactorResolutionFromOutDirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4269BadReactorResolutionFromOutDirTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4270ArtifactHandlersFromPluginDepsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4270ArtifactHandlersFromPluginDepsTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4305LocalRepoBasedirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4305LocalRepoBasedirTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,7 +52,6 @@ public class MavenITmng4305LocalRepoBasedirTest extends AbstractMavenIntegration
         Properties props = verifier.loadProperties("target/basedir.properties");
 
         // NOTE: This deliberately compares the paths on the String level, not via File.equals()
-        assertEquals(
-                verifier.getLocalRepository().toString(), props.getProperty("localRepositoryBasedir"));
+        assertEquals(verifier.getLocalRepository().toString(), props.getProperty("localRepositoryBasedir"));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4309StrictChecksumValidationForMetadataTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4309StrictChecksumValidationForMetadataTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4326LocalSnapshotSuppressesRemoteCheckTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4326LocalSnapshotSuppressesRemoteCheckTest.java
@@ -21,9 +21,9 @@ package org.apache.maven.it;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.nio.file.Path;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.Deque;
 import java.util.List;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4343MissingReleaseUpdatePolicyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4343MissingReleaseUpdatePolicyTest.java
@@ -21,9 +21,9 @@ package org.apache.maven.it;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.nio.file.Path;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4353PluginDependencyResolutionFromPomRepoTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4353PluginDependencyResolutionFromPomRepoTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4360WebDavSupportTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4360WebDavSupportTest.java
@@ -21,9 +21,9 @@ package org.apache.maven.it;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.nio.file.Path;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4368TimestampAwareArtifactInstallerTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4368TimestampAwareArtifactInstallerTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -62,8 +63,7 @@ public class MavenITmng4368TimestampAwareArtifactInstallerTest extends AbstractM
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        Path installedPom =
-                verifier.getArtifactPath("org.apache.maven.its.mng4368", "test", "0.1-SNAPSHOT", "pom");
+        Path installedPom = verifier.getArtifactPath("org.apache.maven.its.mng4368", "test", "0.1-SNAPSHOT", "pom");
 
         String pom = Files.readString(installedPom);
         assertTrue(pom.indexOf("Branch-A") > 0);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4381ExtensionSingletonComponentTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4381ExtensionSingletonComponentTest.java
@@ -43,8 +43,7 @@ public class MavenITmng4381ExtensionSingletonComponentTest extends AbstractMaven
         Path testDir = extractResources("mng-4381");
 
         // First, build the test plugin
-        Verifier verifier =
-                newVerifier(testDir.resolve("sub-a/maven-it-plugin-extension-consumer"));
+        Verifier verifier = newVerifier(testDir.resolve("sub-a/maven-it-plugin-extension-consumer"));
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
         verifier.addCliArgument("install");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4408NonExistentSettingsFileTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4408NonExistentSettingsFileTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 
-import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Map;
+
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4428FollowHttpRedirectTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4428FollowHttpRedirectTest.java
@@ -18,13 +18,15 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4452ResolutionOfSnapshotWithClassifierTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4452ResolutionOfSnapshotWithClassifierTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4459InMemorySettingsKeptEncryptedTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4459InMemorySettingsKeptEncryptedTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,9 @@ public class MavenITmng4459InMemorySettingsKeptEncryptedTest extends AbstractMav
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
         verifier.getSystemProperties()
-                .setProperty("settings.security", testDir.resolve("settings-security.xml").toString());
+                .setProperty(
+                        "settings.security",
+                        testDir.resolve("settings-security.xml").toString());
         verifier.addCliArgument("--settings");
         verifier.addCliArgument("settings.xml");
         verifier.addCliArgument("validate");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4464PlatformIndependentFileSeparatorTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4464PlatformIndependentFileSeparatorTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
@@ -21,8 +21,8 @@ package org.apache.maven.it;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Deque;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4554PluginPrefixMappingUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4554PluginPrefixMappingUpdateTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,8 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
@@ -92,7 +94,7 @@ public class MavenITmng4554PluginPrefixMappingUpdateTest extends AbstractMavenIn
             } catch (IOException e) {
                 // expected when running test on Windows using embedded Maven (JAR files locked by plugin class realm)
                 assertFalse(Files.exists(verifier.getArtifactMetadataPath(
-                                "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml")));
+                        "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml")));
             }
             Map<String, String> filterProps = verifier.newDefaultFilterMap();
             NetworkConnector connector = (NetworkConnector) server.getConnectors()[0];
@@ -170,7 +172,7 @@ public class MavenITmng4554PluginPrefixMappingUpdateTest extends AbstractMavenIn
             } catch (IOException e) {
                 // expected when running test on Windows using embedded Maven (JAR files locked by plugin class realm)
                 assertFalse(Files.exists(verifier.getArtifactMetadataPath(
-                                "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml")));
+                        "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml")));
             }
             Map<String, String> filterProps = verifier.newDefaultFilterMap();
             NetworkConnector connector = (NetworkConnector) server.getConnectors()[0];
@@ -251,7 +253,7 @@ public class MavenITmng4554PluginPrefixMappingUpdateTest extends AbstractMavenIn
             } catch (IOException e) {
                 // expected when running test on Windows using embedded Maven (JAR files locked by plugin class realm)
                 assertFalse(Files.exists(verifier.getArtifactMetadataPath(
-                                "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml")));
+                        "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml")));
             }
             Map<String, String> filterProps = verifier.newDefaultFilterMap();
             NetworkConnector connector = (NetworkConnector) server.getConnectors()[0];

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4559MultipleJvmArgsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4559MultipleJvmArgsTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4559SpacesInJvmOptsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4559SpacesInJvmOptsTest.java
@@ -37,8 +37,7 @@ class MavenITmng4559SpacesInJvmOptsTest extends AbstractMavenIntegrationTestCase
      */
     @Test
     void testIt() throws Exception {
-        Path basedir =
-                extractResources("mng-4559-spaces-jvm-opts");
+        Path basedir = extractResources("mng-4559-spaces-jvm-opts");
 
         Verifier verifier = newVerifier(basedir);
         verifier.setEnvironmentVariable("MAVEN_OPTS", "-Dprop.maven-opts=\"foo bar\"");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660OutdatedPackagedArtifact.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660OutdatedPackagedArtifact.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
+
 import org.junit.jupiter.api.Test;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
@@ -58,8 +59,7 @@ public class MavenITmng4660OutdatedPackagedArtifact extends AbstractMavenIntegra
         verifier1.addCliArgument("package");
         verifier1.execute();
 
-        Path module1Jar =
-                testDir.resolve("module-a/target/module-a-1.0.jar").toAbsolutePath();
+        Path module1Jar = testDir.resolve("module-a/target/module-a-1.0.jar").toAbsolutePath();
         verifier1.verifyErrorFreeLog();
         verifier1.verifyFilePresent(module1Jar.toString());
 
@@ -83,16 +83,14 @@ public class MavenITmng4660OutdatedPackagedArtifact extends AbstractMavenIntegra
         verifier2.addCliArgument("compile");
         verifier2.execute();
 
-        Path module1PropertiesFile = testDir
-                .resolve("module-a/target/classes/example.properties")
-                .toAbsolutePath();
+        Path module1PropertiesFile =
+                testDir.resolve("module-a/target/classes/example.properties").toAbsolutePath();
 
         verifier2.verifyFilePresent(module1PropertiesFile.toString());
         assertTrue(
                 Files.getLastModifiedTime(module1PropertiesFile).compareTo(Files.getLastModifiedTime(module1Jar)) >= 0);
 
-        Path module1Class = testDir
-                .resolve("module-a/target/classes/org/apache/maven/it/Example.class")
+        Path module1Class = testDir.resolve("module-a/target/classes/org/apache/maven/it/Example.class")
                 .toAbsolutePath();
         verifier2.verifyErrorFreeLog();
         verifier2.verifyFilePresent(module1Class.toString());

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4679SnapshotUpdateInPluginTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4679SnapshotUpdateInPluginTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4745PluginVersionUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4745PluginVersionUpdateTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4874UpdateLatestPluginVersionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4874UpdateLatestPluginVersionTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4952MetadataReleaseInfoUpdateTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4952MetadataReleaseInfoUpdateTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4991NonProxyHostsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4991NonProxyHostsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5011ConfigureCollectionArrayFromUserPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5011ConfigureCollectionArrayFromUserPropertiesTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,12 +54,8 @@ public class MavenITmng5011ConfigureCollectionArrayFromUserPropertiesTest extend
         assertEquals("0", props.getProperty("stringParams"));
 
         assertEquals("2", props.getProperty("fileParams"));
-        ItUtils.assertCanonicalFileEquals(
-                testDir.resolve("foo"),
-                Path.of(props.getProperty("fileParams.0")));
-        assertEquals(
-                testDir.resolve("bar"),
-                Path.of(props.getProperty("fileParams.1")));
+        ItUtils.assertCanonicalFileEquals(testDir.resolve("foo"), Path.of(props.getProperty("fileParams.0")));
+        assertEquals(testDir.resolve("bar"), Path.of(props.getProperty("fileParams.1")));
 
         assertEquals("5", props.getProperty("listParam"));
         assertEquals("", props.getProperty("listParam.0", ""));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5012CollectionVsArrayParamCoercionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5012CollectionVsArrayParamCoercionTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,7 +48,6 @@ public class MavenITmng5012CollectionVsArrayParamCoercionTest extends AbstractMa
 
         Properties props = verifier.loadProperties("target/config.properties");
         ItUtils.assertCanonicalFileEquals(
-                testDir.resolve("src/main/java"),
-                Paths.get(props.getProperty("stringParams.0")));
+                testDir.resolve("src/main/java"), Paths.get(props.getProperty("stringParams.0")));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
@@ -22,8 +22,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5224InjectedSettings.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5224InjectedSettings.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5280SettingsProfilesRepositoriesOrderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5280SettingsProfilesRepositoriesOrderTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.it;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,8 +28,7 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5338FileOptionToDirectory.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5338FileOptionToDirectory.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5382Jsr330Plugin.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5382Jsr330Plugin.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5387ArtifactReplacementPlugin.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5387ArtifactReplacementPlugin.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5482AetherNotFoundTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5482AetherNotFoundTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5530MojoExecutionScopeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5530MojoExecutionScopeTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5578SessionScopeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5578SessionScopeTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenITmng5578SessionScopeTest extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5591WorkspaceReader.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5591WorkspaceReader.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenITmng5591WorkspaceReader extends AbstractMavenIntegrationTestCase {
@@ -47,8 +48,8 @@ public class MavenITmng5591WorkspaceReader extends AbstractMavenIntegrationTestC
 
         // compile the test project
         verifier = newVerifier(projectDir);
-        verifier.addCliArgument("-Dmaven.ext.class.path="
-                + extensionDir.resolve("target/mng-5591-workspace-reader-extension-0.1.jar"));
+        verifier.addCliArgument(
+                "-Dmaven.ext.class.path=" + extensionDir.resolve("target/mng-5591-workspace-reader-extension-0.1.jar"));
         verifier.addCliArgument("compile");
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5608ProfileActivationWarningTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5608ProfileActivationWarningTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5659ProjectSettingsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5659ProjectSettingsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5668AfterPhaseExecutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5668AfterPhaseExecutionTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,9 +57,12 @@ class MavenITmng5668AfterPhaseExecutionTest extends AbstractMavenIntegrationTest
         verifier.verifyFilePresent("target/after-verify.txt");
 
         // Verify the execution order through timestamps
-        long beforeTime = Files.getLastModifiedTime(testDir.resolve("target/before-verify.txt")).toMillis();
-        long failTime = Files.getLastModifiedTime(testDir.resolve("target/verify-failed.txt")).toMillis();
-        long afterTime = Files.getLastModifiedTime(testDir.resolve("target/after-verify.txt")).toMillis();
+        long beforeTime = Files.getLastModifiedTime(testDir.resolve("target/before-verify.txt"))
+                .toMillis();
+        long failTime = Files.getLastModifiedTime(testDir.resolve("target/verify-failed.txt"))
+                .toMillis();
+        long afterTime = Files.getLastModifiedTime(testDir.resolve("target/after-verify.txt"))
+                .toMillis();
 
         assertTrue(beforeTime <= failTime);
         assertTrue(failTime <= afterTime);

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5669ReadPomsOnce.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5669ReadPomsOnce.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +46,8 @@ public class MavenITmng5669ReadPomsOnce extends AbstractMavenIntegrationTestCase
         Verifier verifier = newVerifier(testDir);
         Map<String, String> filterProperties = Collections.singletonMap(
                 "${javaAgentJar}",
-                verifier.getArtifactPath("org.apache.maven.its", "core-it-javaagent", "2.1-SNAPSHOT", "jar").toString());
+                verifier.getArtifactPath("org.apache.maven.its", "core-it-javaagent", "2.1-SNAPSHOT", "jar")
+                        .toString());
         verifier.filterFile(".mvn/jvm.config", ".mvn/jvm.config", null, filterProperties);
 
         verifier.setForkJvm(true); // pick up agent
@@ -80,7 +82,8 @@ public class MavenITmng5669ReadPomsOnce extends AbstractMavenIntegrationTestCase
         Verifier verifier = newVerifier(testDir);
         Map<String, String> filterProperties = Collections.singletonMap(
                 "${javaAgentJar}",
-                verifier.getArtifactPath("org.apache.maven.its", "core-it-javaagent", "2.1-SNAPSHOT", "jar").toString());
+                verifier.getArtifactPath("org.apache.maven.its", "core-it-javaagent", "2.1-SNAPSHOT", "jar")
+                        .toString());
         verifier.filterFile(".mvn/jvm.config", ".mvn/jvm.config", null, filterProperties);
 
         verifier.setLogFileName("log-bc.txt");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5716ToolchainsTypeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5716ToolchainsTypeTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5742BuildExtensionClassloaderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5742BuildExtensionClassloaderTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5753CustomMojoExecutionConfiguratorTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5753CustomMojoExecutionConfiguratorTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5760ResumeFeatureTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5760ResumeFeatureTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5771CoreExtensionsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5771CoreExtensionsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5889FindBasedir.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5889FindBasedir.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,8 +90,7 @@ public class MavenITmng5889FindBasedir extends AbstractMavenIntegrationTestCase 
         }
 
         Verifier verifier = newVerifier(basedir);
-        verifier.addCliArgument(
-                "-Dexpression.outputFile=" + basedir.resolve("expression.properties"));
+        verifier.addCliArgument("-Dexpression.outputFile=" + basedir.resolve("expression.properties"));
         verifier.addCliArgument(option); // -f/--file client/pom.xml
         verifier.addCliArgument((pom ? testDir.resolve("pom.xml") : testDir).toString());
         verifier.setForkJvm(true); // force forked JVM since we need the shell script to detect .mvn/ location

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6084Jsr250PluginTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6084Jsr250PluginTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6118SubmoduleInvocation.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6118SubmoduleInvocation.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6127PluginExecutionConfigurationInterferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6127PluginExecutionConfigurationInterferenceTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6210CoreExtensionsCustomScopesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6210CoreExtensionsCustomScopesTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6223FindBasedir.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6223FindBasedir.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -90,8 +91,7 @@ public class MavenITmng6223FindBasedir extends AbstractMavenIntegrationTestCase 
         }
 
         Verifier verifier = newVerifier(basedir);
-        verifier.addCliArgument(
-                "-Dexpression.outputFile=" + basedir.resolve("expression.properties"));
+        verifier.addCliArgument("-Dexpression.outputFile=" + basedir.resolve("expression.properties"));
         verifier.addCliArgument(option); // -f/--file client/pom.xml
         verifier.addCliArgument((pom ? testDir.resolve("pom.xml") : testDir).toString());
         verifier.setForkJvm(true); // force forked JVM since we need the shell script to detect .mvn/ location

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6255FixConcatLines.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6255FixConcatLines.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -77,8 +78,8 @@ class MavenITmng6255FixConcatLines extends AbstractMavenIntegrationTestCase {
 
         Verifier verifier = newVerifier(baseDir);
         verifier.setLogFileName("log-" + test + ".txt");
-        verifier.addCliArgument(
-                "-Dexpression.outputFile=" + baseDir.resolve("expression-" + test + ".properties").toAbsolutePath());
+        verifier.addCliArgument("-Dexpression.outputFile="
+                + baseDir.resolve("expression-" + test + ".properties").toAbsolutePath());
         verifier.setForkJvm(true); // custom .mvn/jvm.config
         verifier.addCliArgument("validate");
         verifier.execute();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6386BaseUriPropertyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6386BaseUriPropertyTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6511OptionalProjectSelectionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6511OptionalProjectSelectionTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6566ExecuteAnnotationShouldNotReExecuteGoalsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6566ExecuteAnnotationShouldNotReExecuteGoalsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,8 +70,7 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
 
         assertTextEquals(
                 testDir.resolve("expected/parent.pom"),
-                verifier.getArtifactPath(
-                        "org.sonatype.mavenbook.multi", "parent", "0.9-MNG6656-SNAPSHOT", "pom"));
+                verifier.getArtifactPath("org.sonatype.mavenbook.multi", "parent", "0.9-MNG6656-SNAPSHOT", "pom"));
 
         assertTextEquals(
                 testDir.resolve("expected/parent-build.pom"),
@@ -107,14 +107,10 @@ public class MavenITmng6656BuildConsumer extends AbstractMavenIntegrationTestCas
         assertEquals(
                 String.join(
                         "\n",
-                        Files.readAllLines(file1).stream()
-                                .map(String::trim)
-                                .toList()),
+                        Files.readAllLines(file1).stream().map(String::trim).toList()),
                 String.join(
                         "\n",
-                        Files.readAllLines(file2).stream()
-                                .map(String::trim)
-                                .toList()),
+                        Files.readAllLines(file2).stream().map(String::trim).toList()),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6720FailFastTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6720FailFastTest.java
@@ -52,14 +52,14 @@ class MavenITmng6720FailFastTest extends AbstractMavenIntegrationTestCase {
             // expected
         }
 
-        List<String> module1Lines = verifier.loadFile(
-                testDir.resolve("module-1/target/surefire-reports/mng6720.Module1Test-output.txt"));
+        List<String> module1Lines =
+                verifier.loadFile(testDir.resolve("module-1/target/surefire-reports/mng6720.Module1Test-output.txt"));
         assertTrue(module1Lines.contains("Module1"), "module-1 should be executed");
-        List<String> module2Lines = verifier.loadFile(
-                testDir.resolve("module-2/target/surefire-reports/mng6720.Module2Test-output.txt"));
+        List<String> module2Lines =
+                verifier.loadFile(testDir.resolve("module-2/target/surefire-reports/mng6720.Module2Test-output.txt"));
         assertTrue(module2Lines.contains("Module2"), "module-2 should be executed");
-        List<String> module3Lines = verifier.loadFile(
-                testDir.resolve("module-3/target/surefire-reports/mng6720.Module3Test-output.txt"));
+        List<String> module3Lines =
+                verifier.loadFile(testDir.resolve("module-3/target/surefire-reports/mng6720.Module3Test-output.txt"));
         assertTrue(module3Lines.isEmpty(), "module-3 should be skipped");
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6754TimestampInMultimoduleProject.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6754TimestampInMultimoduleProject.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6759TransitiveDependencyRepositoriesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6759TransitiveDependencyRepositoriesTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.net.URI;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,8 +42,7 @@ public class MavenITmng6759TransitiveDependencyRepositoriesTest extends Abstract
         Path testDir = extractResources(RESOURCE_PATH);
 
         // First, build the test plugin
-        Verifier verifier =
-                newVerifier(testDir.resolve("mng6759-plugin-resolves-project-dependencies"));
+        Verifier verifier = newVerifier(testDir.resolve("mng6759-plugin-resolves-project-dependencies"));
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
         verifier.addCliArgument("install");
@@ -59,7 +59,8 @@ public class MavenITmng6759TransitiveDependencyRepositoriesTest extends Abstract
 
     private void installDependencyCInCustomRepo() throws Exception {
         Path dependencyCProjectDir = extractResources(RESOURCE_PATH + "/dependency-in-custom-repo");
-        URI customRepoUri = dependencyCProjectDir.resolve("target").resolve("repo").toUri();
+        URI customRepoUri =
+                dependencyCProjectDir.resolve("target").resolve("repo").toUri();
         Verifier verifier = newVerifier(dependencyCProjectDir);
 
         verifier.deleteDirectory("target");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 
-
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,8 +70,7 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
 
         assertTextEquals(
                 testDir.resolve("expected/parent.pom"),
-                verifier.getArtifactPath(
-                        "org.sonatype.mavenbook.multi", "parent", "0.9-MNG6957-SNAPSHOT", "pom"));
+                verifier.getArtifactPath("org.sonatype.mavenbook.multi", "parent", "0.9-MNG6957-SNAPSHOT", "pom"));
 
         assertTextEquals(
                 testDir.resolve("expected/parent-build.pom"),
@@ -132,14 +132,10 @@ public class MavenITmng6957BuildConsumer extends AbstractMavenIntegrationTestCas
         assertEquals(
                 String.join(
                         "\n",
-                        Files.readAllLines(file1).stream()
-                                .map(String::trim)
-                                .toList()),
+                        Files.readAllLines(file1).stream().map(String::trim).toList()),
                 String.join(
                         "\n",
-                        Files.readAllLines(file2).stream()
-                                .map(String::trim)
-                                .toList()),
+                        Files.readAllLines(file2).stream().map(String::trim).toList()),
                 "pom files differ " + file1 + " " + file2);
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6972AllowAccessToGraphPackageTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6972AllowAccessToGraphPackageTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,13 +46,13 @@ public class MavenITmng6972AllowAccessToGraphPackageTest extends AbstractMavenIn
         verifier.deleteArtifact("mng-6972-allow-access-to-graph-package", "build-plugin", "1.0", "jar");
         verifier.deleteArtifact("mng-6972-allow-access-to-graph-package", "using-module", "1.0", "jar");
 
-        verifier = newVerifier(testDir.resolve( "build-plugin"));
+        verifier = newVerifier(testDir.resolve("build-plugin"));
         verifier.getSystemProperties().put("maven.multiModuleProjectDirectory", testDir.toString());
         verifier.addCliArgument("install");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        verifier = newVerifier(testDir.resolve( "using-module"));
+        verifier = newVerifier(testDir.resolve("using-module"));
         verifier.getSystemProperties().put("maven.multiModuleProjectDirectory", testDir.toString());
         verifier.addCliArgument("install");
         verifier.execute();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7038RootdirTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7038RootdirTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,10 +44,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
 
         verifier.verifyFilePresent("target/pom.properties");
         props = verifier.loadProperties("target/pom.properties");
-        assertEquals(
-                testDir.toString(),
-                props.getProperty("project.properties.rootdir"),
-                "project.properties.rootdir");
+        assertEquals(testDir.toString(), props.getProperty("project.properties.rootdir"), "project.properties.rootdir");
         assertEquals(testDir.toString(), props.getProperty("project.rootDirectory"), "project.rootDirectory");
         assertEquals(testDir.toString(), props.getProperty("session.topDirectory"), "session.topDirectory");
         assertEquals(testDir.toString(), props.getProperty("session.rootDirectory"), "session.rootDirectory");
@@ -91,10 +89,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
 
         verifier.verifyFilePresent("module-b/target/pom.properties");
         props = verifier.loadProperties("module-b/target/pom.properties");
-        assertEquals(
-                testDir.toString(),
-                props.getProperty("project.properties.rootdir"),
-                "project.properties.rootdir");
+        assertEquals(testDir.toString(), props.getProperty("project.properties.rootdir"), "project.properties.rootdir");
         assertEquals(testDir.toString(), props.getProperty("project.rootDirectory"), "project.rootDirectory");
         assertEquals(testDir.toString(), props.getProperty("session.topDirectory"), "session.topDirectory");
         assertEquals(testDir.toString(), props.getProperty("session.rootDirectory"), "session.rootDirectory");
@@ -105,10 +100,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
 
         verifier.verifyFilePresent("module-b/module-b-1/target/pom.properties");
         props = verifier.loadProperties("module-b/module-b-1/target/pom.properties");
-        assertEquals(
-                testDir.toString(),
-                props.getProperty("project.properties.rootdir"),
-                "project.properties.rootdir");
+        assertEquals(testDir.toString(), props.getProperty("project.properties.rootdir"), "project.properties.rootdir");
         assertEquals(testDir.toString(), props.getProperty("project.rootDirectory"), "project.rootDirectory");
         assertEquals(testDir.toString(), props.getProperty("session.topDirectory"), "session.topDirectory");
         assertEquals(testDir.toString(), props.getProperty("session.rootDirectory"), "session.rootDirectory");
@@ -189,10 +181,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
 
         verifier.verifyFilePresent("target/pom.properties");
         props = verifier.loadProperties("target/pom.properties");
-        assertEquals(
-                testDir.toString(),
-                props.getProperty("project.properties.rootdir"),
-                "project.properties.rootdir");
+        assertEquals(testDir.toString(), props.getProperty("project.properties.rootdir"), "project.properties.rootdir");
         assertEquals(testDir.toString(), props.getProperty("project.rootDirectory"), "project.rootDirectory");
         assertEquals(
                 testDir.resolve("module-b"),
@@ -206,10 +195,7 @@ public class MavenITmng7038RootdirTest extends AbstractMavenIntegrationTestCase 
 
         verifier.verifyFilePresent("module-b-1/target/pom.properties");
         props = verifier.loadProperties("module-b-1/target/pom.properties");
-        assertEquals(
-                testDir.toString(),
-                props.getProperty("project.properties.rootdir"),
-                "project.properties.rootdir");
+        assertEquals(testDir.toString(), props.getProperty("project.properties.rootdir"), "project.properties.rootdir");
         assertEquals(testDir.toString(), props.getProperty("project.rootDirectory"), "project.rootDirectory");
         assertEquals(
                 testDir.resolve("module-b"),

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7045DropUselessAndOutdatedCdiApiTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7045DropUselessAndOutdatedCdiApiTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7051OptionalProfileActivationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7051OptionalProfileActivationTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenITmng7051OptionalProfileActivationTest extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7110ExtensionClassloader.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7110ExtensionClassloader.java
@@ -23,6 +23,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7112ProjectsWithNonRecursiveTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7112ProjectsWithNonRecursiveTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenITmng7112ProjectsWithNonRecursiveTest extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7128BlockExternalHttpReactorTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7128BlockExternalHttpReactorTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 class MavenITmng7128BlockExternalHttpReactorTest extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7160ExtensionClassloader.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7160ExtensionClassloader.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenITmng7160ExtensionClassloader extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7228LeakyModelTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7228LeakyModelTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7244IgnorePomPrefixInExpressions.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7244IgnorePomPrefixInExpressions.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7255InferredGroupIdTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7255InferredGroupIdTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7335MissingJarInParallelBuild.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7335MissingJarInParallelBuild.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 class MavenITmng7335MissingJarInParallelBuild extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7390SelectModuleOutsideCwdTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7390SelectModuleOutsideCwdTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7404IgnorePrefixlessExpressionsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7404IgnorePrefixlessExpressionsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7443ConsistencyOfOptionalProjectsAndProfilesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7443ConsistencyOfOptionalProjectsAndProfilesTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470ResolverTransportTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470ResolverTransportTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7487DeadlockTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7487DeadlockTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 public class MavenITmng7487DeadlockTest extends AbstractMavenIntegrationTestCase {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7504NotWarnUnsupportedReportPluginsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7504NotWarnUnsupportedReportPluginsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7587Jsr330.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7587Jsr330.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7772CoreExtensionFoundTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7772CoreExtensionFoundTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7772CoreExtensionsNotFoundTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7772CoreExtensionsNotFoundTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7819FileLockingWithSnapshotsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7819FileLockingWithSnapshotsTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7836AlternativePomSyntaxTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7836AlternativePomSyntaxTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8106OverlappingDirectoryRolesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8106OverlappingDirectoryRolesTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,8 @@ public class MavenITmng8106OverlappingDirectoryRolesTest extends AbstractMavenIn
     public void testDirectoryOverlap() throws Exception {
         Path testDir = extractResources("mng-8106");
         String repo = testDir.resolve("repo").toString();
-        String tailRepo = Path.of(System.getProperty("user.home"), ".m2", "repository").toString();
+        String tailRepo =
+                Path.of(System.getProperty("user.home"), ".m2", "repository").toString();
 
         Verifier verifier = newVerifier(testDir.resolve("plugin"));
         verifier.addCliArgument("-X");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8181CentralRepoTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8181CentralRepoTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8230CIFriendlyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8230CIFriendlyTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8331VersionedAndUnversionedDependenciesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8331VersionedAndUnversionedDependenciesTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 
-import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8347TransitiveDependencyManagerTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8347TransitiveDependencyManagerTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8379SettingsDecryptTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8379SettingsDecryptTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8414ConsumerPomWithNewFeaturesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8414ConsumerPomWithNewFeaturesTest.java
@@ -42,8 +42,7 @@ class MavenITmng8414ConsumerPomWithNewFeaturesTest extends AbstractMavenIntegrat
      */
     @Test
     void testNotPreserving() throws Exception {
-        Path basedir =
-                extractResources("mng-8414-consumer-pom-with-new-features");
+        Path basedir = extractResources("mng-8414-consumer-pom-with-new-features");
 
         Verifier verifier = newVerifier(basedir.toString(), null);
         verifier.addCliArguments("package", "-Dmaven.consumer.pom.flatten=true");
@@ -73,8 +72,7 @@ class MavenITmng8414ConsumerPomWithNewFeaturesTest extends AbstractMavenIntegrat
      */
     @Test
     void testPreserving() throws Exception {
-        Path basedir =
-                extractResources("mng-8414-consumer-pom-with-new-features");
+        Path basedir = extractResources("mng-8414-consumer-pom-with-new-features");
 
         Verifier verifier = newVerifier(basedir.toString(), null);
         verifier.setLogFileName("log-preserving.txt");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8523ModelPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8523ModelPropertiesTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,8 +39,7 @@ class MavenITmng8523ModelPropertiesTest extends AbstractMavenIntegrationTestCase
      */
     @Test
     void testIt() throws Exception {
-        Path basedir =
-                extractResources("mng-8523-model-properties");
+        Path basedir = extractResources("mng-8523-model-properties");
 
         Verifier verifier = newVerifier(basedir);
         verifier.addCliArguments("install", "-DmavenVersion=4.0.0-rc-2", "-Dmaven.consumer.pom.flatten=true");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8525MavenDIPlugin.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8525MavenDIPlugin.java
@@ -19,6 +19,7 @@
 package org.apache.maven.it;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8527ConsumerPomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8527ConsumerPomTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,8 +40,7 @@ class MavenITmng8527ConsumerPomTest extends AbstractMavenIntegrationTestCase {
      */
     @Test
     void testIt() throws Exception {
-        Path basedir =
-                extractResources("mng-8527-consumer-pom");
+        Path basedir = extractResources("mng-8527-consumer-pom");
 
         Verifier verifier = newVerifier(basedir);
         verifier.addCliArguments("install", "-Dmaven.consumer.pom.flatten=true");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8598JvmConfigSubstitutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8598JvmConfigSubstitutionTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Path;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,8 +37,7 @@ public class MavenITmng8598JvmConfigSubstitutionTest extends AbstractMavenIntegr
         Path testDir = extractResources("mng-8598");
 
         Verifier verifier = newVerifier(testDir);
-        verifier.addCliArgument(
-                "-Dexpression.outputFile=" + testDir.resolve("target/pom.properties"));
+        verifier.addCliArgument("-Dexpression.outputFile=" + testDir.resolve("target/pom.properties"));
         verifier.setForkJvm(true); // custom .mvn/jvm.config
         verifier.addCliArgument("validate");
         verifier.execute();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8736ConcurrentFileActivationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8736ConcurrentFileActivationTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8750NewScopesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8750NewScopesTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;

--- a/its/core-it-suite/src/test/resources/gh-11055-di-service-injection/src/test/java/com/gitlab/tkslaw/ditests/TestProviders.java
+++ b/its/core-it-suite/src/test/resources/gh-11055-di-service-injection/src/test/java/com/gitlab/tkslaw/ditests/TestProviders.java
@@ -24,13 +24,13 @@ import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Priority;
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
-import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.apache.maven.api.services.DependencyResolver;
 import org.apache.maven.api.services.OsService;
 import org.apache.maven.api.services.ToolchainManager;
 import org.apache.maven.impl.DefaultToolchainManager;
 import org.apache.maven.impl.InternalSession;
 import org.apache.maven.impl.model.DefaultOsService;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.mockito.Mockito;
 
 import static org.apache.maven.testing.plugin.MojoExtension.getBasedir;

--- a/its/core-it-suite/src/test/resources/gh-11314-v3-mojo-injection/consumer/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11314-v3-mojo-injection/consumer/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.apache.maven.its.gh11314</groupId>
     <artifactId>test-project</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>consumer</artifactId>
   <packaging>jar</packaging>
 

--- a/its/core-it-suite/src/test/resources/gh-11314-v3-mojo-injection/plugin/src/main/java/org/apache/maven/its/gh11314/TestMojo.java
+++ b/its/core-it-suite/src/test/resources/gh-11314-v3-mojo-injection/plugin/src/main/java/org/apache/maven/its/gh11314/TestMojo.java
@@ -18,14 +18,12 @@
  */
 package org.apache.maven.its.gh11314;
 
-import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.toolchain.ToolchainFactory;
 
 /**

--- a/its/core-it-suite/src/test/resources/gh-11314-v3-mojo-injection/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11314-v3-mojo-injection/pom.xml
@@ -6,12 +6,12 @@
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
   <modules>
     <module>plugin</module>
     <module>consumer</module>
   </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>

--- a/its/core-it-suite/src/test/resources/gh-11356-invalid-transitive-repository/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11356-invalid-transitive-repository/pom.xml
@@ -19,23 +19,23 @@ under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
 
-    <groupId>org.apache.maven.reproducer</groupId>
-    <artifactId>reproducer-debezium</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  <groupId>org.apache.maven.reproducer</groupId>
+  <artifactId>reproducer-debezium</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <debezium-version>3.3.1.Final</debezium-version>
-    </properties>
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <debezium-version>3.3.1.Final</debezium-version>
+  </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-connector-db2</artifactId>
-            <version>${debezium-version}</version>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>io.debezium</groupId>
+      <artifactId>debezium-connector-db2</artifactId>
+      <version>${debezium-version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/its/core-it-suite/src/test/resources/gh-11378-sealed-parameter-config/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11378-sealed-parameter-config/pom.xml
@@ -6,12 +6,12 @@
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
   <modules>
     <module>plugin</module>
     <module>consumer</module>
   </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>

--- a/its/core-it-suite/src/test/resources/gh-11381/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11381/pom.xml
@@ -17,8 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.gh11381</groupId>
@@ -32,8 +31,8 @@ under the License.
   <build>
     <resources>
       <resource>
-        <directory>${project.basedir}/rest</directory>
         <targetPath>target-dir</targetPath>
+        <directory>${project.basedir}/rest</directory>
         <includes>
           <include>**/*.yml</include>
         </includes>
@@ -41,4 +40,3 @@ under the License.
     </resources>
   </build>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11384/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11384/pom.xml
@@ -15,4 +15,3 @@
     <project.url>https://github.com/slackapi/java-slack-sdk</project.url>
   </properties>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11399-flatten-plugin-parent-cycle/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11399-flatten-plugin-parent-cycle/pom.xml
@@ -17,52 +17,47 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache</groupId>
-        <artifactId>apache</artifactId>
-        <version>35</version>
-    </parent>
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>35</version>
+  </parent>
 
-    <groupId>org.apache.maven.its.gh11399</groupId>
-    <artifactId>test-project</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  <groupId>org.apache.maven.its.gh11399</groupId>
+  <artifactId>test-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-    <name>GH-11399 Flatten Plugin Parent Cycle Test</name>
-    <description>
-        Test project to verify that flatten-maven-plugin with updatePomFile=true
-        does not cause a false parent cycle detection error.
-    </description>
+  <name>GH-11399 Flatten Plugin Parent Cycle Test</name>
+  <description>Test project to verify that flatten-maven-plugin with updatePomFile=true
+        does not cause a false parent cycle detection error.</description>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.7.3</version>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>target</outputDirectory>
-                            <updatePomFile>true</updatePomFile>
-                            <pomElements>
-                                <parent>expand</parent>
-                            </pomElements>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.7.3</version>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <outputDirectory>target</outputDirectory>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <parent>expand</parent>
+              </pomElements>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11409/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11409/pom.xml
@@ -17,9 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>test.gh11409</groupId>
@@ -46,4 +44,3 @@ under the License.
     </profile>
   </profiles>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11409/subproject/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11409/subproject/pom.xml
@@ -17,9 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -45,4 +43,3 @@ under the License.
     </profile>
   </profiles>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/bom/pom.xml
@@ -17,9 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -33,11 +31,11 @@ under the License.
 
   <name>GH-11427 BOM</name>
 
-    <properties>
-        <junit.version>4.13.2</junit.version>
-    </properties>
+  <properties>
+    <junit.version>4.13.2</junit.version>
+  </properties>
 
-    <dependencyManagement>
+  <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.apache.maven.its.gh-11427</groupId>
@@ -52,4 +50,3 @@ under the License.
     </dependencies>
   </dependencyManagement>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/module/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/module/pom.xml
@@ -17,9 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -33,16 +31,15 @@ under the License.
 
   <name>GH-11427 Module</name>
 
-    <properties>
-        <junit.version>4.13.2</junit.version>
-    </properties>
+  <properties>
+    <junit.version>4.13.2</junit.version>
+  </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+  </dependencies>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11427-bom-consumer-pom/pom.xml
@@ -17,9 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.gh-11427</groupId>
@@ -34,4 +32,3 @@ under the License.
     <module>module</module>
   </modules>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/flattened/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/flattened/pom.xml
@@ -35,4 +35,3 @@ under the License.
     </mixin>
   </mixins>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/flattened/src/main/java/Test.java
+++ b/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/flattened/src/main/java/Test.java
@@ -17,4 +17,3 @@
  * under the License.
  */
 public class Test {}
-

--- a/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/non-flattened/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/non-flattened/pom.xml
@@ -35,4 +35,3 @@ under the License.
     </mixin>
   </mixins>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/non-flattened/src/main/java/Test.java
+++ b/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/non-flattened/src/main/java/Test.java
@@ -17,4 +17,3 @@
  * under the License.
  */
 public class Test {}
-

--- a/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/preserve-model-version/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/preserve-model-version/pom.xml
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.2.0" root="true" preserve.model.version="true">
+<project xmlns="http://maven.apache.org/POM/4.2.0" preserve.model.version="true" root="true">
   <modelVersion>4.2.0</modelVersion>
   <groupId>org.apache.maven.its.gh11456</groupId>
   <artifactId>preserve-model-version</artifactId>
@@ -35,4 +35,3 @@ under the License.
     </mixin>
   </mixins>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/preserve-model-version/src/main/java/Test.java
+++ b/its/core-it-suite/src/test/resources/gh-11456-mixins-consumer-pom/preserve-model-version/src/main/java/Test.java
@@ -17,4 +17,3 @@
  * under the License.
  */
 public class Test {}
-

--- a/its/core-it-suite/src/test/resources/gh-11485-at-sign/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11485-at-sign/pom.xml
@@ -17,9 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.gh11485</groupId>
@@ -28,10 +26,8 @@ under the License.
   <packaging>pom</packaging>
 
   <name>Test @ character in jvm.config</name>
-  <description>
-    Verify that @ character in jvm.config values is handled correctly.
-    This is important for Jenkins workspaces like workspace/project_PR-350@2
-  </description>
+  <description>Verify that @ character in jvm.config values is handled correctly.
+    This is important for Jenkins workspaces like workspace/project_PR-350@2</description>
 
   <properties>
     <pathWithAtProp>${path.with.at}</pathWithAtProp>
@@ -48,10 +44,10 @@ under the License.
         <version>2.1-SNAPSHOT</version>
         <executions>
           <execution>
-            <phase>validate</phase>
             <goals>
               <goal>eval</goal>
             </goals>
+            <phase>validate</phase>
             <configuration>
               <outputFile>target/pom.properties</outputFile>
               <expressions>
@@ -67,4 +63,3 @@ under the License.
     </plugins>
   </build>
 </project>
-

--- a/its/core-it-suite/src/test/resources/gh-11715/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11715/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.1.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
   <modelVersion>4.1.0</modelVersion>
   <groupId>org.apache.maven.its.gh11715</groupId>
   <artifactId>effective-pom-namespace</artifactId>

--- a/its/core-it-suite/src/test/resources/gh-11772-consumer-pom-410/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-11772-consumer-pom-410/pom.xml
@@ -24,10 +24,6 @@ under the License.
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <subprojects>
-    <subproject>child</subproject>
-  </subprojects>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -37,5 +33,9 @@ under the License.
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <subprojects>
+    <subproject>child</subproject>
+  </subprojects>
 
 </project>

--- a/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/child-b/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/child-b/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/child/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.gh12303</groupId>

--- a/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/resource-bundle/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12303-ci-friendly-revision-remote-resources/resource-bundle/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.gh12303</groupId>

--- a/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12305-invalid-collect-request/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.maven.its.gh12305</groupId>
   <artifactId>test</artifactId>

--- a/its/core-it-suite/src/test/resources/gh-2576-itr-not-honored/consumer/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-2576-itr-not-honored/consumer/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.apache.maven.its.gh2576</groupId>
-    <artifactId>consumer</artifactId>
-    <version>1.0-SNAPSHOT</version>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.gh2576</groupId>
+  <artifactId>consumer</artifactId>
+  <version>1.0-SNAPSHOT</version>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.maven.its.gh2576</groupId>
-            <artifactId>dep</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.gh2576</groupId>
+      <artifactId>dep</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/its/core-it-suite/src/test/resources/gh-2576-itr-not-honored/dep/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-2576-itr-not-honored/dep/pom.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.maven.its.gh2576</groupId>
-        <artifactId>parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.gh2576</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>dep</artifactId>
+  <artifactId>dep</artifactId>
 
-    <repositories>
-        <repository>
-            <id>foo</id>
-            <url>file:///${basedir}/../repo</url>
-            <snapshots>
-                <checksumPolicy>ignore</checksumPolicy>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+        <checksumPolicy>ignore</checksumPolicy>
+      </snapshots>
+      <id>foo</id>
+      <url>file:///${basedir}/../repo</url>
+    </repository>
+  </repositories>
 </project>

--- a/its/core-it-suite/src/test/resources/gh-2576-itr-not-honored/parent/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-2576-itr-not-honored/parent/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.apache.maven.its.gh2576</groupId>
-    <artifactId>parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.gh2576</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 </project>

--- a/its/core-it-suite/src/test/resources/settings-profile-aether-properties/pom.xml
+++ b/its/core-it-suite/src/test/resources/settings-profile-aether-properties/pom.xml
@@ -26,9 +26,7 @@ under the License.
   <packaging>pom</packaging>
 
   <name>Maven Integration Test :: Settings Profile Aether Properties</name>
-  <description>
-    Minimal project for proving that aether.enhancedLocalRepository.*
+  <description>Minimal project for proving that aether.enhancedLocalRepository.*
     properties set in an active-by-default settings.xml profile are honored
-    by the resolver at local repository manager initialization.
-  </description>
+    by the resolver at local repository manager initialization.</description>
 </project>


### PR DESCRIPTION
## Summary

- The `its/core-it-suite/pom.xml` pluginManagement override for `spotless-maven-plugin` only specified `<includes>` and `<excludes>`, which inadvertently wiped out the formatting steps (`palantirJavaFormat`, `removeUnusedImports`, `importOrder`, `licenseHeader` for Java; `sortPom` for POM).
- The `its/` parent chain inherits from `apache:38` (not `maven-parent:48` where these steps are defined), so there was no parent config to inherit — `combine.children="append"` alone could not fix this.
- Added the formatting steps explicitly along with the `maven-shared-resources` dependency (needed for `importOrder` and `licenseHeader` config files), and applied formatting to all files in the module.

## Test plan

- [x] `mvn -B com.diffplug.spotless:spotless-maven-plugin:check -f its/core-it-suite` passes
- [x] Verified formatting is enforced by creating a deliberately badly formatted file and confirming spotless catches it
- [x] CI passes

_Claude Code on behalf of Guillaume Nodet_