### PR TITLE
[#12331] Fix clean/site lifecycle bindings executing after pom.xml goals

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/Lifecycles.java
@@ -74,6 +74,7 @@ public class Lifecycles {
                 .version(c[2])
                 .executions(Collections.singletonList(PluginExecution.newBuilder()
                         .id("default-" + c[3])
+                        .priority(-1)
                         .phase(phase)
                         .goals(Collections.singletonList(c[3]))
                         .location("", DefaultLifecycleRegistry.DEFAULT_LIFECYCLE_INPUT_LOCATION)

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/LifecycleExecutorTest.java
@@ -314,6 +314,24 @@ class LifecycleExecutorTest extends AbstractCoreMavenComponentTestCase {
     }
 
     @Test
+    void testCleanLifecycleBindingRunsBeforePomExecution() throws Exception {
+        File pom = getProject("project-with-clean-phase-execution");
+        MavenSession session = createMavenSession(pom);
+        assertEquals(
+                "project-with-clean-phase-execution",
+                session.getCurrentProject().getArtifactId());
+        List<MojoExecution> executionPlan = getExecutions(calculateExecutionPlan(session, "clean"));
+        assertEquals(2, executionPlan.size());
+        assertListEquals(
+                List.of("clean:clean", "it:it"),
+                executionPlan.stream()
+                        .map(e -> e.getMojoDescriptor().getFullGoalName())
+                        .toList());
+        assertEquals("default-clean", executionPlan.get(0).getExecutionId());
+        assertEquals("user-clean-execution", executionPlan.get(1).getExecutionId());
+    }
+
+    @Test
     void testInvalidGoalName() throws Exception {
         File pom = getProject("project-basic");
         MavenSession session = createMavenSession(pom);

--- a/impl/maven-core/src/test/projects/lifecycle-executor/project-with-clean-phase-execution/pom.xml
+++ b/impl/maven-core/src/test/projects/lifecycle-executor/project-with-clean-phase-execution/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.lifecycle.test</groupId>
+  <artifactId>project-with-clean-phase-execution</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>0.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin</artifactId>
+        <version>0.1</version>
+        <executions>
+          <execution>
+            <id>user-clean-execution</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>it</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Summary

Fix goal bindings in `pom.xml` being executed **before** lifecycle bindings for
the `clean` and `site` lifecycles (regression vs Maven 3, fixes #12331).

## Root cause

`Lifecycles.plugin()` creates executions for built-in `clean` and `site`
lifecycle bindings (e.g. `default-clean`) without setting a priority, so they
defaulted to `0` — the same as user-defined executions from `pom.xml`.

`DefaultLifecycleMappingDelegate` sorts executions within a phase by priority.
When both a lifecycle binding and a pom.xml execution share priority `0`,
ordering falls back to plugin iteration order. Because `LifecycleBindingsMerger`
inserts pom.xml plugins before lifecycle-only plugins, pom.xml executions ended
up running first.

For the `default` lifecycle this was not a problem: packaging bindings (e.g. for
`jar`) are built by `DefaultPackagingRegistry` with `priority(i - mojos.size())`
— always negative — so they already sort before user executions.

## Fix

Add `.priority(-1)` to the `PluginExecution` built in `Lifecycles.plugin()`,
making `clean` and `site` lifecycle bindings consistent with how `default`
lifecycle packaging bindings work.

## Test plan

- [x] `LifecycleExecutorTest`, `DefaultLifecyclesTest`, `BuildPlanCreatorTest`
      all pass (561 tests, 0 failures in `maven-core`)
- [x] Manual reproduction from #12331: `mvn clean` with an antrun execution
      bound to the `clean` phase now runs `default-clean` (maven-clean-plugin)
      before the pom.xml antrun execution, matching Maven 3 behavior
