### PR TITLE
[#11683] Install JUL-to-SLF4J bridge to route java.util.logging through Maven logging

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -70,6 +70,13 @@ under the License.
       <version>${slf4jVersion}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- bridge from java.util.logging (JUL) to SLF4J -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-connector-basic</artifactId>

--- a/impl/maven-cli/pom.xml
+++ b/impl/maven-cli/pom.xml
@@ -196,6 +196,10 @@ under the License.
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -90,6 +90,7 @@ import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.impl.AbstractPosixTerminal;
 import org.jline.terminal.spi.TerminalExt;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.slf4j.spi.LocationAwareLogger;
 
 import static java.util.Objects.requireNonNull;
@@ -428,6 +429,9 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
     }
 
     protected void activateLogging(C context) throws Exception {
+        // Route java.util.logging (JUL) through SLF4J
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
         context.slf4jConfiguration.activate();
         if (context.options().failOnSeverity().isPresent()) {
             String logLevelThreshold = context.options().failOnSeverity().get();

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -429,9 +429,10 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
     }
 
     protected void activateLogging(C context) throws Exception {
-        // Route java.util.logging (JUL) through SLF4J
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+        }
         context.slf4jConfiguration.activate();
         if (context.options().failOnSeverity().isPresent()) {
             String logLevelThreshold = context.options().failOnSeverity().get();

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/LookupInvokerLoggingTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/LookupInvokerLoggingTest.java
@@ -19,15 +19,20 @@
 package org.apache.maven.cling.invoker;
 
 import java.util.Optional;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
 
 import org.apache.maven.api.Constants;
 import org.apache.maven.cling.logging.Slf4jConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for logging configuration behavior in LookupInvoker.
@@ -119,6 +124,83 @@ class LookupInvokerLoggingTest {
         // Verify that setRootLoggerLevel was called
         assertEquals(1, slf4jConfiguration.setRootLoggerLevelCallCount);
         assertEquals(Slf4jConfiguration.Level.ERROR, slf4jConfiguration.lastSetLevel);
+    }
+
+    // --- JUL-to-SLF4J bridge tests (GH-11683) ---
+
+    @Test
+    void testJulBridgeIsInstalledDuringActivateLogging() {
+        // Ensure clean state
+        SLF4JBridgeHandler.uninstall();
+        assertFalse(SLF4JBridgeHandler.isInstalled(), "Bridge should not be installed before test");
+
+        // Simulate what activateLogging() does
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+        }
+
+        assertTrue(SLF4JBridgeHandler.isInstalled(), "SLF4JBridgeHandler should be installed after activateLogging");
+
+        // Clean up
+        SLF4JBridgeHandler.uninstall();
+    }
+
+    @Test
+    void testJulBridgeIsNotReinstalledWhenAlreadyPresent() {
+        // Install the bridge first
+        SLF4JBridgeHandler.uninstall();
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+        assertTrue(SLF4JBridgeHandler.isInstalled());
+
+        // Record the handlers before the second call
+        Logger rootLogger = Logger.getLogger("");
+        Handler[] handlersBefore = rootLogger.getHandlers();
+
+        // Simulate a second activateLogging() call — the guard should skip re-installation
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+        }
+
+        // Handlers should be the same objects — no removal/reinstall occurred
+        Handler[] handlersAfter = rootLogger.getHandlers();
+        assertEquals(handlersBefore.length, handlersAfter.length, "Handler count should not change on second call");
+        for (int i = 0; i < handlersBefore.length; i++) {
+            assertTrue(
+                    handlersBefore[i] == handlersAfter[i],
+                    "Handler instance at index " + i + " should be the same object (no reinstall)");
+        }
+
+        // Clean up
+        SLF4JBridgeHandler.uninstall();
+    }
+
+    @Test
+    void testJulMessagesAreRoutedThroughSlf4j() {
+        // Install the bridge
+        SLF4JBridgeHandler.uninstall();
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+
+        // Verify a JUL logger's handlers now include SLF4JBridgeHandler
+        Logger rootLogger = Logger.getLogger("");
+        boolean hasBridgeHandler = false;
+        for (Handler handler : rootLogger.getHandlers()) {
+            if (handler instanceof SLF4JBridgeHandler) {
+                hasBridgeHandler = true;
+                break;
+            }
+        }
+        assertTrue(hasBridgeHandler, "Root JUL logger should have SLF4JBridgeHandler installed");
+
+        // Verify that logging through JUL does not throw (bridge is functional)
+        Logger julLogger = Logger.getLogger("org.apache.maven.test.jul");
+        julLogger.info("Test message routed through SLF4J bridge");
+
+        // Clean up
+        SLF4JBridgeHandler.uninstall();
     }
 
     // Mock classes for testing

--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,11 @@ under the License.
         <optional>true</optional>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4jVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logbackClassicVersion}</version>


### PR DESCRIPTION
## Summary

Backport of the JUL-to-SLF4J bridge fix to the `maven-4.0.x` branch.

Libraries that use `java.util.logging` (JUL) currently write their log output directly to `stderr`, bypassing Maven's logging configuration. This PR adds the `jul-to-slf4j` bridge so that JUL output is routed through SLF4J and Maven's logging system.

### Changes

- **pom.xml**: Add `jul-to-slf4j` to dependency management
- **apache-maven/pom.xml**: Add `jul-to-slf4j` as a runtime dependency
- **impl/maven-cli/pom.xml**: Add `jul-to-slf4j` dependency
- **LookupInvoker.java**: Install `SLF4JBridgeHandler` at the start of `activateLogging()` to redirect JUL to SLF4J

## Test plan

- [x] Verify build compiles with the new dependency
- [ ] Run Maven with a plugin/library that uses JUL and confirm its log output goes through Maven's logging instead of raw stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)