### PR TITLE
[Backport 4.0.x] Fix NPE in DefaultLookup.lookupOptional() when container returns null

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLookup.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLookup.java
@@ -64,7 +64,7 @@ public class DefaultLookup implements Lookup {
     @Override
     public <T> Optional<T> lookupOptional(Class<T> type) {
         try {
-            return Optional.of(container.lookup(type));
+            return Optional.ofNullable(container.lookup(type));
         } catch (ComponentLookupException e) {
             if (e.getCause() instanceof NoSuchElementException) {
                 return Optional.empty();
@@ -76,7 +76,7 @@ public class DefaultLookup implements Lookup {
     @Override
     public <T> Optional<T> lookupOptional(Class<T> type, String name) {
         try {
-            return Optional.of(container.lookup(type, name));
+            return Optional.ofNullable(container.lookup(type, name));
         } catch (ComponentLookupException e) {
             if (e.getCause() instanceof NoSuchElementException) {
                 return Optional.empty();


### PR DESCRIPTION
Backport of #12336 to `maven-4.0.x`.

Cherry-pick of 712b5c0791 — clean, no conflicts.

## Summary

- `PlexusContainer.lookup()` can return `null` instead of throwing `ComponentLookupException`. `DefaultLookup.lookupOptional()` wraps the result with `Optional.of()`, which throws `NullPointerException` on null input. Changed to `Optional.ofNullable()` so a null result is correctly represented as `Optional.empty()`.
- This fixes `maven-jdeprscan-plugin` integration tests (`list-default`, `list-forremoval`) which fail on Maven 4.0.x because `DefaultToolchainManager.retrieveContext()` calls `lookupOptional(Project.class)` and the container returns null.