### PR TITLE
Bugfix: use GAV and not GAPV in source labels for profiles (#12406)

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -799,7 +799,7 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                 // Fallback to old behavior if map is empty
                 // This happens when no profiles are active or there's an issue with profile tracking
                 project.setInjectedProfileIds(
-                        result.getEffectiveModel().getId(), getProfileIds(result.getActivePomProfiles()));
+                        getModelDataId(result.getEffectiveModel()), getProfileIds(result.getActivePomProfiles()));
             } else {
                 for (Map.Entry<String, List<org.apache.maven.api.model.Profile>> entry : profilesByModel.entrySet()) {
                     project.setInjectedProfileIds(entry.getKey(), getProfileIds(entry.getValue()));
@@ -950,6 +950,16 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                                 e));
             }
             project.setRemoteArtifactRepositories(remoteRepositories);
+        }
+
+        /**
+         * Emulates Maven 3.x {@code ModelData#getId} method, that unlike model, returned {@code GAV} and not {@code GAPV}.
+         */
+        private static String getModelDataId(Model model) {
+            return ((model.getGroupId() == null) ? "[inherited]" : model.getGroupId()) + ":"
+                    + model.getArtifactId()
+                    + ":"
+                    + ((model.getVersion() == null) ? "[inherited]" : model.getVersion());
         }
 
         /**

--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultMavenProjectBuilderTest.java
@@ -626,4 +626,59 @@ class DefaultMavenProjectBuilderTest extends AbstractMavenProjectTestCase {
         assertEquals("1.0", child.getArtifact().getVersion(), "artifact version should match inherited version");
         assertEquals("org.different.group", child.getGroupId(), "groupId should be from child POM");
     }
+
+    /**
+     * Tests that parent profile source keys use consistent GAV format (groupId:artifactId:version)
+     * across both cache-miss and cache-hit paths in DefaultModelBuilder.readAsParentModel().
+     *
+     * <p>Before the fix, the cache-miss path used ModelProblemUtils.toId() (GAV) while the cache-hit
+     * path used Model.getId() (GAPV, which includes packaging). This meant the same parent's profiles
+     * could appear under different keys depending on build order.
+     */
+    @Test
+    void testParentProfileSourceKeyConsistentAcrossModules() throws Exception {
+        File pom = getTestFile("src/test/resources/projects/multimodule-parent-profiles/pom.xml");
+        ProjectBuildingRequest configuration = newBuildingRequest();
+        configuration.setLocalRepository(getLocalRepository());
+        InternalSession internalSession = InternalSession.from(configuration.getRepositorySession());
+        InternalMavenSession mavenSession = InternalMavenSession.from(internalSession);
+        mavenSession
+                .getMavenSession()
+                .getRequest()
+                .setRootDirectory(pom.toPath().getParent());
+
+        List<ProjectBuildingResult> results = projectBuilder.build(List.of(pom), true, configuration);
+        assertEquals(3, results.size());
+
+        // The parent GAV key (without packaging) that all children should use
+        String parentGav = "org.apache.maven.test:multimodule-parent-profiles:1.0-SNAPSHOT";
+
+        for (ProjectBuildingResult result : results) {
+            MavenProject project = result.getProject();
+            if ("pom".equals(project.getPackaging()) && "multimodule-parent-profiles".equals(project.getArtifactId())) {
+                continue; // skip the parent itself
+            }
+
+            // Verify that the parent profile source key uses GAV format (no packaging component)
+            assertTrue(
+                    project.getInjectedProfileIds().containsKey(parentGav),
+                    "Profile source key for " + project.getArtifactId()
+                            + " should use GAV format '" + parentGav
+                            + "', but found keys: "
+                            + project.getInjectedProfileIds().keySet());
+
+            // Verify the parent-profile was actually tracked
+            assertTrue(
+                    project.getInjectedProfileIds().get(parentGav).contains("parent-profile"),
+                    "parent-profile should be listed under GAV key for " + project.getArtifactId());
+
+            // Verify no GAPV key exists (would include ":pom:" packaging)
+            for (String key : project.getInjectedProfileIds().keySet()) {
+                assertFalse(
+                        key.contains(":pom:"),
+                        "Profile source key for " + project.getArtifactId()
+                                + " should not contain packaging, but found: " + key);
+            }
+        }
+    }
 }

--- a/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-a/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-a/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>multimodule-parent-profiles</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>child-a</artifactId>
+</project>

--- a/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-b/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/child-b/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>multimodule-parent-profiles</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>child-b</artifactId>
+</project>

--- a/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/pom.xml
+++ b/impl/maven-core/src/test/resources/projects/multimodule-parent-profiles/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>multimodule-parent-profiles</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>child-a</module>
+        <module>child-b</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>parent-profile</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+    </profiles>
+</project>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1893,7 +1893,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                         replayRecordIntoContext(e.getKey(), profileActivationContext);
                     }
                     // Add the activated profiles from cache to the result
-                    addActivePomProfiles(cached.model().getId(), cached.activatedProfiles());
+                    // Use ModelProblemUtils.toId() to get groupId:artifactId:version format (without packaging)
+                    addActivePomProfiles(ModelProblemUtils.toId(cached.model()), cached.activatedProfiles());
                     return cached.model();
                 }
             }


### PR DESCRIPTION
This introduces no behaviour change between Maven 3 and 4, merely the labels for "source" of profiles got different.

Fixes #12405

Backport of 923106abde67d83279bfb4cdf24f45fa92960113
