### PR TITLE
[#11449] Fix Mockito agent: use late binding @{} interpolation (backport to 4.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,8 @@ under the License.
     <woodstoxVersion>7.2.1</woodstoxVersion>
     <xmlunitVersion>2.12.0</xmlunitVersion>
     <jacocoArgLine />
+    <argLine.xmx>-Xmx256m</argLine.xmx>
+    <argLine.mockito />
 
     <version.spotless-maven-plugin>3.0.0</version.spotless-maven-plugin>
     <version.palantirJavaFormat>2.80.0</version.palantirJavaFormat>
@@ -734,7 +736,7 @@ under the License.
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
-            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <argLine>${argLine.xmx} @{jacocoArgLine} ${argLine.mockito}</argLine>
             <systemPropertyVariables combine.children="append">
               <version.toolbox>${toolboxVersion}</version.toolbox>
             </systemPropertyVariables>
@@ -745,7 +747,7 @@ under the License.
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
             <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
-            <argLine>-Xmx256m @{jacocoArgLine}</argLine>
+            <argLine>${argLine.xmx} @{jacocoArgLine} ${argLine.mockito}</argLine>
             <systemPropertyVariables combine.children="append">
               <version.toolbox>${toolboxVersion}</version.toolbox>
             </systemPropertyVariables>
@@ -982,19 +984,9 @@ under the License.
           <name>org.mockito:mockito-core:jar</name>
         </property>
       </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <argLine>-Xmx256m -javaagent:${org.mockito:mockito-core:jar}</argLine>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
+      <properties>
+        <argLine.mockito>-javaagent:@{org.mockito:mockito-core:jar}</argLine.mockito>
+      </properties>
     </profile>
     <profile>
       <id>graph</id>
@@ -1269,13 +1261,15 @@ under the License.
     </profile>
     <profile>
       <id>jacoco</id>
+      <properties>
+        <argLine.xmx>-Xmx1G</argLine.xmx>
+      </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-Xmx1G @{jacocoArgLine}</argLine>
               <reportsDirectory>${project.build.directory}/test-results-surefire</reportsDirectory>
             </configuration>
           </plugin>


### PR DESCRIPTION
Backport of #12369 to `maven-4.0.x`.

The mockito profile used Maven property interpolation (`${...}`) which resolves at POM parse time — before the `dependency:properties` goal runs and sets the `org.mockito:mockito-core:jar` property. This caused the javaagent path to remain unresolved.

Fix: use Surefire/Failsafe late-binding property interpolation (`@{...}`) which resolves the property at test execution time, after `dependency:properties` has already set it.

Also:
- Restore `@{jacocoArgLine}` placeholder
- Extend the profile to cover `maven-failsafe-plugin` as well

Cherry-picked from 6f4644329f (master).

Fixes: https://github.com/apache/maven/issues/11449