### PR TITLE
Port #11908: Do not force metadata download for plugin prefix resolution (#11905)

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
@@ -25,8 +25,10 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,16 +109,20 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
                         LinkedHashMap::new,
                         Collectors.mapping(Plugin::getArtifactId, Collectors.toSet())));
         request.getPluginGroups().forEach(g -> candidates.put(g, null));
-        PluginPrefixResult result = resolveFromRepository(request, candidates);
-
-        // If we haven't been able to resolve the plugin from the repository,
-        // as a last resort, we go through all declared plugins, load them
+        PluginPrefixResult result = null;
+        // First, we go through all declared plugins, load them
         // one by one, and try to find a matching prefix.
-        if (result == null && build != null) {
-            result = resolveFromProject(request, build.getPlugins());
-            if (result == null && management != null) {
-                result = resolveFromProject(request, management.getPlugins());
-            }
+        if (build != null) {
+            result = resolveFromProject(
+                    request,
+                    build.getPlugins(),
+                    management != null ? management.getPlugins() : Collections.emptyList());
+        }
+
+        // Second, we use G level metadata to discover prefix
+        // This order allows user managed clashing prefixes (they can declare them in POM)
+        if (result == null) {
+            result = resolveFromRepository(request, candidates);
         }
 
         if (result == null) {
@@ -137,7 +143,28 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
         return result;
     }
 
-    private PluginPrefixResult resolveFromProject(PluginPrefixRequest request, List<Plugin> plugins) {
+    private PluginPrefixResult resolveFromProject(
+            PluginPrefixRequest request, List<Plugin> plugins, List<Plugin> pluginMgmt) {
+        if (plugins.isEmpty() && pluginMgmt.isEmpty()) {
+            return null;
+        }
+        PluginPrefixResult result = null;
+        Set<Plugin> candidates = new LinkedHashSet<>();
+        Stream.concat(plugins.stream(), pluginMgmt.stream())
+                .filter(p -> p.getArtifactId().contains(request.getPrefix()))
+                .forEach(candidates::add);
+        if (!candidates.isEmpty()) {
+            result = doResolveFromProject(request, candidates);
+        }
+        if (result == null) {
+            Set<Plugin> remainder = new LinkedHashSet<>(plugins);
+            remainder.removeAll(candidates);
+            result = doResolveFromProject(request, remainder);
+        }
+        return result;
+    }
+
+    private PluginPrefixResult doResolveFromProject(PluginPrefixRequest request, Collection<Plugin> plugins) {
         for (Plugin plugin : plugins) {
             try {
                 PluginDescriptor pluginDescriptor =


### PR DESCRIPTION
Port of #11908 from maven-3.10.x to master. Fixes #11905 on Maven 4.x.

Changes plugin prefix resolution order: resolve from project-declared plugins first (user intent takes priority), then fall back to repository metadata. Also adds heuristics to prioritize plugins whose artifactId matches the prefix.

Original fix by @cstamas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)