### PR TITLE
Remove consumer-side dependency filtering workarounds for uninterpolated expressions

### DIFF
--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/ArtifactDescriptorReaderDelegate.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/ArtifactDescriptorReaderDelegate.java
@@ -64,18 +64,12 @@ public class ArtifactDescriptorReaderDelegate {
         }
 
         for (org.apache.maven.model.Dependency dependency : model.getDependencies()) {
-            if (hasUninterpolatedExpression(dependency)) {
-                continue;
-            }
             result.addDependency(convert(dependency, stereotypes));
         }
 
         DependencyManagement mgmt = model.getDependencyManagement();
         if (mgmt != null) {
             for (org.apache.maven.model.Dependency dependency : mgmt.getDependencies()) {
-                if (hasUninterpolatedExpression(dependency)) {
-                    continue;
-                }
                 result.addManagedDependency(convert(dependency, stereotypes));
             }
         }
@@ -140,12 +134,6 @@ public class ArtifactDescriptorReaderDelegate {
 
     private Exclusion convert(org.apache.maven.model.Exclusion exclusion) {
         return new Exclusion(exclusion.getGroupId(), exclusion.getArtifactId(), "*", "*");
-    }
-
-    private static boolean hasUninterpolatedExpression(org.apache.maven.model.Dependency dependency) {
-        return containsPlaceholder(dependency.getGroupId())
-                || containsPlaceholder(dependency.getArtifactId())
-                || containsPlaceholder(dependency.getVersion());
     }
 
     private static boolean containsPlaceholder(String value) {

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -147,11 +147,6 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
         DependencyManagement depMgmt = project.getDependencyManagement();
         if (depMgmt != null) {
             for (Dependency dependency : depMgmt.getDependencies()) {
-                if (containsPlaceholder(dependency.getGroupId())
-                        || containsPlaceholder(dependency.getArtifactId())
-                        || containsPlaceholder(dependency.getVersion())) {
-                    continue;
-                }
                 collect.addManagedDependency(RepositoryUtils.toDependency(dependency, stereotypes));
             }
         }
@@ -200,10 +195,6 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
         }
 
         return result;
-    }
-
-    private static boolean containsPlaceholder(String value) {
-        return value != null && value.contains("${");
     }
 
     private void process(DefaultDependencyResolutionResult result, Collection<ArtifactResult> results) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultDependencyResolver.java
