### PR TITLE
[Backport 4.0.x] Switch default resolver transport from JDK/methanol to Apache HttpClient

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -83,15 +83,10 @@ under the License.
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-transport-wagon</artifactId>
     </dependency>
-    <!-- HTTP/1.1, medium priority, Java8+ -->
+    <!-- HTTP/1.1, default transport, Java8+ -->
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-transport-apache</artifactId>
-    </dependency>
-    <!-- HTTP/1.1 and HTTP/2, high priority, Java11+ -->
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-jdk</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/impl/maven-cli/pom.xml
+++ b/impl/maven-cli/pom.xml
@@ -142,7 +142,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-jdk</artifactId>
+      <artifactId>maven-resolver-transport-apache</artifactId>
     </dependency>
 
     <dependency>

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/AbstractUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/AbstractUpgradeStrategy.java
@@ -51,8 +51,8 @@ import org.codehaus.plexus.components.secdispatcher.internal.dispatchers.LegacyD
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
 import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.transport.apache.ApacheTransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
-import org.eclipse.aether.transport.jdk.JdkTransporterFactory;
 
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PARENT;
 
@@ -309,10 +309,10 @@ public abstract class AbstractUpgradeStrategy implements UpgradeStrategy {
 
     static class TransporterFactoryConfig {
         @Provides
-        @Named(JdkTransporterFactory.NAME)
-        static TransporterFactory jdkTransporterFactory(
+        @Named(ApacheTransporterFactory.NAME)
+        static TransporterFactory apacheTransporterFactory(
                 ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
-            return new JdkTransporterFactory(checksumExtractor, pathProcessor);
+            return new ApacheTransporterFactory(checksumExtractor, pathProcessor);
         }
 
         @Provides

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470ResolverTransportTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470ResolverTransportTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,9 +39,7 @@ public class MavenITmng7470ResolverTransportTest extends AbstractMavenIntegratio
 
     private int port;
 
-    private static final ArtifactVersion JDK_TRANSPORT_USABLE_ON_JDK_SINCE = new DefaultArtifactVersion("11");
-
-    private static final ArtifactVersion JDK_TRANSPORT_IN_MAVEN_SINCE =
+    private static final ArtifactVersion APACHE_TRANSPORT_RENAMED_SINCE =
             new DefaultArtifactVersion("4.0.0-alpha-9-SNAPSHOT");
 
     public MavenITmng7470ResolverTransportTest() {
@@ -108,33 +105,18 @@ public class MavenITmng7470ResolverTransportTest extends AbstractMavenIntegratio
 
     private static final String APACHE_LOG_SNIPPET = "[DEBUG] Using transporter ApacheTransporter";
 
-    private static final String JDK_LOG_SNIPPET = "[DEBUG] Using transporter JdkTransporter";
-
     /**
-     * Returns {@code true} if JDK HttpClient transport is usable (Java11 or better).
+     * Returns {@code true} if the Apache transport uses the new class name (ApacheTransporter)
+     * rather than the old one (HttpTransporter). This changed in 4.0.0-alpha-9 with the
+     * Resolver 2.0.0 upgrade.
      */
-    private boolean isJdkTransportUsable() {
-        return JDK_TRANSPORT_USABLE_ON_JDK_SINCE.compareTo(getJavaVersion()) < 1;
-    }
-
-    /**
-     * Returns {@code true} if JDK HttpClient transport is present in Maven (since 4.0.0-alpha-9, the Resolver 2.0.0
-     * upgrade).
-     */
-    private boolean isJdkTransportPresent() {
-        return JDK_TRANSPORT_IN_MAVEN_SINCE.compareTo(getMavenVersion()) < 1;
-    }
-
-    private String defaultLogSnippet() {
-        if (isJdkTransportUsable() && isJdkTransportPresent()) {
-            return JDK_LOG_SNIPPET;
-        }
-        return isJdkTransportPresent() ? APACHE_LOG_SNIPPET : APACHE_LOG_SNIPPET_OLD;
+    private boolean isApacheTransportRenamed() {
+        return APACHE_TRANSPORT_RENAMED_SINCE.compareTo(getMavenVersion()) < 1;
     }
 
     @Test
     public void testResolverTransportDefault() throws Exception {
-        performTest(null, defaultLogSnippet());
+        performTest(null, isApacheTransportRenamed() ? APACHE_LOG_SNIPPET : APACHE_LOG_SNIPPET_OLD);
     }
 
     @Test
@@ -145,13 +127,7 @@ public class MavenITmng7470ResolverTransportTest extends AbstractMavenIntegratio
     @Test
     public void testResolverTransportApache() throws Exception {
         performTest(
-                isJdkTransportPresent() ? "apache" : "native",
-                isJdkTransportPresent() ? APACHE_LOG_SNIPPET : APACHE_LOG_SNIPPET_OLD);
-    }
-
-    @Test
-    public void testResolverTransportJdk() throws Exception {
-        Assumptions.assumeTrue(isJdkTransportUsable() && isJdkTransportPresent());
-        performTest("jdk", JDK_LOG_SNIPPET);
+                isApacheTransportRenamed() ? "apache" : "native",
+                isApacheTransportRenamed() ? APACHE_LOG_SNIPPET : APACHE_LOG_SNIPPET_OLD);
     }
 }


### PR DESCRIPTION
Backport of #12338 to `maven-4.0.x`.

Cherry-pick of ffd7baa041 — conflict resolved in the IT test.

## Summary

- Remove `maven-resolver-transport-jdk` from the distribution, making Apache HttpClient the only bundled HTTP transport
- The JDK HTTP transport (backed by methanol) has proven flaky on Windows CI with race conditions in the gzip/inflater code path (`NullPointerException: Inflater has been closed`)

## Changes

- `apache-maven/pom.xml`: removed `maven-resolver-transport-jdk` dependency from the distribution
- `impl/maven-cli/pom.xml`: switched `mvnup` dependency from `transport-jdk` to `transport-apache`
- `AbstractUpgradeStrategy` (mvnup): switched DI provider from `JdkTransporterFactory` to `ApacheTransporterFactory`
- `MavenITmng7470ResolverTransportTest`: default transport test now expects `ApacheTransporter`; removed `testResolverTransportJdk` test; simplified version-detection helpers (kept backward compat for old `HttpTransporter` class name)

## Conflict resolution

The IT test on `maven-4.0.x` has a version-range constructor `super("[3.9.0,)")` and backward-compat logic for the old `HttpTransporter` class name (pre-4.0.0-alpha-9). These were preserved. JDK-specific helpers (`isJdkTransportUsable`, `isJdkTransportPresent`) were replaced with a single `isApacheTransportRenamed()` method.