### PR TITLE
reject path-traversal segments in coordinate ids and versions

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -1151,6 +1151,9 @@ public class DefaultModelValidator implements ModelValidator {
     }
 
     private boolean isValidId(String id) {
+        if (isPathTraversalSegment(id)) {
+            return false;
+        }
         for (int i = 0; i < id.length(); i++) {
             char c = id.charAt(i);
             if (!isValidIdCharacter(c)) {
@@ -1158,6 +1161,15 @@ public class DefaultModelValidator implements ModelValidator {
             }
         }
         return true;
+    }
+
+    /**
+     * An id or version made up only of {@code .} or {@code ..} is a filesystem path-traversal segment. The dotted
+     * characters pass the allowed-character checks yet map straight to a directory component when the value is turned
+     * into a local repository path, so such values are rejected here.
+     */
+    private static boolean isPathTraversalSegment(String id) {
+        return ".".equals(id) || "..".equals(id);
     }
 
     private boolean isValidIdCharacter(char c) {
@@ -1193,6 +1205,9 @@ public class DefaultModelValidator implements ModelValidator {
     }
 
     private boolean isValidIdWithWildCards(String id) {
+        if (isPathTraversalSegment(id)) {
+            return false;
+        }
         for (int i = 0; i < id.length(); i++) {
             char c = id.charAt(i);
             if (!isValidIdWithWildCardCharacter(c)) {
@@ -1633,6 +1648,18 @@ public class DefaultModelValidator implements ModelValidator {
         }
 
         if (hasExpression(string)) {
+            addViolation(
+                    problems,
+                    severity,
+                    version,
+                    prefix + fieldName,
+                    sourceHint,
+                    "must be a valid version but is '" + string + "'.",
+                    tracker);
+            return false;
+        }
+
+        if (isPathTraversalSegment(string)) {
             addViolation(
                     problems,
                     severity,

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -1164,9 +1164,10 @@ public class DefaultModelValidator implements ModelValidator {
     }
 
     /**
-     * An id or version made up only of {@code .} or {@code ..} is a filesystem path-traversal segment. The dotted
-     * characters pass the allowed-character checks yet map straight to a directory component when the value is turned
-     * into a local repository path, so such values are rejected here.
+     * {@code .} and {@code ..} pass the allowed-character checks, but the default local repository layout uses
+     * ids and versions verbatim as directory names, so these values map onto the {@code .} and {@code ..}
+     * filesystem path segments and escape the coordinate's directory. They are rejected because of that mapping,
+     * not because the names themselves are otherwise invalid.
      */
     private static boolean isPathTraversalSegment(String id) {
         return ".".equals(id) || "..".equals(id);

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -181,6 +181,22 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testCoordinateIdsWithPathTraversal() throws Exception {
+        SimpleProblemCollector result = validate("coordinate-ids-path-traversal-pom.xml");
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m -> m.contains("'artifactId'") && m.contains("does not match a valid id pattern")),
+                "artifactId '..' must be rejected: " + result.getErrors());
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m ->
+                                m.contains("dependencies.dependency.version") && m.contains("must be a valid version")),
+                "dependency version '..' must be rejected: " + result.getErrors());
+    }
+
+    @Test
     void testMissingType() throws Exception {
         SimpleProblemCollector result = validate("missing-type-pom.xml");
 

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -197,6 +197,27 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testCoordinateIdsWithSingleDotPathTraversal() throws Exception {
+        SimpleProblemCollector result = validate("coordinate-ids-path-traversal-dot-pom.xml");
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m -> m.contains("'groupId'") && m.contains("does not match a valid id pattern")),
+                "groupId '..' must be rejected: " + result.getErrors());
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m -> m.contains("'artifactId'") && m.contains("does not match a valid id pattern")),
+                "artifactId '.' must be rejected: " + result.getErrors());
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m ->
+                                m.contains("dependencies.dependency.version") && m.contains("must be a valid version")),
+                "dependency version '.' must be rejected: " + result.getErrors());
+    }
+
+    @Test
     void testMissingType() throws Exception {
         SimpleProblemCollector result = validate("missing-type-pom.xml");
 

--- a/compat/maven-model-builder/src/test/resources/poms/validation/coordinate-ids-path-traversal-dot-pom.xml
+++ b/compat/maven-model-builder/src/test/resources/poms/validation/coordinate-ids-path-traversal-dot-pom.xml
@@ -1,0 +1,34 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>..</groupId>
+  <artifactId>.</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>other.group</groupId>
+      <artifactId>lib</artifactId>
+      <version>.</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/compat/maven-model-builder/src/test/resources/poms/validation/coordinate-ids-path-traversal-pom.xml
+++ b/compat/maven-model-builder/src/test/resources/poms/validation/coordinate-ids-path-traversal-pom.xml
@@ -1,0 +1,34 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test.group</groupId>
+  <artifactId>..</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>other.group</groupId>
+      <artifactId>lib</artifactId>
+      <version>..</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1790,6 +1790,9 @@ public class DefaultModelValidator implements ModelValidator {
     }
 
     private boolean isValidCoordinatesId(String id) {
+        if (isPathTraversalSegment(id)) {
+            return false;
+        }
         for (int index = 0; index < id.length(); index++) {
             char character = id.charAt(index);
             if (!isValidCoordinatesIdCharacter(character)) {
@@ -1797,6 +1800,15 @@ public class DefaultModelValidator implements ModelValidator {
             }
         }
         return true;
+    }
+
+    /**
+     * A coordinate id or version made up only of {@code .} or {@code ..} is a filesystem path-traversal segment.
+     * The dotted characters pass the allowed-character checks yet map straight to a directory component when the
+     * value is turned into a local repository path, so such values are rejected here.
+     */
+    private static boolean isPathTraversalSegment(String id) {
+        return ".".equals(id) || "..".equals(id);
     }
 
     private boolean isValidCoordinatesIdCharacter(char character) {
@@ -1879,6 +1891,9 @@ public class DefaultModelValidator implements ModelValidator {
     }
 
     private boolean isValidCoordinatesIdWithWildCards(String id) {
+        if (isPathTraversalSegment(id)) {
+            return false;
+        }
         for (int index = 0; index < id.length(); index++) {
             char character = id.charAt(index);
             if (!isValidCoordinatesIdWithWildCardCharacter(character)) {
@@ -2331,6 +2346,18 @@ public class DefaultModelValidator implements ModelValidator {
         }
 
         if (hasExpression(string)) {
+            addViolation(
+                    problems,
+                    severity,
+                    version,
+                    prefix + fieldName,
+                    sourceHint,
+                    "must be a valid version but is '" + string + "'.",
+                    tracker);
+            return false;
+        }
+
+        if (isPathTraversalSegment(string)) {
             addViolation(
                     problems,
                     severity,

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1803,9 +1803,10 @@ public class DefaultModelValidator implements ModelValidator {
     }
 
     /**
-     * A coordinate id or version made up only of {@code .} or {@code ..} is a filesystem path-traversal segment.
-     * The dotted characters pass the allowed-character checks yet map straight to a directory component when the
-     * value is turned into a local repository path, so such values are rejected here.
+     * {@code .} and {@code ..} pass the allowed-character checks, but the default local repository layout uses
+     * coordinate ids and versions verbatim as directory names, so these values map onto the {@code .} and
+     * {@code ..} filesystem path segments and escape the coordinate's directory. They are rejected because of
+     * that mapping, not because the names themselves are otherwise invalid.
      */
     private static boolean isPathTraversalSegment(String id) {
         return ".".equals(id) || "..".equals(id);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -225,6 +225,23 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testCoordinateIdsWithPathTraversal() throws Exception {
+        SimpleProblemCollector result = validate("coordinate-ids-path-traversal-pom.xml");
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m -> m.contains("'artifactId'")
+                                && m.contains("does not match a valid coordinate id pattern")),
+                "artifactId '..' must be rejected: " + result.getErrors());
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m ->
+                                m.contains("dependencies.dependency.version") && m.contains("must be a valid version")),
+                "dependency version '..' must be rejected: " + result.getErrors());
+    }
+
+    @Test
     void testMissingType() throws Exception {
         SimpleProblemCollector result = validate("missing-type-pom.xml");
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -242,6 +242,29 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testCoordinateIdsWithSingleDotPathTraversal() throws Exception {
+        SimpleProblemCollector result = validate("coordinate-ids-path-traversal-dot-pom.xml");
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m ->
+                                m.contains("'groupId'") && m.contains("does not match a valid coordinate id pattern")),
+                "groupId '..' must be rejected: " + result.getErrors());
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m -> m.contains("'artifactId'")
+                                && m.contains("does not match a valid coordinate id pattern")),
+                "artifactId '.' must be rejected: " + result.getErrors());
+
+        assertTrue(
+                result.getErrors().stream()
+                        .anyMatch(m ->
+                                m.contains("dependencies.dependency.version") && m.contains("must be a valid version")),
+                "dependency version '.' must be rejected: " + result.getErrors());
+    }
+
+    @Test
     void testMissingType() throws Exception {
         SimpleProblemCollector result = validate("missing-type-pom.xml");
 

--- a/impl/maven-impl/src/test/resources/poms/validation/coordinate-ids-path-traversal-dot-pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/coordinate-ids-path-traversal-dot-pom.xml
@@ -1,0 +1,34 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>..</groupId>
+  <artifactId>.</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>other.group</groupId>
+      <artifactId>lib</artifactId>
+      <version>.</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/validation/coordinate-ids-path-traversal-pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/coordinate-ids-path-traversal-pom.xml
@@ -1,0 +1,34 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test.group</groupId>
+  <artifactId>..</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>other.group</groupId>
+      <artifactId>lib</artifactId>
+      <version>..</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
Fixes #12427.

Coordinate ids and versions equal to `.` or `..` pass model validation but land as raw directory segments when an artifact is mapped to its local repository path (`groupId/artifactId/version/...`):

- `isValidCoordinatesId`/`isValidId` accept them because every character is individually allowed, so an artifactId of `..` is a path-traversal segment
- `validateVersion` only bans the filesystem metacharacters, so a dependency version of `..` slips through the same way
- same gap in the compat maven-model-builder validator and in the wildcard-id variant

Reject `.` and `..` at each check. Regression test added in both modules; it fails on the unpatched validators and passes after.

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] You have run the Core IT successfully.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

