### PR TITLE
Fix #12522: handle unprovisionable ProjectExecutionListeners from non-extension plugins

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/CompoundProjectExecutionListener.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/CompoundProjectExecutionListener.java
@@ -19,12 +19,31 @@
 package org.apache.maven.lifecycle.internal;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 import org.apache.maven.execution.ProjectExecutionEvent;
 import org.apache.maven.execution.ProjectExecutionListener;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Aggregates multiple {@link ProjectExecutionListener} instances and delegates to each in turn.
+ *
+ * <p>The backing collection is typically a Sisu live-injected list that dynamically includes
+ * all {@code ProjectExecutionListener} implementations discovered across all classrealms.
+ * When a plugin that is <b>not</b> configured as an extension ships JSR 330 components that
+ * implement this interface, Sisu will discover and include them even though the plugin never
+ * opted in via {@code <extensions>true</extensions>}. Lazy provisioning of such components
+ * may fail because their plugin-internal dependencies are not bound in Maven's container.
+ * This class therefore catches provisioning failures during iteration and logs them at debug
+ * level instead of aborting the build.</p>
+ *
+ * @see <a href="https://github.com/apache/maven/issues/12522">GH-12522</a>
+ */
 public class CompoundProjectExecutionListener implements ProjectExecutionListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompoundProjectExecutionListener.class);
