### PR TITLE
Bump actions/setup-java from 5.4.0 to 5.5.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 21
           distribution: 'zulu'
@@ -131,11 +131,12 @@ jobs:
           path: built-maven/
 
       - name: Set up JDK
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
           cache: 'maven'
+          show-download-progress: true # ITs verify transfer progress output
 
       - name: Set up Maven
         run:


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-java` from 5.4.0 to 5.5.0
- Adds `show-download-progress: true` to the integration-test job to fix CI failures

## Context

Supersedes #12438.

`setup-java` v5.5.0 ([changelog](https://github.com/actions/setup-java/releases/tag/v5.5.0)) introduces a new default that sets `MAVEN_ARGS=-ntp` (`--no-transfer-progress`) to suppress Maven transfer/download progress output in CI logs ([actions/setup-java#1053](https://github.com/actions/setup-java/pull/1053)).

Since `MAVEN_ARGS` is honored by Maven 3.9.0+, this suppresses transfer progress output in the forked Maven processes spawned by the integration tests, breaking 3 ITs that verify transfer listener behavior:

| Test | What it checks |
|---|---|
| `MavenITmng4829ChecksumFailureWarningTest` | Checksum failure warnings are logged during transfer |
| `MavenITmng4461ArtifactUploadMonitorTest` | Artifact upload progress appears in logs |
| `MavenITmng6240PluginExtensionAetherProvider` | Resolved dependency count from transfer listener output |

The fix adds `show-download-progress: true` to the `setup-java` step in the integration-test job, which opts out of the new `-ntp` default. The build job keeps the default (cleaner logs).

## Test plan
- [ ] All 15 integration-test matrix jobs pass (3 OS × 5 JDK)
- [ ] Build job still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)