### PR TITLE
Fix #12474: Filter uninterpolated managed deps at model level

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -1009,6 +1009,14 @@ public class DefaultModelBuilder implements ModelBuilder {
                 resultModel = transformer.transformEffectiveModel(resultModel);
             }
 
+            // Filter out managed dependencies with uninterpolated property expressions.
+            // Published POMs may declare managed dependencies whose versions reference properties
+            // not defined in the consumer's context (e.g. ${osgi.version}, ${guava-version}).
+            // Maven 3 silently ignored these when unused; Maven 4's resolver validator rejects
+            // them during collectDependencies(), causing "Invalid Collect Request: null" errors.
+            // By stripping them here, all consumers (plugins, lifecycle, etc.) get a clean model.
+            resultModel = filterUninterpolatedManagedDependencies(resultModel);
+
             result.setEffectiveModel(resultModel);
             // Set the default relative path for the parent in the file model
             if (result.getFileModel().getParent() != null
@@ -2387,6 +2395,56 @@ public class DefaultModelBuilder implements ModelBuilder {
             profiles.add(profile);
         }
         return modified ? model.withProfiles(profiles) : model;
+    }
+
+    /**
+     * Filters out managed dependencies whose groupId, artifactId, or version still contains
+     * unresolved {@code ${…}} property expressions after model interpolation.
+     * <p>
+     * Published POMs in Maven repositories sometimes declare managed dependencies that reference
+     * properties defined only in their own build context. When such a POM is consumed as a
+     * transitive dependency or imported BOM, those properties may not be available, leaving
+     * the expressions unresolved. Maven 3 silently tolerated these entries (they only mattered
+     * if actually used). Maven 4's stricter resolver validator rejects them during
+     * {@code collectDependencies()}, causing an "Invalid Collect Request: null" build failure
+     * even when the managed dependency is never actually used.
+     * <p>
+     * Filtering at the effective model level ensures all consumers — lifecycle dependency
+     * resolution, third-party plugins (e.g. enforcer), and any code using
+     * {@code project.getDependencyManagement()} — see only fully interpolated entries.
+     *
+     * @param model the effective model after interpolation
+     * @return the model with uninterpolated managed dependencies removed
+     * @see <a href="https://github.com/apache/maven/issues/12474">gh-12474</a>
+     */
+    static Model filterUninterpolatedManagedDependencies(Model model) {
+        DependencyManagement mgmt = model.getDependencyManagement();
+        if (mgmt == null || mgmt.getDependencies().isEmpty()) {
+            return model;
+        }
+        List<Dependency> filtered = null;
+        List<Dependency> deps = mgmt.getDependencies();
+        for (int i = 0; i < deps.size(); i++) {
+            Dependency dep = deps.get(i);
+            if (containsExpression(dep.getGroupId())
+                    || containsExpression(dep.getArtifactId())
+                    || containsExpression(dep.getVersion())) {
+                if (filtered == null) {
+                    // lazily copy the list up to this point
+                    filtered = new ArrayList<>(deps.subList(0, i));
+                }
+            } else if (filtered != null) {
+                filtered.add(dep);
+            }
+        }
+        if (filtered == null) {
+            return model;
+        }
+        return model.withDependencyManagement(mgmt.withDependencies(filtered));
+    }
+
+    private static boolean containsExpression(String value) {
+        return value != null && value.contains("${");
     }
 
     private Model interpolateModel(Model model, ModelBuilderRequest request, ModelProblemCollector problems) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -444,6 +444,78 @@ class DefaultModelBuilderTest {
                 "Managed dependency version should be interpolated, not ${managed.version}");
     }
 
