### PR TITLE
Avoid IllegalStateException on duplicate profile ids in DefaultModelBuilder

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1397,7 +1397,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             setSource(inputModel);
             inputModel = modelNormalizer.mergeDuplicates(inputModel, request, this);
 
-            Map<String, Activation> interpolatedActivations = getProfileActivations(inputModel);
+            List<Activation> interpolatedActivations = getProfileActivations(inputModel);
             inputModel = injectProfileActivations(inputModel, interpolatedActivations);
 
             // profile injection
@@ -2367,20 +2367,21 @@ public class DefaultModelBuilder implements ModelBuilder {
                 model);
     }
 
-    private Map<String, Activation> getProfileActivations(Model model) {
+    private List<Activation> getProfileActivations(Model model) {
         return model.getProfiles().stream()
-                .filter(p -> p.getActivation() != null)
-                .collect(Collectors.toMap(Profile::getId, Profile::getActivation));
+                .map(Profile::getActivation)
+                .collect(Collectors.toList());
     }
 
-    private Model injectProfileActivations(Model model, Map<String, Activation> activations) {
+    private Model injectProfileActivations(Model model, List<Activation> activations) {
         List<Profile> profiles = new ArrayList<>();
         boolean modified = false;
-        for (Profile profile : model.getProfiles()) {
+        for (int i = 0; i < model.getProfiles().size(); i++) {
+            Profile profile = model.getProfiles().get(i);
             Activation activation = profile.getActivation();
             if (activation != null) {
                 // restore activation
-                profile = profile.withActivation(activations.get(profile.getId()));
+                profile = profile.withActivation(activations.get(i));
                 modified = true;
             }
             profiles.add(profile);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2368,9 +2368,7 @@ public class DefaultModelBuilder implements ModelBuilder {
     }
 
     private List<Activation> getProfileActivations(Model model) {
-        return model.getProfiles().stream()
-                .map(Profile::getActivation)
-                .collect(Collectors.toList());
+        return model.getProfiles().stream().map(Profile::getActivation).collect(Collectors.toList());
     }
 
     private Model injectProfileActivations(Model model, List<Activation> activations) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -29,6 +29,7 @@ import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.Model;
+import org.apache.maven.api.model.Profile;
 import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.services.ModelBuilder;
 import org.apache.maven.api.services.ModelBuilderRequest;
@@ -150,6 +151,32 @@ class DefaultModelBuilderTest {
         result = builder.newSession().build(request);
         assertNotNull(result);
         assertEquals("0.2.0", result.getEffectiveModel().getVersion());
+    }
+
+    @Test
+    public void testDuplicateProfileIdsRetainActivations() {
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.CONSUMER_DEPENDENCY)
+                .source(Sources.resolvedSource(
+                        getPom("duplicate-profile-ids"), "org.apache.maven.test:duplicate-profile-ids:1.0.0"))
+                .build();
+        ModelBuilderResult result = assertDoesNotThrow(() -> builder.newSession().build(request));
+        assertNotNull(result);
+
+        List<Profile> profiles = result.getEffectiveModel().getProfiles();
+        assertEquals(2, profiles.size());
+        assertEquals("default", profiles.get(0).getId());
+        assertEquals("default", profiles.get(1).getId());
+        assertNotNull(profiles.get(0).getActivation());
+        assertNotNull(profiles.get(1).getActivation());
+        assertTrue(profiles.get(0).getActivation().isActiveByDefault());
+        assertEquals(
+                "duplicate.profile",
+                profiles.get(1).getActivation().getProperty().getName());
+        assertEquals(
+                "enabled",
+                profiles.get(1).getActivation().getProperty().getValue());
     }
 
     @Test

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -161,7 +161,8 @@ class DefaultModelBuilderTest {
                 .source(Sources.resolvedSource(
                         getPom("duplicate-profile-ids"), "org.apache.maven.test:duplicate-profile-ids:1.0.0"))
                 .build();
-        ModelBuilderResult result = assertDoesNotThrow(() -> builder.newSession().build(request));
+        ModelBuilderResult result =
+                assertDoesNotThrow(() -> builder.newSession().build(request));
         assertNotNull(result);
 
         List<Profile> profiles = result.getEffectiveModel().getProfiles();
@@ -174,9 +175,7 @@ class DefaultModelBuilderTest {
         assertEquals(
                 "duplicate.profile",
                 profiles.get(1).getActivation().getProperty().getName());
-        assertEquals(
-                "enabled",
-                profiles.get(1).getActivation().getProperty().getValue());
+        assertEquals("enabled", profiles.get(1).getActivation().getProperty().getValue());
     }
 
     @Test

--- a/impl/maven-impl/src/test/resources/poms/factory/duplicate-profile-ids.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/duplicate-profile-ids.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+         root="true">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>duplicate-profile-ids</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+        <profile>
+            <id>default</id>
+            <activation>
+                <property>
+                    <name>duplicate.profile</name>
+                    <value>enabled</value>
+                </property>
+            </activation>
+        </profile>
+    </profiles>
+
+</project>


### PR DESCRIPTION
## Summary
Projects with duplicate profile ids build again instead of dying with `java.lang.IllegalStateException: Duplicate key default (attempted merging values ...)`. Maven 3 accepted these POMs; Maven 4 rc-1/rc-2 crash during dependency collection.

## Why this matters

In #10209, @gnodet confirmed the exception is misleading: the activation save/restore map in model building is keyed by profile id, so the real condition is two `<profile>` entries sharing an id (e.g. two `<id>default</id>`), surfacing as an opaque JDK collector error instead of a model diagnostic. @cstamas linked the regression to the MNG-8391 change. The issue is labeled bug/priority:major with no prior PRs.

## Changes
- `getProfileActivations` / `injectProfileActivations` in `DefaultModelBuilder` no longer key the activation save/restore by profile id - activations round-trip positionally with `model.getProfiles()`, so duplicate ids cannot collide in a map. This restores Maven 3's leniency in the model-building path while `DefaultModelValidator` remains the single owner of the duplicate-id diagnostic ("must be unique but found duplicate profile with id ..."), so no raw `IllegalStateException` escapes to the user.

## Testing
`mvn -pl impl/maven-impl -am test -Dtest=DefaultModelBuilderTest` - 13 tests, 0 failures, including a new test with `duplicate-profile-ids.xml` (two profiles sharing an id, each with its own activation) verifying model building succeeds and both activations survive the save/restore round-trip.

Fixes #10209
