### PR TITLE
[#12353] Add jaxb2-maven-plugin to mvnup plugin upgrade list

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -97,7 +97,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID,
                     "maven-resources-plugin",
                     "3.3.1",
-                    "Beta/RC versions compiled against different Maven 4 API signatures"));
+                    "Beta/RC versions compiled against different Maven 4 API signatures"),
+            new PluginUpgrade(
+                    "org.codehaus.mojo",
+                    "jaxb2-maven-plugin",
+                    "3.2.0",
+                    "Versions before 3.2.0 depend on jaxb-parent:3.0.0 which contains invalid XML rejected by Maven 4"));
 
     private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
             "org.codehaus.mojo",
@@ -270,6 +275,9 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         upgrades.put(
                 DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-resources-plugin",
                 new PluginUpgradeInfo(DEFAULT_MAVEN_PLUGIN_GROUP_ID, "maven-resources-plugin", "3.3.1"));
+        upgrades.put(
+                "org.codehaus.mojo:jaxb2-maven-plugin",
+                new PluginUpgradeInfo("org.codehaus.mojo", "jaxb2-maven-plugin", "3.2.0"));
         return upgrades;
     }
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -431,6 +431,45 @@ class PluginUpgradeStrategyTest {
         }
 
         @Test
+        @DisplayName("should upgrade jaxb2-maven-plugin when below minimum")
+        void shouldUpgradeJaxb2MavenPluginWhenBelowMinimum() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>jaxb2-maven-plugin</artifactId>
+                                <version>3.1.0</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Plugin upgrade should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have upgraded jaxb2-maven-plugin");
+
+            Editor editor = new Editor(document);
+            Element root = editor.root();
+            String version = root.path("build", "plugins", "plugin", "version")
+                    .map(Element::textContentTrimmed)
+                    .orElse(null);
+            assertEquals("3.2.0", version);
+        }
+
+        @Test
         @DisplayName("should not upgrade when version is already higher")
         void shouldNotUpgradeWhenVersionAlreadyHigher() throws Exception {
             String pomXml = """


### PR DESCRIPTION
## Summary

- Add `jaxb2-maven-plugin` (min version 3.2.0) to the mvnup plugin upgrade list
- `jaxb2-maven-plugin` versions before 3.2.0 depend on `jaxb-parent:3.0.0` which contains `<Xlint:all />` — an element with an undeclared namespace prefix that Maven 4's namespace-aware StAX parser rejects
- This causes transitive dependencies (`jaxb-core`, `jaxb-impl`) to be lost from the plugin classrealm, resulting in `ClassNotFoundException` at runtime
- `jaxb-parent:3.0.2` (used by `jaxb2-maven-plugin` 3.2.0+) fixed the invalid XML upstream

## Test plan

- [x] Added unit test verifying `jaxb2-maven-plugin` 3.1.0 gets upgraded to 3.2.0
- [x] All 31 `PluginUpgradeStrategyTest` tests pass
- [x] Verified end-to-end: `jaxb2-maven-plugin:3.1.0` fails on Maven 4 SNAPSHOT, `3.2.0` succeeds

Closes #12353

🤖 Generated with [Claude Code](https://claude.com/claude-code)