+    @Test
+    void testFilterUninterpolatedManagedDependenciesNoManagement() {
+        Model model = Model.newInstance();
+        Model result = DefaultModelBuilder.filterUninterpolatedManagedDependencies(model);
+        assertNull(result.getDependencyManagement());
+    }
+
+    @Test
+    void testFilterUninterpolatedManagedDependenciesAllInterpolated() {
+        Model model = Model.newBuilder()
+                .dependencyManagement(org.apache.maven.api.model.DependencyManagement.newBuilder()
+                        .dependencies(List.of(
+                                Dependency.newBuilder()
+                                        .groupId("org.example")
+                                        .artifactId("lib-a")
+                                        .version("1.0")
+                                        .build(),
+                                Dependency.newBuilder()
+                                        .groupId("org.example")
+                                        .artifactId("lib-b")
+                                        .version("2.0")
+                                        .build()))
+                        .build())
+                .build();
+        Model result = DefaultModelBuilder.filterUninterpolatedManagedDependencies(model);
+        assertEquals(2, result.getDependencyManagement().getDependencies().size());
+    }
+
+    @Test
+    void testFilterUninterpolatedManagedDependenciesRemovesUninterpolatedVersion() {
+        Model model = Model.newBuilder()
+                .dependencyManagement(org.apache.maven.api.model.DependencyManagement.newBuilder()
+                        .dependencies(List.of(
+                                Dependency.newBuilder()
+                                        .groupId("org.example")
+                                        .artifactId("lib-a")
+                                        .version("1.0")
+                                        .build(),
+                                Dependency.newBuilder()
+                                        .groupId("org.example")
+                                        .artifactId("lib-bad")
+                                        .version("${undefined.version}")
+                                        .build(),
+                                Dependency.newBuilder()
+                                        .groupId("org.example")
+                                        .artifactId("lib-c")
+                                        .version("3.0")
+                                        .build()))
+                        .build())
+                .build();
+        Model result = DefaultModelBuilder.filterUninterpolatedManagedDependencies(model);
+        List<Dependency> deps = result.getDependencyManagement().getDependencies();
+        assertEquals(2, deps.size());
+        assertEquals("lib-a", deps.get(0).getArtifactId());
+        assertEquals("lib-c", deps.get(1).getArtifactId());
+    }
+
+    @Test
+    void testFilterUninterpolatedManagedDependenciesRemovesUninterpolatedGroupId() {
+        Model model = Model.newBuilder()
+                .dependencyManagement(org.apache.maven.api.model.DependencyManagement.newBuilder()
+                        .dependencies(List.of(Dependency.newBuilder()
+                                .groupId("${project.groupId}")
+                                .artifactId("lib")
+                                .version("1.0")
+                                .build()))
+                        .build())
+                .build();
+        Model result = DefaultModelBuilder.filterUninterpolatedManagedDependencies(model);
+        assertTrue(result.getDependencyManagement().getDependencies().isEmpty());
+    }
+
     private Path getPom(String name) {
         return Paths.get("src/test/resources/poms/factory/" + name + ".xml").toAbsolutePath();
     }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12474InvalidCollectRequestUninterpolatedManagedDepsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12474InvalidCollectRequestUninterpolatedManagedDepsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify that inheriting a managed dependency whose version contains an unresolved
