### PR TITLE
Use hardened XmlService.newXMLInputFactory() consistently in extractModelId

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultModelXmlFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.impl;
 
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -187,17 +186,6 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
         }
     }
 
-    static class InputFactoryHolder {
-        static final XMLInputFactory XML_INPUT_FACTORY;
-
-        static {
-            XMLInputFactory factory = XmlService.newXMLInputFactory();
-            factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, true);
-            factory.setProperty(XMLInputFactory.IS_COALESCING, true);
-            XML_INPUT_FACTORY = factory;
-        }
-    }
-
     /**
      * Extracts the modelId (groupId:artifactId:version) from a POM XML stream
      * by parsing just enough XML to get the GAV coordinates.
@@ -207,7 +195,7 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
      */
     private static String extractModelId(InputStream inputStream) {
         try {
-            XMLStreamReader xmlReader = XMLInputFactory.newFactory().createXMLStreamReader(inputStream);
+            XMLStreamReader xmlReader = XmlService.newXMLInputFactory().createXMLStreamReader(inputStream);
             try {
                 return extractModelId(xmlReader);
             } finally {
@@ -220,7 +208,7 @@ public class DefaultModelXmlFactory implements ModelXmlFactory {
 
     private static String extractModelId(Reader reader) {
         try {
-            XMLStreamReader xmlReader = XMLInputFactory.newFactory().createXMLStreamReader(reader);
+            XMLStreamReader xmlReader = XmlService.newXMLInputFactory().createXMLStreamReader(reader);
             try {
                 return extractModelId(xmlReader);
             } finally {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultModelXmlFactoryTest.java
@@ -150,6 +150,34 @@ class DefaultModelXmlFactoryTest {
     }
 
     @Test
+    void testReadPomWithDoctypeDeclaration() throws Exception {
+        // Verify that a POM containing a DOCTYPE declaration with an external entity
+        // is handled gracefully: the pre-parse (extractModelId) should ignore DTDs
+        // and still extract the GAV coordinates correctly
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE project [
+                  <!ENTITY ext SYSTEM "file:///nonexistent/path">
+                ]>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>doctype-test</artifactId>
+                  <version>1.0.0</version>
+                </project>""";
+
+        // Use a Reader (not a Path) so the extractModelId pre-parse is triggered
+        // when no modelId is set on the request
+        XmlReaderRequest request =
+                XmlReaderRequest.builder().reader(new StringReader(xml)).build();
+
+        Model model = factory.read(request);
+        assertEquals("com.example", model.getGroupId());
+        assertEquals("doctype-test", model.getArtifactId());
+        assertEquals("1.0.0", model.getVersion());
+    }
+
+    @Test
     void testWriteWithFormatterEnablesLocationTracking() throws Exception {
         String xml = """
                 <project xmlns="http://maven.apache.org/POM/4.0.0">


### PR DESCRIPTION
## Summary

- Replace raw `XMLInputFactory.newFactory()` with `XmlService.newXMLInputFactory()` in `DefaultModelXmlFactory.extractModelId` to use the same hardened factory (DTD and external entity support disabled) that the rest of the codebase uses.
- Remove the unused `InputFactoryHolder` inner class.
- Add test for POM parsing with DOCTYPE declarations.

## Test plan

- [x] Existing `DefaultModelXmlFactoryTest` tests pass (9/9)
- [x] New `testReadPomWithDoctypeDeclaration` test verifies graceful handling of DOCTYPEs during the pre-parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)