### PR TITLE
[MNG-8425] Fix mvnenc init saving invalid master source configuration

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/goals/Init.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/goals/Init.java
@@ -144,19 +144,12 @@ public class Init extends InteractiveGoalSupport {
                             throw new InterruptedException();
                         }
                         String userInput = editMap.get("edit").getResult();
-                        if (template.contains("$")) {
-                            String prefix = template.substring(0, template.indexOf('$'));
-                            if (!prefix.isEmpty() && !userInput.startsWith(prefix)) {
-                                userInput = prefix + userInput;
-                            }
+                        String prefix = template.substring(0, template.indexOf('$'));
+                        if (!prefix.isEmpty() && !userInput.startsWith(prefix)) {
+                            userInput = prefix + userInput;
                         }
-                        final String finalResult = userInput;
-                        dispatcherConfigResult.put(editable.getKey(), new PromptResultItemIF() {
-                            @Override
-                            public String getResult() {
-                                return finalResult;
-                            }
-                        });
+                        String result = userInput;
+                        dispatcherConfigResult.put(editable.getKey(), () -> result);
                     }
                 }
 

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/goals/Init.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnenc/goals/Init.java
@@ -143,7 +143,20 @@ public class Init extends InteractiveGoalSupport {
                         if (editMap.isEmpty()) {
                             throw new InterruptedException();
                         }
-                        dispatcherConfigResult.put(editable.getKey(), editMap.get("edit"));
+                        String userInput = editMap.get("edit").getResult();
+                        if (template.contains("$")) {
+                            String prefix = template.substring(0, template.indexOf('$'));
+                            if (!prefix.isEmpty() && !userInput.startsWith(prefix)) {
+                                userInput = prefix + userInput;
+                            }
+                        }
+                        final String finalResult = userInput;
+                        dispatcherConfigResult.put(editable.getKey(), new PromptResultItemIF() {
+                            @Override
+                            public String getResult() {
+                                return finalResult;
+                            }
+                        });
                     }
                 }
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnenc/goals/InitTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnenc/goals/InitTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnenc.goals;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.api.cli.InvokerRequest;
+import org.apache.maven.api.cli.mvnenc.EncryptOptions;
+import org.apache.maven.api.services.MessageBuilderFactory;
+import org.apache.maven.cling.invoker.mvnenc.EncryptContext;
+import org.codehaus.plexus.components.secdispatcher.DispatcherMeta;
+import org.codehaus.plexus.components.secdispatcher.SecDispatcher;
+import org.codehaus.plexus.components.secdispatcher.model.Config;
+import org.codehaus.plexus.components.secdispatcher.model.ConfigProperty;
+import org.codehaus.plexus.components.secdispatcher.model.SettingsSecurity;
+import org.jline.consoleui.prompt.ConsolePrompt;
+import org.jline.consoleui.prompt.PromptResultItemIF;
+import org.jline.consoleui.prompt.builder.PromptBuilder;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class InitTest {
+
+    @Test
+    void testPrefixPrependedToUserInput() throws Exception {
+        MessageBuilderFactory messageBuilderFactory = mock(MessageBuilderFactory.class, Mockito.RETURNS_DEEP_STUBS);
+        SecDispatcher secDispatcher = mock(SecDispatcher.class);
+
+        SettingsSecurity settingsSecurity = new SettingsSecurity();
+        when(secDispatcher.readConfiguration(true)).thenReturn(settingsSecurity);
+
+        DispatcherMeta meta = mock(DispatcherMeta.class);
+        when(meta.name()).thenReturn("master");
+        DispatcherMeta.Field field = mock(DispatcherMeta.Field.class);
+        when(field.getKey()).thenReturn("password");
+        when(meta.fields()).thenReturn(Collections.singletonList(field));
+
+        when(secDispatcher.availableDispatchers()).thenReturn(Collections.singleton(meta));
+
+        Init init = new Init(messageBuilderFactory, secDispatcher);
+
+        InvokerRequest invokerRequest = mock(InvokerRequest.class, Mockito.RETURNS_DEEP_STUBS);
+        when(invokerRequest.cwd()).thenReturn(java.nio.file.Paths.get(""));
+        when(invokerRequest.installationDirectory()).thenReturn(java.nio.file.Paths.get(""));
+        when(invokerRequest.userHomeDirectory()).thenReturn(java.nio.file.Paths.get(""));
+        when(invokerRequest.topDirectory()).thenReturn(java.nio.file.Paths.get(""));
+        when(invokerRequest.rootDirectory()).thenReturn(java.util.Optional.empty());
+        EncryptOptions options = mock(EncryptOptions.class);
+        EncryptContext context = new EncryptContext(invokerRequest, options);
+        // avoid null pointers for lists
+        context.header = new java.util.ArrayList<>();
+        context.style = new org.jline.utils.AttributedStyle();
+        org.jline.terminal.Terminal terminal = mock(org.jline.terminal.Terminal.class);
+        java.io.PrintWriter printWriter = mock(java.io.PrintWriter.class);
+        when(terminal.writer()).thenReturn(printWriter);
+        context.terminal = terminal;
+
+        try (MockedConstruction<ConsolePrompt> mockedPrompt =
+                Mockito.mockConstruction(ConsolePrompt.class, (mock, ctx) -> {
+                    PromptBuilder builderMock = mock(PromptBuilder.class, Mockito.RETURNS_DEEP_STUBS);
+                    when(mock.getPromptBuilder()).thenReturn(builderMock);
+
+                    Map<String, PromptResultItemIF> dispatcherResult = new HashMap<>();
+                    dispatcherResult.put("defaultDispatcher", createResult("master"));
+
+                    Map<String, PromptResultItemIF> configureResult = new HashMap<>();
+                    configureResult.put("password", createResult("env:$MVN_PASSWORD"));
+
+                    Map<String, PromptResultItemIF> editResult = new HashMap<>();
+                    editResult.put(
+                            "edit", createResult("my_password_var")); // User inputs "my_password_var" without prefix
+
+                    Map<String, PromptResultItemIF> confirmResult = new HashMap<>();
+                    org.jline.consoleui.prompt.ConfirmResult confirm =
+                            mock(org.jline.consoleui.prompt.ConfirmResult.class);
+                    when(confirm.getConfirmed())
+                            .thenReturn(org.jline.consoleui.elements.ConfirmChoice.ConfirmationValue.YES);
+                    confirmResult.put("confirm", confirm);
+
+                    when(mock.prompt(any(java.util.List.class), any(java.util.List.class)))
+                            .thenReturn(dispatcherResult, configureResult, editResult, confirmResult);
+                })) {
+            init.doExecute(context);
+        }
+
+        // Validate that the SettingsSecurity model has the prepended prefix
+        List<Config> configs = settingsSecurity.getConfigurations();
+        assertEquals(1, configs.size());
+        Config config = configs.get(0);
+        assertEquals("master", config.getName());
+        assertEquals(1, config.getProperties().size());
+        ConfigProperty prop = config.getProperties().get(0);
+        assertEquals("password", prop.getName());
+        // The expected value should be env:my_password_var because the template was env:$MVN_PASSWORD
+        assertEquals("env:my_password_var", prop.getValue());
+    }
+
+    private PromptResultItemIF createResult(String value) {
+        return new PromptResultItemIF() {
+            @Override
+            public String getResult() {
+                return value;
+            }
+        };
+    }
+}

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnenc/goals/InitTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnenc/goals/InitTest.java
@@ -18,10 +18,14 @@
  */
 package org.apache.maven.cling.invoker.mvnenc.goals;
 
