### PR TITLE
configure ATR project

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,3 +31,30 @@ notifications:
   commits: commits@maven.apache.org
   issues: issues@maven.apache.org
   pullrequests: issues@maven.apache.org
+
+# https://release-test.apache.org/projects/maven
+project:
+  metadata:
+    key: maven
+    committee: maven
+    name: Apache Maven
+    description: "Maven is a project development management and comprehension tool.
+      Based on the concept of a project object model: builds, dependency management,
+      documentation creation, site publication, and distribution publication are all controlled from the declarative file.
+      Maven can be extended by plugins to utilise a number of other development tools for reporting or the build process."
+    short_description: Maven is a project development management and comprehension tool.
+    homepage: https://maven.apache.org/
+    download_page: https://maven.apache.org/download.html
+    bug_database: https://github.com/apache/maven/issues
+    mailing_lists: https://maven.apache.org/mailing-lists.html
+    repositories:
+      - https://github.com/apache/maven.git
+    categories:
+      - build-management
+    programming_languages:
+      - Java
+  policy:
+    github_repository_name: maven
+    download_path_suffix: maven-{{MAJOR}}/{{VERSION}}
+  features:
+    atr_sync: true


### PR DESCRIPTION
https://release-test.apache.org/projects/maven

notice the `download_path_suffix` that is quite special to match our `maven-X` structure in https://downloads.apache.org/maven/ / https://archive.apache.org/dist/maven/ / https://dist.apache.org/repos/dist/release/maven/ / https://dist.apache.org/repos/dist/atr/maven/ / https://dist.apache.org/repos/dist/dev/maven/

`{{MAJOR}}` won't be automatically replaced by ATR at the Finish stage, but I hope the release manager will see and update (and we could probably ask Tooling to force reject such a value if it remains as-is when submitting the form)

@cstamas @gnodet do you intend to use ATR for managing the VOTE of next Maven releases?

notice:
- this PR can be back-ported to 4.0.x and 3.10.x branches, even if it won't really do anything there: just for consistency
- configuration of `push-to-atr` profile will be done in another PR
