### PR TITLE
MNG-7884: Add --print-build-order option to print reactor build order without building

### DIFF
--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
@@ -103,6 +103,13 @@ public interface MavenOptions extends Options {
     Optional<Boolean> failFast();
 
     /**
+     * Requests that Maven print the reactor build order and exit, without executing the build.
+     *
+     * @return {@code true} if the reactor build order should be printed and the build skipped.
+     */
+    Optional<Boolean> printBuildOrder();
+
+    /**
      * Indicates whether Maven should run all builds but defer error reporting to the end.
      *
      * @return an {@link Optional} containing true if error reporting should be deferred to the end, false if not, or empty if not specified

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
@@ -105,7 +105,8 @@ public interface MavenOptions extends Options {
     /**
      * Requests that Maven print the reactor build order and exit, without executing the build.
      *
-     * @return {@code true} if the reactor build order should be printed and the build skipped.
+     * @return an {@link Optional} containing true if the reactor build order should be printed
+     *         and the build skipped, false if not, or empty if not specified.
      */
     @Nonnull
     Optional<Boolean> printBuildOrder();

--- a/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
+++ b/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
@@ -107,6 +107,7 @@ public interface MavenOptions extends Options {
      *
      * @return {@code true} if the reactor build order should be printed and the build skipped.
      */
+    @Nonnull
     Optional<Boolean> printBuildOrder();
 
     /**

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/CommonsCliMavenOptions.java
@@ -103,6 +103,14 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
     }
 
     @Override
+    public Optional<Boolean> printBuildOrder() {
+        if (commandLine.hasOption(CLIManager.PRINT_BUILD_ORDER)) {
+            return Optional.of(Boolean.TRUE);
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<Boolean> failAtEnd() {
         if (commandLine.hasOption(CLIManager.FAIL_AT_END)) {
             return Optional.of(Boolean.TRUE);
@@ -238,6 +246,7 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
         public static final String CHECKSUM_FAILURE_POLICY = "C";
         public static final String CHECKSUM_WARNING_POLICY = "c";
         public static final String FAIL_FAST = "ff";
+        public static final String PRINT_BUILD_ORDER = "pbo";
         public static final String FAIL_AT_END = "fae";
         public static final String FAIL_NEVER = "fn";
         public static final String RESUME = "r";
@@ -359,6 +368,10 @@ public class CommonsCliMavenOptions extends CommonsCliOptions implements MavenOp
                     .hasArg()
                     .desc(
                             "If set, Maven will load command line options from the specified file and merge with CLI specified ones.")
+                    .get());
+            options.addOption(Option.builder(PRINT_BUILD_ORDER)
+                    .longOpt("print-build-order")
+                    .desc("Print the reactor build order and exit without building")
                     .get());
         }
     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/LayeredMavenOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/LayeredMavenOptions.java
@@ -90,6 +90,11 @@ public class LayeredMavenOptions<O extends MavenOptions> extends LayeredOptions<
     }
 
     @Override
+    public Optional<Boolean> printBuildOrder() {
+        return returnFirstPresentOrEmpty(MavenOptions::printBuildOrder);
+    }
+
+    @Override
     public Optional<Boolean> failAtEnd() {
         return returnFirstPresentOrEmpty(MavenOptions::failAtEnd);
     }


### PR DESCRIPTION
<!--
Please open pull requests against one of the following branches:

- master — default target for all changes (new features + bug fixes).  
  If the change should also go to maven-4.0.x, request a backport in the PR.

- maven-3.10.x — target for 3.x changes (new features + bug fixes).  
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.

Backports are typically handled by maintainers; 
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

## What
Adds a new CLI flag `--print-build-order` (short form `-pbo`) that prints the reactor's
topologically-sorted build order and exits, without executing the build lifecycle.

## Why
Closes #8733 (MNG-7884). This is useful for analyzing a multi-module build's execution
order without committing to a full build — e.g. in CI diagnostics, scripting, or simply
understanding module interdependencies in large reactors.

## How
- Added `printBuildOrder()` to the `MavenOptions` API interface (`api/maven-api-cli`).
- Implemented option parsing in `CommonsCliMavenOptions` (new `PRINT_BUILD_ORDER` constant
  and `Option` registration in the nested `CLIManager`).
- Added the corresponding merge-layer override in `LayeredMavenOptions`.
- (In progress) Wiring the parsed value into `MavenExecutionRequest` via
  `MavenInvoker.populateRequest(...)`.
- (In progress) Adding `isPrintBuildOrder()`/`setPrintBuildOrder(boolean)` to
  `MavenExecutionRequest`/`DefaultMavenExecutionRequest`.
- (In progress) In `DefaultMaven.doExecute(...)`, after the authoritative `buildGraph(session)`
  call succeeds, checking the flag and — if set — printing the sorted project list and
  returning a clean success result before `lifecycleStarter.execute(session)` runs.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
