### PR TITLE
Backport #12446: Fix deadlock in AbstractRequestCache

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/AbstractRequestCache.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/AbstractRequestCache.java
@@ -19,9 +19,11 @@
 package org.apache.maven.impl.cache;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.apache.maven.api.cache.BatchRequestException;
@@ -44,6 +46,27 @@ import org.apache.maven.api.services.Result;
 public abstract class AbstractRequestCache implements RequestCache {
 
     /**
+     * Tracks which {@link CachingSupplier} instances are currently being batch-resolved
+     * on the current thread. Used by {@link CachingSupplier#apply} to detect re-entrant
+     * calls and avoid deadlock: if the current thread is already resolving a CachingSupplier,
+     * {@code apply()} will invoke the fallback supplier instead of waiting for
+     * {@link CachingSupplier#complete} (which would never arrive on the same thread).
+     */
+    private static final ThreadLocal<Set<CachingSupplier<?, ?>>> RESOLVING_ON_THREAD =
+            ThreadLocal.withInitial(HashSet::new);
+
+    /**
+     * Checks whether the given CachingSupplier is currently being batch-resolved
+     * on the calling thread.
+     *
+     * @param cs the CachingSupplier to check
+     * @return {@code true} if a batch resolution for {@code cs} is in progress on this thread
+     */
+    static boolean isResolvingOnCurrentThread(CachingSupplier<?, ?> cs) {
+        return RESOLVING_ON_THREAD.get().contains(cs);
+    }
+
+    /**
      * Executes and optionally caches a single request.
      * <p>
      * The caching behavior is determined by the specific implementation of {@link #doCache(Request, Function)}.
@@ -60,14 +83,7 @@ public abstract class AbstractRequestCache implements RequestCache {
     @SuppressWarnings("all")
     public <REQ extends Request<?>, REP extends Result<REQ>> REP request(REQ req, Function<REQ, REP> supplier) {
         CachingSupplier<REQ, REP> cs = doCache(req, supplier);
-        try {
-            return cs.apply(req);
-        } catch (CachingSupplier.CyclicCacheAccessException e) {
-            // Re-entrant access from the same thread (e.g., a batch requests() computation
-            // triggered a singular request() that found the same cached entry). Compute
-            // directly with the caller's supplier to break the cycle.
-            return supplier.apply(req);
-        }
+        return cs.apply(req);
     }
 
     /**
@@ -77,8 +93,20 @@ public abstract class AbstractRequestCache implements RequestCache {
      * only the non-cached requests using the provided supplier function.
      * </p>
      * <p>
-     * If any request in the batch fails, a {@link BatchRequestException} is thrown, containing
-     * details of all failed requests.
+     * This implementation uses {@link CachingSupplier#complete} with {@code wait/notifyAll}
+     * to coordinate batch results, and a {@link ThreadLocal} re-entrancy guard to prevent
+     * deadlocks when batch resolution triggers nested calls (e.g., parent POM resolution
+     * during artifact resolution).
+     * </p>
+     * <p>
+     * <b>Concurrent calls</b> for the same request on different threads: the first thread
+     * performs the resolution; the second thread's {@link CachingSupplier#apply} blocks
+     * (via {@code Object.wait()}) until {@code complete()} is called, avoiding duplicate work.
+     * </p>
+     * <p>
+     * <b>Re-entrant calls</b> on the same thread: detected via {@link #RESOLVING_ON_THREAD}.
+     * {@link CachingSupplier#apply} skips the wait and invokes the fallback supplier directly
+     * so the inner call can complete without waiting for the outer call's batch result.
      * </p>
      *
      * @param <REQ> The request type
@@ -92,57 +120,84 @@ public abstract class AbstractRequestCache implements RequestCache {
     @SuppressWarnings("unchecked")
     public <REQ extends Request<?>, REP extends Result<REQ>> List<REP> requests(
             List<REQ> reqs, Function<List<REQ>, List<REP>> supplier) {
-        final Map<REQ, Object> nonCachedResults = new IdentityHashMap<>();
-        List<RequestResult<REQ, REP>> allResults = new ArrayList<>(reqs.size());
-
-        Function<REQ, REP> individualSupplier = req -> {
-            synchronized (nonCachedResults) {
-                while (!nonCachedResults.containsKey(req)) {
-                    try {
-                        nonCachedResults.wait();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException(e);
-                    }
-                }
-                Object val = nonCachedResults.get(req);
-                if (val instanceof CachingSupplier.AltRes altRes) {
-                    uncheckedThrow(altRes.throwable);
-                }
-                return (REP) val;
-            }
-        };
+        // Create a fallback supplier that can resolve individual requests independently.
+        // This is stored in newly created CachingSupplier instances and used only when
+        // a re-entrant call on the same thread needs to resolve a request whose batch
+        // resolution is still in progress higher up the call stack.
+        Function<REQ, REP> singleSupplier = req -> supplier.apply(List.of(req)).get(0);
 
         List<CachingSupplier<REQ, REP>> suppliers = new ArrayList<>(reqs.size());
         List<REQ> nonCached = new ArrayList<>();
         for (REQ req : reqs) {
-            CachingSupplier<REQ, REP> cs = doCache(req, individualSupplier);
+            CachingSupplier<REQ, REP> cs = doCache(req, singleSupplier);
             suppliers.add(cs);
             if (cs.getValue() == null) {
                 nonCached.add(req);
             }
         }
 
+        // Resolve non-cached requests in batch and directly set results on CachingSuppliers
         if (!nonCached.isEmpty()) {
-            synchronized (nonCachedResults) {
+            // Use IdentityHashMap: request objects may have unstable hashCode() due to
+            // mutable RequestTrace/ModelBuilderRequest data that changes during batch resolution.
+            // Since we always use the same object references for put and get, identity is safe.
+            Map<REQ, Integer> reqToIndex = new IdentityHashMap<>();
+            List<CachingSupplier<REQ, REP>> nonCachedSuppliers = new ArrayList<>(nonCached.size());
+            for (int i = 0; i < reqs.size(); i++) {
+                if (suppliers.get(i).getValue() == null) {
+                    reqToIndex.put(reqs.get(i), i);
+                    nonCachedSuppliers.add(suppliers.get(i));
+                }
+            }
+
+            // Mark these CachingSuppliers as being batch-resolved, and register them
+            // on this thread so that re-entrant apply() calls skip the wait.
+            Set<CachingSupplier<?, ?>> resolving = RESOLVING_ON_THREAD.get();
+            for (CachingSupplier<REQ, REP> cs : nonCachedSuppliers) {
+                cs.setBatchResolving(true);
+                resolving.add(cs);
+            }
+            try {
                 try {
                     List<REP> reps = supplier.apply(nonCached);
                     for (int i = 0; i < reps.size(); i++) {
-                        nonCachedResults.put(nonCached.get(i), reps.get(i));
+                        Integer idx = reqToIndex.get(nonCached.get(i));
+                        if (idx != null) {
+                            suppliers.get(idx).complete(reps.get(i));
+                        }
                     }
                 } catch (MavenExecutionException e) {
                     // If batch request fails, mark all non-cached requests as failed
+                    CachingSupplier.AltRes failure = new CachingSupplier.AltRes(e.getCause());
                     for (REQ req : nonCached) {
-                        nonCachedResults.put(
-                                req, new CachingSupplier.AltRes(e.getCause())); // Mark as processed but failed
+                        Integer idx = reqToIndex.get(req);
+                        if (idx != null) {
+                            suppliers.get(idx).complete(failure);
+                        }
                     }
-                } finally {
-                    nonCachedResults.notifyAll();
+                } catch (Throwable e) {
+                    // Ensure waiting concurrent threads are unblocked on unexpected errors.
+                    // We mark all non-cached requests as failed and fall through to the
+                    // collection loop, which produces a consistent BatchRequestException
+                    // with per-request RequestResult details — same as MavenExecutionException.
+                    CachingSupplier.AltRes failure = new CachingSupplier.AltRes(e);
+                    for (REQ req : nonCached) {
+                        Integer idx = reqToIndex.get(req);
+                        if (idx != null) {
+                            suppliers.get(idx).complete(failure);
+                        }
+                    }
+                }
+            } finally {
+                for (CachingSupplier<REQ, REP> cs : nonCachedSuppliers) {
+                    cs.setBatchResolving(false);
+                    resolving.remove(cs);
                 }
             }
         }
 
         // Collect results in original order
+        List<RequestResult<REQ, REP>> allResults = new ArrayList<>(reqs.size());
         boolean hasFailures = false;
         for (int i = 0; i < reqs.size(); i++) {
             REQ req = reqs.get(i);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/CachingSupplier.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/CachingSupplier.java
@@ -30,8 +30,6 @@ import java.util.function.Function;
 public class CachingSupplier<REQ, REP> implements Function<REQ, REP> {
     protected final Function<REQ, REP> supplier;
     protected volatile Object value;
-    // Guarded by synchronized(this) — tracks which thread is currently computing
-    private Thread computingThread;
 
     public CachingSupplier(Function<REQ, REP> supplier) {
         this.supplier = supplier;
@@ -41,6 +39,25 @@ public class CachingSupplier<REQ, REP> implements Function<REQ, REP> {
         return value;
     }
 
+    /**
+     * Directly sets the cached value without invoking the supplier, then notifies
+     * any threads blocked in {@link #apply(Object)} waiting for the result.
+     * <p>
+     * This is used by {@link AbstractRequestCache#requests} to set batch-resolved results
+     * on CachingSupplier instances. Concurrent callers blocked in {@code apply()} will
+     * be woken up and see this value instead of invoking the supplier redundantly.
+     *
+     * @param result the result to cache (may be a normal result or an {@link AltRes} for errors)
+     */
+    public void complete(Object result) {
+        synchronized (this) {
+            if (value == null) {
+                value = result;
+            }
+            this.notifyAll();
+        }
+    }
+
     @Override
     @SuppressWarnings({"unchecked", "checkstyle:InnerAssignment"})
     public REP apply(REQ req) {
@@ -48,18 +65,27 @@ public class CachingSupplier<REQ, REP> implements Function<REQ, REP> {
         if ((v = value) == null) {
             synchronized (this) {
                 if ((v = value) == null) {
-                    if (computingThread == Thread.currentThread()) {
-                        throw new CyclicCacheAccessException();
+                    // If a batch resolution is in progress on another thread, wait for
+                    // complete() rather than invoking the supplier redundantly.
+                    // Re-entrant calls on the SAME thread must NOT wait (that would deadlock),
+                    // so AbstractRequestCache marks CachingSuppliers it is currently resolving
+                    // in a ThreadLocal; those are excluded from waiting.
+                    if (batchResolving && !AbstractRequestCache.isResolvingOnCurrentThread(this)) {
+                        while ((v = value) == null && batchResolving) {
+                            try {
+                                this.wait();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                break;
+                            }
+                        }
                     }
-                    computingThread = Thread.currentThread();
-                    try {
-                        v = value = supplier.apply(req);
-                    } catch (CyclicCacheAccessException e) {
-                        throw e;
-                    } catch (Exception e) {
-                        v = value = new AltRes(e);
-                    } finally {
-                        computingThread = null;
+                    if ((v = value) == null) {
+                        try {
+                            v = value = supplier.apply(req);
+                        } catch (Exception e) {
+                            v = value = new AltRes(e);
+                        }
                     }
                 }
             }
@@ -71,14 +97,27 @@ public class CachingSupplier<REQ, REP> implements Function<REQ, REP> {
     }
 
     /**
-     * Thrown when a re-entrant call is detected on the same thread that is already
-     * computing this supplier's value. Prevents self-deadlock when a batch
-     * {@code requests()} computation triggers a singular {@code request()} that
-     * finds the same CachingSupplier in the cache.
+     * Marks this supplier as having a batch resolution in progress.
+     * Concurrent threads calling {@link #apply} will wait for {@link #complete}
+     * instead of invoking the supplier independently.
+     * <p>
+     * When clearing the flag ({@code resolving = false}), any threads still blocked
+     * in {@link #apply(Object)} are notified so they can proceed to the fallback
+     * supplier. This handles edge cases where {@link #complete} was never called
+     * (e.g., batch supplier returned fewer results than expected).
+     *
+     * @param resolving {@code true} when batch resolution starts, {@code false} when it ends
      */
-    public static class CyclicCacheAccessException extends RuntimeException {
-        CyclicCacheAccessException() {}
+    void setBatchResolving(boolean resolving) {
+        this.batchResolving = resolving;
+        if (!resolving) {
+            synchronized (this) {
+                this.notifyAll();
+            }
+        }
     }
+
+    private volatile boolean batchResolving;
 
     /**
      * Special holder class for exceptions that occur during supplier execution.

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/cache/AbstractRequestCacheTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/cache/AbstractRequestCacheTest.java
@@ -20,6 +20,14 @@ package org.apache.maven.impl.cache;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import org.apache.maven.api.ProtoSession;
@@ -159,6 +167,285 @@ class AbstractRequestCacheTest {
         assertEquals(request2, results.get(1).getRequest());
     }
 
+    /**
+     * Tests that re-entrant calls to {@code requests()} do not deadlock.
+     * <p>
+     * This reproduces the scenario from issue #12445: an outer {@code requests()} call
+     * creates CachingSupplier instances that are stored in the cache. During batch resolution
+     * (inside the outer call's batch supplier), a nested {@code requests()} call is triggered
+     * (e.g., parent POM resolution during artifact resolution). If the inner call hits the
+     * same cache entry (same request key), it gets back the CachingSupplier from the outer call.
+     * <p>
+     * Before the fix, the CachingSupplier wrapped a wait-based supplier that referenced the
+     * outer call's {@code nonCachedResults} HashMap. The inner call would wait on that HashMap
+     * forever, since the outer call couldn't populate it until the inner call completed.
+     */
+    @Test
+    void testReentrantRequestsDoesNotDeadlock() throws Exception {
+        // Use a caching implementation that stores CachingSuppliers in a shared map
+        CachingTestRequestCache cachingCache = new CachingTestRequestCache();
+
+        // "parentPom" is the request that will be resolved by both the outer and inner calls
+        TestRequest artifact = createTestRequest("artifact");
+        TestRequest parentPom = createTestRequest("parentPom");
+
+        // The outer batch supplier resolves requests, but during resolution of "artifact",
+        // it triggers a nested requests() call for "parentPom"
+        Function<List<TestRequest>, List<TestResult>> outerBatchSupplier = reqs -> {
+            List<TestResult> results = new java.util.ArrayList<>();
+            for (TestRequest req : reqs) {
+                if (req.equals(artifact)) {
+                    // Simulate parent POM resolution: re-entrant call for "parentPom"
+                    List<TestResult> innerResults = cachingCache.requests(
+                            List.of(parentPom),
+                            innerReqs -> innerReqs.stream().map(TestResult::new).toList());
+                    // After inner call completes, outer resolution succeeds
+                    assertEquals(1, innerResults.size());
+                }
+                results.add(new TestResult(req));
+            }
+            return results;
+        };
+
+        // Execute with a timeout to detect deadlock
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<List<TestResult>> future =
+                    executor.submit(() -> cachingCache.requests(List.of(artifact, parentPom), outerBatchSupplier));
+
+            // If this deadlocks, the future will time out
+            List<TestResult> results = future.get(5, TimeUnit.SECONDS);
+
+            assertEquals(2, results.size());
+            assertEquals(artifact, results.get(0).getRequest());
+            assertEquals(parentPom, results.get(1).getRequest());
+        } catch (TimeoutException e) {
+            throw new AssertionError(
+                    "Deadlock detected: re-entrant requests() call did not complete within 5 seconds", e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Tests that a concurrent singular {@code request()} call waits for an
+     * in-progress batch resolution instead of invoking the supplier independently.
+     * <p>
+     * Thread A starts a batch resolution via {@code requests()} (which marks the
+     * CachingSupplier as {@code batchResolving} and registers it on the current thread).
+     * While Thread A is still inside its batch supplier, Thread B calls {@code request()}
+     * for the same key. Thread B's {@code cs.apply()} should see {@code batchResolving == true},
+     * wait for {@code complete()}, and return the batch result without running its own supplier.
+     */
+    @Test
+    void testConcurrentRequestDoesNotDuplicateResolution() throws Exception {
+        CachingTestRequestCache cachingCache = new CachingTestRequestCache();
+
+        TestRequest sharedReq = createTestRequest("shared");
+
+        java.util.concurrent.atomic.AtomicInteger resolutionCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        CountDownLatch batchStarted = new CountDownLatch(1);
+        CountDownLatch proceedWithBatch = new CountDownLatch(1);
+
+        // Thread A's batch supplier: signals when it starts, then waits before completing
+        Function<List<TestRequest>, List<TestResult>> slowBatchSupplier = reqs -> {
+            resolutionCount.incrementAndGet();
+            batchStarted.countDown();
+            try {
+                proceedWithBatch.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return reqs.stream().map(TestResult::new).toList();
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            // Thread A: starts batch resolution via requests(), pauses inside the supplier
+            Future<List<TestResult>> futureA =
+                    executor.submit(() -> cachingCache.requests(List.of(sharedReq), slowBatchSupplier));
+
+            // Wait for Thread A's batch supplier to start
+            assertTrue(batchStarted.await(5, TimeUnit.SECONDS), "Thread A's batch should have started");
+
+            // Thread B: calls request() (singular) for the same key.
+            // It gets the same CachingSupplier from the cache, sees batchResolving == true,
+            // and should wait for Thread A's complete() instead of invoking its own supplier.
+            Future<TestResult> futureB = executor.submit(() -> cachingCache.request(sharedReq, req -> {
+                resolutionCount.incrementAndGet();
+                return new TestResult(req);
+            }));
+
+            // Give Thread B time to enter apply() and start waiting
+            Thread.sleep(200);
+
+            // Let Thread A's batch complete — this calls complete() which wakes Thread B
+            proceedWithBatch.countDown();
+
+            // Both should complete
+            List<TestResult> resultsA = futureA.get(5, TimeUnit.SECONDS);
+            TestResult resultB = futureB.get(5, TimeUnit.SECONDS);
+
+            assertEquals(1, resultsA.size());
+            assertNotNull(resultB);
+
+            // The shared request should have been resolved only once (by Thread A's batch).
+            // Thread B should have waited for Thread A's complete() call, not invoked its
+            // own supplier.
+            assertEquals(1, resolutionCount.get(), "Request should be resolved only once, not duplicated");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Tests that batch resolution is resilient to requests whose {@code hashCode()} changes
+     * during resolution (e.g., because {@code RequestTrace} includes mutable
+     * {@code ModelBuilderRequest} data).
+     * <p>
+     * The {@code reqToIndex} map inside {@code requests()} uses {@code IdentityHashMap}
+     * specifically to handle this: after the batch supplier mutates request data,
+     * lookups still succeed because they compare by reference identity, not by
+     * {@code equals()/hashCode()}.
+     */
+    @Test
+    void testBatchResolutionWithUnstableHashCode() {
+        // Use identity-based cache to match real DefaultRequestCache behavior
+        IdentityCachingTestRequestCache cachingCache = new IdentityCachingTestRequestCache();
+
+        // Create requests with mutable trace data that affects hashCode()
+        MutableHashCodeRequest req1 = new MutableHashCodeRequest("req1", "traceA");
+        MutableHashCodeRequest req2 = new MutableHashCodeRequest("req2", "traceB");
+
+        int originalHash1 = req1.hashCode();
+        int originalHash2 = req2.hashCode();
+
+        java.util.concurrent.atomic.AtomicInteger supplierCallCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        Function<List<MutableHashCodeRequest>, List<MutableHashCodeResult>> batchSupplier = reqs -> {
+            supplierCallCount.incrementAndGet();
+            // Mutate trace data during resolution — this changes hashCode()
+            for (MutableHashCodeRequest r : reqs) {
+                r.setTraceData(r.getTraceData() + "-mutated");
+            }
+            return reqs.stream().map(MutableHashCodeResult::new).toList();
+        };
+
+        // Resolve the batch — hashCode changes inside the supplier
+        List<MutableHashCodeResult> results = cachingCache.requests(List.of(req1, req2), batchSupplier);
+
+        // Verify results were delivered despite hashCode mutation
+        assertEquals(2, results.size());
+        assertEquals(req1, results.get(0).getRequest());
+        assertEquals(req2, results.get(1).getRequest());
+        assertEquals(1, supplierCallCount.get());
+
+        // Verify hashCode actually changed
+        assertTrue(
+                req1.hashCode() != originalHash1 || req2.hashCode() != originalHash2,
+                "hashCode should have changed after mutation");
+    }
+
+    /**
+     * Tests that a concurrent {@code request()} call does not hang when the batch
+     * supplier returns fewer results than expected (partial batch).
+     * <p>
+     * In this scenario, {@link CachingSupplier#complete} is never called for one
+     * of the CachingSuppliers. The waiting thread in {@code apply()} must still
+     * be unblocked when {@code setBatchResolving(false)} is called in the
+     * {@code finally} block, which calls {@code notifyAll()} to wake any waiters.
+     * The unblocked thread then falls through to the fallback supplier.
+     */
+    @Test
+    void testConcurrentRequestUnblockedOnPartialBatchResult() throws Exception {
+        CachingTestRequestCache cachingCache = new CachingTestRequestCache();
+
+        TestRequest req1 = createTestRequest("req1");
+        TestRequest req2 = createTestRequest("req2");
+
+        CountDownLatch batchStarted = new CountDownLatch(1);
+        CountDownLatch proceedWithBatch = new CountDownLatch(1);
+
+        // Batch supplier that only resolves req1, "forgetting" req2
+        Function<List<TestRequest>, List<TestResult>> partialBatchSupplier = reqs -> {
+            batchStarted.countDown();
+            try {
+                proceedWithBatch.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            // Return only the first result — req2's CachingSupplier never gets complete()
+            return List.of(new TestResult(reqs.get(0)));
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            // Thread A: starts batch resolution for [req1, req2]
+            Future<List<TestResult>> futureA =
+                    executor.submit(() -> cachingCache.requests(List.of(req1, req2), partialBatchSupplier));
+
+            // Wait for Thread A's batch supplier to start
+            assertTrue(batchStarted.await(5, TimeUnit.SECONDS), "Batch should have started");
+
+            // Thread B: calls request() for req2 — gets the same CachingSupplier,
+            // sees batchResolving == true, and waits in apply()
+            Future<TestResult> futureB = executor.submit(() -> cachingCache.request(req2, req -> {
+                // Fallback supplier — should be invoked after setBatchResolving(false)
+                return new TestResult(req);
+            }));
+
+            // Give Thread B time to enter apply() and start waiting
+            Thread.sleep(200);
+
+            // Let Thread A's batch complete — only resolves req1
+            proceedWithBatch.countDown();
+
+            // Thread A should complete (req2 gets resolved via fallback in collection loop)
+            List<TestResult> resultsA = futureA.get(5, TimeUnit.SECONDS);
+            assertNotNull(resultsA);
+
+            // Thread B should also complete — setBatchResolving(false) + notifyAll()
+            // unblocks it, and it falls through to its fallback supplier
+            TestResult resultB = futureB.get(5, TimeUnit.SECONDS);
+            assertNotNull(resultB);
+            assertEquals(req2, resultB.getRequest());
+        } catch (TimeoutException e) {
+            throw new AssertionError("Thread hung: setBatchResolving(false) did not unblock waiting thread", e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Tests that batch results are properly cached in CachingSupplier instances
+     * so subsequent calls return the cached values.
+     */
+    @Test
+    void testBatchResultsAreCached() {
+        CachingTestRequestCache cachingCache = new CachingTestRequestCache();
+
+        TestRequest req1 = createTestRequest("req1");
+        TestRequest req2 = createTestRequest("req2");
+
+        java.util.concurrent.atomic.AtomicInteger supplierCallCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        Function<List<TestRequest>, List<TestResult>> batchSupplier = reqs -> {
+            supplierCallCount.incrementAndGet();
+            return reqs.stream().map(TestResult::new).toList();
+        };
+
+        // First call should invoke the batch supplier
+        List<TestResult> results1 = cachingCache.requests(List.of(req1, req2), batchSupplier);
+        assertEquals(2, results1.size());
+        assertEquals(1, supplierCallCount.get());
+
+        // Second call with same requests should use cached values
+        List<TestResult> results2 = cachingCache.requests(List.of(req1, req2), batchSupplier);
+        assertEquals(2, results2.size());
+        // Supplier should not have been called again
+        assertEquals(1, supplierCallCount.get());
+    }
+
     // Helper methods and test classes
 
     private TestRequest createTestRequest(String id) {
@@ -225,6 +512,110 @@ class AbstractRequestCacheTest {
         @Nonnull
         public TestRequest getRequest() {
             return request;
+        }
+    }
+
+    /**
+     * A cache implementation that stores CachingSupplier instances in a shared map,
+     * simulating the real DefaultRequestCache behavior where the same CachingSupplier
+     * can be returned for the same request key across different requests() calls.
+     */
+    static class CachingTestRequestCache extends AbstractRequestCache {
+        private final Map<TestRequest, CachingSupplier<?, ?>> cache = new ConcurrentHashMap<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <REQ extends Request<?>, REP extends Result<REQ>> CachingSupplier<REQ, REP> doCache(
+                REQ req, Function<REQ, REP> supplier) {
+            return (CachingSupplier<REQ, REP>)
+                    cache.computeIfAbsent((TestRequest) req, r -> new CachingSupplier<>(supplier));
+        }
+    }
+
+    /**
+     * A request implementation whose hashCode() depends on mutable trace data,
+     * simulating ResolverRequest with mutable RequestTrace/ModelBuilderRequest data.
+     */
+    static class MutableHashCodeRequest implements Request<ProtoSession> {
+        private final String id;
+        private String traceData;
+
+        MutableHashCodeRequest(String id, String traceData) {
+            this.id = id;
+            this.traceData = traceData;
+        }
+
+        String getTraceData() {
+            return traceData;
+        }
+
+        void setTraceData(String traceData) {
+            this.traceData = traceData;
+        }
+
+        @Override
+        @Nonnull
+        public ProtoSession getSession() {
+            return mock(ProtoSession.class);
+        }
+
+        @Override
+        public RequestTrace getTrace() {
+            return null;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            MutableHashCodeRequest that = (MutableHashCodeRequest) obj;
+            return java.util.Objects.equals(id, that.id) && java.util.Objects.equals(traceData, that.traceData);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(id, traceData);
+        }
+
+        @Override
+        @Nonnull
+        public String toString() {
+            return "MutableHashCodeRequest[" + id + ", " + traceData + "]";
+        }
+    }
+
+    static class MutableHashCodeResult implements Result<MutableHashCodeRequest> {
+        private final MutableHashCodeRequest request;
+
+        MutableHashCodeResult(MutableHashCodeRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        @Nonnull
+        public MutableHashCodeRequest getRequest() {
+            return request;
+        }
+    }
+
+    /**
+     * Cache implementation using identity-based storage (IdentityHashMap).
+     * Simulates real DefaultRequestCache behavior where request identity —
+     * not equals/hashCode — determines cache hits.
+     */
+    static class IdentityCachingTestRequestCache extends AbstractRequestCache {
+        private final java.util.IdentityHashMap<Object, CachingSupplier<?, ?>> cache =
+                new java.util.IdentityHashMap<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <REQ extends Request<?>, REP extends Result<REQ>> CachingSupplier<REQ, REP> doCache(
+                REQ req, Function<REQ, REP> supplier) {
+            return (CachingSupplier<REQ, REP>) cache.computeIfAbsent(req, r -> new CachingSupplier<>(supplier));
         }
     }
 


### PR DESCRIPTION
## Summary

Backport of #12446, which fixes #12445.

Cherry-pick of squash-merge commit c6de104bff92fc0c4572813bac82935470441dc4 from `master` to `maven-4.0.x`.

The fix replaces the wait/notify pattern in `AbstractRequestCache.requests()` with direct value setting via `CachingSupplier.complete()`, preventing deadlocks when re-entrant `requests()` calls occur (e.g., parent POM resolution during artifact resolution). It also adds `ThreadLocal` re-entrancy detection and `setBatchResolving()` so concurrent threads wait for in-progress batch results while same-thread re-entrant calls use a fallback supplier.

Conflicts were resolved during cherry-pick (the 4.0.x branch had a `CyclicCacheAccessException`-based approach that was replaced by the new batch-resolution pattern).

## Test plan

- [ ] CI passes on maven-4.0.x
- [ ] `AbstractRequestCacheTest` passes (included in this backport)


🤖 Generated with [Claude Code](https://claude.com/claude-code)