### PR TITLE
Remove deprecated methods use

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/transfer/AbstractMavenTransferListener.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/transfer/AbstractMavenTransferListener.java
@@ -236,7 +236,7 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
         message.append(darkOff).append(resource.getResourceName());
         message.append(darkOn).append(" (").append(format.format(contentLength));
 
-        long duration = System.currentTimeMillis() - resource.getTransferStartTime();
+        long duration = System.currentTimeMillis() - resource.getStartTime().toEpochMilli();
         if (duration > 0L) {
             double bytesPerSecond = contentLength / (duration / 1000.0);
             message.append(" at ").append(format.format((long) bytesPerSecond)).append("/s");

--- a/maven-embedder/src/main/java/org/apache/maven/cli/transfer/Slf4jMavenTransferListener.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/transfer/Slf4jMavenTransferListener.java
@@ -84,7 +84,7 @@ public class Slf4jMavenTransferListener extends AbstractTransferListener {
         message.append(resource.getRepositoryUrl()).append(resource.getResourceName());
         message.append(" (").append(format.format(contentLength));
 
-        long duration = System.currentTimeMillis() - resource.getTransferStartTime();
+        long duration = System.currentTimeMillis() - resource.getStartTime().toEpochMilli();
         if (duration > 0L) {
             double bytesPerSecond = contentLength / (duration / 1000.0);
             message.append(" at ").append(format.format((long) bytesPerSecond)).append("/s");


### PR DESCRIPTION
Just to get rid of warnings. Aligning to Maven 4 is IMHO really not needed, as Maven 4 has much more, like monotonic clock and is Java 17 using APIs that Maven 3.x has no access.
