### PR TITLE
Fix #12464: Skip MAVEN_ARGS for non-default main classes (--up, --enc, --shell)

### DIFF
--- a/apache-maven/src/assembly/maven/bin/mvn
+++ b/apache-maven/src/assembly/maven/bin/mvn
@@ -290,10 +290,20 @@ cmd="\"$JAVACMD\" \
 
 if [ -n "$MAVEN_DEBUG_SCRIPT" ]; then
   echo "[DEBUG] Launching JVM with command:" >&2
-  printf '[DEBUG]   %s' "$cmd" >&2; printf ' %s' "$MAVEN_ARGS" >&2; printf ' "%s"' "$@" >&2; echo >&2
+  printf '[DEBUG]   %s' "$cmd" >&2
+  if [ "$MAVEN_MAIN_CLASS" = "org.apache.maven.cling.MavenCling" ]; then
+    printf ' %s' "$MAVEN_ARGS" >&2
+  fi
+  printf ' "%s"' "$@" >&2; echo >&2
 fi
 
 # User arguments ("$@") and MAVEN_ARGS are passed outside the eval'd string
 # to preserve literal values (backslashes, ${...} placeholders) without
 # shell re-parsing. Only the base command uses eval for MAVEN_OPTS word splitting.
-eval exec "$cmd" '$MAVEN_ARGS' '"$@"'
+# MAVEN_ARGS is only passed for the default Maven build command (MavenCling),
+# not for sub-commands like --up, --enc, or --shell which have their own options.
+if [ "$MAVEN_MAIN_CLASS" = "org.apache.maven.cling.MavenCling" ]; then
+  eval exec "$cmd" '$MAVEN_ARGS' '"$@"'
+else
+  eval exec "$cmd" '"$@"'
+fi

--- a/apache-maven/src/assembly/maven/bin/mvn.cmd
+++ b/apache-maven/src/assembly/maven/bin/mvn.cmd
@@ -291,6 +291,10 @@ for %%i in ("%MAVEN_HOME%"\boot\plexus-classworlds-*) do set LAUNCHER_JAR="%%i"
 set LAUNCHER_CLASS=org.codehaus.plexus.classworlds.launcher.Launcher
 if "%MAVEN_MAIN_CLASS%"=="" @set MAVEN_MAIN_CLASS=org.apache.maven.cling.MavenCling
 
+@REM Only pass MAVEN_ARGS for the default Maven build command (MavenCling),
+@REM not for sub-commands like --up, --enc, or --shell which have their own options.
+if not "%MAVEN_MAIN_CLASS%"=="org.apache.maven.cling.MavenCling" set "MAVEN_ARGS="
+
 if defined MAVEN_DEBUG_SCRIPT (
   echo [DEBUG] Launching JVM with command:
   echo [DEBUG]   "%JAVACMD%" %INTERNAL_MAVEN_OPTS% %MAVEN_OPTS% %JVM_CONFIG_MAVEN_OPTS% %MAVEN_DEBUG_OPTS% --enable-native-access=ALL-UNNAMED -classpath %LAUNCHER_JAR% "-Dclassworlds.conf=%CLASSWORLDS_CONF%" "-Dmaven.home=%MAVEN_HOME%" "-Dmaven.mainClass=%MAVEN_MAIN_CLASS%" "-Dlibrary.jline.path=%MAVEN_HOME%\lib\jline-native" "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %LAUNCHER_CLASS% %MAVEN_ARGS% %*


### PR DESCRIPTION
## Summary

- In `bin/mvn`, gate `$MAVEN_ARGS` inclusion on `MAVEN_MAIN_CLASS` equaling the default `MavenCling`. When `--up`, `--enc`, or `--shell` is used, the `handle_args` function sets `MAVEN_MAIN_CLASS` to a different class — skip `MAVEN_ARGS` in that case to avoid passing unrecognized build-specific flags (e.g. `-ntp`, `-T4`, `-U`) to sub-commands.
- Apply the same fix in `bin/mvn.cmd` by clearing `MAVEN_ARGS` when the main class is not `MavenCling` (safe because the script runs inside `@setlocal`).
- Debug logging (`MAVEN_DEBUG_SCRIPT`) is also updated to reflect the conditional behavior.

Closes #12464

## Test plan

- [x] Module builds successfully (`mvn verify -pl apache-maven`)
- [ ] Run `MAVEN_ARGS="-ntp -T4" mvn --up check` — should no longer fail with unrecognized option errors
- [ ] Run `MAVEN_ARGS="-ntp -T4" mvn clean install` — should still pass MAVEN_ARGS as before
- [ ] Run `MAVEN_ARGS="-ntp" mvn --enc` — should not fail on `-ntp`
- [ ] Verify `MAVEN_DEBUG_SCRIPT=1 mvn --up check` does not print MAVEN_ARGS in debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)