### PR TITLE
Fix #12536: Handle Ctrl+C on Windows terminals

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -89,6 +89,7 @@ import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.impl.AbstractPosixTerminal;
 import org.jline.terminal.spi.TerminalExt;
+import org.jline.utils.OSUtils;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.slf4j.spi.LocationAwareLogger;
@@ -103,6 +104,8 @@ import static org.apache.maven.cling.invoker.CliUtils.toProperties;
  * @param <C> The context type.
  */
 public abstract class LookupInvoker<C extends LookupContext> implements Invoker {
+    private static final int SIGINT_EXIT_CODE = 130;
+
     protected final Lookup protoLookup;
 
     @Nullable
@@ -312,9 +315,13 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
 
     protected final void createTerminal(C context) {
         if (context.terminal == null) {
-            MessageUtils.systemInstall(
-                    builder -> doCreateTerminal(context, builder),
-                    terminal -> doConfigureWithTerminal(context, terminal));
+            MessageUtils.systemInstall(builder -> doCreateTerminal(context, builder), terminal -> {
+                if (OSUtils.IS_WINDOWS && !context.invokerRequest.embedded()) {
+                    // JLine may consume Ctrl+C as terminal input, bypassing the JVM's shutdown hooks.
+                    terminal.handle(Terminal.Signal.INT, signal -> System.exit(SIGINT_EXIT_CODE));
+                }
+                doConfigureWithTerminal(context, terminal);
+            });
 
             context.terminal = MessageUtils.getTerminal();
             context.closeables.add(MessageUtils::systemUninstall);


### PR DESCRIPTION
<!--
Please open pull requests against one of the following branches:

- master — default target for all changes (new features + bug fixes).  
  If the change should also go to maven-4.0.x, request a backport in the PR.

- maven-3.10.x — target for 3.x changes (new features + bug fixes).  
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.

Backports are typically handled by maintainers; 
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

## Summary

Fixes #12536.

On Windows, JLine handles Ctrl+C as the terminal's `INT` signal. Without an explicit handler, the standalone Maven JVM does not follow its normal interrupt termination path and Maven's shutdown hooks do not run, which can leave long-running child processes alive.

This change registers an `INT` handler for Windows terminals that exits with status `130`. This triggers normal JVM shutdown and its registered cleanup hooks.

Please backport this change to `maven-4.0.x`.

## Testing

- `mvn -Prun-its verify` passes
- Confirmed issue in `4.0.0-rc-5` and `master` on:
  - Windows 11 with PowerShell in Windows Terminal
  - Windows 11 with Git Bash in Windows Terminal
- Confirmed issue is not present in `4.0.0-rc-5` and `master` on:
  - macOS 26 with Fish in Ghostty
  - Arch Linux with Fish in Ghostty
- Confirmed issue is not present in `3.9.16` on all configs listed above
- Confirmed issue is not present with this patch on all configs listed above

No automated regression test is included because the failure requires a real Windows terminal running Maven and a way to send a Ctrl+C event to that console.

## Checklist

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
