### PR TITLE
Feat: Align Maven 3.10.x and 4.0.x

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
+++ b/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.RepositoryUtils;
@@ -54,6 +55,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.Repository;
+import org.apache.maven.model.interpolation.ModelInterpolator;
 import org.apache.maven.repository.Proxy;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Mirror;
@@ -561,13 +563,21 @@ public class MavenRepositorySystem {
 
     public ArtifactRepository createDefaultRemoteRepository(MavenExecutionRequest request) throws Exception {
         return createRepository(
-                RepositorySystem.DEFAULT_REMOTE_REPO_URL,
+                determineDefaultRemoteRepositoryUrl(request),
                 RepositorySystem.DEFAULT_REMOTE_REPO_ID,
                 true,
                 ArtifactRepositoryPolicy.UPDATE_POLICY_DAILY,
                 false,
                 ArtifactRepositoryPolicy.UPDATE_POLICY_DAILY,
                 ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN);
+    }
+
+    private String determineDefaultRemoteRepositoryUrl(MavenExecutionRequest request) {
+        Properties effective = new Properties();
+        effective.putAll(request.getSystemProperties());
+        effective.putAll(request.getUserProperties());
+        return effective.getProperty(
+                ModelInterpolator.MAVEN_REPO_CENTRAL_KEY, ModelInterpolator.DEFAULT_MAVEN_REPO_CENTRAL_URL);
     }
 
     public ArtifactRepository createRepository(

--- a/maven-core/src/main/java/org/apache/maven/repository/RepositorySystem.java
+++ b/maven-core/src/main/java/org/apache/maven/repository/RepositorySystem.java
@@ -31,6 +31,7 @@ import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.Repository;
+import org.apache.maven.model.interpolation.ModelInterpolator;
 import org.apache.maven.settings.Mirror;
 import org.apache.maven.settings.Server;
 import org.eclipse.aether.RepositorySystemSession;
@@ -56,7 +57,7 @@ public interface RepositorySystem {
 
     String DEFAULT_REMOTE_REPO_ID = "central";
 
-    String DEFAULT_REMOTE_REPO_URL = "https://repo.maven.apache.org/maven2";
+    String DEFAULT_REMOTE_REPO_URL = ModelInterpolator.DEFAULT_MAVEN_REPO_CENTRAL_URL;
 
     Artifact createArtifact(String groupId, String artifactId, String version, String packaging);
 

--- a/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulatorTest.java
+++ b/maven-core/src/test/java/org/apache/maven/execution/DefaultMavenExecutionRequestPopulatorTest.java
@@ -61,4 +61,18 @@ public class DefaultMavenExecutionRequestPopulatorTest {
         assertEquals(r.getId(), repositories.get(0).getId());
         assertEquals(r.getUrl(), repositories.get(0).getUrl());
     }
+
+    @Test
+    public void testPopulateDefaultsWithRepoUrlOverride() throws Exception {
+        final String url = "https://testPopulateDefaultsWithRepoUrlOverride/something";
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.getUserProperties().setProperty("maven.repo.central", url);
+
+        testee.populateDefaults(request);
+
+        assertEquals(1, request.getRemoteRepositories().size());
+        assertEquals(url, request.getRemoteRepositories().get(0).getUrl());
+        assertEquals(1, request.getPluginArtifactRepositories().size());
+        assertEquals(url, request.getPluginArtifactRepositories().get(0).getUrl());
+    }
 }

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -89,6 +89,7 @@ import org.apache.maven.jline.MessageUtils;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.message.MessageBuilder;
 import org.apache.maven.model.building.ModelProcessor;
+import org.apache.maven.model.interpolation.ModelInterpolator;
 import org.apache.maven.model.root.RootLocator;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.properties.internal.EnvironmentUtils;
@@ -158,6 +159,14 @@ public class MavenCli {
     public static final File GLOBAL_EXTENSIONS_FILE = new File(System.getProperty("maven.conf"), "extensions.xml");
 
     private static final String MVN_MAVEN_CONFIG = DOT_MVN + "/maven.config";
+
+    /**
+     * One "distinguished" env variable that we want to make into non-prefixed property, if present.
+     *
+     * @see ModelInterpolator
+     * @since 3.10.0
+     */
+    private static final String MAVEN_REPO_CENTRAL_ENV = "env.MAVEN_REPO_CENTRAL";
 
     public static final String STYLE_COLOR_PROPERTY = "style.color";
 
@@ -1635,6 +1644,12 @@ public class MavenCli {
 
         EnvironmentUtils.addEnvVars(systemProperties);
         SystemProperties.addSystemProperties(systemProperties);
+
+        // one distinguished env variable: MAVEN_REPO_CENTRAL; if present, we make it into property
+        if (systemProperties.contains(MAVEN_REPO_CENTRAL_ENV)) {
+            systemProperties.put(
+                    ModelInterpolator.MAVEN_REPO_CENTRAL_KEY, systemProperties.getProperty(MAVEN_REPO_CENTRAL_ENV));
+        }
 
         StringSearchInterpolator interpolator = createInterpolator(cliRequest, cliProperties, systemProperties);
         for (Map.Entry<Object, Object> e : cliProperties.entrySet()) {

--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -1646,7 +1646,7 @@ public class MavenCli {
         SystemProperties.addSystemProperties(systemProperties);
 
         // one distinguished env variable: MAVEN_REPO_CENTRAL; if present, we make it into property
-        if (systemProperties.contains(MAVEN_REPO_CENTRAL_ENV)) {
+        if (systemProperties.containsKey(MAVEN_REPO_CENTRAL_ENV)) {
             systemProperties.put(
                     ModelInterpolator.MAVEN_REPO_CENTRAL_KEY, systemProperties.getProperty(MAVEN_REPO_CENTRAL_ENV));
         }

--- a/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -436,4 +436,25 @@ public class MavenCliTest {
                 new String[] {"prefix:3.0.0:bar", "validate"},
                 request.getCommandLine().getArgs());
     }
+
+    @Test
+    public void testDistinguishedEnvVariableTransformation() throws Exception {
+        try {
+            // Arrange
+            String url = "https://testDistinguishedEnvVariableTransformation/something";
+            System.setProperty("env.MAVEN_REPO_CENTRAL", url);
+            CliRequest request = new CliRequest(new String[] {}, null);
+            request.request.setRootDirectory(Paths.get("myRootDirectory"));
+            request.request.setTopDirectory(Paths.get("myTopDirectory"));
+
+            // Act
+            cli.cli(request);
+            cli.properties(request);
+
+            // Assert
+            assertEquals(url, request.getSystemProperties().getProperty("maven.repo.central"));
+        } finally {
+            System.clearProperty("env.MAVEN_REPO_CENTRAL");
+        }
+    }
 }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator.java
@@ -42,6 +42,7 @@ import org.codehaus.plexus.interpolation.PrefixAwareRecursionInterceptor;
 import org.codehaus.plexus.interpolation.PrefixedObjectValueSource;
 import org.codehaus.plexus.interpolation.PrefixedValueSourceWrapper;
 import org.codehaus.plexus.interpolation.RecursionInterceptor;
+import org.codehaus.plexus.interpolation.SingleResponseValueSource;
 import org.codehaus.plexus.interpolation.ValueSource;
 
 /**
@@ -123,7 +124,7 @@ public abstract class AbstractStringBasedModelInterpolator implements ModelInter
         }
 
         // NOTE: Order counts here!
-        List<ValueSource> valueSources = new ArrayList<>(9);
+        List<ValueSource> valueSources = new ArrayList<>(11);
 
         if (projectDir != null) {
             ValueSource basedirValueSource = new PrefixedValueSourceWrapper(
@@ -196,6 +197,9 @@ public abstract class AbstractStringBasedModelInterpolator implements ModelInter
         });
 
         valueSources.add(modelValueSource2);
+
+        // last source: make sure Maven Repo Central is present (if is present anywhere else, it will prevail this one)
+        valueSources.add(new SingleResponseValueSource(MAVEN_REPO_CENTRAL_KEY, DEFAULT_MAVEN_REPO_CENTRAL_URL));
 
         return valueSources;
     }

--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/ModelInterpolator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/ModelInterpolator.java
@@ -33,6 +33,21 @@ import org.apache.maven.model.building.ModelProblemCollector;
 public interface ModelInterpolator {
 
     /**
+     * Property key that may contain default Maven repository URL.
+     * This key is used in super POM.
+     *
+     * @since 3.10.0
+     */
+    String MAVEN_REPO_CENTRAL_KEY = "maven.repo.central";
+
+    /**
+     * Default value of Maven repository Central URL.
+     *
+     * @since 3.10.0
+     */
+    String DEFAULT_MAVEN_REPO_CENTRAL_URL = "https://repo.maven.apache.org/maven2";
+
+    /**
      * Interpolates expressions in the specified model. Note that implementations are free to either interpolate the
      * provided model directly or to create a clone of the model and interpolate the clone. Callers should always use
      * the returned model and must not rely on the input model being updated.

--- a/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
+++ b/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml
@@ -34,7 +34,7 @@ under the License.
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
+      <url>${maven.repo.central}</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>
@@ -46,7 +46,7 @@ under the License.
     <pluginRepository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
+      <url>${maven.repo.central}</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>


### PR DESCRIPTION
Add support for `MAVEN_REPO_CENTRAL` env variable or `maven.repo.central` property, that is able to redefine Central URL globally.

Changes:
* CLI ensures that IF env var is present, is transformed into property
* MavenRepositorySystem obeys property, if present
* ModelInterpolator (as there is SuperPOM as well) contains the main change. It defines the property and default value, and makes sure new property is always present. SuperPOM is changed too, and now references the new property.
* LegacyRepositorySystem is NOT obeying it (please update)

---

Note: this is quite trivial (and maybe hacky) change, but the goal is that Maven 3.10.x CLI behave same way in respect to mentioned env and/or property variables as Maven 4+ is. MavenCLI does the "dirty job" of lifting env variable into properties, Crux of the change is in ModelBuilder as there is also SuperPOM, that unlike with Maven 4, does contains Central stanza. This also implies, that env detection is supported ONLY if MavenCli is involved (mvn CLI), but is not respected in MIMA-like use cases, but that is IMHO acceptable.