### PR TITLE
[#12301] Use stack-passed Set for activeModelReads cycle detection

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -276,11 +276,6 @@ public class DefaultModelBuilder implements ModelBuilder {
         // Contains both GAV coordinates (groupId:artifactId:version) and file paths
         final Set<String> parentChain;
 
-        // Tracks file paths currently being read by doReadFileModel, shared across
-        // all derived sessions to prevent recursive loops between parent resolution
-        // and enhanced property resolution (GH-12301)
-        final Set<Path> activeModelReads;
-
         ModelBuilderSessionState(ModelBuilderRequest request) {
             this(
                     request.getSession(),
@@ -291,8 +286,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                     List.of(),
                     repos(request),
                     repos(request),
-                    new LinkedHashSet<>(),
-                    ConcurrentHashMap.newKeySet());
+                    new LinkedHashSet<>());
         }
 
         static List<RemoteRepository> repos(ModelBuilderRequest request) {
@@ -312,8 +306,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 List<RemoteRepository> pomRepositories,
                 List<RemoteRepository> externalRepositories,
                 List<RemoteRepository> repositories,
-                Set<String> parentChain,
-                Set<Path> activeModelReads) {
+                Set<String> parentChain) {
             this.session = session;
             this.request = request;
             this.result = result;
@@ -323,7 +316,6 @@ public class DefaultModelBuilder implements ModelBuilder {
             this.externalRepositories = externalRepositories;
             this.repositories = repositories;
             this.parentChain = parentChain;
-            this.activeModelReads = activeModelReads;
             this.result.setSource(this.request.getSource());
         }
 
@@ -374,8 +366,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                     pomRepositories,
                     derivedExtRepos,
                     derivedRepos,
-                    new LinkedHashSet<>(),
-                    activeModelReads);
+                    new LinkedHashSet<>());
         }
 
         @Override
@@ -682,7 +673,7 @@ public class DefaultModelBuilder implements ModelBuilder {
          * are available for CI-friendly version processing and repository URL interpolation.
          * It also includes directory-related properties that may be needed during profile activation.
          */
-        private Map<String, String> getEnhancedProperties(Model model, Path rootDirectory) {
+        private Map<String, String> getEnhancedProperties(Model model, Path rootDirectory, Set<Path> activeModelReads) {
             Map<String, String> properties = new HashMap<>();
 
             // Add directory-specific properties first, as they may be needed for profile activation
@@ -715,7 +706,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                     if (isParentWithinRootDirectory(rootModelPath, rootDirectory)
                             && !activeModelReads.contains(rootModelPath.normalize())) {
                         Model rootModel =
-                                derive(Sources.buildSource(rootModelPath)).readFileModel();
+                                derive(Sources.buildSource(rootModelPath)).readFileModel(activeModelReads);
                         properties.putAll(getPropertiesWithProfiles(rootModel, properties));
                     }
                 }
@@ -1494,14 +1485,18 @@ public class DefaultModelBuilder implements ModelBuilder {
         }
 
         Model readFileModel() throws ModelBuilderException {
-            Model model = cache(request.getSource(), FILE, this::doReadFileModel);
+            return readFileModel(new HashSet<>());
+        }
+
+        Model readFileModel(Set<Path> activeModelReads) throws ModelBuilderException {
+            Model model = cache(request.getSource(), FILE, () -> doReadFileModel(activeModelReads));
             // set the file model in the result outside the cache
             result.setFileModel(model);
             return model;
         }
 
         @SuppressWarnings("checkstyle:methodlength")
-        Model doReadFileModel() throws ModelBuilderException {
+        Model doReadFileModel(Set<Path> activeModelReads) throws ModelBuilderException {
             ModelSource modelSource = request.getSource();
             Model model;
             Path rootDirectory;
@@ -1509,7 +1504,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             setSource(modelSource.getLocation());
             logger.debug("Reading file model from " + modelSource.getLocation());
             Path sourcePath = modelSource.getPath();
-            boolean trackRead = sourcePath != null && activeModelReads.add(sourcePath.normalize());
+            Path normalizedPath = sourcePath != null ? sourcePath.normalize() : null;
+            boolean trackRead = normalizedPath != null && activeModelReads.add(normalizedPath);
             try {
                 try {
                     boolean strict = isBuildRequest();
@@ -1614,7 +1610,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                                 }
 
                                 Model parentModel =
-                                        derive(Sources.buildSource(pomPath)).readFileModel();
+                                        derive(Sources.buildSource(pomPath)).readFileModel(activeModelReads);
                                 String parentGroupId = getGroupId(parentModel);
                                 String parentArtifactId = parentModel.getArtifactId();
                                 String parentVersion = getVersion(parentModel);
@@ -1666,7 +1662,7 @@ public class DefaultModelBuilder implements ModelBuilder {
 
                     // Enhanced property resolution with profile activation for CI-friendly versions and repository URLs
                     // This includes directory properties, profile properties, and user properties
-                    Map<String, String> properties = getEnhancedProperties(model, rootDirectory);
+                    Map<String, String> properties = getEnhancedProperties(model, rootDirectory, activeModelReads);
 
                     // CI friendly version processing with profile-aware properties
                     model = model.with()
@@ -1722,7 +1718,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 return model;
             } finally {
                 if (trackRead) {
-                    activeModelReads.remove(sourcePath.normalize());
+                    activeModelReads.remove(normalizedPath);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Replace the shared `ConcurrentHashMap.newKeySet()` used for `activeModelReads` cycle detection with a `Set<Path>` passed through the call stack.

The original fix (PR #12314) used a shared concurrent set across all derived sessions to prevent the StackOverflowError from GH-12301. While this works correctly on `maven-4.0.x` today, it has a latent race condition: parallel threads in `PhasingExecutor` (`loadFilePom`) that read the same model simultaneously can falsely block each other's `getEnhancedProperties()` from reading that model. This race manifests on `master` (broke `ConsumerPomBuilderTest.testSimpleConsumer` when forward-ported as #12317).

The fix passes the `Set<Path>` as a method parameter through the call chain:
- `doReadFileModel(activeModelReads)` → adds current path, passes to both parent resolution and `getEnhancedProperties()`
- `getEnhancedProperties(model, rootDir, activeModelReads)` → checks set before reading root model
- `readFileModel(activeModelReads)` → threads the set through the cache call

Each call chain (from `readFileModel()` entry point) carries its own set, so parallel threads never interfere.

## Test plan

- [x] `DefaultModelBuilderTest` — 12/12 pass
- [x] `ConsumerPomBuilderTest` — 7/7 pass
- [x] Full IT suite — 1029 pass, 0 failures, 51 skipped

_Fully automatic review from Claude Code_