### PR TITLE
Use GAV in readAsParentModel cache-hit path for profile source keys

### DIFF
--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -739,4 +739,59 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
         assertEquals("1.0", child.getArtifact().getVersion(), "artifact version should match inherited version");
         assertEquals("org.different.group", child.getGroupId(), "groupId should be from child POM");
     }
+
+    /**
+     * Tests that parent profile source keys use consistent GAV format (groupId:artifactId:version)
+     * across both cache-miss and cache-hit paths in DefaultModelBuilder.readAsParentModel().
+     *
+     * <p>Before the fix, the cache-miss path used ModelProblemUtils.toId() (GAV) while the cache-hit
+     * path used Model.getId() (GAPV, which includes packaging). This meant the same parent's profiles
+     * could appear under different keys depending on build order.
+     */
+    @Test
+    void testParentProfileSourceKeyConsistentAcrossModules() throws Exception {
+        File pom = getTestFile("src/test/resources/projects/multimodule-parent-profiles/pom.xml");
+        ProjectBuildingRequest configuration = newBuildingRequest();
+        configuration.setLocalRepository(getLocalRepository());
+        InternalSession internalSession = InternalSession.from(configuration.getRepositorySession());
+        InternalMavenSession mavenSession = InternalMavenSession.from(internalSession);
+        mavenSession
+                .getMavenSession()
+                .getRequest()
+                .setRootDirectory(pom.toPath().getParent());
+
+        List<ProjectBuildingResult> results = projectBuilder.build(List.of(pom), true, configuration);
+        assertEquals(3, results.size());
+
+        // The parent GAV key (without packaging) that all children should use
+        String parentGav = "org.apache.maven.test:multimodule-parent-profiles:1.0-SNAPSHOT";
+
+        for (ProjectBuildingResult result : results) {
+            MavenProject project = result.getProject();
+            if ("pom".equals(project.getPackaging()) && "multimodule-parent-profiles".equals(project.getArtifactId())) {
+                continue; // skip the parent itself
+            }
+
+            // Verify that the parent profile source key uses GAV format (no packaging component)
+            assertTrue(
+                    project.getInjectedProfileIds().containsKey(parentGav),
+                    "Profile source key for " + project.getArtifactId()
+                            + " should use GAV format '" + parentGav
+                            + "', but found keys: "
+                            + project.getInjectedProfileIds().keySet());
+
+            // Verify the parent-profile was actually tracked
+            assertTrue(
+                    project.getInjectedProfileIds().get(parentGav).contains("parent-profile"),
+                    "parent-profile should be listed under GAV key for " + project.getArtifactId());
+
+            // Verify no GAPV key exists (would include ":pom:" packaging)
+            for (String key : project.getInjectedProfileIds().keySet()) {
+                assertFalse(
+                        key.contains(":pom:"),
+                        "Profile source key for " + project.getArtifactId()
+                                + " should not contain packaging, but found: " + key);
+            }
+        }
+    }
 }

--- a/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-a/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-a/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>multimodule-parent-profiles</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>child-a</artifactId>
+</project>

--- a/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-b/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-b/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>multimodule-parent-profiles</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>child-b</artifactId>
+</project>

--- a/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>multimodule-parent-profiles</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>child-a</module>
+        <module>child-b</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>parent-profile</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+    </profiles>
+</project>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1941,7 +1941,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                         replayRecordIntoContext(e.getKey(), profileActivationContext);
                     }
                     // Add the activated profiles from cache to the result
-                    addActivePomProfiles(cached.model().getId(), cached.activatedProfiles());
+                    // Use ModelProblemUtils.toId() to get groupId:artifactId:version format (without packaging)
+                    addActivePomProfiles(ModelProblemUtils.toId(cached.model()), cached.activatedProfiles());
                     return cached.model();
                 }
             }


### PR DESCRIPTION
## Summary

Follow-up to #12406 — fixes the same GAPV vs GAV inconsistency in a different code path.

In `DefaultModelBuilder.readAsParentModel()`, the **cache-hit** path (line 1944) used `Model.getId()` which returns `groupId:artifactId:packaging:version` (GAPV), while the **cache-miss** path (line 1961) correctly used `ModelProblemUtils.toId()` which returns `groupId:artifactId:version` (GAV). This inconsistency could cause the same parent's profiles to be stored under different keys depending on whether the parent model was resolved from cache or freshly built.

The fix is a one-liner: replace `cached.model().getId()` with `ModelProblemUtils.toId(cached.model())` to match the cache-miss path.

- **Cache miss** (line 1961): `ModelProblemUtils.toId(model)` → `g:a:v` ✅
- **Cache hit** (line 1944): `cached.model().getId()` → `g:a:p:v` ❌ → **fixed** to `ModelProblemUtils.toId(cached.model())`

Also adds a test that verifies parent profile source keys use consistent GAV format across child modules in a multi-module build. Note: the cache-hit path requires a matching `ProfileActivationContext.Record` which is hard to trigger in a unit test (sibling modules record different model info), but the fix is correct by inspection — it matches the existing pattern on the cache-miss path.

## Test plan
- [x] Existing `testActivatedProfileBySource` passes
- [x] New `testParentProfileSourceKeyConsistentAcrossModules` passes
- [x] Full `DefaultMavenProjectBuilderTest` suite passes (34 tests)
- [x] Full `DefaultProjectBuilderTest` suite passes (3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)