### PR TITLE
[#11449] Fix Mockito agent: use late binding @{} interpolation and extend to failsafe plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,8 @@ under the License.
     <woodstoxVersion>7.2.1</woodstoxVersion>
     <xmlunitVersion>2.12.0</xmlunitVersion>
     <jacocoArgLine />
+    <argLine.xmx>-Xmx256m</argLine.xmx>
+    <argLine.mockito />
 
     <!-- Set as system property in surefire/failsafe to propagate to tests and IT Verifier -->
     <toolboxVersion>0.14.1</toolboxVersion>
@@ -697,7 +699,7 @@ under the License.
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
-            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <argLine>${argLine.xmx} @{jacocoArgLine} ${argLine.mockito}</argLine>
             <systemPropertyVariables combine.children="append">
               <version.toolbox>${toolboxVersion}</version.toolbox>
             </systemPropertyVariables>
@@ -708,7 +710,7 @@ under the License.
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
             <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
-            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <argLine>${argLine.xmx} @{jacocoArgLine} ${argLine.mockito}</argLine>
             <systemPropertyVariables combine.children="append">
               <version.toolbox>${toolboxVersion}</version.toolbox>
             </systemPropertyVariables>
@@ -945,26 +947,9 @@ under the License.
           <name>org.mockito:mockito-core:jar</name>
         </property>
       </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <argLine>-Xmx256m @{jacocoArgLine} -javaagent:@{org.mockito:mockito-core:jar}</argLine>
-              </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <argLine>-Xmx256m @{jacocoArgLine} -javaagent:@{org.mockito:mockito-core:jar}</argLine>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
+      <properties>
+        <argLine.mockito>-javaagent:@{org.mockito:mockito-core:jar}</argLine.mockito>
+      </properties>
     </profile>
     <profile>
       <id>graph</id>
@@ -1218,13 +1203,15 @@ under the License.
     </profile>
     <profile>
       <id>jacoco</id>
+      <properties>
+        <argLine.xmx>-Xmx1G</argLine.xmx>
+      </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-Xmx1G @{jacocoArgLine}</argLine>
               <reportsDirectory>${project.build.directory}/test-results-surefire</reportsDirectory>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -952,7 +952,14 @@ under the License.
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
-                <argLine>-Xmx256m -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                <argLine>-Xmx256m @{jacocoArgLine} -javaagent:@{org.mockito:mockito-core:jar}</argLine>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <argLine>-Xmx256m @{jacocoArgLine} -javaagent:@{org.mockito:mockito-core:jar}</argLine>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
The mockito profile activated by dependency:properties used Maven property interpolation (\) which resolves at POM parse time - before the dependency:properties goal runs and sets the org.mockito:mockito-core:jar property. This caused the javaagent path to remain unresolved.

Fix: use Surefire/Failsafe late-binding property interpolation (@{...}) which resolves the property at test execution time, after dependency:properties has already set it.

Also:
- Restore @{jacocoArgLine} placeholder (was dropped in previous attempt)
- Extend the profile to cover maven-failsafe-plugin as well

Fixes: https://github.com/apache/maven/issues/11449

<!--
Please open pull requests against one of the following branches:

- master — default target for all changes (new features + bug fixes).  
  If the change should also go to maven-4.0.x, request a backport in the PR.

- maven-3.10.x — target for 3.x changes (new features + bug fixes).  
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.

Backports are typically handled by maintainers; 
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)