### PR TITLE
Introduce validation control

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -446,6 +446,17 @@ public final class Constants {
     public static final String MAVEN_RESOLVER_TRANSPORT = "maven.resolver.transport";
 
     /**
+     * Resolver validation control. Source of this config is Java System properties, as it is early configuration.
+     * This configuration provides "escape hatch" for those projects, that are forced to use non-conformant solutions.
+     * Can be <code>default</code> (full validation), <code>mild</code> (only uninterpolated placeholders) or
+     * <code>off</code> (no validation, as in Maven 3.9.x).
+     *
+     * @since 3.10.0
+     */
+    @Config(defaultValue = "default")
+    public static final String MAVEN_RESOLVER_VALIDATION = "maven.resolver.validation";
+
+    /**
      * Plugin validation level.
      *
      * @since 3.9.2

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -446,10 +446,10 @@ public final class Constants {
     public static final String MAVEN_RESOLVER_TRANSPORT = "maven.resolver.transport";
 
     /**
-     * Resolver validation control. Source of this config is Java System properties, as it is early configuration.
-     * This configuration provides "escape hatch" for those projects, that are forced to use non-conformant solutions.
+     * Resolver validation control.
      * Can be <code>default</code> (full validation), <code>mild</code> (only uninterpolated placeholders) or
      * <code>off</code> (no validation, as in Maven 3.9.x).
+     * This configuration provides "escape hatch" for those projects, that are forced to use non-conformant solutions.
      *
      * @since 3.10.0
      */

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidator.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.impl.resolver.validator;
 
+import java.util.Locale;
+
+import org.apache.maven.api.Constants;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.metadata.Metadata;
@@ -31,67 +34,101 @@ import org.eclipse.aether.util.PathUtils;
  * elements enter resolver; if it does, is most likely some bug.
  */
 public class MavenValidator implements Validator {
+    private enum ValidationLevel {
+        DEFAULT(true, true),
+        MILD(true, false),
+        OFF(false, false);
+
+        private final boolean validatePlaceholder;
+        private final boolean validatePathComponents;
+
+        ValidationLevel(boolean validatePlaceholder, boolean validatePathComponents) {
+            this.validatePlaceholder = validatePlaceholder;
+            this.validatePathComponents = validatePathComponents;
+        }
+    }
+
+    private static final ValidationLevel VALIDATION_LEVEL = ValidationLevel.valueOf(
+            System.getProperty(Constants.MAVEN_RESOLVER_VALIDATION, ValidationLevel.DEFAULT.name())
+                    .toUpperCase(Locale.ROOT));
+
     protected boolean containsPlaceholder(String value) {
         return value != null && value.contains("${");
     }
 
     @Override
     public void validateArtifact(Artifact artifact) throws IllegalArgumentException {
-        if (containsPlaceholder(artifact.getGroupId())
-                || containsPlaceholder(artifact.getArtifactId())
-                || containsPlaceholder(artifact.getVersion())
-                || containsPlaceholder(artifact.getClassifier())
-                || containsPlaceholder(artifact.getExtension())) {
-            throw new IllegalArgumentException("Not fully interpolated artifact " + artifact);
+        if (VALIDATION_LEVEL.validatePlaceholder) {
+            if (containsPlaceholder(artifact.getGroupId())
+                    || containsPlaceholder(artifact.getArtifactId())
+                    || containsPlaceholder(artifact.getVersion())
+                    || containsPlaceholder(artifact.getClassifier())
+                    || containsPlaceholder(artifact.getExtension())) {
+                throw new IllegalArgumentException("Not fully interpolated artifact " + artifact);
+            }
         }
-        PathUtils.validateArtifactComponents(artifact);
+        if (VALIDATION_LEVEL.validatePathComponents) {
+            PathUtils.validateArtifactComponents(artifact);
+        }
     }
 
     @Override
     public void validateMetadata(Metadata metadata) throws IllegalArgumentException {
-        if (containsPlaceholder(metadata.getGroupId())
-                || containsPlaceholder(metadata.getArtifactId())
-                || containsPlaceholder(metadata.getVersion())
-                || containsPlaceholder(metadata.getType())) {
-            throw new IllegalArgumentException("Not fully interpolated metadata " + metadata);
+        if (VALIDATION_LEVEL.validatePlaceholder) {
+            if (containsPlaceholder(metadata.getGroupId())
+                    || containsPlaceholder(metadata.getArtifactId())
+                    || containsPlaceholder(metadata.getVersion())
+                    || containsPlaceholder(metadata.getType())) {
+                throw new IllegalArgumentException("Not fully interpolated metadata " + metadata);
+            }
         }
-        PathUtils.validateMetadataComponents(metadata);
+        if (VALIDATION_LEVEL.validatePathComponents) {
+            PathUtils.validateMetadataComponents(metadata);
+        }
     }
 
     @Override
     public void validateDependency(Dependency dependency) throws IllegalArgumentException {
         Artifact artifact = dependency.getArtifact();
-        if (containsPlaceholder(artifact.getGroupId())
-                || containsPlaceholder(artifact.getArtifactId())
-                || containsPlaceholder(artifact.getVersion())
-                || containsPlaceholder(artifact.getClassifier())
-                || containsPlaceholder(artifact.getExtension())
-                || containsPlaceholder(dependency.getScope())
-                || dependency.getExclusions().stream()
-                        .anyMatch(e -> containsPlaceholder(e.getGroupId())
-                                || containsPlaceholder(e.getArtifactId())
-                                || containsPlaceholder(e.getClassifier())
-                                || containsPlaceholder(e.getExtension()))) {
-            throw new IllegalArgumentException("Not fully interpolated dependency " + dependency);
+        if (VALIDATION_LEVEL.validatePlaceholder) {
+            if (containsPlaceholder(artifact.getGroupId())
+                    || containsPlaceholder(artifact.getArtifactId())
+                    || containsPlaceholder(artifact.getVersion())
+                    || containsPlaceholder(artifact.getClassifier())
+                    || containsPlaceholder(artifact.getExtension())
+                    || containsPlaceholder(dependency.getScope())
+                    || dependency.getExclusions().stream()
+                            .anyMatch(e -> containsPlaceholder(e.getGroupId())
+                                    || containsPlaceholder(e.getArtifactId())
+                                    || containsPlaceholder(e.getClassifier())
+                                    || containsPlaceholder(e.getExtension()))) {
+                throw new IllegalArgumentException("Not fully interpolated dependency " + dependency);
+            }
         }
-        PathUtils.validateArtifactComponents(artifact);
+        if (VALIDATION_LEVEL.validatePathComponents) {
+            PathUtils.validateArtifactComponents(artifact);
+        }
     }
 
     @Override
     public void validateLocalRepository(LocalRepository localRepository) throws IllegalArgumentException {
-        if (containsPlaceholder(localRepository.getBasePath().toString())
-                || containsPlaceholder(localRepository.getContentType())
-                || containsPlaceholder(localRepository.getId())) {
-            throw new IllegalArgumentException("Not fully interpolated local repository " + localRepository);
+        if (VALIDATION_LEVEL.validatePlaceholder) {
+            if (containsPlaceholder(localRepository.getBasePath().toString())
+                    || containsPlaceholder(localRepository.getContentType())
+                    || containsPlaceholder(localRepository.getId())) {
+                throw new IllegalArgumentException("Not fully interpolated local repository " + localRepository);
+            }
         }
     }
 
     @Override
     public void validateRemoteRepository(RemoteRepository remoteRepository) throws IllegalArgumentException {
-        if (containsPlaceholder(remoteRepository.getUrl())
-                || containsPlaceholder(remoteRepository.getContentType())
-                || containsPlaceholder(remoteRepository.getId())) {
-            throw new IllegalArgumentException("Not fully interpolated remote repository " + remoteRepository);
+        if (VALIDATION_LEVEL.validatePlaceholder) {
+            if (containsPlaceholder(remoteRepository.getUrl())
+                    || containsPlaceholder(remoteRepository.getContentType())
+                    || containsPlaceholder(remoteRepository.getId())) {
+                throw new IllegalArgumentException("Not fully interpolated remote repository " + remoteRepository);
+            }
         }
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidator.java
@@ -18,9 +18,6 @@
  */
 package org.apache.maven.impl.resolver.validator;
 
-import java.util.Locale;
-
-import org.apache.maven.api.Constants;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.metadata.Metadata;
@@ -34,23 +31,11 @@ import org.eclipse.aether.util.PathUtils;
  * elements enter resolver; if it does, is most likely some bug.
  */
 public class MavenValidator implements Validator {
-    private enum ValidationLevel {
-        DEFAULT(true, true),
-        MILD(true, false),
-        OFF(false, false);
+    private final boolean validatePathComponents;
 
-        private final boolean validatePlaceholder;
-        private final boolean validatePathComponents;
-
-        ValidationLevel(boolean validatePlaceholder, boolean validatePathComponents) {
-            this.validatePlaceholder = validatePlaceholder;
-            this.validatePathComponents = validatePathComponents;
-        }
+    public MavenValidator(boolean validatePathComponents) {
+        this.validatePathComponents = validatePathComponents;
     }
-
-    private static final ValidationLevel VALIDATION_LEVEL = ValidationLevel.valueOf(
-            System.getProperty(Constants.MAVEN_RESOLVER_VALIDATION, ValidationLevel.DEFAULT.name())
-                    .toUpperCase(Locale.ROOT));
 
     protected boolean containsPlaceholder(String value) {
         return value != null && value.contains("${");
@@ -58,31 +43,27 @@ public class MavenValidator implements Validator {
 
     @Override
     public void validateArtifact(Artifact artifact) throws IllegalArgumentException {
-        if (VALIDATION_LEVEL.validatePlaceholder) {
-            if (containsPlaceholder(artifact.getGroupId())
-                    || containsPlaceholder(artifact.getArtifactId())
-                    || containsPlaceholder(artifact.getVersion())
-                    || containsPlaceholder(artifact.getClassifier())
-                    || containsPlaceholder(artifact.getExtension())) {
-                throw new IllegalArgumentException("Not fully interpolated artifact " + artifact);
-            }
+        if (containsPlaceholder(artifact.getGroupId())
+                || containsPlaceholder(artifact.getArtifactId())
+                || containsPlaceholder(artifact.getVersion())
+                || containsPlaceholder(artifact.getClassifier())
+                || containsPlaceholder(artifact.getExtension())) {
+            throw new IllegalArgumentException("Not fully interpolated artifact " + artifact);
         }
-        if (VALIDATION_LEVEL.validatePathComponents) {
+        if (validatePathComponents) {
             PathUtils.validateArtifactComponents(artifact);
         }
     }
 
     @Override
     public void validateMetadata(Metadata metadata) throws IllegalArgumentException {
-        if (VALIDATION_LEVEL.validatePlaceholder) {
-            if (containsPlaceholder(metadata.getGroupId())
-                    || containsPlaceholder(metadata.getArtifactId())
-                    || containsPlaceholder(metadata.getVersion())
-                    || containsPlaceholder(metadata.getType())) {
-                throw new IllegalArgumentException("Not fully interpolated metadata " + metadata);
-            }
+        if (containsPlaceholder(metadata.getGroupId())
+                || containsPlaceholder(metadata.getArtifactId())
+                || containsPlaceholder(metadata.getVersion())
+                || containsPlaceholder(metadata.getType())) {
+            throw new IllegalArgumentException("Not fully interpolated metadata " + metadata);
         }
-        if (VALIDATION_LEVEL.validatePathComponents) {
+        if (validatePathComponents) {
             PathUtils.validateMetadataComponents(metadata);
         }
     }
@@ -90,45 +71,39 @@ public class MavenValidator implements Validator {
     @Override
     public void validateDependency(Dependency dependency) throws IllegalArgumentException {
         Artifact artifact = dependency.getArtifact();
-        if (VALIDATION_LEVEL.validatePlaceholder) {
-            if (containsPlaceholder(artifact.getGroupId())
-                    || containsPlaceholder(artifact.getArtifactId())
-                    || containsPlaceholder(artifact.getVersion())
-                    || containsPlaceholder(artifact.getClassifier())
-                    || containsPlaceholder(artifact.getExtension())
-                    || containsPlaceholder(dependency.getScope())
-                    || dependency.getExclusions().stream()
-                            .anyMatch(e -> containsPlaceholder(e.getGroupId())
-                                    || containsPlaceholder(e.getArtifactId())
-                                    || containsPlaceholder(e.getClassifier())
-                                    || containsPlaceholder(e.getExtension()))) {
-                throw new IllegalArgumentException("Not fully interpolated dependency " + dependency);
-            }
+        if (containsPlaceholder(artifact.getGroupId())
+                || containsPlaceholder(artifact.getArtifactId())
+                || containsPlaceholder(artifact.getVersion())
+                || containsPlaceholder(artifact.getClassifier())
+                || containsPlaceholder(artifact.getExtension())
+                || containsPlaceholder(dependency.getScope())
+                || dependency.getExclusions().stream()
+                        .anyMatch(e -> containsPlaceholder(e.getGroupId())
+                                || containsPlaceholder(e.getArtifactId())
+                                || containsPlaceholder(e.getClassifier())
+                                || containsPlaceholder(e.getExtension()))) {
+            throw new IllegalArgumentException("Not fully interpolated dependency " + dependency);
         }
-        if (VALIDATION_LEVEL.validatePathComponents) {
+        if (validatePathComponents) {
             PathUtils.validateArtifactComponents(artifact);
         }
     }
 
     @Override
     public void validateLocalRepository(LocalRepository localRepository) throws IllegalArgumentException {
-        if (VALIDATION_LEVEL.validatePlaceholder) {
-            if (containsPlaceholder(localRepository.getBasePath().toString())
-                    || containsPlaceholder(localRepository.getContentType())
-                    || containsPlaceholder(localRepository.getId())) {
-                throw new IllegalArgumentException("Not fully interpolated local repository " + localRepository);
-            }
+        if (containsPlaceholder(localRepository.getBasePath().toString())
+                || containsPlaceholder(localRepository.getContentType())
+                || containsPlaceholder(localRepository.getId())) {
+            throw new IllegalArgumentException("Not fully interpolated local repository " + localRepository);
         }
     }
 
     @Override
     public void validateRemoteRepository(RemoteRepository remoteRepository) throws IllegalArgumentException {
-        if (VALIDATION_LEVEL.validatePlaceholder) {
-            if (containsPlaceholder(remoteRepository.getUrl())
-                    || containsPlaceholder(remoteRepository.getContentType())
-                    || containsPlaceholder(remoteRepository.getId())) {
-                throw new IllegalArgumentException("Not fully interpolated remote repository " + remoteRepository);
-            }
+        if (containsPlaceholder(remoteRepository.getUrl())
+                || containsPlaceholder(remoteRepository.getContentType())
+                || containsPlaceholder(remoteRepository.getId())) {
+            throw new IllegalArgumentException("Not fully interpolated remote repository " + remoteRepository);
         }
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidatorFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidatorFactory.java
@@ -18,19 +18,34 @@
  */
 package org.apache.maven.impl.resolver.validator;
 
+import org.apache.maven.api.Constants;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Singleton;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.spi.validator.Validator;
 import org.eclipse.aether.spi.validator.ValidatorFactory;
+import org.eclipse.aether.util.ConfigUtils;
 
 @Named
 @Singleton
 public class MavenValidatorFactory implements ValidatorFactory {
-    private final MavenValidator instance = new MavenValidator();
+    public enum ValidationLevel {
+        DEFAULT,
+        MILD,
+        OFF;
+    }
+
+    private final MavenValidator defaultValidator = new MavenValidator(true);
+    private final MavenValidator mildValidator = new MavenValidator(false);
+    private final Validator offValidator = new Validator() {};
 
     @Override
-    public Validator newInstance(RepositorySystemSession repositorySystemSession) {
-        return instance;
+    public Validator newInstance(RepositorySystemSession session) {
+        return switch (ConfigUtils.getEnum(
+                session, ValidationLevel.class, ValidationLevel.DEFAULT, Constants.MAVEN_RESOLVER_VALIDATION)) {
+            case DEFAULT -> defaultValidator;
+            case MILD -> mildValidator;
+            case OFF -> offValidator;
+        };
     }
 }


### PR DESCRIPTION
Enables validation level choice in Maven Resolver validator.

This change should go to every Maven version having `MavenValidator` (3.10, 4.0 and 4.1).

Related: https://github.com/apache/maven-resolver/issues/2007
