### PR TITLE
Drop mention of Plexus XML

### DIFF
--- a/maven-core/src/site/apt/default-bindings.apt.vm
+++ b/maven-core/src/site/apt/default-bindings.apt.vm
@@ -26,7 +26,7 @@
 Plugin Bindings for <<<default>>> Lifecycle Reference
 
   The {{{./lifecycles.html}<<<default>>> lifecycle}} is defined without any plugin binding; plugin bindings are defined separately
-  in <<<META-INF/plexus/default-bindings.xml>>> because they are specific for each packaging:
+  because they are specific for each packaging:
 
 %{toc|fromDepth=2}
 


### PR DESCRIPTION
As there is no such file anymore. Still, the sentence as is, is correct, just how they are defined was not true (in Plexus XML file).
