### PR TITLE
Introduce validation control

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -446,6 +446,17 @@ public final class Constants {
     public static final String MAVEN_RESOLVER_TRANSPORT = "maven.resolver.transport";
 
     /**
+     * Resolver validation control.
+     * Can be <code>default</code> (full validation), <code>mild</code> (only uninterpolated placeholders) or
+     * <code>off</code> (no validation, as in Maven 3.9.x).
+     * This configuration provides "escape hatch" for those projects, that are forced to use non-conformant solutions.
+     *
+     * @since 3.10.0
+     */
+    @Config(defaultValue = "default")
+    public static final String MAVEN_RESOLVER_VALIDATION = "maven.resolver.validation";
+
+    /**
      * Plugin validation level.
      *
      * @since 3.9.2

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidator.java
@@ -31,6 +31,12 @@ import org.eclipse.aether.util.PathUtils;
  * elements enter resolver; if it does, is most likely some bug.
  */
 public class MavenValidator implements Validator {
+    private final boolean validatePathComponents;
+
+    public MavenValidator(boolean validatePathComponents) {
+        this.validatePathComponents = validatePathComponents;
+    }
+
     protected boolean containsPlaceholder(String value) {
         return value != null && value.contains("${");
     }
@@ -44,7 +50,9 @@ public class MavenValidator implements Validator {
                 || containsPlaceholder(artifact.getExtension())) {
             throw new IllegalArgumentException("Not fully interpolated artifact " + artifact);
         }
-        PathUtils.validateArtifactComponents(artifact);
+        if (validatePathComponents) {
+            PathUtils.validateArtifactComponents(artifact);
+        }
     }
 
     @Override
@@ -55,7 +63,9 @@ public class MavenValidator implements Validator {
                 || containsPlaceholder(metadata.getType())) {
             throw new IllegalArgumentException("Not fully interpolated metadata " + metadata);
         }
-        PathUtils.validateMetadataComponents(metadata);
+        if (validatePathComponents) {
+            PathUtils.validateMetadataComponents(metadata);
+        }
     }
 
     @Override
@@ -74,7 +84,9 @@ public class MavenValidator implements Validator {
                                 || containsPlaceholder(e.getExtension()))) {
             throw new IllegalArgumentException("Not fully interpolated dependency " + dependency);
         }
-        PathUtils.validateArtifactComponents(artifact);
+        if (validatePathComponents) {
+            PathUtils.validateArtifactComponents(artifact);
+        }
     }
 
     @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidatorFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/validator/MavenValidatorFactory.java
@@ -18,19 +18,34 @@
  */
 package org.apache.maven.impl.resolver.validator;
 
+import org.apache.maven.api.Constants;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Singleton;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.spi.validator.Validator;
 import org.eclipse.aether.spi.validator.ValidatorFactory;
+import org.eclipse.aether.util.ConfigUtils;
 
 @Named
 @Singleton
 public class MavenValidatorFactory implements ValidatorFactory {
-    private final MavenValidator instance = new MavenValidator();
+    public enum ValidationLevel {
+        DEFAULT,
+        MILD,
+        OFF;
+    }
+
+    private final MavenValidator defaultValidator = new MavenValidator(true);
+    private final MavenValidator mildValidator = new MavenValidator(false);
+    private final Validator offValidator = new Validator() {};
 
     @Override
-    public Validator newInstance(RepositorySystemSession repositorySystemSession) {
-        return instance;
+    public Validator newInstance(RepositorySystemSession session) {
+        return switch (ConfigUtils.getEnum(
+                session, ValidationLevel.class, ValidationLevel.DEFAULT, Constants.MAVEN_RESOLVER_VALIDATION)) {
+            case DEFAULT -> defaultValidator;
+            case MILD -> mildValidator;
+            case OFF -> offValidator;
+        };
     }
 }


### PR DESCRIPTION
Enables validation level choice in Maven Resolver validator.

This change should go to every Maven version having `MavenValidator` (3.10, 4.0 and 4.1).

Related: apache/maven-resolver#2007

Backport of: 5703b7db075bc5cd7974e6bd7fa9ab2eba90818a