+
     private final Collection<ProjectExecutionListener> listeners;
 
     public CompoundProjectExecutionListener(Collection<ProjectExecutionListener> listeners) {
@@ -33,29 +52,69 @@ public class CompoundProjectExecutionListener implements ProjectExecutionListene
 
     @Override
     public void beforeProjectExecution(ProjectExecutionEvent event) throws LifecycleExecutionException {
-        for (ProjectExecutionListener listener : listeners) {
+        for (ProjectExecutionListener listener : safeListeners()) {
             listener.beforeProjectExecution(event);
         }
     }
 
     @Override
     public void beforeProjectLifecycleExecution(ProjectExecutionEvent event) throws LifecycleExecutionException {
-        for (ProjectExecutionListener listener : listeners) {
+        for (ProjectExecutionListener listener : safeListeners()) {
             listener.beforeProjectLifecycleExecution(event);
         }
     }
 
     @Override
     public void afterProjectExecutionSuccess(ProjectExecutionEvent event) throws LifecycleExecutionException {
-        for (ProjectExecutionListener listener : listeners) {
+        for (ProjectExecutionListener listener : safeListeners()) {
             listener.afterProjectExecutionSuccess(event);
         }
     }
 
     @Override
     public void afterProjectExecutionFailure(ProjectExecutionEvent event) {
-        for (ProjectExecutionListener listener : listeners) {
+        for (ProjectExecutionListener listener : safeListeners()) {
             listener.afterProjectExecutionFailure(event);
         }
+    }
+
+    /**
+     * Returns the listeners that can actually be provisioned, silently skipping any that
+     * fail during lazy creation (typically components from non-extension plugins whose
+     * internal dependencies are not available in Maven's container).
+     */
+    private Iterable<ProjectExecutionListener> safeListeners() {
+        return () -> new Iterator<>() {
+            private final Iterator<ProjectExecutionListener> delegate = listeners.iterator();
+            private ProjectExecutionListener next;
+
+            @Override
+            public boolean hasNext() {
+                while (next == null && delegate.hasNext()) {
+                    try {
+                        next = delegate.next();
+                    } catch (RuntimeException e) {
+                        // Sisu wraps provisioning failures in RuntimeException (ProvisionException).
+                        // This happens when a non-extension plugin ships JSR 330 components whose
+                        // dependencies cannot be resolved in Maven's container.
+                        LOGGER.debug(
+                                "Skipping ProjectExecutionListener that could not be provisioned"
+                                        + " (likely from a non-extension plugin): {}",
+                                e.getMessage());
+                    }
+                }
+                return next != null;
+            }
+
+            @Override
+            public ProjectExecutionListener next() {
+                if (!hasNext()) {
+                    throw new java.util.NoSuchElementException();
+                }
+                ProjectExecutionListener result = next;
+                next = null;
+                return result;
+            }
+        };
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test for <a href="https://github.com/apache/maven/issues/12522">GH-12522</a>.
+ *
+ * Verifies that plugins that are NOT configured with {@code <extensions>true</extensions>}
+ * do not have their JSR330/Plexus components picked up as extensions. Prior to the fix,
+ * Maven would discover and attempt to provision extension components from non-extension
+ * plugins, causing build failures such as {@code Unable to provision} errors.
+ *
+ * The reproducer uses {@code tycho-bnd-plugin} which ships JSR330 components but is not
+ * configured as an extension in the POM.
+ */
+class MavenITgh12522NonExtensionPluginTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a build using a plugin with JSR330 components (tycho-bnd-plugin)
+     * that is NOT marked as an extension succeeds without provisioning errors.
+     */
+    @Test
+    void testNonExtensionPluginComponentsNotPickedUp() throws Exception {
+        Path testDir = extractResources("gh-12522-non-extension-plugin");
+
+        Verifier verifier = newVerifier(testDir.toString(), "remote");
+        verifier.addCliArgument("process-classes");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        verifier.verifyTextNotInLog("Unable to provision");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
@@ -26,18 +26,22 @@ import org.junit.jupiter.api.Test;
  * This is a test for <a href="https://github.com/apache/maven/issues/12522">GH-12522</a>.
  *
  * Verifies that plugins that are NOT configured with {@code <extensions>true</extensions>}
- * do not have their JSR330/Plexus components picked up as extensions. Prior to the fix,
- * Maven would discover and attempt to provision extension components from non-extension
- * plugins, causing build failures such as {@code Unable to provision} errors.
+ * do not cause build failures when they ship JSR330 components whose internal dependencies
+ * cannot be resolved in Maven's container. Prior to the fix, Sisu's live-injected
+ * {@code List<ProjectExecutionListener>} would pick up such components and attempt to
+ * provision them, causing {@code Unable to provision} errors that aborted the build.
  *
- * The reproducer uses {@code tycho-bnd-plugin} which ships JSR330 components but is not
+ * The reproducer uses {@code tycho-bnd-plugin} which ships a {@code ProjectExecutionListener}
+ * ({@code BndProjectExecutionListener}) as a {@code @Named} JSR330 component but is not
  * configured as an extension in the POM.
  */
 class MavenITgh12522NonExtensionPluginTest extends AbstractMavenIntegrationTestCase {
 
     /**
      * Verify that a build using a plugin with JSR330 components (tycho-bnd-plugin)
-     * that is NOT marked as an extension succeeds without provisioning errors.
+     * that is NOT marked as an extension completes successfully. The plugin's
+     * {@code ProjectExecutionListener} should be silently skipped rather than
+     * causing the build to fail with a provisioning error.
      */
     @Test
     void testNonExtensionPluginComponentsNotPickedUp() throws Exception {
@@ -47,7 +51,5 @@ class MavenITgh12522NonExtensionPluginTest extends AbstractMavenIntegrationTestC
         verifier.addCliArgument("process-classes");
         verifier.execute();
         verifier.verifyErrorFreeLog();
-
-        verifier.verifyTextNotInLog("Unable to provision");
     }
 }

--- a/its/core-it-suite/src/test/resources/gh-12522-non-extension-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12522-non-extension-plugin/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12522</groupId>
+  <artifactId>non-extension-plugin</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>GH-12522 Non-Extension Plugin Test</name>
+  <description>Test that plugins NOT marked with extensions=true do not have their
+    JSR330/Plexus components picked up as extensions. Reproducer from
+    https://github.com/apache/maven/issues/12522 using tycho-bnd-plugin.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-bnd-plugin</artifactId>
+        <version>5.0.3</version>
+        <executions>
+          <execution>
+            <id>bnd-process</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>process-classes</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Summary

Fixes https://github.com/apache/maven/issues/12522

When a plugin ships JSR 330 components (e.g. `ProjectExecutionListener` implementations) but is **not** configured with `<extensions>true</extensions>`, Sisu's component discovery still registers them in the global `BeanLocator`. The live-injected `List<ProjectExecutionListener>` in `LifecycleModuleBuilder` picks these up, and lazy provisioning fails when the component's plugin-internal dependencies (e.g. Tycho's `MavenReactorRepository`) are not bound in Maven's container — aborting the build with `Unable to provision` errors.

### Root cause

`DefaultMavenPluginManager.discoverPluginComponents()` calls `container.discoverComponents(pluginRealm, ...)` for **all** plugins, not just extension-marked ones. This is required for mojo loading (Sisu-backed `container.lookup()` needs the discovery), so it cannot simply be gated behind `plugin.isExtensions()`. However, it means ALL `@Named` components from any plugin realm become globally visible — including lifecycle listeners that were never intended to run as Maven extensions.

### Fix

Make `CompoundProjectExecutionListener` resilient to provisioning failures during iteration of the Sisu live list. When `iterator.next()` throws a `ProvisionException` (because a non-extension plugin's component has unresolvable dependencies), the listener is skipped with a debug log instead of aborting the build.

### Changes

- **`CompoundProjectExecutionListener`**: Added `safeListeners()` method that wraps the Sisu live-list iterator with defensive error handling, catching `RuntimeException` (Guice `ProvisionException`) during lazy provisioning
- **`MavenITgh12522NonExtensionPluginTest`**: Integration test using `tycho-bnd-plugin` (ships `BndProjectExecutionListener` as a `@Named` JSR 330 component) to verify the build succeeds without provisioning errors

### Test plan

- [x] IT `MavenITgh12522NonExtensionPluginTest` passes — build with `tycho-bnd-plugin` (non-extension) completes successfully
- [x] Before the fix, the same IT fails with `Unable to provision: No implementation for MavenReactorRepository`