### PR TITLE
Refactor MNG-11133 test to use maven-it-plugin-expression

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng11133MixinsPrecedenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng11133MixinsPrecedenceTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * MNG-11133: Mixins should override properties inherited from parent.
@@ -37,13 +37,15 @@ public class MavenITmng11133MixinsPrecedenceTest extends AbstractMavenIntegratio
         Verifier verifier = newVerifier(testDir);
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
-        verifier.addCliArgument("help:effective-pom");
-        verifier.addCliArgument("-Doutput=target/effective-pom.xml");
+        verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        verifier.verifyFilePresent("target/effective-pom.xml");
-        String effectivePom = Files.readString(testDir.resolve("target/effective-pom.xml"));
-        assertTrue(effectivePom.contains("<maven.compiler.release>21</maven.compiler.release>"));
+        verifier.verifyFilePresent("target/model.properties");
+        Properties props = verifier.loadProperties("target/model.properties");
+        assertEquals(
+                "21",
+                props.getProperty("project.properties.maven.compiler.release"),
+                "Property from mixin should override the parent's value");
     }
 }

--- a/its/core-it-suite/src/test/resources/mng-11133-mixins/project/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-11133-mixins/project/pom.xml
@@ -31,6 +31,30 @@ under the License.
   <artifactId>project</artifactId>
   <version>1.0</version>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputFile>target/model.properties</outputFile>
+              <expressions>
+                <expression>project/properties</expression>
+              </expressions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <mixins>
     <mixin>
       <relativePath>../mixins/mixin.xml</relativePath>


### PR DESCRIPTION
## Summary
- Replace `help:effective-pom` + `Files.readString()` + `String.contains()` with the conventional `maven-it-plugin-expression` approach using `verifier.loadProperties()` in `MavenITmng11133MixinsPrecedenceTest`
- This is the same pattern applied in PR #12461 for `MavenITmng8432MixinsPropertiesTest` — more robust against whitespace/formatting changes in effective POM XML
- Added the expression plugin to the test resource `pom.xml` to evaluate `project/properties` at the `validate` phase

## Test plan
- [x] `MavenITmng11133MixinsPrecedenceTest` passes locally (1 test, 0 failures)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)