### PR TITLE
Fix #12507: dont wipe unresolved ${...} expressions in CLI-supplied property values

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -438,7 +438,11 @@ public abstract class BaseParser implements Parser {
         Map<String, String> userSpecifiedProperties = context.options != null
                 ? new HashMap<>(context.options.userProperties().orElse(new HashMap<>()))
                 : new HashMap<>();
-        createInterpolator().interpolate(userSpecifiedProperties, paths::get);
+        // Resolve only early-available path placeholders (session.topDirectory & co); leave everything
+        // else literal so it can be evaluated later with full session/project context by the
+        // plugin parameter expression evaluator (gh-12507: wiping unresolved ${...} to the empty
+        // string silently broke e.g. -DaltDeploymentRepository=id::file://${project.build.directory}/x).
+        createInterpolator().interpolate(userSpecifiedProperties, paths::get, false);
 
         // ----------------------------------------------------------------------
         // Load config files

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/12507">gh-12507</a>:
+ * {@code ${...}} expressions inside CLI-supplied plugin parameter values must be resolved
+ * against the session/project context (Maven 3 semantics), not silently replaced with the
+ * empty string. The real-world trigger is
+ * {@code -DaltDeploymentRepository=id::file://${project.build.directory}/deploy}, which under
+ * the regression deploys to the filesystem root ({@code file:///deploy}).
+ */
+class MavenITgh12507CliParamNestedInterpolationTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a system-property expression inside a CLI-supplied parameter value is resolved.
+     */
+    @Test
+    void testNestedSystemPropertyExpression() throws Exception {
+        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("-Dconfig.stringParam=PRE-${user.dir}-POST");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/config.properties");
+        assertEquals("PRE-" + basedir + "-POST", props.getProperty("stringParam"));
+    }
+
+    /**
+     * Verify that a project expression inside a CLI-supplied parameter value is resolved.
+     */
+    @Test
+    void testNestedProjectExpression() throws Exception {
+        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("-Dconfig.stringParam=PRE-${project.build.directory}-POST");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/config.properties");
+        assertEquals(
+                "PRE-" + basedir.resolve("target") + "-POST",
+                props.getProperty("stringParam"));
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12507-cli-param-nested-interpolation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12507-cli-param-nested-interpolation/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12507</groupId>
+  <artifactId>cli-param-nested-interpolation</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: gh-12507</name>
+  <description>Test that ${...} expressions inside CLI-supplied plugin parameter values (-Dconfig.stringParam=...)
+    are resolved against the session/project context like Maven 3 does, instead of being replaced with the
+    empty string.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-configuration</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <configuration>
+          <propertiesFile>target/config.properties</propertiesFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>config</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Fixes #12507.

## Root cause

`BaseParser.populateUserProperties()` interpolates user-specified `-D` values at CLI parse time via the `Interpolator` convenience overload, which defaults to `defaultsToEmpty=true`, against a callback that only knows the `extraInterpolationSource()` paths (`session.topDirectory` / `session.rootDirectory`). Every other expression — system properties like `${user.dir}`, project references like `${project.build.directory}` — was silently replaced with the empty string before any session/project context existed.

Maven 3 resolves such expressions at mojo configuration time; the v3-compat `PluginParameterExpressionEvaluator` in Maven 4 would too, but it only ever saw the already-wiped value.

This is independent of the recent launcher quoting fixes (#11978 / #11983): those fixed the shell layer so `${...}` arguments reach the JVM intact. On rc-5 the launcher bug masked this issue with a loud `bad substitution` shell error; with the launcher fix shipping in rc-6, users hit this silent empty-substitution instead.

## Fix

Pass `defaultsToEmpty=false` for the user-specified properties: placeholders that cannot be resolved from the early paths map stay literal and are evaluated later with full session/project context. The `${session.topDirectory}` / `${session.rootDirectory}` support from #2480 is unaffected.

## Testing

- New IT `MavenITgh12507CliParamNestedInterpolationTest` (two cases: `${user.dir}` and `${project.build.directory}` in a CLI-supplied plugin parameter): red against the current master distro (`expected: <PRE-…-POST> but was: <PRE--POST>`), green with the fix.
- All 33 `maven-cli` test suites pass.
- End-to-end: `mvn deploy '-DaltDeploymentRepository=test::file://${project.build.directory}/deploy'` deploys to `target/deploy/…` again (was: `file:///deploy` → `Read-only file system`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
