### PR TITLE
Fix mvnup comment formatting for override comments

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -781,7 +781,10 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 managedPluginsElement, upgrade.groupId(), upgrade.artifactId(), upgrade.minVersion());
 
         if (fromRemoteParent) {
-            managedPluginsElement.insertChildBefore(plugin, Comment.of(" Override version inherited from parent "));
+            managedPluginsElement.insertChildBefore(
+                    plugin,
+                    Comment.of(" Override version inherited from parent ")
+                            .precedingWhitespace(plugin.precedingWhitespace()));
             context.detail("Added plugin management for " + upgrade.groupId() + ":" + upgrade.artifactId() + " version "
                     + upgrade.minVersion() + " (overrides version inherited from parent)");
         } else {
@@ -820,7 +823,9 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                             pluginsElement, upgrade.groupId(), upgrade.artifactId(), upgrade.minVersion());
                     if (!localPluginKeys.contains(pluginKey)) {
                         pluginsElement.insertChildBefore(
-                                plugin, Comment.of(" Override version inherited from parent "));
+                                plugin,
+                                Comment.of(" Override version inherited from parent ")
+                                        .precedingWhitespace(plugin.precedingWhitespace()));
                     }
                     hasUpgrades = true;
                     context.detail("Added " + upgrade.groupId() + ":" + upgrade.artifactId() + " version "

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import eu.maveniverse.domtrip.Comment;
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Editor;
 import eu.maveniverse.domtrip.Element;
@@ -58,8 +57,8 @@ import static eu.maveniverse.domtrip.maven.MavenPomElements.Plugins.MAVEN_4_COMP
 import static eu.maveniverse.domtrip.maven.MavenPomElements.Plugins.MAVEN_PLUGIN_PREFIX;
 
 /**
- * Strategy for upgrading Maven plugins to recommended versions.
- * Handles plugin version upgrades in build/plugins and build/pluginManagement sections.
+ * Strategy for upgrading Maven plugins to recommended versions. Handles plugin version upgrades in build/plugins and
+ * build/pluginManagement sections.
  */
 @Named
 @Singleton
@@ -202,9 +201,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     }
 
     /**
-     * Upgrades plugins in the document.
-     * Checks both build/plugins and build/pluginManagement/plugins sections.
-     * Only processes plugins explicitly defined in the current POM document.
+     * Upgrades plugins in the document. Checks both build/plugins and build/pluginManagement/plugins sections. Only
+     * processes plugins explicitly defined in the current POM document.
      */
     private boolean upgradePluginsInDocument(Document pomDocument, UpgradeContext context) {
         Element root = pomDocument.root();
@@ -392,11 +390,9 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 String currentVersion = propertyElement.textContentTrimmed();
                 if (isVersionBelow(currentVersion, upgrade.minVersion)) {
                     editor.setTextContent(propertyElement, upgrade.minVersion);
-                    context.detail("Upgraded property " + propertyName + " (for " + upgrade.groupId
-                            + ":"
-                            + upgrade.artifactId + ") from " + currentVersion + " to " + upgrade.minVersion
-                            + " in "
-                            + sectionName);
+                    context.detail(
+                            "Upgraded property " + propertyName + " (for " + upgrade.groupId + ":" + upgrade.artifactId
+                                    + ") from " + currentVersion + " to " + upgrade.minVersion + " in " + sectionName);
                     return true;
                 } else {
                     context.debug("Property " + propertyName + " version " + currentVersion + " is already >= "
@@ -453,8 +449,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     }
 
     /**
-     * Simple version comparison to check if current version is below minimum version.
-     * This is a basic implementation that works for most Maven plugin versions.
+     * Simple version comparison to check if current version is below minimum version. This is a basic implementation
+     * that works for most Maven plugin versions.
      */
     private boolean isVersionBelow(String currentVersion, String minVersion) {
         if (currentVersion == null || minVersion == null) {
@@ -479,9 +475,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     }
 
     /**
-     * Analyzes plugins using effective models built from the temp directory.
-     * Returns analysis results with two maps: plugins needing pluginManagement entries
-     * and plugins needing direct build/plugins overrides.
+     * Analyzes plugins using effective models built from the temp directory. Returns analysis results with two maps:
+     * plugins needing pluginManagement entries and plugins needing direct build/plugins overrides.
      */
     private PluginAnalysisResults analyzePluginsUsingEffectiveModels(
             UpgradeContext context, Map<Path, Document> pomMap, Path tempDir) {
@@ -547,10 +542,9 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     }
 
     /**
-     * Analyzes plugins from the effective model and determines which ones need upgrades.
-     * Separates plugins into those overridable via pluginManagement and those requiring
-     * a direct build/plugins entry (because the version is set explicitly in an inherited
-     * parent's build/plugins, not via pluginManagement).
+     * Analyzes plugins from the effective model and determines which ones need upgrades. Separates plugins into those
+     * overridable via pluginManagement and those requiring a direct build/plugins entry (because the version is set
+     * explicitly in an inherited parent's build/plugins, not via pluginManagement).
      */
     private PluginAnalysis analyzePluginsFromEffectiveModel(
             UpgradeContext context, Model effectiveModel, Map<String, PluginUpgrade> pluginUpgrades) {
@@ -630,9 +624,9 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     }
 
     /**
-     * Finds the last local parent in the hierarchy where plugin management should be added.
-     * This implements the algorithm: start with the effective model, check if parent is in pomMap,
-     * if so continue to its parent, else that's the target.
+     * Finds the last local parent in the hierarchy where plugin management should be added. This implements the
+     * algorithm: start with the effective model, check if parent is in pomMap, if so continue to its parent, else
+     * that's the target.
      */
     private Path findLastLocalParentForPluginManagement(
             UpgradeContext context, Path tempPomPath, Map<Path, Document> pomMap, Path tempDir, Path commonRoot) {
@@ -781,10 +775,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 managedPluginsElement, upgrade.groupId(), upgrade.artifactId(), upgrade.minVersion());
 
         if (fromRemoteParent) {
-            managedPluginsElement.insertChildBefore(
-                    plugin,
-                    Comment.of(" Override version inherited from parent ")
-                            .precedingWhitespace(plugin.precedingWhitespace()));
+            new Editor(managedPluginsElement.document())
+                    .insertCommentBefore(plugin, " Override version inherited from parent ");
             context.detail("Added plugin management for " + upgrade.groupId() + ":" + upgrade.artifactId() + " version "
                     + upgrade.minVersion() + " (overrides version inherited from parent)");
         } else {
@@ -794,9 +786,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     }
 
     /**
-     * Adds direct plugin entries in build/plugins for plugins inherited from remote parents.
-     * This is necessary when a parent POM sets an explicit version in its build/plugins
-     * that pluginManagement alone cannot override.
+     * Adds direct plugin entries in build/plugins for plugins inherited from remote parents. This is necessary when a
+     * parent POM sets an explicit version in its build/plugins that pluginManagement alone cannot override.
      */
     private boolean addDirectPluginOverrides(
             UpgradeContext context, Document pomDocument, Set<String> pluginKeys, Set<String> localPluginKeys) {
@@ -822,15 +813,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     Element plugin = DomUtils.createPlugin(
                             pluginsElement, upgrade.groupId(), upgrade.artifactId(), upgrade.minVersion());
                     if (!localPluginKeys.contains(pluginKey)) {
-                        pluginsElement.insertChildBefore(
-                                plugin,
-                                Comment.of(" Override version inherited from parent ")
-                                        .precedingWhitespace(plugin.precedingWhitespace()));
+                        new Editor(pluginsElement.document())
+                                .insertCommentBefore(plugin, " Override version inherited from parent ");
                     }
                     hasUpgrades = true;
                     context.detail("Added " + upgrade.groupId() + ":" + upgrade.artifactId() + " version "
-                            + upgrade.minVersion()
-                            + " in build/plugins (overrides version locked by parent)");
+                            + upgrade.minVersion() + " in build/plugins (overrides version locked by parent)");
                 }
             }
         }
