### PR TITLE
Forward port Maven 3.10.0 PluginDependenciesResolver changes

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/internal/BootstrapCoreExtensionManager.java
@@ -59,7 +59,7 @@ import org.apache.maven.impl.model.DefaultInterpolator;
 import org.apache.maven.internal.impl.DefaultArtifactManager;
 import org.apache.maven.internal.impl.DefaultSession;
 import org.apache.maven.plugin.PluginResolutionException;
-import org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver;
+import org.apache.maven.plugin.internal.PluginDependenciesResolver;
 import org.apache.maven.resolver.MavenChainedWorkspaceReader;
 import org.apache.maven.resolver.RepositorySystemSessionFactory;
 import org.codehaus.plexus.DefaultPlexusContainer;
@@ -97,7 +97,7 @@ public class BootstrapCoreExtensionManager {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private final DefaultPluginDependenciesResolver pluginDependenciesResolver;
+    private final PluginDependenciesResolver pluginDependenciesResolver;
 
     private final RepositorySystemSessionFactory repositorySystemSessionFactory;
 
@@ -113,7 +113,7 @@ public class BootstrapCoreExtensionManager {
 
     @Inject
     public BootstrapCoreExtensionManager(
-            DefaultPluginDependenciesResolver pluginDependenciesResolver,
+            PluginDependenciesResolver pluginDependenciesResolver,
             RepositorySystemSessionFactory repositorySystemSessionFactory,
             CoreExports coreExports,
             PlexusContainer container,
@@ -213,7 +213,7 @@ public class BootstrapCoreExtensionManager {
             throws ExtensionResolutionException {
         try {
             /* TODO: Enhance the PluginDependenciesResolver to provide a
-             * resolveCoreExtension method which uses a CoreExtension
+             * resolveCoreExtensionAndFlatten method which uses a CoreExtension
              * object instead of a Plugin as this makes no sense.
              */
             Plugin plugin = Plugin.newBuilder()
@@ -222,7 +222,7 @@ public class BootstrapCoreExtensionManager {
                     .version(interpolator.apply(extension.getVersion()))
                     .build();
 
-            DependencyResult result = pluginDependenciesResolver.resolveCoreExtension(
+            DependencyResult result = pluginDependenciesResolver.resolveCoreExtensionAndFlatten(
                     new org.apache.maven.model.Plugin(plugin), dependencyFilter, repositories, repoSession);
             return result.getArtifactResults().stream()
                     .filter(ArtifactResult::isResolved)

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/extensions/BootstrapCoreExtensionManager.java
@@ -62,7 +62,7 @@ import org.apache.maven.impl.model.DefaultInterpolator;
 import org.apache.maven.internal.impl.DefaultArtifactManager;
 import org.apache.maven.internal.impl.DefaultSession;
 import org.apache.maven.plugin.PluginResolutionException;
-import org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver;
+import org.apache.maven.plugin.internal.PluginDependenciesResolver;
 import org.apache.maven.resolver.MavenChainedWorkspaceReader;
 import org.apache.maven.resolver.RepositorySystemSessionFactory;
 import org.codehaus.plexus.DefaultPlexusContainer;
@@ -98,7 +98,7 @@ public class BootstrapCoreExtensionManager {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private final DefaultPluginDependenciesResolver pluginDependenciesResolver;
+    private final PluginDependenciesResolver pluginDependenciesResolver;
 
     private final RepositorySystemSessionFactory repositorySystemSessionFactory;
 
@@ -116,7 +116,7 @@ public class BootstrapCoreExtensionManager {
 
     @Inject
     public BootstrapCoreExtensionManager(
-            DefaultPluginDependenciesResolver pluginDependenciesResolver,
+            PluginDependenciesResolver pluginDependenciesResolver,
             RepositorySystemSessionFactory repositorySystemSessionFactory,
             CoreExports coreExports,
             PlexusContainer container,
@@ -218,7 +218,7 @@ public class BootstrapCoreExtensionManager {
             throws ExtensionResolutionException {
         try {
             /* TODO: Enhance the PluginDependenciesResolver to provide a
-             * resolveCoreExtension method which uses a CoreExtension
+             * resolveCoreExtensionAndFlatten method which uses a CoreExtension
              * object instead of a Plugin as this makes no sense.
              */
             Plugin plugin = Plugin.newBuilder()
@@ -227,7 +227,7 @@ public class BootstrapCoreExtensionManager {
                     .version(interpolator.apply(extension.getVersion()))
                     .build();
 
-            DependencyResult result = pluginDependenciesResolver.resolveCoreExtension(
+            DependencyResult result = pluginDependenciesResolver.resolveCoreExtensionAndFlatten(
                     new org.apache.maven.model.Plugin(plugin), dependencyFilter, repositories, repoSession);
             return result.getArtifactResults().stream()
                     .filter(ArtifactResult::isResolved)

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -412,7 +412,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
         DependencyFilter dependencyFilter = project.getExtensionDependencyFilter();
         dependencyFilter = AndDependencyFilter.newInstance(dependencyFilter, filter);
 
-        DependencyResult result = pluginDependenciesResolver.resolvePlugin(
+        DependencyResult result = pluginDependenciesResolver.resolvePluginAndFlatten(
                 plugin,
                 RepositoryUtils.toArtifact(pluginArtifact),
                 dependencyFilter,
@@ -1036,7 +1036,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
             Plugin extensionPlugin, List<RemoteRepository> repositories, RepositorySystemSession session)
             throws PluginResolutionException {
         DependencyResult root =
-                pluginDependenciesResolver.resolvePlugin(extensionPlugin, null, null, repositories, session);
+                pluginDependenciesResolver.resolvePluginAndFlatten(extensionPlugin, null, null, repositories, session);
         return toMavenArtifacts(root);
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -153,8 +153,21 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
 
     /**
      * @since 3.3.0
+     * @deprecated Is unused since 3.10+
      */
-    public DependencyResult resolveCoreExtension(
+    @Deprecated
+    public DependencyNode resolveCoreExtension(
+            Plugin plugin,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException {
+        return resolveCoreExtensionAndFlatten(plugin, dependencyFilter, repositories, session)
+                .getRoot();
+    }
+
+    @Override
+    public DependencyResult resolveCoreExtensionAndFlatten(
             Plugin plugin,
             DependencyFilter dependencyFilter,
             List<RemoteRepository> repositories,
@@ -194,8 +207,20 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
         }
     }
 
+    @Deprecated
     @Override
     public DependencyResult resolvePlugin(
+            Plugin plugin,
+            Artifact artifact,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException {
+        return resolvePluginAndFlatten(plugin, artifact, dependencyFilter, repositories, session);
+    }
+
+    @Override
+    public DependencyResult resolvePluginAndFlatten(
             Plugin plugin,
             Artifact pluginArtifact,
             DependencyFilter dependencyFilter,

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDependenciesResolver.java
@@ -61,7 +61,9 @@ public interface PluginDependenciesResolver {
      * @param session The repository session to use for resolving the plugin artifacts, must not be {@code null}.
      * @return The dependency tree denoting the resolved plugin class path, never {@code null}.
      * @throws PluginResolutionException If any dependency could not be resolved.
+     * @deprecated This method should be avoided, as it requires manual flattening; use {@link #resolvePluginAndFlatten(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)} instead to let Resolver handle it.
      */
+    @Deprecated
     DependencyNode resolve(
             Plugin plugin,
             Artifact pluginArtifact,
@@ -70,11 +72,63 @@ public interface PluginDependenciesResolver {
             RepositorySystemSession session)
             throws PluginResolutionException;
 
+    /**
+     * Resolves the runtime dependencies of the specified core extension (as {@link Plugin} as GAV carrier).
+     *
+     * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
+     * @param dependencyFilter A filter to exclude artifacts from resolution (but not collection), may be {@code null}.
+     * @param repositories The plugin repositories to use for resolving the plugin artifacts, must not be {@code null}.
+     * @param session The repository session to use for resolving the plugin artifacts, must not be {@code null}.
+     * @return The dependency resolution result having the resolved extension class path but also the tree, never {@code null}.
+     * @throws PluginResolutionException If any dependency could not be resolved.
+     * @since 3.10.0
+     */
+    DependencyResult resolveCoreExtensionAndFlatten(
+            Plugin plugin,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException;
+
+    /**
+     * Resolves the runtime dependencies of the specified plugin.
+     *
+     * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
+     * @param artifact The plugin's main artifact, may be {@code null}.
+     * @param dependencyFilter A filter to exclude artifacts from resolution (but not collection), may be {@code null}.
+     * @param repositories The plugin repositories to use for resolving the plugin artifacts, must not be {@code null}.
+     * @param session The repository session to use for resolving the plugin artifacts, must not be {@code null}.
+     * @return The dependency resolution result having the resolved plugin class path but also the tree, never {@code null}.
+     * @throws PluginResolutionException If any dependency could not be resolved.
+     * @since 4.0.0-beta-2
+     * @deprecated Use {@link #resolvePluginAndFlatten(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)} instead.
+     */
+    @Deprecated
     DependencyResult resolvePlugin(
             Plugin plugin,
             Artifact artifact,
             DependencyFilter dependencyFilter,
-            List<RemoteRepository> remotePluginRepositories,
-            RepositorySystemSession repositorySession)
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException;
+
+    /**
+     * Resolves the runtime dependencies of the specified plugin.
+     *
+     * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
+     * @param pluginArtifact The plugin's main artifact, may be {@code null}.
+     * @param dependencyFilter A filter to exclude artifacts from resolution (but not collection), may be {@code null}.
+     * @param repositories The plugin repositories to use for resolving the plugin artifacts, must not be {@code null}.
+     * @param session The repository session to use for resolving the plugin artifacts, must not be {@code null}.
+     * @return The dependency resolution result having the resolved plugin class path but also the tree, never {@code null}.
+     * @throws PluginResolutionException If any dependency could not be resolved.
+     * @since 3.10.0
+     */
+    DependencyResult resolvePluginAndFlatten(
+            Plugin plugin,
+            Artifact pluginArtifact,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
             throws PluginResolutionException;
 }


### PR DESCRIPTION
Also, restore binary compatibility that was broken in 4-beta-2.

This PR aligns PluginDependenciesResolver with changes happened in Maven 3.10.x, and also restores binary incompatibility happened in DefaultPluginDependenciesResolver that used to be injected directly.

Backport from master c1de26776af18e095171885601df3f50a2473f8b
