### PR TITLE
Fix Spotless formatting in DefaultModelBuilder (#12352)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1762,8 +1762,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                                     .build();
                         } catch (ModelBuilderException e) {
                             logger.debug(
-                                    "Could not read root model properties for CI-friendly version interpolation",
-                                    e);
+                                    "Could not read root model properties for CI-friendly version interpolation", e);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Fix the remaining Spotless formatting violation in `DefaultModelBuilder.java` that was causing CI failure on PR #12352
- The exception argument `e` in the `logger.debug()` call needed to be on the same line as the message string, not on a separate line

## Test plan
- [x] `mvn spotless:check` passes locally on maven-impl module
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)