### PR TITLE
Make LookupContext#closeables thread safe

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
@@ -105,7 +105,7 @@ public class LookupContext implements AutoCloseable {
     public Settings effectiveSettings;
     public PersistedToolchains effectiveToolchains;
 
-    public final List<AutoCloseable> closeables = new ArrayList<>();
+    public final List<AutoCloseable> closeables = Collections.synchronizedList(new ArrayList<>());
 
     @Override
     public void close() throws InvokerException {


### PR DESCRIPTION
This collection is modified by multiple threads, e.g. the FastTerminal setup thread calling context.closeables.add(out::flush). This can result in closeables being lost and can make subsequent builds with the embedded runner fail.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
