### PR TITLE
[#11683] Install JUL-to-SLF4J bridge to route java.util.logging through Maven logging

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -78,6 +78,13 @@ under the License.
       <version>${slf4jVersion}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- bridge from java.util.logging (JUL) to SLF4J -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-connector-basic</artifactId>

--- a/impl/maven-cli/pom.xml
+++ b/impl/maven-cli/pom.xml
@@ -196,6 +196,10 @@ under the License.
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -429,9 +429,10 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
     }
 
     protected void activateLogging(C context) throws Exception {
-        // Route java.util.logging (JUL) through SLF4J
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+        }
 
         context.slf4jConfiguration.activate();
         if (context.options().failOnSeverity().isPresent()) {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -90,6 +90,7 @@ import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.impl.AbstractPosixTerminal;
 import org.jline.terminal.spi.TerminalExt;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.slf4j.spi.LocationAwareLogger;
 
 import static java.util.Objects.requireNonNull;
@@ -428,6 +429,10 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
     }
 
     protected void activateLogging(C context) throws Exception {
+        // Route java.util.logging (JUL) through SLF4J
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+
         context.slf4jConfiguration.activate();
         if (context.options().failOnSeverity().isPresent()) {
             String logLevelThreshold = context.options().failOnSeverity().get();

--- a/pom.xml
+++ b/pom.xml
@@ -507,6 +507,11 @@ under the License.
         <optional>true</optional>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4jVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logbackClassicVersion}</version>


### PR DESCRIPTION
## Summary
- Adds the `jul-to-slf4j` bridge dependency so that libraries using `java.util.logging` (JUL) have their log output routed through SLF4J and Maven's logging system, instead of writing directly to stderr.
- Installs `SLF4JBridgeHandler` in `LookupInvoker.activateLogging()`, following the same pattern as the existing `jcl-over-slf4j` and `slf4j-jdk-platform-logging` bridges.

Fixes #11683

## Changes
- **pom.xml**: Added `jul-to-slf4j` to dependency management
- **apache-maven/pom.xml**: Added `jul-to-slf4j` as runtime dependency in the distribution
- **impl/maven-cli/pom.xml**: Added `jul-to-slf4j` compile dependency
- **LookupInvoker.java**: Installed `SLF4JBridgeHandler` during logging activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)