### PR TITLE
Backport #12523 to 4.0.x: preserve unresolved ${...} in CLI -D values

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/BaseParser.java
@@ -438,7 +438,11 @@ public abstract class BaseParser implements Parser {
         Map<String, String> userSpecifiedProperties = context.options != null
                 ? new HashMap<>(context.options.userProperties().orElse(new HashMap<>()))
                 : new HashMap<>();
-        createInterpolator().interpolate(userSpecifiedProperties, paths::get);
+        // Resolve only early-available path placeholders (session.topDirectory & co); leave everything
+        // else literal so it can be evaluated later with full session/project context by the
+        // plugin parameter expression evaluator (gh-12507: wiping unresolved ${...} to the empty
+        // string silently broke e.g. -DaltDeploymentRepository=id::file://${project.build.directory}/x).
+        createInterpolator().interpolate(userSpecifiedProperties, paths::get, false);
 
         // ----------------------------------------------------------------------
         // Load config files

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11978PlaceholderInCliArgTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh11978PlaceholderInCliArgTest.java
@@ -56,8 +56,10 @@ class MavenITgh11978PlaceholderInCliArgTest extends AbstractMavenIntegrationTest
         verifier.verifyErrorFreeLog(); // primary check: shell crash produces non-zero exit
 
         // Secondary: verify the literal placeholder flowed through Maven.
-        // Maven resolves the unknown ${some.maven.placeholder} to empty.
+        // Unknown ${...} expressions are preserved as literals (Maven 3 semantics, see gh-12507);
+        // they are not replaced with empty strings at CLI parse time.
         Properties props = verifier.loadProperties("target/pom.properties");
-        assertEquals("-value__end-", props.getProperty("project.properties.pom.placeholder"));
+        assertEquals(
+                "-value_${some.maven.placeholder}_end-", props.getProperty("project.properties.pom.placeholder"));
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test set for <a href="https://github.com/apache/maven/issues/12507">gh-12507</a>:
+ * {@code ${...}} expressions inside CLI-supplied plugin parameter values must be resolved
+ * against the session/project context (Maven 3 semantics), not silently replaced with the
+ * empty string. The real-world trigger is
+ * {@code -DaltDeploymentRepository=id::file://${project.build.directory}/deploy}, which under
+ * the regression deploys to the filesystem root ({@code file:///deploy}).
+ */
+class MavenITgh12507CliParamNestedInterpolationTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a system-property expression inside a CLI-supplied parameter value is resolved.
+     */
+    @Test
+    void testNestedSystemPropertyExpression() throws Exception {
+        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("-Dconfig.stringParam=PRE-${user.dir}-POST");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/config.properties");
+        assertEquals("PRE-" + basedir + "-POST", props.getProperty("stringParam"));
+    }
+
+    /**
+     * Verify that a project expression inside a CLI-supplied parameter value is resolved.
+     */
+    @Test
+    void testNestedProjectExpression() throws Exception {
+        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("-Dconfig.stringParam=PRE-${project.build.directory}-POST");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/config.properties");
+        assertEquals(
+                "PRE-" + basedir.resolve("target") + "-POST",
+                props.getProperty("stringParam"));
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12507CliParamNestedInterpolationTest.java
@@ -35,14 +35,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class MavenITgh12507CliParamNestedInterpolationTest extends AbstractMavenIntegrationTestCase {
 
+    MavenITgh12507CliParamNestedInterpolationTest() {
+        super("[4.0.0-rc-6,)");
+    }
+
     /**
      * Verify that a system-property expression inside a CLI-supplied parameter value is resolved.
      */
     @Test
     void testNestedSystemPropertyExpression() throws Exception {
-        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+        Path basedir = extractResources("/gh-12507-cli-param-nested-interpolation")
+                .getAbsoluteFile()
+                .toPath();
 
-        Verifier verifier = newVerifier(basedir);
+        Verifier verifier = newVerifier(basedir.toString());
         verifier.addCliArgument("-Dconfig.stringParam=PRE-${user.dir}-POST");
         verifier.addCliArgument("validate");
         verifier.execute();
@@ -57,9 +63,11 @@ class MavenITgh12507CliParamNestedInterpolationTest extends AbstractMavenIntegra
      */
     @Test
     void testNestedProjectExpression() throws Exception {
-        Path basedir = extractResources("gh-12507-cli-param-nested-interpolation");
+        Path basedir = extractResources("/gh-12507-cli-param-nested-interpolation")
+                .getAbsoluteFile()
+                .toPath();
 
-        Verifier verifier = newVerifier(basedir);
+        Verifier verifier = newVerifier(basedir.toString());
         verifier.addCliArgument("-Dconfig.stringParam=PRE-${project.build.directory}-POST");
         verifier.addCliArgument("validate");
         verifier.execute();

--- a/its/core-it-suite/src/test/resources/gh-12507-cli-param-nested-interpolation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12507-cli-param-nested-interpolation/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12507</groupId>
+  <artifactId>cli-param-nested-interpolation</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: gh-12507</name>
+  <description>Test that ${...} expressions inside CLI-supplied plugin parameter values (-Dconfig.stringParam=...)
+    are resolved against the session/project context like Maven 3 does, instead of being replaced with the
+    empty string.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-configuration</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <configuration>
+          <propertiesFile>target/config.properties</propertiesFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>config</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Backport of #12523 (fix for #12507) to the `maven-4.0.x` line, so the fix ships in `4.0.0-rc-6`. cc @gnodet (confirmed on Slack).

The three commits from #12523 cherry-pick cleanly — the production fix is byte-identical to what landed on `master`:

- **`Add failing IT for #12507`** — new `MavenITgh12507CliParamNestedInterpolationTest`
- **`Fix #12507: dont wipe unresolved ${...} in -D values`** — `BaseParser.populateUserProperties` passes `defaultsToEmpty=false`, preserving unresolved `${...}` at CLI parse time so the plugin parameter expression evaluator resolves project/session context later (Maven 3 semantics)
- **`Update gh-11978 IT to expect Maven 3 semantics for unknown placeholders`** (@gnodet)

One backport-specific commit on top:

- **`Port gh-12507 IT to the 4.0.x test-harness API`** — the new IT was written against master's newer test harness (Path-based `Verifier`, no-arg `AbstractMavenIntegrationTestCase`); on `maven-4.0.x` the harness is File/String-based and requires a version-range `super()` call. Ported accordingly and gated `[4.0.0-rc-6,)` (the fix's first release; the built `4.0.0-SNAPSHOT` satisfies the range, so the body runs rather than skips).

**Local verification** against a `maven-4.0.x` distribution built from this branch (JDK 17):

```
MavenITgh12507CliParamNestedInterpolationTest  Tests run: 2, Failures: 0, Skipped: 0
MavenITgh11978PlaceholderInCliArgTest          Tests run: 1, Failures: 0, Skipped: 0
```

Both actually execute (not skipped by the version gate). Original authorship preserved on the cherry-picked commits.

Refs #12507, #12523.
