### PR TITLE
Preserve dependency scope in plugin artifacts - fix #12497

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
+++ b/maven-core/src/main/java/org/apache/maven/RepositoryUtils.java
@@ -64,7 +64,16 @@ public class RepositoryUtils {
         return (string == null || string.length() <= 0) ? null : string;
     }
 
-    private static org.apache.maven.artifact.Artifact toArtifact(Dependency dependency) {
+    /**
+     * Converts a {@link Dependency} object to a Maven {@link org.apache.maven.artifact.Artifact} object.
+     *
+     * @param dependency the dependency to be converted; may be null. If null, the method returns null.
+     * @return the equivalent {@link org.apache.maven.artifact.Artifact} object with the same attributes as the
+     *         provided dependency, or null if the input dependency is null.
+     *
+     * @since 3.10.0
+     */
+    public static org.apache.maven.artifact.Artifact toArtifact(Dependency dependency) {
         if (dependency == null) {
             return null;
         }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -106,7 +106,6 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.filter.AndDependencyFilter;
 
@@ -394,10 +393,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                 project.getRemotePluginRepositories(),
                 repositorySession);
 
-        pluginArtifacts = result.getArtifactResults().stream()
-                .filter(ArtifactResult::isResolved)
-                .map(r -> RepositoryUtils.toArtifact(r.getArtifact()))
-                .collect(Collectors.toList());
+        pluginArtifacts = toMavenArtifacts(result);
 
         pluginRealm = classRealmManager.createPluginRealm(
                 plugin, parent, null, foreignImports, toAetherArtifacts(pluginArtifacts));
@@ -433,6 +429,13 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
 
     private List<org.eclipse.aether.artifact.Artifact> toAetherArtifacts(final List<Artifact> pluginArtifacts) {
         return new ArrayList<>(RepositoryUtils.toArtifacts(pluginArtifacts));
+    }
+
+    private List<Artifact> toMavenArtifacts(DependencyResult dependencyResult) {
+        return dependencyResult.getDependencyNodeResults().stream()
+                .filter(n -> n.getArtifact().getPath() != null)
+                .map(n -> RepositoryUtils.toArtifact(n.getDependency()))
+                .collect(Collectors.toList());
     }
 
     private Map<String, ClassLoader> calcImports(MavenProject project, ClassLoader parent, List<String> imports) {
@@ -829,9 +832,6 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
             throws PluginResolutionException {
         DependencyResult result =
                 pluginDependenciesResolver.resolvePluginAndFlatten(extensionPlugin, null, null, repositories, session);
-        return result.getArtifactResults().stream()
-                .filter(ArtifactResult::isResolved)
-                .map(r -> RepositoryUtils.toArtifact(r.getArtifact()))
-                .collect(Collectors.toList());
+        return toMavenArtifacts(result);
     }
 }


### PR DESCRIPTION
What changed:
- Added `RepositoryUtils.toArtifact(ArtifactResult)` to convert resolved artifacts and copy dependency metadata from - Made RepositoryUtils.toArtifact(Dependency) public (was package-private).
- Added private DefaultMavenPluginManager.toMavenArtifacts(DependencyResult) that iterates over dependency graph nodes instead of raw artifact results.
- Used toMavenArtifacts for both plugin realm and extension artifact resolution.

Why:
- `PluginDescriptor.getArtifacts()` returned artifacts with `null` scope in Maven 3.10.0-rc-1.
- Restoring scope/optional metadata brings behavior back in line with 3.9.x and avoids regressions in plugins that depend on artifact scope.

Analogous fix was applied to Maven 4 in apache/maven#1928

fix #12497

<!--
Please open pull requests against one of the following branches:

- master — default target for all changes (new features + bug fixes).  
  If the change should also go to maven-4.0.x, request a backport in the PR.

- maven-3.10.x — target for 3.x changes (new features + bug fixes).  
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.

Backports are typically handled by maintainers; 
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
