### PR TITLE
Fix #12507: preserve unresolved ${...} in CLI -D values (Maven 3 semantics)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -438,7 +438,11 @@ public abstract class BaseParser implements Parser {
         Map<String, String> userSpecifiedProperties = context.options != null
                 ? new HashMap<>(context.options.userProperties().orElse(new HashMap<>()))
                 : new HashMap<>();
-        createInterpolator().interpolate(userSpecifiedProperties, paths::get);
+        // Resolve only early-available path placeholders (session.topDirectory & co); leave everything
+        // else literal so it can be evaluated later with full session/project context by the
+        // plugin parameter expression evaluator (gh-12507: wiping unresolved ${...} to the empty
+        // string silently broke e.g. -DaltDeploymentRepository=id::file://${project.build.directory}/x).
+        createInterpolator().interpolate(userSpecifiedProperties, paths::get, false);
 
         // ----------------------------------------------------------------------
         // Load config files

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11978PlaceholderInCliArgTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11978PlaceholderInCliArgTest.java
@@ -50,8 +50,10 @@ class MavenITgh11978PlaceholderInCliArgTest extends AbstractMavenIntegrationTest
         verifier.verifyErrorFreeLog(); // primary check: shell crash produces non-zero exit
 
         // Secondary: verify the literal placeholder flowed through Maven.
-        // Maven resolves the unknown ${some.maven.placeholder} to empty.
+        // Unknown ${...} expressions are preserved as literals (Maven 3 semantics, see gh-12507);
+        // they are not replaced with empty strings at CLI parse time.
         Properties props = verifier.loadProperties("target/pom.properties");
-        assertEquals("-value__end-", props.getProperty("project.properties.pom.placeholder"));
+        assertEquals(
+                "-value_${some.maven.placeholder}_end-", props.getProperty("project.properties.pom.placeholder"));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/12507">gh-12507</a>:
+ * {@code ${...}} expressions inside CLI-supplied plugin parameter values must be resolved
+ * against the session/project context (Maven 3 semantics), not silently replaced with the
+ * empty string. The real-world trigger is
+ * {@code -DaltDeploymentRepository=id::file://${project.build.directory}/deploy}, which under
+ * the regression deploys to the filesystem root ({@code file:///deploy}).
+ */
+class MavenITgh12507CliParamNestedInterpolationTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a system-property expression inside a CLI-supplied parameter value is resolved.
+     */
+    @Test
+    void testNestedSystemPropertyExpression() throws Exception {
+        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("-Dconfig.stringParam=PRE-${user.dir}-POST");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/config.properties");
+        assertEquals("PRE-" + basedir + "-POST", props.getProperty("stringParam"));
+    }
+
+    /**
+     * Verify that a project expression inside a CLI-supplied parameter value is resolved.
+     */
+    @Test
+    void testNestedProjectExpression() throws Exception {
+        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("-Dconfig.stringParam=PRE-${project.build.directory}-POST");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/config.properties");
+        assertEquals(
+                "PRE-" + basedir.resolve("target") + "-POST",
+                props.getProperty("stringParam"));
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12507-cli-param-nested-interpolation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12507-cli-param-nested-interpolation/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12507</groupId>
+  <artifactId>cli-param-nested-interpolation</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: gh-12507</name>
+  <description>Test that ${...} expressions inside CLI-supplied plugin parameter values (-Dconfig.stringParam=...)
+    are resolved against the session/project context like Maven 3 does, instead of being replaced with the
+    empty string.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-configuration</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <configuration>
+          <propertiesFile>target/config.properties</propertiesFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>config</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Summary

Fixes #12507. Supersedes #12515 (adds the missing test update that unblocks CI).

`BaseParser.populateUserProperties()` interpolates user-specified `-D` values at CLI parse time against a callback that only knows `session.topDirectory` / `session.rootDirectory`. Every other expression — `${project.build.directory}`, `${user.dir}`, etc. — was silently replaced with `""` because the `Interpolator.interpolate(Map, UnaryOperator)` convenience overload defaults to `defaultsToEmpty=true`.

This broke common CI patterns like `-DaltDeploymentRepository=id::file://${project.build.directory}/deploy` (URL becomes `file:///deploy` → wrong path, no error).

### Root cause

PR #2480 added early interpolation of `-D` values to support `${session.topDirectory}`, but the `defaultsToEmpty=true` API default was not appropriate for this call site — it wiped all expressions the early callback couldn't resolve. Maven 3 left them literal for later evaluation at mojo configuration time.

### Changes

- **`BaseParser.java`**: Pass `defaultsToEmpty=false` so unresolved placeholders stay literal for later evaluation by the plugin parameter expression evaluator. The `${session.topDirectory}` / `${session.rootDirectory}` support from #2480 is unaffected.
- **`MavenITgh11978PlaceholderInCliArgTest`**: Update assertion to expect Maven 3 semantics — unknown `${...}` preserved as literal, not emptied. The emptying was an unintended side effect of #2480, not a deliberate behavior. The test's primary purpose (launcher doesn't crash on `${...}`) is unchanged.
- **New IT `MavenITgh12507CliParamNestedInterpolationTest`**: Two cases (`${user.dir}` and `${project.build.directory}` in CLI-supplied plugin parameters) — red on current master, green with the fix.

### Credits

Original fix and IT by @ascheman in #12515. This PR adds the `MavenITgh11978PlaceholderInCliArgTest` update and rebases onto current master to unblock CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)