@@ -174,8 +174,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
                         session.getNode(result.getRoot(), request.getVerbose()),
                         0);
             } catch (DependencyCollectionException e) {
-                String enhancedMessage = enhanceCollectionError(e, collectRequest);
-                throw new DependencyResolverException(enhancedMessage, e);
+                throw new DependencyResolverException(e.getMessage(), e);
             }
         } finally {
             RequestTraceHelper.exit(trace);
@@ -274,62 +273,5 @@ public class DefaultDependencyResolver implements DependencyResolver {
 
     private static DependencyResolverException cannotReadModuleInfo(final Path path, final IOException cause) {
         return new DependencyResolverException("Cannot read module information of " + path, cause);
-    }
-
-    private static boolean containsUnresolvedExpression(String value) {
-        return value != null && value.contains("${") && value.contains("}");
-    }
-
-    private static String enhanceCollectionError(DependencyCollectionException e, CollectRequest request) {
-        if (e.getMessage() != null && e.getMessage().contains("Invalid Collect Request")) {
-            StringBuilder enhanced = new StringBuilder();
-            enhanced.append("Failed to collect dependencies");
-
-            org.eclipse.aether.graph.Dependency root = request.getRoot();
-            if (root != null && root.getArtifact() != null) {
-                org.eclipse.aether.artifact.Artifact artifact = root.getArtifact();
-                String groupId = artifact.getGroupId();
-                String artifactId = artifact.getArtifactId();
-                String version = artifact.getVersion();
-
-                if (containsUnresolvedExpression(groupId)
-                        || containsUnresolvedExpression(artifactId)
-                        || containsUnresolvedExpression(version)) {
-                    enhanced.append(" due to unresolved expression(s) in dependency: ")
-                            .append(groupId)
-                            .append(":")
-                            .append(artifactId)
-                            .append(":")
-                            .append(version)
-                            .append(".\n")
-                            .append("Please check that all properties are defined in your POM or settings.xml.");
-                    return enhanced.toString();
-                }
-            }
-
-            for (org.eclipse.aether.graph.Dependency dep : request.getDependencies()) {
-                if (dep != null && dep.getArtifact() != null) {
-                    org.eclipse.aether.artifact.Artifact artifact = dep.getArtifact();
-                    String groupId = artifact.getGroupId();
-                    String artifactId = artifact.getArtifactId();
-                    String version = artifact.getVersion();
-
-                    if (containsUnresolvedExpression(groupId)
-                            || containsUnresolvedExpression(artifactId)
-                            || containsUnresolvedExpression(version)) {
-                        enhanced.append(" due to unresolved expression(s) in dependency: ")
-                                .append(groupId)
-                                .append(":")
-                                .append(artifactId)
-                                .append(":")
-                                .append(version)
-                                .append(".\n")
-                                .append("Please check that all properties are defined in your POM or settings.xml.");
-                        return enhanced.toString();
-                    }
-                }
-            }
-        }
-        return e.getMessage();
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
@@ -121,7 +121,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         Model model = loadPom(session, request, result);
         if (model != null) {
             populateResult(InternalSession.from(session), result, model);
-            filterUninterpolated(result);
+            filterUninterpolatedRepositories(result);
         }
 
         return result;
@@ -351,20 +351,12 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         }
 
         for (org.apache.maven.api.model.Dependency dependency : model.getDependencies()) {
-            if (hasUninterpolatedExpression(dependency)) {
-                logger.debug("Filtered dependency with uninterpolated expression: {}", dependency);
-                continue;
-            }
             result.addDependency(convert(dependency, stereotypes));
         }
 
         DependencyManagement dependencyManagement = model.getDependencyManagement();
         if (dependencyManagement != null) {
             for (org.apache.maven.api.model.Dependency dependency : dependencyManagement.getDependencies()) {
-                if (hasUninterpolatedExpression(dependency)) {
-                    logger.debug("Filtered managed dependency with uninterpolated expression: {}", dependency);
-                    continue;
-                }
                 result.addManagedDependency(convert(dependency, stereotypes));
             }
         }
@@ -431,13 +423,12 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         return new Exclusion(exclusion.getGroupId(), exclusion.getArtifactId(), "*", "*");
     }
 
-    private static boolean hasUninterpolatedExpression(org.apache.maven.api.model.Dependency dependency) {
-        return containsPlaceholder(dependency.getGroupId())
-                || containsPlaceholder(dependency.getArtifactId())
-                || containsPlaceholder(dependency.getVersion());
-    }
-
-    private void filterUninterpolated(ArtifactDescriptorResult result) {
+    /**
+     * Filters out repositories with uninterpolated expressions in their ID or URL.
+     * Unlike dependency filtering (which is now handled by the resolver's re-entrancy detection),
+     * repository filtering has independent value: you cannot connect to a URL like {@code ${something}}.
+     */
+    private void filterUninterpolatedRepositories(ArtifactDescriptorResult result) {
         result.getRepositories().removeIf(repo -> {
             if (containsPlaceholder(repo.getId()) || containsPlaceholder(repo.getUrl())) {
                 logger.debug("Filtered repository with uninterpolated expression: {}", repo);
@@ -445,26 +436,6 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
             }
             return false;
         });
-        result.getDependencies().removeIf(dep -> {
-            if (hasUninterpolatedExpression(dep.getArtifact())) {
-                logger.debug("Filtered dependency with uninterpolated expression: {}", dep);
-                return true;
-            }
-            return false;
-        });
-        result.getManagedDependencies().removeIf(dep -> {
-            if (hasUninterpolatedExpression(dep.getArtifact())) {
-                logger.debug("Filtered managed dependency with uninterpolated expression: {}", dep);
-                return true;
-            }
-            return false;
-        });
-    }
-
-    private static boolean hasUninterpolatedExpression(Artifact artifact) {
-        return containsPlaceholder(artifact.getGroupId())
-                || containsPlaceholder(artifact.getArtifactId())
-                || containsPlaceholder(artifact.getVersion());
     }
 
     private static boolean containsPlaceholder(String value) {


### PR DESCRIPTION
## Summary

Companion PR to [apache/maven-resolver#1957](https://github.com/apache/maven-resolver/pull/1957), which adds re-entrancy detection to `DefaultRepositorySystem`. With the resolver now skipping validation on re-entrant calls, the consumer-side workarounds that filtered dependencies with uninterpolated `${…}` expressions are no longer needed.

> **⚠️ Depends on:** This PR must be merged **after** [apache/maven-resolver#1957](https://github.com/apache/maven-resolver/pull/1957) is merged and the resolver dependency in Maven's `pom.xml` is updated to include the re-entrancy fix. Until then, the `MavenITgh12305` integration test will fail (expected — it tests the exact scenario these workarounds protected against).

**Removed workarounds** (all purely defensive against `MavenValidator` rejection on re-entry):

- `DefaultArtifactDescriptorReader`: dependency and managed dependency filtering in `populateResult()` and `filterUninterpolated()`
- `ArtifactDescriptorReaderDelegate` (compat): dependency and managed dependency filtering in `populateResult()`
- `DefaultProjectDependenciesResolver`: managed dependency placeholder check before `collectDependencies()`
- `DefaultDependencyResolver`: `enhanceCollectionError()` for "Invalid Collect Request" with unresolved expressions (error path no longer reachable)

**Kept**: Repository filtering (URLs with `${…}` are genuinely invalid — you can't connect to them).

This is a **net deletion** of ~116 lines of workaround code across 4 files.

## Context

These workarounds were introduced across several PRs (#12049, #12084, #12204, #12305) to work around the fact that Maven 4's `MavenValidator` rejected artifacts with uninterpolated expressions during re-entrant `RepositorySystem` calls (model builder → model resolver → `RepositorySystem` chain). The resolver fix addresses this at the source by detecting re-entrancy via `RequestTrace` ancestry and skipping validation on inner calls.

## IT failure analysis

The `MavenITgh12305InvalidCollectRequestUninterpolatedManagedDepsTest` IT fails because it tests building a project that imports a BOM with uninterpolated `${osgi.version}` in managed dependencies. Without either the consumer-side workarounds (removed here) or the resolver-side re-entrancy fix (not yet in Maven's resolver dependency), the `MavenValidator` rejects the expression. Once Maven's resolver dependency is updated to include the re-entrancy fix, this IT will pass without the workarounds.

## Test plan

- [x] `mvn test -pl compat/maven-resolver-provider` — all tests pass
- [x] `mvn test -pl impl/maven-impl` — all tests pass
- [x] `mvn test -pl impl/maven-core` — all tests pass
- [x] CI: only `MavenITgh12305` IT fails (expected — needs resolver fix integrated)
- [ ] Full CI after resolver dependency update

🤖 Generated with [Claude Code](https://claude.com/claude-code)