@@ -880,9 +868,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             Map<Path, Set<String>> pluginsNeedingManagement, Map<Path, Set<String>> pluginsNeedingDirectOverride) {}
 
     /**
-     * Holds plugin upgrade information for Maven 4 compatibility.
-     * This class contains the minimum version requirements for plugins
-     * that need to be upgraded to work properly with Maven 4.
+     * Holds plugin upgrade information for Maven 4 compatibility. This class contains the minimum version requirements
+     * for plugins that need to be upgraded to work properly with Maven 4.
      */
     public static class PluginUpgradeInfo {
         /** The Maven groupId of the plugin */
@@ -897,9 +884,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         /**
          * Creates a new plugin upgrade information holder.
          *
-         * @param groupId the Maven groupId of the plugin
-         * @param artifactId the Maven artifactId of the plugin
-         * @param minVersion the minimum version required for Maven 4 compatibility
+         * @param groupId
+         *            the Maven groupId of the plugin
+         * @param artifactId
+         *            the Maven artifactId of the plugin
+         * @param minVersion
+         *            the minimum version required for Maven 4 compatibility
          */
         PluginUpgradeInfo(String groupId, String artifactId, String minVersion) {
             this.groupId = groupId;

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -858,6 +858,9 @@ class PluginUpgradeStrategyTest {
                 assertTrue(
                         xml.contains("<artifactId>maven-enforcer-plugin</artifactId>"),
                         "Should add pluginManagement for maven-enforcer-plugin");
+                // Verify the comment is on its own line, not appended to the previous closing tag
+                assertFalse(
+                        xml.contains("</plugin><!--"), "Comment should be on its own line, not appended to </plugin>");
             } finally {
                 try (var walk = Files.walk(tempDir)) {
                     walk.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
@@ -920,6 +923,8 @@ class PluginUpgradeStrategyTest {
             assertTrue(
                     xml.contains("Override version inherited from parent"),
                     "Should add comment explaining the override");
+            // Verify the comment is on its own line, not appended to the previous closing tag
+            assertFalse(xml.contains("</plugin><!--"), "Comment should be on its own line, not appended to </plugin>");
 
             // Verify NO direct build/plugins entry for enforcer (PM override is sufficient)
             Element buildPlugins = root.childElement("build")

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -47,8 +47,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for the {@link PluginUpgradeStrategy} class.
- * Tests plugin version upgrades, plugin management additions, and Maven 4 compatibility.
+ * Unit tests for the {@link PluginUpgradeStrategy} class. Tests plugin version upgrades, plugin management additions,
+ * and Maven 4 compatibility.
  */
 @DisplayName("PluginUpgradeStrategy")
 class PluginUpgradeStrategyTest {
@@ -161,23 +161,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should not modify plugin when version is already sufficient")
         void shouldNotModifyPluginWhenVersionAlreadySufficient() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-compiler-plugin</artifactId>
-                                <version>3.13.0</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-compiler-plugin</artifactId>
+                                    <version>3.13.0</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -193,23 +193,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade milestone version below release minimum")
         void shouldUpgradeMilestoneVersionBelowRelease() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-enforcer-plugin</artifactId>
-                                <version>3.0.0-M1</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-enforcer-plugin</artifactId>
+                                    <version>3.0.0-M1</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -232,25 +232,25 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade plugin in pluginManagement")
         void shouldUpgradePluginInPluginManagement() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <pluginManagement>
-                            <plugins>
-                                <plugin>
-                                    <groupId>org.apache.maven.plugins</groupId>
-                                    <artifactId>maven-enforcer-plugin</artifactId>
-                                    <version>2.0.0</version>
-                                </plugin>
-                            </plugins>
-                        </pluginManagement>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <pluginManagement>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-enforcer-plugin</artifactId>
+                                        <version>2.0.0</version>
+                                    </plugin>
+                                </plugins>
+                            </pluginManagement>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -274,26 +274,26 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade plugin with property version")
         void shouldUpgradePluginWithPropertyVersion() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <properties>
-                        <shade.plugin.version>3.0.0</shade.plugin.version>
-                    </properties>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-shade-plugin</artifactId>
-                                <version>${shade.plugin.version}</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <properties>
+                            <shade.plugin.version>3.0.0</shade.plugin.version>
+                        </properties>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-shade-plugin</artifactId>
+                                    <version>${shade.plugin.version}</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -317,23 +317,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade surefire plugin when below minimum")
         void shouldUpgradeSurefirePluginWhenBelowMinimum() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-surefire-plugin</artifactId>
-                                <version>3.1.2</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-surefire-plugin</artifactId>
+                                    <version>3.1.2</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -356,23 +356,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade failsafe plugin when below minimum")
         void shouldUpgradeFailsafePluginWhenBelowMinimum() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-failsafe-plugin</artifactId>
-                                <version>3.1.2</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-failsafe-plugin</artifactId>
+                                    <version>3.1.2</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -395,23 +395,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade surefire-report plugin when below minimum")
         void shouldUpgradeSurefireReportPluginWhenBelowMinimum() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-surefire-report-plugin</artifactId>
-                                <version>3.1.2</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-surefire-report-plugin</artifactId>
+                                    <version>3.1.2</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -434,23 +434,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade jaxb2-maven-plugin when below minimum")
         void shouldUpgradeJaxb2MavenPluginWhenBelowMinimum() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>jaxb2-maven-plugin</artifactId>
-                                <version>3.1.0</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.codehaus.mojo</groupId>
+                                    <artifactId>jaxb2-maven-plugin</artifactId>
+                                    <version>3.1.0</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -473,23 +473,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should not upgrade when version is already higher")
         void shouldNotUpgradeWhenVersionAlreadyHigher() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>flatten-maven-plugin</artifactId>
-                                <version>1.3.0</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.codehaus.mojo</groupId>
+                                    <artifactId>flatten-maven-plugin</artifactId>
+                                    <version>1.3.0</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -512,22 +512,22 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade plugin without explicit groupId")
         void shouldUpgradePluginWithoutExplicitGroupId() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <artifactId>maven-shade-plugin</artifactId>
-                                <version>3.1.0</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-shade-plugin</artifactId>
+                                    <version>3.1.0</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -553,23 +553,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should not upgrade plugin without version")
         void shouldNotUpgradePluginWithoutVersion() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>exec-maven-plugin</artifactId>
-                                <!-- No version - inherited from parent or pluginManagement -->
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.codehaus.mojo</groupId>
+                                    <artifactId>exec-maven-plugin</artifactId>
+                                    <!-- No version - inherited from parent or pluginManagement -->
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -585,23 +585,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should not upgrade when property is not found")
         void shouldNotUpgradeWhenPropertyNotFound() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>exec-maven-plugin</artifactId>
-                                <version>${exec.plugin.version}</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.codehaus.mojo</groupId>
+                                    <artifactId>exec-maven-plugin</artifactId>
+                                    <version>${exec.plugin.version}</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -622,30 +622,30 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should upgrade extra-enforcer-rules dependency when below minimum")
         void shouldUpgradeExtraEnforcerRulesDependency() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-enforcer-plugin</artifactId>
-                                <version>3.5.0</version>
-                                <dependencies>
-                                    <dependency>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <artifactId>extra-enforcer-rules</artifactId>
-                                        <version>1.0-beta-4</version>
-                                    </dependency>
-                                </dependencies>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-enforcer-plugin</artifactId>
+                                    <version>3.5.0</version>
+                                    <dependencies>
+                                        <dependency>
+                                            <groupId>org.codehaus.mojo</groupId>
+                                            <artifactId>extra-enforcer-rules</artifactId>
+                                            <version>1.0-beta-4</version>
+                                        </dependency>
+                                    </dependencies>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -665,30 +665,30 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should not upgrade extra-enforcer-rules when version is already sufficient")
         void shouldNotUpgradeExtraEnforcerRulesWhenSufficient() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-enforcer-plugin</artifactId>
-                                <version>3.5.0</version>
-                                <dependencies>
-                                    <dependency>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <artifactId>extra-enforcer-rules</artifactId>
-                                        <version>1.8.0</version>
-                                    </dependency>
-                                </dependencies>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-enforcer-plugin</artifactId>
+                                    <version>3.5.0</version>
+                                    <dependencies>
+                                        <dependency>
+                                            <groupId>org.codehaus.mojo</groupId>
+                                            <artifactId>extra-enforcer-rules</artifactId>
+                                            <version>1.8.0</version>
+                                        </dependency>
+                                    </dependencies>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -709,23 +709,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should add pluginManagement before existing plugins section")
         void shouldAddPluginManagementBeforeExistingPluginsSection() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-compiler-plugin</artifactId>
-                                <version>3.8.1</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-compiler-plugin</artifactId>
+                                    <version>3.8.1</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -819,19 +819,19 @@ class PluginUpgradeStrategyTest {
             // still get a pluginManagement override with a comment explaining it overrides
             // the parent, so that Maven 4 incompatible plugin versions get upgraded.
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>org.apache</groupId>
-                        <artifactId>apache</artifactId>
-                        <version>23</version>
-                    </parent>
-                    <groupId>org.example</groupId>
-                    <artifactId>test-child</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>org.apache</groupId>
+                            <artifactId>apache</artifactId>
+                            <version>23</version>
+                        </parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>test-child</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </project>
+                    """;
 
             Path tempDir = Files.createTempDirectory("mvnup-test-");
             try {
@@ -881,19 +881,19 @@ class PluginUpgradeStrategyTest {
             // In this case, adding a pluginManagement override with a comment in the child
             // is sufficient; no direct build/plugins entry should be added for enforcer.
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>org.apache</groupId>
-                        <artifactId>apache</artifactId>
-                        <version>23</version>
-                    </parent>
-                    <groupId>org.example</groupId>
-                    <artifactId>test-child</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>org.apache</groupId>
+                            <artifactId>apache</artifactId>
+                            <version>23</version>
+                        </parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>test-child</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Path pomPath = Paths.get("/project/pom.xml").toAbsolutePath();
@@ -947,28 +947,28 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should not duplicate plugin in build/plugins when already locally declared")
         void shouldNotDuplicatePluginInBuildPluginsWhenAlreadyDeclared() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>org.apache</groupId>
-                        <artifactId>apache</artifactId>
-                        <version>23</version>
-                    </parent>
-                    <groupId>org.example</groupId>
-                    <artifactId>test-child</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-enforcer-plugin</artifactId>
-                                <version>3.0.0</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>org.apache</groupId>
+                            <artifactId>apache</artifactId>
+                            <version>23</version>
+                        </parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>test-child</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-enforcer-plugin</artifactId>
+                                    <version>3.0.0</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Path pomPath = Paths.get("/project/pom.xml").toAbsolutePath();
@@ -1016,27 +1016,27 @@ class PluginUpgradeStrategyTest {
             // Since the child does declare the plugin, mvnup should add a pluginManagement
             // entry to override the inherited version.
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>org.apache</groupId>
-                        <artifactId>apache</artifactId>
-                        <version>23</version>
-                    </parent>
-                    <groupId>org.example</groupId>
-                    <artifactId>test-child</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-enforcer-plugin</artifactId>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>org.apache</groupId>
+                            <artifactId>apache</artifactId>
+                            <version>23</version>
+                        </parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>test-child</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-enforcer-plugin</artifactId>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Path tempDir = Files.createTempDirectory("mvnup-test-");
             try {
@@ -1083,17 +1083,17 @@ class PluginUpgradeStrategyTest {
             // POM inherits from a remote parent that does not exist.
             // The effective model analysis should warn (not silently swallow) the failure.
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>com.nonexistent.test</groupId>
-                        <artifactId>nonexistent-parent</artifactId>
-                        <version>1.0.0</version>
-                    </parent>
-                    <artifactId>test-child</artifactId>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.nonexistent.test</groupId>
+                            <artifactId>nonexistent-parent</artifactId>
+                            <version>1.0.0</version>
+                        </parent>
+                        <artifactId>test-child</artifactId>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -1115,21 +1115,21 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should handle malformed POM gracefully")
         void shouldHandleMalformedPOMGracefully() throws Exception {
             String malformedPomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <!-- Missing required elements -->
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <!-- Missing required elements -->
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(malformedPomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -1166,23 +1166,23 @@ class PluginUpgradeStrategyTest {
         @DisplayName("should format pluginManagement with proper indentation")
         void shouldFormatPluginManagementWithProperIndentation() throws Exception {
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-compiler-plugin</artifactId>
-                                <version>3.1</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-compiler-plugin</artifactId>
+                                    <version>3.1</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
@@ -1211,23 +1211,23 @@ class PluginUpgradeStrategyTest {
         void shouldFormatPluginManagementWithProperIndentationWhenAdded() throws Exception {
             // Use a POM that will trigger pluginManagement addition by having a plugin without version
             String pomXml = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0.0</version>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-enforcer-plugin</artifactId>
-                                <!-- No version - should trigger pluginManagement addition -->
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>test</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-enforcer-plugin</artifactId>
+                                    <!-- No version - should trigger pluginManagement addition -->
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
 
             Document document = Document.of(pomXml);
             Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ under the License.
     <byteBuddyVersion>1.18.11</byteBuddyVersion>
     <classWorldsVersion>2.12.0</classWorldsVersion>
     <commonsCliVersion>1.11.0</commonsCliVersion>
-    <domtripVersion>1.5.2</domtripVersion>
+    <domtripVersion>1.6.0</domtripVersion>
     <guiceVersion>5.1.0</guiceVersion>
     <guavaVersion>33.6.0-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>


### PR DESCRIPTION
## Summary

- Fix `PluginUpgradeStrategy` to set `precedingWhitespace` on `Comment` nodes inserted before plugin elements, so the "Override version inherited from parent" comment appears on its own line instead of being appended to the preceding `</plugin>` closing tag
- Add test assertions to verify comments are not on the same line as closing tags

## Problem

When mvnup adds plugin management entries for plugins inherited from a remote parent, it inserts a `<!-- Override version inherited from parent -->` comment before the `<plugin>` element. The `Comment.of(...)` factory creates a comment with no `precedingWhitespace`, causing it to render on the same line as the previous `</plugin>` closing tag:

```xml
            </plugin><!-- Override version inherited from parent -->
            <plugin>
```

This breaks projects that enforce POM formatting (e.g. via `spotless-maven-plugin`), which expect:

```xml
            </plugin>
            <!-- Override version inherited from parent -->
            <plugin>
```

## Fix

Set `precedingWhitespace` on the `Comment` node to match the plugin element's indentation at both insertion sites in `PluginUpgradeStrategy`:
- `addPluginManagementEntryFromUpgrade()` — for `build/pluginManagement/plugins`
- `addDirectPluginOverrides()` — for `build/plugins`

Fixes gnodet/maven4-testing#23134

## Test plan

- [x] Existing `PluginUpgradeStrategyTest` passes (31 tests)
- [x] New assertions verify comments are on their own line (`assertFalse(xml.contains("</plugin><!--"), ...)`)
- [x] Full `maven-cli` module verify passes (468 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)