### PR TITLE
Make LookupContext#closeables thread safe (backport to 4.0.x)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupContext.java
@@ -105,7 +105,7 @@ public class LookupContext implements AutoCloseable {
     public Settings effectiveSettings;
     public PersistedToolchains effectiveToolchains;
 
-    public final List<AutoCloseable> closeables = new ArrayList<>();
+    public final List<AutoCloseable> closeables = Collections.synchronizedList(new ArrayList<>());
 
     @Override
     public void close() throws InvokerException {


### PR DESCRIPTION
Backport of #12411 to `maven-4.0.x`.

This collection is modified by multiple threads, e.g. the FastTerminal setup thread calling `context.closeables.add(out::flush)`. This can result in closeables being lost and can make subsequent builds with the embedded runner fail.

Cherry-picked from c48ad2012c (master).