### PR TITLE
Fix Javadoc about default value

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -479,9 +479,9 @@ public final class Constants {
 
     /**
      * User property for controlling consumer POM flattening behavior.
-     * When set to <code>true</code> (default), consumer POMs are flattened by removing
+     * When set to <code>true</code>, consumer POMs are flattened by removing
      * dependency management and keeping only direct dependencies with transitive scopes.
-     * When set to <code>false</code>, consumer POMs preserve dependency management
+     * When set to <code>false</code> (default), consumer POMs preserve dependency management
      * like parent POMs, allowing dependency management to be inherited by consumers.
      *
      * @since 4.1.0


### PR DESCRIPTION
Correct Javadoc for actual default value false.

See also previous comment here: https://github.com/apache/maven/pull/11347#pullrequestreview-3487936493

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
