### PR TITLE
Try to use RAT 0.18 - help needed with Maven project structure

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,4 +2,4 @@ Apache Maven
 Copyright 2001-2026 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -372,7 +372,7 @@ under the License.
                   <pluginExecutionFilter>
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
-                    <versionRange>[0.11,)</versionRange>
+                    <versionRange>[0.18,)</versionRange>
                     <goals>
                       <goal>check</goal>
                     </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -810,25 +810,29 @@ under the License.
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
+          <version>0.18</version><!-- Remove if correct version comes from parent -->
           <configuration>
-            <excludes>
+            <inputExcludeStds>
+              <exclude>ALL</exclude>
+            </inputExcludeStds>
+            <inputExcludeParsedScm>GIT</inputExcludeParsedScm>
+            <inputExcludes>
               <exclude>Jenkinsfile</exclude>
               <exclude>**/.gitattributes</exclude>
-              <exclude>src/main/resources/META-INF/services/**</exclude>
+              <exclude>src/main/resources/META-INF/services</exclude>
               <exclude>src/test/resources*/**</exclude>
-              <exclude>src/test/projects/**</exclude>
-              <exclude>src/test/remote-repo/**</exclude>
-              <exclude>its/**</exclude>
+              <exclude>src/test/projects</exclude>
+              <exclude>src/test/remote-repo</exclude>
+              <exclude>its</exclude>
               <exclude>**/*.odg</exclude>
               <exclude>**/*.svg</exclude>
               <exclude>.asf.yaml</exclude>
-              <exclude>.mvn/**</exclude>
-              <exclude>.jbang/**</exclude>
+              <exclude>.jbang</exclude>
               <!--
                 ! Excluded the license files itself cause they do not have a license of themselves.
               -->
               <exclude>src/main/appended-resources/licenses/**</exclude>
-            </excludes>
+            </inputExcludes>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -810,7 +810,8 @@ under the License.
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.18</version><!-- Remove if correct version comes from parent -->
+          <version>0.18</version>
+          <!-- Remove if correct version comes from parent -->
           <configuration>
             <inputExcludeStds>
               <exclude>ALL</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -810,8 +810,8 @@ under the License.
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.18</version>
           <!-- Remove if correct version comes from parent -->
+          <version>0.18</version>
           <configuration>
             <inputExcludeStds>
               <exclude>ALL</exclude>


### PR DESCRIPTION
Trying to add configuration for RAT 0.18, but the basic scan does not pass and reports many thousand new unlicensed files .... as I'm not sure about the Maven project layout I don't know where RAT is configured for the whole project.

Can you help out? @slachiewicz @slawekjaranowski 