### PR TITLE
Add IT for dual-API plugin pattern (compile for Maven 3, enhance for Maven 4)

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITDualApiPluginTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITDualApiPluginTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for a Maven plugin that compiles against Maven 3 API
+ * but detects and leverages the Maven 4 API at runtime via reflection.
+ * <p>
+ * Verifies:
+ * <ol>
+ *   <li>The plugin compiles successfully against Maven 3.9.x API when built by Maven 4</li>
+ *   <li>The plugin detects Maven 4 at runtime via
+ *       {@code Class.forName("org.apache.maven.api.Session")}</li>
+ *   <li>The plugin extracts enhanced info from the Maven 4 {@code Session} via
+ *       {@code MavenSession.getSession()} reflection bridge</li>
+ *   <li>Maven 3 baseline output (GAV, dependencies) is always present</li>
+ *   <li>Maven 4 enhanced output (maven version, root/top directory, start time,
+ *       concurrency, reactor count) is present when running on Maven 4</li>
+ * </ol>
+ */
+public class MavenITDualApiPluginTest extends AbstractMavenIntegrationTestCase {
+
+    private Path testDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        testDir = extractResources("mng-dual-api-plugin");
+    }
+
+    @Test
+    public void testDualApiPluginDetectsMaven4() throws Exception {
+        //
+        // Step 1: Build and install the dual-API plugin.
+        // It compiles against Maven 3.9.x API (provided scope),
+        // which Maven 4's compat module satisfies at runtime.
+        //
+        Verifier v0 = newVerifier(testDir);
+        v0.setAutoclean(false);
+        v0.deleteDirectory("target");
+        v0.deleteArtifacts("org.apache.maven.its.dualapi");
+        v0.addCliArgument("install");
+        v0.execute();
+        v0.verifyErrorFreeLog();
+
+        //
+        // Step 2: Execute the plugin's project-info goal against the same project.
+        // Since we're running on Maven 4, the plugin should:
+        //   - detect Maven 4 runtime
+        //   - emit [MVN3] baseline info
+        //   - emit [MVN4] enhanced info from the new API
+        //
+        Verifier v1 = newVerifier(testDir);
+        v1.setAutoclean(false);
+        v1.addCliArgument(
+                "org.apache.maven.its.dualapi:dual-api-maven-plugin:0.0.1-SNAPSHOT:project-info");
+        v1.execute();
+        v1.verifyErrorFreeLog();
+
+        // ── Verify runtime detection ────────────────────────────────
+        v1.verifyTextInLog("[RUNTIME] Maven 4");
+
+        // ── Verify Maven 3 baseline output is present ───────────────
+        v1.verifyTextInLog("[MVN3] groupId = org.apache.maven.its.dualapi");
+        v1.verifyTextInLog("[MVN3] artifactId = dual-api-maven-plugin");
+        v1.verifyTextInLog("[MVN3] version = 0.0.1-SNAPSHOT");
+        v1.verifyTextInLog("[MVN3] packaging = maven-plugin");
+
+        // ── Verify Maven 4 enhanced output is present ───────────────
+        // These are extracted via reflection on org.apache.maven.api.Session
+        v1.verifyTextInLog("[MVN4] maven.version = ");
+        v1.verifyTextInLog("[MVN4] root.directory = ");
+        v1.verifyTextInLog("[MVN4] top.directory = ");
+        v1.verifyTextInLog("[MVN4] start.time = ");
+        v1.verifyTextInLog("[MVN4] degree.of.concurrency = ");
+        v1.verifyTextInLog("[MVN4] reactor.project.count = ");
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-dual-api-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-dual-api-plugin/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.dualapi</groupId>
+  <artifactId>dual-api-maven-plugin</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>Dual-API Maven Plugin (IT)</name>
+  <description>
+    Integration test plugin that compiles against Maven 3 API but detects
+    and leverages Maven 4 immutable API at runtime via reflection.
+    Demonstrates the "compile for 3, enhance for 4" pattern.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+    <maven3.version>3.9.9</maven3.version>
+    <!--
+      Maven 4 API version for optional compile-time access.
+      At runtime on Maven 3 these classes are absent; the plugin
+      catches NoClassDefFoundError at the boundary and falls back.
+    -->
+    <maven4.api.version>4.0.0-rc-3</maven4.api.version>
+  </properties>
+
+  <dependencies>
+    <!-- ════════════════════════════════════════════════════════════
+         Maven 3 Plugin API — the mandatory compile-time contract.
+         These are always available at runtime (Maven 3 ships them
+         directly; Maven 4 provides them via its compat module).
+         ════════════════════════════════════════════════════════════ -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven3.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven3.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- ════════════════════════════════════════════════════════════
+         Maven 4 API — optional compile-time dependency.
+         Lets Maven4Enhancer use real typed imports (Session, Project,
+         Version, etc.) instead of reflection for every method call.
+         At runtime on Maven 3 these classes simply don't exist;
+         the Mojo catches NoClassDefFoundError at the boundary.
+         ════════════════════════════════════════════════════════════ -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-core</artifactId>
+      <version>${maven4.api.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!--
+            The IT framework injects -Dmaven.compiler.release=8 via MAVEN_OPTS.
+            Using explicit <release> in plugin config overrides that property.
+          -->
+          <release>17</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.15.1</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-dual-api-plugin/src/main/java/org/apache/maven/its/dualapi/Maven4Enhancer.java
+++ b/its/core-it-suite/src/test/resources/mng-dual-api-plugin/src/main/java/org/apache/maven/its/dualapi/Maven4Enhancer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.dualapi;
+
+import java.util.Map;
+
+import org.apache.maven.api.Project;
+import org.apache.maven.api.Session;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * Extracts enhanced information using the <b>real typed</b> Maven 4 API.
+ * <p>
+ * This class directly imports {@link Session}, {@link Project}, etc. —
+ * no reflection needed for individual method calls. The Maven 4 API
+ * dependency is {@code provided + optional} in the POM, so the code
+ * compiles cleanly but the classes are absent at runtime on Maven 3.
+ * <p>
+ * <b>The calling code must catch {@link NoClassDefFoundError}</b> around
+ * any reference to this class. On Maven 3 there are two possible
+ * outcomes:
+ * <ol>
+ *   <li>{@code maven-api-core} is <b>not</b> on the classpath — the JVM
+ *       throws {@link NoClassDefFoundError} when it tries to load this
+ *       class. The Mojo's catch block handles that.</li>
+ *   <li>{@code maven-api-core} <b>is</b> on the classpath (Maven 3
+ *       resolved the artifact from Central) — this class loads, but
+ *       {@link MavenRuntimeDetector#getMaven4Session} returns
+ *       {@code null} because the {@code MavenSession.getSession()}
+ *       bridge method doesn't exist on Maven 3. Handled here.</li>
+ * </ol>
+ * Both paths result in no Maven 4 data being emitted.
+ *
+ * <pre>
+ * // In the Mojo — the ONE place we catch the error:
+ * try {
+ *     Maven4Enhancer.tryEnhance(mavenSession, log);
+ * } catch (NoClassDefFoundError e) {
+ *     // Maven 3 path 1: class can't load, fall back gracefully
+ * }
+ * </pre>
+ */
+public final class Maven4Enhancer {
+
+    private Maven4Enhancer() {}
+
+    /**
+     * Single entry point called from the Mojo.
+     * <p>
+     * Obtains the Maven 4 {@link Session} via the
+     * {@link MavenRuntimeDetector} bridge, then logs enhanced info.
+     * If the bridge returns {@code null}, logs a diagnostic message.
+     *
+     * @param legacy the Maven 3 session (injected into the Mojo)
+     * @param log    the Mojo logger
+     */
+    public static void tryEnhance(MavenSession legacy, Log log) {
+        Session session = MavenRuntimeDetector.getMaven4Session(legacy);
+        if (session != null) {
+            log.info("[RUNTIME] Maven 4");
+            enhance(session, log);
+        } else {
+            // Maven 4 API classes are on the classpath (this class loaded),
+            // but MavenSession.getSession() bridge is absent — Maven 3
+            // resolved the api jar from Central without actually running
+            // Maven 4.  Treat as Maven 3.
+            log.info("[RUNTIME] Maven 3 (API jar present but bridge absent)");
+        }
+    }
+
+    /**
+     * Logs enhanced project information using the Maven 4 Session API.
+     * <p>
+     * Every call here is a direct, type-safe method invocation — no
+     * reflection, no string-based method names, full IDE navigation
+     * and compile-time checking.
+     */
+    private static void enhance(Session session, Log log) {
+        // ── Session-level info ──────────────────────────────────
+        log.info("[MVN4] maven.version = " + session.getMavenVersion());
+        log.info("[MVN4] root.directory = " + session.getRootDirectory());
+        log.info("[MVN4] top.directory = " + session.getTopDirectory());
+        log.info("[MVN4] start.time = " + session.getStartTime());
+        log.info("[MVN4] degree.of.concurrency = " + session.getDegreeOfConcurrency());
+
+        // ── Reactor ─────────────────────────────────────────────
+        log.info("[MVN4] reactor.project.count = " + session.getProjects().size());
+        log.info("[MVN4] remote.repository.count = " + session.getRemoteRepositories().size());
+
+        // ── Properties (typed Map<String,String>, not Properties) ─
+        Map<String, String> sysProps = session.getSystemProperties();
+        log.info("[MVN4] system.properties.count = " + sysProps.size());
+
+        Map<String, String> userProps = session.getUserProperties();
+        log.info("[MVN4] user.properties.count = " + userProps.size());
+
+        // ── Per-project info (first project in reactor) ─────────
+        if (!session.getProjects().isEmpty()) {
+            Project project = session.getProjects().get(0);
+            // Effective properties merge system < project < user
+            Map<String, String> effective = session.getEffectiveProperties(project);
+            log.info("[MVN4] effective.properties.count = " + effective.size());
+        }
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-dual-api-plugin/src/main/java/org/apache/maven/its/dualapi/MavenRuntimeDetector.java
+++ b/its/core-it-suite/src/test/resources/mng-dual-api-plugin/src/main/java/org/apache/maven/its/dualapi/MavenRuntimeDetector.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.dualapi;
+
+import java.lang.reflect.Method;
+
+import org.apache.maven.api.Session;
+import org.apache.maven.execution.MavenSession;
+
+/**
+ * Bridges from the legacy {@link MavenSession} (Maven 3 API) to the new
+ * immutable {@link Session} (Maven 4 API).
+ * <p>
+ * The ONE place where reflection is unavoidable: Maven 3's
+ * {@code MavenSession} does not declare a {@code getSession()} method
+ * that returns {@code org.apache.maven.api.Session} — that method was
+ * added by Maven 4's compat module. So we call it reflectively,
+ * then cast the result to the real typed {@link Session}.
+ * <p>
+ * <b>Callers must catch {@link NoClassDefFoundError}</b> around any
+ * reference to this class, because importing {@link Session} triggers
+ * a class-load that fails on Maven 3 (the class doesn't exist).
+ */
+public final class MavenRuntimeDetector {
+
+    private MavenRuntimeDetector() {}
+
+    /**
+     * Obtains the Maven 4 {@link Session} from a legacy
+     * {@link MavenSession} via the one-shot reflection bridge.
+     *
+     * @param legacy the injected Maven 3 session
+     * @return the Maven 4 Session, or {@code null} if the bridge
+     *         method is absent or returns null
+     */
+    public static Session getMaven4Session(MavenSession legacy) {
+        try {
+            Method getSession = legacy.getClass().getMethod("getSession");
+            Object result = getSession.invoke(legacy);
+            if (result instanceof Session) {
+                return (Session) result;
+            }
+        } catch (ReflectiveOperationException e) {
+            // getSession() doesn't exist — shouldn't happen if we got
+            // this far (class loading already proved Maven 4 API is
+            // present), but handle gracefully.
+        }
+        return null;
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-dual-api-plugin/src/main/java/org/apache/maven/its/dualapi/ProjectInfoMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-dual-api-plugin/src/main/java/org/apache/maven/its/dualapi/ProjectInfoMojo.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.dualapi;
+
+import javax.inject.Inject;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * A Mojo that displays project information using the Maven 3 API, then
+ * automatically enhances the output with Maven 4 API data when available.
+ * <p>
+ * Extends {@link AbstractMojo} (Maven 3 API) — this class has <b>no
+ * imports from {@code org.apache.maven.api.*}</b>, so it loads cleanly
+ * on both Maven 3 and Maven 4.
+ * <p>
+ * Maven 4 code lives in {@link Maven4Enhancer} and
+ * {@link MavenRuntimeDetector}, which DO import Maven 4 types. The JVM
+ * only loads those classes when first referenced; on Maven 3, the load
+ * fails with {@link NoClassDefFoundError}, which we catch right here
+ * at the boundary.
+ * <p>
+ * Log output uses bracketed tags for easy assertion:
+ * <ul>
+ *   <li>{@code [RUNTIME] Maven 3} or {@code [RUNTIME] Maven 4}</li>
+ *   <li>{@code [MVN3] key = value} — always emitted</li>
+ *   <li>{@code [MVN4] key = value} — only on Maven 4</li>
+ * </ul>
+ */
+@Mojo(name = "project-info", requiresProject = true)
+public class ProjectInfoMojo extends AbstractMojo {
+
+    private final MavenProject project;
+    private final MavenSession mavenSession;
+
+    @Inject
+    public ProjectInfoMojo(MavenProject project, MavenSession mavenSession) {
+        this.project = project;
+        this.mavenSession = mavenSession;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        Log log = getLog();
+
+        // ── Maven 3 baseline (always available) ────────────────
+        log.info("[MVN3] groupId = " + project.getGroupId());
+        log.info("[MVN3] artifactId = " + project.getArtifactId());
+        log.info("[MVN3] version = " + project.getVersion());
+        log.info("[MVN3] packaging = " + project.getPackaging());
+        log.info("[MVN3] dependencies.size = " + project.getDependencies().size());
+
+        // ── Maven 4 enhanced output ────────────────────────────
+        // This try block is the SOLE boundary where we catch
+        // NoClassDefFoundError.  Maven4Enhancer imports
+        // org.apache.maven.api.Session — on Maven 3 that class
+        // doesn't exist, so the JVM throws NoClassDefFoundError
+        // the instant it tries to load Maven4Enhancer.
+        //
+        // NOTE: this class (ProjectInfoMojo) must NOT import
+        // anything from org.apache.maven.api.*, otherwise it
+        // would itself fail to load on Maven 3, before we ever
+        // reach this try block.
+        try {
+            Maven4Enhancer.tryEnhance(mavenSession, log);
+        } catch (NoClassDefFoundError e) {
+            // Maven 3: org.apache.maven.api.Session doesn't exist,
+            // so loading Maven4Enhancer (which imports it) fails.
+            // This is the expected, designed-for code path.
+            log.info("[RUNTIME] Maven 3");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an integration test demonstrating the **"compile for 3, enhance for 4"** plugin pattern — a Maven plugin that:

- Compiles against Maven 3.9.x API (`maven-plugin-api`, `maven-core`)
- Optionally uses Maven 4's typed API (`Session`, `Project`) at runtime
- Falls back gracefully on Maven 3 — no crashes, no Maven 4 data leaks

### Architecture

```
ProjectInfoMojo.java          ← NO Maven 4 imports (loads on Maven 3)
  │
  │ try { Maven4Enhancer.tryEnhance(...) }
  │ catch (NoClassDefFoundError) { /* Maven 3 path 1 */ }
  │
  ├── Maven4Enhancer.java     ← imports Session, Project (real typed API)
  └── MavenRuntimeDetector.java ← one reflection call for MavenSession.getSession() bridge
```

### Key design points

- **One reflection call**: only `MavenSession.getSession()` uses reflection — it's the bridge method added by Maven 4's compat module that doesn't exist on Maven 3
- **Everything else is typed**: `session.getMavenVersion()`, `session.getRootDirectory()`, `session.getProjects()`, etc. — direct, compile-time checked
- **Two Maven 3 fallback paths**:
  1. `NoClassDefFoundError` — Maven 4 API classes absent from classpath
  2. API jar resolved from Central but `getSession()` bridge absent — handled in `tryEnhance()`

### Verified on both runtimes

| Runtime | `[MVN3]` tags | `[MVN4]` tags | Detection |
|---------|:-----------:|:-----------:|-----------|
| Maven 3.9.16 | ✅ all 5 | ✅ none | `[RUNTIME] Maven 3` |
| Maven 4.1.0-SNAPSHOT | ✅ all 5 | ✅ all 10 | `[RUNTIME] Maven 4` |

## Test plan

- [x] IT passes on Maven 4 (`mvn verify -Prun-its -Dits.test=MavenITDualApiPluginTest`)
- [x] Plugin builds and runs correctly on Maven 3.9.16 (manual test)
- [x] No `[MVN4]` data emitted on Maven 3
- [x] All `[MVN4]` data emitted on Maven 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)