+import java.io.PrintWriter;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.maven.api.cli.InvokerRequest;
 import org.apache.maven.api.cli.mvnenc.EncryptOptions;
@@ -32,10 +36,15 @@ import org.codehaus.plexus.components.secdispatcher.SecDispatcher;
 import org.codehaus.plexus.components.secdispatcher.model.Config;
 import org.codehaus.plexus.components.secdispatcher.model.ConfigProperty;
 import org.codehaus.plexus.components.secdispatcher.model.SettingsSecurity;
+import org.jline.consoleui.elements.ConfirmChoice;
+import org.jline.consoleui.prompt.ConfirmResult;
 import org.jline.consoleui.prompt.ConsolePrompt;
 import org.jline.consoleui.prompt.PromptResultItemIF;
 import org.jline.consoleui.prompt.builder.PromptBuilder;
-import org.junit.jupiter.api.Test;
+import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedStyle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 
@@ -46,8 +55,15 @@ import static org.mockito.Mockito.when;
 
 class InitTest {
 
-    @Test
-    void testPrefixPrependedToUserInput() throws Exception {
+    @ParameterizedTest
+    @CsvSource({
+        "env:$MVN_PASSWORD, my_password_var, env:my_password_var",
+        "env:$MVN_PASSWORD, env:my_password_var, env:my_password_var",
+        "system-property:$systemproperty, my_prop, system-property:my_prop",
+        "system-property:$systemproperty, system-property:my_prop, system-property:my_prop",
+        "$VAR, my_var, my_var"
+    })
+    void testPrefixPrependedToUserInput(String template, String userInput, String expectedValue) throws Exception {
         MessageBuilderFactory messageBuilderFactory = mock(MessageBuilderFactory.class, Mockito.RETURNS_DEEP_STUBS);
         SecDispatcher secDispatcher = mock(SecDispatcher.class);
 
@@ -65,18 +81,18 @@ class InitTest {
         Init init = new Init(messageBuilderFactory, secDispatcher);
 
         InvokerRequest invokerRequest = mock(InvokerRequest.class, Mockito.RETURNS_DEEP_STUBS);
-        when(invokerRequest.cwd()).thenReturn(java.nio.file.Paths.get(""));
-        when(invokerRequest.installationDirectory()).thenReturn(java.nio.file.Paths.get(""));
-        when(invokerRequest.userHomeDirectory()).thenReturn(java.nio.file.Paths.get(""));
-        when(invokerRequest.topDirectory()).thenReturn(java.nio.file.Paths.get(""));
-        when(invokerRequest.rootDirectory()).thenReturn(java.util.Optional.empty());
+        when(invokerRequest.cwd()).thenReturn(Paths.get(""));
+        when(invokerRequest.installationDirectory()).thenReturn(Paths.get(""));
+        when(invokerRequest.userHomeDirectory()).thenReturn(Paths.get(""));
+        when(invokerRequest.topDirectory()).thenReturn(Paths.get(""));
+        when(invokerRequest.rootDirectory()).thenReturn(Optional.empty());
         EncryptOptions options = mock(EncryptOptions.class);
         EncryptContext context = new EncryptContext(invokerRequest, options);
         // avoid null pointers for lists
-        context.header = new java.util.ArrayList<>();
-        context.style = new org.jline.utils.AttributedStyle();
-        org.jline.terminal.Terminal terminal = mock(org.jline.terminal.Terminal.class);
-        java.io.PrintWriter printWriter = mock(java.io.PrintWriter.class);
+        context.header = new ArrayList<>();
+        context.style = new AttributedStyle();
+        Terminal terminal = mock(Terminal.class);
+        PrintWriter printWriter = mock(PrintWriter.class);
         when(terminal.writer()).thenReturn(printWriter);
         context.terminal = terminal;
 
@@ -89,20 +105,17 @@ class InitTest {
                     dispatcherResult.put("defaultDispatcher", createResult("master"));
 
                     Map<String, PromptResultItemIF> configureResult = new HashMap<>();
-                    configureResult.put("password", createResult("env:$MVN_PASSWORD"));
+                    configureResult.put("password", createResult(template));
 
                     Map<String, PromptResultItemIF> editResult = new HashMap<>();
-                    editResult.put(
-                            "edit", createResult("my_password_var")); // User inputs "my_password_var" without prefix
+                    editResult.put("edit", createResult(userInput));
 
                     Map<String, PromptResultItemIF> confirmResult = new HashMap<>();
-                    org.jline.consoleui.prompt.ConfirmResult confirm =
-                            mock(org.jline.consoleui.prompt.ConfirmResult.class);
-                    when(confirm.getConfirmed())
-                            .thenReturn(org.jline.consoleui.elements.ConfirmChoice.ConfirmationValue.YES);
+                    ConfirmResult confirm = mock(ConfirmResult.class);
+                    when(confirm.getConfirmed()).thenReturn(ConfirmChoice.ConfirmationValue.YES);
                     confirmResult.put("confirm", confirm);
 
-                    when(mock.prompt(any(java.util.List.class), any(java.util.List.class)))
+                    when(mock.prompt(any(List.class), any(List.class)))
                             .thenReturn(dispatcherResult, configureResult, editResult, confirmResult);
                 })) {
             init.doExecute(context);
@@ -116,16 +129,10 @@ class InitTest {
         assertEquals(1, config.getProperties().size());
         ConfigProperty prop = config.getProperties().get(0);
         assertEquals("password", prop.getName());
-        // The expected value should be env:my_password_var because the template was env:$MVN_PASSWORD
-        assertEquals("env:my_password_var", prop.getValue());
+        assertEquals(expectedValue, prop.getValue());
     }
 
     private PromptResultItemIF createResult(String value) {
-        return new PromptResultItemIF() {
-            @Override
-            public String getResult() {
-                return value;
-            }
-        };
+        return () -> value;
     }
 }


### PR DESCRIPTION
## [MNG-8425] Fix mvnenc init saving invalid master source configuration

Fixes #10202

### Description

This PR fixes [MNG-8425](https://issues.apache.org/jira/browse/MNG-8425) (#10202) where `mvn --enc init` generates an invalid `settings-security4.xml`, causing `mvn --enc encrypt` to fail with "Maven Encryption is not configured."

### Root Cause

When the encryption wizard prompts the user to customize an editable value, the template is presented as `env:$VARIABLE_NAME`. The user is expected to replace only the `$VARIABLE_NAME` portion (e.g., typing `MVN_PASSWORD`), but the `Init` goal saves the raw user input directly — resulting in `<value>MVN_PASSWORD</value>` instead of the correct `<value>env:MVN_PASSWORD</value>`.

The `MasterDispatcher` in `plexus-sec-dispatcher` then fails validation because no `MasterSource` recognizes a config string without its required prefix (`env:`, `sys-property:`, etc.), producing the error: `Configured Source configuration not handled`.

### Fix

In `Init.java`, after the user provides their input for an editable field, the code now:
1. Extracts the prefix from the template (everything before the `$` placeholder).
2. Checks if the user's input already includes the prefix.
3. Prepends the prefix automatically if missing.

This ensures the generated `settings-security4.xml` always contains well-formed source values like `env:MVN_PASSWORD`.

### Testing

- All 468 tests in `maven-cli` pass.
- Manually verified that `mvn --enc init` now writes the correct `env:` prefix and `mvn --enc encrypt` succeeds afterward.

---

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [ ] You have run the [Core IT][core-its] successfully.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

[core-its]: https://maven.apache.org/core-its/core-it-suite/
