### PR TITLE
Fix illegal reflective access warning on JDK 11 (fixes #12167)

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -212,5 +212,6 @@ exec "$JAVACMD" \
   "-Dclassworlds.conf=${MAVEN_HOME}/bin/m2.conf" \
   "-Dmaven.home=${MAVEN_HOME}" \
   "-Dlibrary.jline.path=${MAVEN_HOME}/lib/jline-native" \
+  "-Dorg.jline.terminal.exec.redirectPipeCreationMode=native" \
   "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
   ${CLASSWORLDS_LAUNCHER} ${MAVEN_ARGS} "$@"

--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -212,6 +212,6 @@ exec "$JAVACMD" \
   "-Dclassworlds.conf=${MAVEN_HOME}/bin/m2.conf" \
   "-Dmaven.home=${MAVEN_HOME}" \
   "-Dlibrary.jline.path=${MAVEN_HOME}/lib/jline-native" \
-  "-Dorg.jline.terminal.exec.redirectPipeCreationMode=native" \
+  "-Dorg.jline.terminal.exec.redirectPipeCreationMode=native,reflection" \
   "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
   ${CLASSWORLDS_LAUNCHER} ${MAVEN_ARGS} "$@"

--- a/apache-maven/src/bin/mvn.cmd
+++ b/apache-maven/src/bin/mvn.cmd
@@ -191,6 +191,7 @@ set "INTERNAL_MAVEN_OPTS=--enable-native-access=ALL-UNNAMED %INTERNAL_MAVEN_OPTS
   "-Dclassworlds.conf=%MAVEN_HOME%\bin\m2.conf" ^
   "-Dmaven.home=%MAVEN_HOME%" ^
   "-Dlibrary.jline.path=%MAVEN_HOME%\lib\jline-native" ^
+  "-Dorg.jline.terminal.exec.redirectPipeCreationMode=native" ^
   "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
   %CLASSWORLDS_LAUNCHER% %MAVEN_ARGS% %MAVEN_CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error

--- a/apache-maven/src/bin/mvn.cmd
+++ b/apache-maven/src/bin/mvn.cmd
@@ -191,7 +191,7 @@ set "INTERNAL_MAVEN_OPTS=--enable-native-access=ALL-UNNAMED %INTERNAL_MAVEN_OPTS
   "-Dclassworlds.conf=%MAVEN_HOME%\bin\m2.conf" ^
   "-Dmaven.home=%MAVEN_HOME%" ^
   "-Dlibrary.jline.path=%MAVEN_HOME%\lib\jline-native" ^
-  "-Dorg.jline.terminal.exec.redirectPipeCreationMode=native" ^
+  "-Dorg.jline.terminal.exec.redirectPipeCreationMode=native,reflection" ^
   "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
   %CLASSWORLDS_LAUNCHER% %MAVEN_ARGS% %MAVEN_CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error


### PR DESCRIPTION
## Summary

- Set `org.jline.terminal.exec.redirectPipeCreationMode=native` in both `mvn` and `mvn.cmd` launcher scripts to prevent JLine's `ExecTerminalProvider` from using reflection to access `ProcessBuilder$RedirectPipeImpl`
- This avoids the "WARNING: Illegal reflective access" messages on JDK 9-15 when stdout is redirected (e.g. `mvn -v | cat` or `mvn -v > file.txt`)

The property is a JLine 3.x configuration knob (see [jline/jline3#951](https://github.com/jline/jline3/issues/951)) that switches pipe creation from reflection-based to native (JNI), which is already available since Maven ships `jline-terminal-jni` and sets `-Dlibrary.jline.path`.

Fixes #12167

## Test plan

- [ ] On JDK 11, verify `mvn -v | cat` no longer prints the "Illegal reflective access" warning
- [ ] On JDK 8, verify `mvn -v` still works (property is harmless — exec provider falls back)
- [ ] On JDK 17+, verify no regressions


🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_