### PR TITLE
Forward-port #11985: remove redundant required MDO attrs + add extension coordinate validation (#11979)

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -133,7 +133,6 @@
         <field xdoc.separator="blank">
           <name>groupId</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description>
             A universally unique identifier for a project. It is normal to
             use a fully-qualified package name to distinguish it from other
@@ -154,7 +153,6 @@
         <field>
           <name>version</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>The current version of the artifact produced by this project.</description>
           <type>String</type>
         </field>
@@ -181,8 +179,7 @@
         <field xdoc.separator="blank">
           <name>name</name>
           <version>3.0.0+</version>
-          <required>true</required>
-          <description>The full name of the project.</description>
+          <description>The full name of the project. If not specified, the artifactId will be used.</description>
           <type>String</type>
         </field>
         <field>
@@ -247,7 +244,6 @@
         <field>
           <name>inceptionYear</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description>The year of the project's inception, specified with 4 digits. This value is
             used when generating copyright notices as well as being informational.</description>
           <type>String</type>
@@ -369,7 +365,6 @@
         <field xdoc.separator="blank" xml.insertParentFieldsUpTo="pluginRepositories">
           <name>build</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description>Information required to build the project.</description>
           <association>
             <type>Build</type>
@@ -906,7 +901,6 @@
         <field>
           <name>sourceDirectory</name>
           <version>3.0.0+</version>
-          <required>true</required>
           <description>
             This element specifies a directory containing the source of the project. The
             generated build system will compile the sources from this directory when the project is
@@ -923,7 +917,6 @@
         <field>
           <name>scriptSourceDirectory</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>
             This element specifies a directory containing the script sources of the
             project. This directory is meant to be different from the sourceDirectory, in that its
@@ -943,7 +936,6 @@
         <field>
           <name>testSourceDirectory</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>
             This element specifies a directory containing the unit test source of the
             project. The generated build system will compile these directories when the project is
@@ -2969,7 +2961,6 @@
       <fields>
         <field>
           <name>id</name>
-          <required>true</required>
           <version>4.0.0+</version>
           <type>String</type>
           <defaultValue>default</defaultValue>
@@ -2989,7 +2980,6 @@
         <field xml.tagName="build">
           <name>build</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>Information required to build the project.</description>
           <association>
             <type>BuildBase</type>
@@ -3328,7 +3318,6 @@
           <name>groupId</name>
           <version>4.0.0+</version>
           <type>String</type>
-          <required>true</required>
           <defaultValue>org.apache.maven.plugins</defaultValue>
           <description>The group ID of the reporting plugin in the repository.</description>
         </field>
@@ -3422,7 +3411,6 @@
         <field>
           <name>id</name>
           <type>String</type>
-          <required>true</required>
           <description>The unique id for this report set, to be used during POM inheritance and profile injection
             for merging of report sets.
           </description>
@@ -3431,7 +3419,6 @@
         <field>
           <name>reports</name>
           <version>4.0.0+</version>
-          <required>true</required>
           <description>The list of reports from this plugin which should be generated from this set.</description>
           <association>
             <type>String</type>

--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -179,7 +179,7 @@
         <field xdoc.separator="blank">
           <name>name</name>
           <version>3.0.0+</version>
-          <description>The full name of the project. If not specified, the artifactId will be used.</description>
+          <description>The full name of the project.</description>
           <type>String</type>
         </field>
         <field>

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -966,4 +966,16 @@ class DefaultModelValidatorTest {
                     "Concurrent validation failed: " + failure.get().getMessage(), failure.get());
         }
     }
+
+    @Test
+    void testMinimalWithParent() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/minimal-with-parent.xml");
+        assertViolations(result, 0, 0, 0);
+    }
+
+    @Test
+    void testMinimalWithoutParent() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/minimal-without-parent.xml");
+        assertViolations(result, 0, 0, 0);
+    }
 }

--- a/compat/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-with-parent.xml
+++ b/compat/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-with-parent.xml
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.validation</groupId>
+    <artifactId>parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>project</artifactId>
+
+</project>

