### PR TITLE
[MNG-8650] Fix MAVEN_ARGS backslash stripping on Windows

### DIFF
--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -286,15 +286,14 @@ cmd="\"$JAVACMD\" \
   \"-Dmaven.mainClass=$MAVEN_MAIN_CLASS\" \
   \"-Dlibrary.jline.path=${MAVEN_HOME}/lib/jline-native\" \
   \"-Dmaven.multiModuleProjectDirectory=$MAVEN_PROJECTBASEDIR\" \
-  $LAUNCHER_CLASS \
-  $MAVEN_ARGS"
+  $LAUNCHER_CLASS"
 
 if [ -n "$MAVEN_DEBUG_SCRIPT" ]; then
   echo "[DEBUG] Launching JVM with command:" >&2
-  printf '[DEBUG]   %s' "$cmd" >&2; printf ' "%s"' "$@" >&2; echo >&2
+  printf '[DEBUG]   %s' "$cmd" >&2; printf ' %s' "$MAVEN_ARGS" >&2; printf ' "%s"' "$@" >&2; echo >&2
 fi
 
-# User arguments ("$@") are passed directly to preserve literal values
-# like ${...} Maven property placeholders without shell expansion.
-# Only the base command uses eval for MAVEN_OPTS word splitting.
-eval exec "$cmd" '"$@"'
+# User arguments ("$@") and MAVEN_ARGS are passed outside the eval'd string
+# to preserve literal values (backslashes, ${...} placeholders) without
+# shell re-parsing. Only the base command uses eval for MAVEN_OPTS word splitting.
+eval exec "$cmd" '$MAVEN_ARGS' '"$@"'


### PR DESCRIPTION
Fixes #11487

## Summary

- Move `$MAVEN_ARGS` out of the `eval`'d `cmd` string in the `mvn` launcher script
- The variable reference is now single-quoted (`'$MAVEN_ARGS'`) on the `eval` line, so `eval` expands it as a normal variable rather than re-parsing the already-expanded value — preserving backslashes
- Same approach used for `"$@"` in PR #11983

## Root cause

`eval exec "$cmd"` re-parses the expanded string. When `$MAVEN_ARGS` was embedded in `cmd` at assignment time, its value became literal text in the `eval`'d string, causing backslashes (e.g. Windows paths like `C:\Users\...`) to be interpreted as escape characters and stripped.

## Test plan

- [ ] Set `MAVEN_ARGS="-Dfoo=C:\path\to\file"` and verify the property value reaches Maven with backslashes intact
- [ ] Verify `MAVEN_OPTS` with quoted values still works correctly (eval still handles those)
- [ ] Verify `MAVEN_ARGS` with multiple space-separated arguments still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)