+ * {@code ${…}} property placeholder does not cause an "Invalid Collect Request: null"
+ * build failure, even when a plugin (such as {@code maven-enforcer-plugin}) constructs
+ * its own {@code CollectRequest} from {@code project.getDependencyManagement()}.
+ * <p>
+ * This is a regression test for a problem where the resolver's {@code MavenValidator}
+ * rejected uninterpolated managed dependencies during {@code collectDependencies()}.
+ * The previous fix (#12305) filtered these entries in {@code ArtifactDescriptorReaderDelegate}
+ * and {@code DefaultProjectDependenciesResolver}, but third-party plugins that build
+ * their own {@code CollectRequest} directly from the project model still hit the error.
+ * The fix for this issue (#12474) filters uninterpolated managed dependencies at the
+ * model builder level, so all consumers see clean data.
+ *
+ * @see <a href="https://github.com/apache/maven/issues/12474">gh-12474</a>
+ */
+public class MavenITgh12474InvalidCollectRequestUninterpolatedManagedDepsTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    public void testInheritedUninterpolatedManagedDepsWithEnforcer() throws Exception {
+        Path testDir = extractResources("/gh-12474-invalid-collect-request-managed-deps");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.deleteArtifacts("org.apache.maven.its.gh12474");
+        verifier.filterFile("settings-template.xml", "settings.xml");
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings.xml");
+        verifier.addCliArgument("package");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12474-invalid-collect-request-managed-deps/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12474-invalid-collect-request-managed-deps/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12474</groupId>
+    <artifactId>parent-with-uninterpolated-managed-dep</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>child</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <!--
+    This project inherits a managed dependency with an uninterpolated version
+    from its parent POM. The managed dependency is never used as an actual
+    dependency, so the build must succeed.
+
+    The enforcer plugin is included because it constructs its own CollectRequest
+    using project.getDependencyManagement() directly, which was the original
+    code path that triggered the "Invalid Collect Request: null" error.
+  -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <dependencyConvergence/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12474-invalid-collect-request-managed-deps/repo/org/apache/maven/its/gh12474/parent-with-uninterpolated-managed-dep/1.0/parent-with-uninterpolated-managed-dep-1.0.pom
+++ b/its/core-it-suite/src/test/resources/gh-12474-invalid-collect-request-managed-deps/repo/org/apache/maven/its/gh12474/parent-with-uninterpolated-managed-dep/1.0/parent-with-uninterpolated-managed-dep-1.0.pom
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.gh12474</groupId>
+  <artifactId>parent-with-uninterpolated-managed-dep</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <!--
+    This parent POM declares a managed dependency whose version references a property
+    that is NOT defined anywhere. When a child project inherits this entry, the version
+    remains as the literal string "${undefined.lib.version}". Maven 3 silently tolerates
+    this as long as the managed dependency is never actually used. Maven 4's resolver
+    validator must also tolerate it.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.example</groupId>
+        <artifactId>lib-with-undefined-version</artifactId>
+        <version>${undefined.lib.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12474-invalid-collect-request-managed-deps/settings-template.xml
+++ b/its/core-it-suite/src/test/resources/gh-12474-invalid-collect-request-managed-deps/settings-template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <profiles>
+    <profile>
+      <id>maven-core-it-repo</id>
+      <repositories>
+        <repository>
+          <id>maven-core-it</id>
+          <url>@baseurl@/repo</url>
+          <releases>
+            <checksumPolicy>ignore</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>maven-core-it-repo</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
## Summary

- Filter out managed dependencies with uninterpolated `${…}` property expressions in `DefaultModelBuilder.buildEffectiveModel()`, so all consumers (lifecycle, third-party plugins, etc.) see a clean model
- Root cause: published POMs (e.g. mina-sshd, activemq-openwire) declare managed dependencies with property expressions that are undefined in the consumer's context; Maven 4's stricter `MavenValidator` rejects these during `collectDependencies()`, causing "Invalid Collect Request: null" errors
- The prior fix for #12305 filtered entries in `ArtifactDescriptorReaderDelegate` and `DefaultProjectDependenciesResolver`, but plugins like `maven-enforcer-plugin` that build their own `CollectRequest` from `project.getDependencyManagement()` bypassed those fix points
- Includes 4 unit tests for `filterUninterpolatedManagedDependencies()` and an integration test exercising the enforcer plugin `dependencyConvergence` rule with inherited uninterpolated managed dependencies

## Test plan

- [x] Unit tests pass: 4 new tests in `DefaultModelBuilderTest`
- [x] Manual validation: mina-sshd and activemq-openwire build successfully with the fix
- [ ] CI passes
- [ ] Existing `MavenITgh12305` IT test still passes (no regression)

Closes #12474

🤖 Generated with [Claude Code](https://claude.com/claude-code)