### PR TITLE
[MNG-8432] Integration test for MNG-8432 using mixins

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8432MixinsPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8432MixinsPropertiesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8432">MNG-8432</a>.
+ * <p>
+ * Demonstrates that the {@code <mixins>} feature (Maven 4.2.0+) is the proper solution
+ * for inheriting both dependency management and properties from a BOM-like project,
+ * instead of extending BOM import semantics.
+ * </p>
+ */
+public class MavenITmng8432MixinsPropertiesTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a project using a mixin inherits both properties and
+     * dependency management from the mixin POM.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void testMixinProvidesDependencyManagementAndProperties() throws Exception {
+        Path testDir = extractResources("/mng-8432-mixins-properties");
+
+        // 1. Install the mixin-bom which provides properties and dependencyManagement
+        Verifier verifier = newVerifier(testDir.resolve("mixin-bom"));
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.mng8432");
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // 2. Build the consuming project and dump its effective POM
+        Path projectDir = testDir.resolve("project");
+        verifier = newVerifier(projectDir);
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.addCliArgument("help:effective-pom");
+        verifier.addCliArgument("-Doutput=target/effective-pom.xml");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // 3. Verify the effective POM contains the mixin's property
+        verifier.verifyFilePresent("target/effective-pom.xml");
+        String effectivePom = Files.readString(projectDir.resolve("target/effective-pom.xml"));
+        assertTrue(
+                effectivePom.contains("<mixin.property>mixin-value</mixin.property>"),
+                "Property from mixin BOM should be inherited by the consuming project");
+
+        // 4. Verify the effective POM contains the managed dependency from the mixin
+        assertTrue(
+                effectivePom.contains("<artifactId>managed-dep</artifactId>"),
+                "Dependency management from mixin BOM should be inherited by the consuming project");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8432MixinsPropertiesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8432MixinsPropertiesTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8432">MNG-8432</a>.
@@ -54,26 +54,24 @@ public class MavenITmng8432MixinsPropertiesTest extends AbstractMavenIntegration
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        // 2. Build the consuming project and dump its effective POM
-        Path projectDir = testDir.resolve("project");
-        verifier = newVerifier(projectDir);
+        // 2. Build the consuming project and evaluate model expressions
+        verifier = newVerifier(testDir.resolve("project"));
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
-        verifier.addCliArgument("help:effective-pom");
-        verifier.addCliArgument("-Doutput=target/effective-pom.xml");
+        verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        // 3. Verify the effective POM contains the mixin's property
-        verifier.verifyFilePresent("target/effective-pom.xml");
-        String effectivePom = Files.readString(projectDir.resolve("target/effective-pom.xml"));
-        assertTrue(
-                effectivePom.contains("<mixin.property>mixin-value</mixin.property>"),
+        // 3. Verify the model contains the mixin's property and managed dependency
+        verifier.verifyFilePresent("target/model.properties");
+        Properties props = verifier.loadProperties("target/model.properties");
+        assertEquals(
+                "mixin-value",
+                props.getProperty("project.properties.mixin.property"),
                 "Property from mixin BOM should be inherited by the consuming project");
-
-        // 4. Verify the effective POM contains the managed dependency from the mixin
-        assertTrue(
-                effectivePom.contains("<artifactId>managed-dep</artifactId>"),
+        assertEquals(
+                "org.apache.maven.its.mng8432:managed-dep:jar",
+                props.getProperty("project.dependencyManagement.dependencies.0.managementKey"),
                 "Dependency management from mixin BOM should be inherited by the consuming project");
     }
 }

--- a/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/managed-dep/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/managed-dep/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.mng8432</groupId>
+  <artifactId>managed-dep</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: MNG-8432 :: Managed Dep</name>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/mixin-bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/mixin-bom/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.2.0 http://maven.apache.org/xsd/maven-4.2.0.xsd">
+  <modelVersion>4.2.0</modelVersion>
+  <groupId>org.apache.maven.its.mng8432</groupId>
+  <artifactId>mixin-bom</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: MNG-8432 :: Mixin BOM</name>
+
+  <properties>
+    <mixin.property>mixin-value</mixin.property>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.mng8432</groupId>
+        <artifactId>managed-dep</artifactId>
+        <version>1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/project/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/project/pom.xml
@@ -15,6 +15,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputFile>target/model.properties</outputFile>
+              <expressions>
+                <expression>project/properties</expression>
+                <expression>project/dependencyManagement</expression>
+              </expressions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <mixins>
     <mixin>
       <groupId>org.apache.maven.its.mng8432</groupId>

--- a/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/project/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8432-mixins-properties/project/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" root="true" xsi:schemaLocation="http://maven.apache.org/POM/4.2.0 http://maven.apache.org/xsd/maven-4.2.0.xsd">
+  <modelVersion>4.2.0</modelVersion>
+  <groupId>org.apache.maven.its.mng8432</groupId>
+  <artifactId>project</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: MNG-8432 :: Project</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.mng8432</groupId>
+      <artifactId>managed-dep</artifactId>
+    </dependency>
+  </dependencies>
+
+  <mixins>
+    <mixin>
+      <groupId>org.apache.maven.its.mng8432</groupId>
+      <artifactId>mixin-bom</artifactId>
+      <version>1.0</version>
+    </mixin>
+  </mixins>
+</project>


### PR DESCRIPTION
This PR adds an integration test to demonstrate and document the correct usage of the `<mixins>` feature (introduced in Maven 4.2.0) as the native and architecturally preferred solution to [MNG-8432](https://issues.apache.org/jira/browse/MNG-8432).

As discussed in the original PR #12417 (which proposed extending `<dependency>` BOM imports to include properties), inheriting both dependency management and properties from a shared BOM-like module is a highly requested use case (e.g. for Spring Boot, Quarkus). However, extending `dependencyManagement` imports to pull properties introduces significant risks around property pollution, silent semantic drift, and ordering fragility.

Instead, as @gnodet correctly pointed out, **Mixins** are the supported mechanism for this use case. Following his suggestion, this integration test (`MavenITmng8432MixinsPropertiesTest`) explicitly verifies that when a project uses a `<mixin>`, it successfully inherits both:
1. `dependencyManagement` (verified by the consumer being able to resolve the managed dependency)
2. `properties` (verified by checking the `effective-pom` for the inherited property)

This serves as both a regression test for the mixin functionality and as executable documentation for users encountering the MNG-8432 use case.