--- a/compat/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-without-parent.xml
+++ b/compat/maven-model-builder/src/test/resources/poms/validation/raw-model/minimal-without-parent.xml
@@ -1,0 +1,29 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>groupId</groupId>
+  <artifactId>project</artifactId>
+  <version>project</version>
+
+</project>

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -632,7 +632,6 @@ public class MavenProject implements Cloneable {
     }
 
     public String getName() {
-        // TODO this should not be allowed to be null.
         if (getModel().getName() != null) {
             return getModel().getName();
         } else {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -55,6 +55,7 @@ import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.DistributionManagement;
 import org.apache.maven.api.model.Exclusion;
+import org.apache.maven.api.model.Extension;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputLocationTracker;
 import org.apache.maven.api.model.Model;
@@ -1066,6 +1067,24 @@ public class DefaultModelValidator implements ModelValidator {
                             plugin);
 
                     validate20EffectivePluginDependencies(problems, plugin, validationLevel);
+                }
+
+                for (Extension extension : build.getExtensions()) {
+                    validateStringNotEmpty(
+                            "build.extensions.extension.groupId",
+                            problems,
+                            Severity.WARNING,
+                            Version.V20,
+                            extension.getGroupId(),
+                            extension);
+
+                    validateStringNotEmpty(
+                            "build.extensions.extension.artifactId",
+                            problems,
+                            Severity.WARNING,
+                            Version.V20,
+                            extension.getArtifactId(),
+                            extension);
                 }
 
                 validate20RawResources(problems, build.getResources(), "build.resources.resource.", validationLevel);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -1022,4 +1022,26 @@ class DefaultModelValidatorTest {
                 "raw-model/profile-activation-condition-with-basedir.xml", ModelValidator.VALIDATION_LEVEL_STRICT);
         assertViolations(result, 0, 0, 0);
     }
+
+    @Test
+    void testMissingExtensionCoordinates() throws Exception {
+        SimpleProblemCollector result = validate("missing-extension-coordinates.xml");
+
+        assertViolations(result, 0, 0, 2);
+
+        assertContains(result.getWarnings().get(0), "'build.extensions.extension.groupId' is missing.");
+        assertContains(result.getWarnings().get(1), "'build.extensions.extension.artifactId' is missing.");
+    }
+
+    @Test
+    void minimalWithParent() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/minimal-with-parent.xml");
+        assertViolations(result, 0, 0, 0);
+    }
+
+    @Test
+    void minimalWithoutParent() throws Exception {
+        SimpleProblemCollector result = validateRaw("raw-model/minimal-without-parent.xml");
+        assertViolations(result, 0, 0, 0);
+    }
 }

--- a/impl/maven-impl/src/test/resources/poms/validation/missing-extension-coordinates.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/missing-extension-coordinates.xml
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>foo</artifactId>
+  <groupId>foo</groupId>
+  <version>99.44</version>
+  <packaging>jar</packaging>
+  <build>
+    <extensions>
+      <extension>
+        <version>1.0</version>
+      </extension>
+    </extensions>
+  </build>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/minimal-with-parent.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/minimal-with-parent.xml
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.validation</groupId>
+    <artifactId>parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>project</artifactId>
+
+</project>

--- a/impl/maven-impl/src/test/resources/poms/validation/raw-model/minimal-without-parent.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/raw-model/minimal-without-parent.xml
@@ -1,0 +1,29 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>groupId</groupId>
+  <artifactId>project</artifactId>
+  <version>project</version>
+
+</project>


### PR DESCRIPTION
Forward-port of PR #11985 from maven-3.10.x to master, plus extension coordinate validation.

## Changes

### MDO annotation cleanup (forward-port of #11985)
Removes `<required>true</required>` from 13 fields in `maven.mdo` that were never validated and whose enforcement would break existing POMs. Updates `Model.name` description to document artifactId fallback.

### Extension coordinate validation (new)
Adds WARNING-level validation for missing `build.extensions.extension.groupId` and `build.extensions.extension.artifactId` in `DefaultModelValidator`. These were the most actionable validation gaps identified in #11979.

### Tests
- Unit tests for extension coordinate validation (missing-extension-coordinates.xml)
- Minimal POM validation tests (with/without parent)

Fixes #11979