### PR TITLE
Introduce validation control

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/MavenValidator.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/MavenValidator.java
@@ -34,6 +34,12 @@ import org.eclipse.aether.util.PathUtils;
  * and to keep very same behavior as Maven 3 did so far. If you want more, upgrade to Maven 4 ;)
  */
 public class MavenValidator implements Validator {
+    private final boolean validatePathComponents;
+
+    public MavenValidator(boolean validatePathComponents) {
+        this.validatePathComponents = validatePathComponents;
+    }
+
     protected boolean containsPlaceholder(String value) {
         return value != null && value.contains("${");
     }
@@ -47,7 +53,9 @@ public class MavenValidator implements Validator {
                 || containsPlaceholder(artifact.getExtension())) {
             throw new IllegalArgumentException("Not fully interpolated artifact " + artifact);
         }
-        PathUtils.validateArtifactComponents(artifact);
+        if (validatePathComponents) {
+            PathUtils.validateArtifactComponents(artifact);
+        }
     }
 
     @Override
@@ -58,7 +66,9 @@ public class MavenValidator implements Validator {
                 || containsPlaceholder(metadata.getType())) {
             throw new IllegalArgumentException("Not fully interpolated metadata " + metadata);
         }
-        PathUtils.validateMetadataComponents(metadata);
+        if (validatePathComponents) {
+            PathUtils.validateMetadataComponents(metadata);
+        }
     }
 
     @Override
@@ -77,7 +87,9 @@ public class MavenValidator implements Validator {
                                 || containsPlaceholder(e.getExtension()))) {
             throw new IllegalArgumentException("Not fully interpolated dependency " + dependency);
         }
-        PathUtils.validateArtifactComponents(artifact);
+        if (validatePathComponents) {
+            PathUtils.validateArtifactComponents(artifact);
+        }
     }
 
     @Override

--- a/maven-core/src/main/java/org/apache/maven/internal/aether/MavenValidatorFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/MavenValidatorFactory.java
@@ -24,14 +24,44 @@ import javax.inject.Singleton;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.spi.validator.Validator;
 import org.eclipse.aether.spi.validator.ValidatorFactory;
+import org.eclipse.aether.util.ConfigUtils;
 
 @Named
 @Singleton
 public class MavenValidatorFactory implements ValidatorFactory {
-    private final MavenValidator instance = new MavenValidator();
+    /**
+     * Resolver validation control.
+     * Can be <code>default</code> (full validation), <code>mild</code> (only uninterpolated placeholders) or
+     * <code>off</code> (no validation, as in Maven 3.9.x).
+     * This configuration provides "escape hatch" for those projects, that are forced to use non-conformant solutions.
+     * Default value is {@code default}.
+     *
+     * @since 3.10.0
+     */
+    public static final String MAVEN_RESOLVER_VALIDATION = "maven.resolver.validation";
+
+    public enum ValidationLevel {
+        DEFAULT,
+        MILD,
+        OFF;
+    }
+
+    private final MavenValidator defaultValidator = new MavenValidator(true);
+    private final MavenValidator mildValidator = new MavenValidator(false);
+    private final Validator offValidator = new Validator() {};
 
     @Override
-    public Validator newInstance(RepositorySystemSession repositorySystemSession) {
-        return instance;
+    public Validator newInstance(RepositorySystemSession session) {
+        switch (ConfigUtils.getEnum(
+                session, ValidationLevel.class, ValidationLevel.DEFAULT, MAVEN_RESOLVER_VALIDATION)) {
+            case DEFAULT:
+                return defaultValidator;
+            case MILD:
+                return mildValidator;
+            case OFF:
+                return offValidator;
+            default:
+                throw new IllegalArgumentException("Unknown validation level");
+        }
     }
 }


### PR DESCRIPTION
Enables validation level choice in Maven Resolver validator.

This change should go to every Maven version having `MavenValidator` (3.10, 4.0 and 4.1).

Related: apache/maven-resolver#2007

Backport of: 5703b7db075bc5cd7974e6bd7fa9ab2eba90818a
