### PR TITLE
[MNG-8507] Forward port: Reduce allocation pressure in model building pipeline

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java
@@ -563,9 +563,8 @@ public class DefaultProjectBuilder implements ProjectBuilder {
                     File pom = r.getSource().getPath().toFile();
                     MavenProject project =
                             projectIndex.get(r.getEffectiveModel().getId());
-                    Path rootDirectory =
-                            rootLocator.findRoot(pom.getParentFile().toPath());
-                    project.setRootDirectory(rootDirectory);
+                    project.setRootDirectory(
+                            rootLocator.findRoot(pom.getParentFile().toPath()));
                     project.setFile(pom);
                     project.setExecutionRoot(pom.equals(pomFile));
                     initProject(project, r);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -1217,7 +1217,11 @@ public class MavenProject implements Cloneable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getGroupId(), getArtifactId(), getVersion());
+        // Inlined hash avoids Object[] varargs allocation from Objects.hash()
+        int result = 31 + Objects.hashCode(getGroupId());
+        result = 31 * result + Objects.hashCode(getArtifactId());
+        result = 31 * result + Objects.hashCode(getVersion());
+        return result;
     }
 
     public List<Extension> getBuildExtensions() {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/InternalSession.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/InternalSession.java
@@ -49,6 +49,9 @@ import static org.apache.maven.impl.ImplUtils.cast;
 public interface InternalSession extends Session {
 
     static InternalSession from(Session session) {
+        if (session instanceof InternalSession is) {
+            return is;
+        }
         return cast(InternalSession.class, session, "session should be an " + InternalSession.class);
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PropertiesAsMap.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PropertiesAsMap.java
@@ -34,13 +34,14 @@ public class PropertiesAsMap extends AbstractMap<String, String> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set<Entry<String, String>> entrySet() {
         return new AbstractSet<Entry<String, String>>() {
             @Override
             public Iterator<Entry<String, String>> iterator() {
                 Iterator<Entry<Object, Object>> iterator = properties.entrySet().iterator();
                 return new Iterator<Entry<String, String>>() {
-                    Entry<String, String> next;
+                    Entry<Object, Object> next;
 
                     {
                         advance();
@@ -51,22 +52,7 @@ public class PropertiesAsMap extends AbstractMap<String, String> {
                         while (iterator.hasNext()) {
                             Entry<Object, Object> e = iterator.next();
                             if (PropertiesAsMap.matches(e)) {
-                                next = new Entry<String, String>() {
-                                    @Override
-                                    public String getKey() {
-                                        return (String) e.getKey();
-                                    }
-
-                                    @Override
-                                    public String getValue() {
-                                        return (String) e.getValue();
-                                    }
-
-                                    @Override
-                                    public String setValue(String value) {
-                                        return (String) e.setValue(value);
-                                    }
-                                };
+                                next = e;
                                 break;
                             }
                         }
@@ -79,21 +65,26 @@ public class PropertiesAsMap extends AbstractMap<String, String> {
 
                     @Override
                     public Entry<String, String> next() {
-                        Entry<String, String> item = next;
+                        Entry<Object, Object> item = next;
                         if (item == null) {
                             throw new NoSuchElementException();
                         }
                         advance();
-                        return item;
+                        // Safe cast: matches() guarantees both key and value are Strings.
+                        return (Entry<String, String>) (Entry<?, ?>) item;
                     }
                 };
             }
 
             @Override
             public int size() {
-                return (int) properties.entrySet().stream()
-                        .filter(PropertiesAsMap::matches)
-                        .count();
+                int count = 0;
+                for (Entry<Object, Object> e : properties.entrySet()) {
+                    if (PropertiesAsMap.matches(e)) {
+                        count++;
+                    }
+                }
+                return count;
             }
         };
     }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultInterpolator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultInterpolator.java
@@ -414,7 +414,14 @@ public class DefaultInterpolator implements Interpolator {
         if (val == null || val.isEmpty()) {
             return val;
         }
-        val = val.replace(MARKER, "$");
+        // Fast path: if the string contains neither the escape marker ($__)
+        // nor the escape char (\), there is nothing to unescape.
+        if (val.indexOf(MARKER.charAt(0)) < 0 && val.indexOf(ESCAPE_CHAR) < 0) {
+            return val;
+        }
+        if (val.contains(MARKER)) {
+            val = val.replace(MARKER, "$");
+        }
         int escape = val.indexOf(ESCAPE_CHAR);
         while (escape >= 0 && escape < val.length() - 1) {
             char c = val.charAt(escape + 1);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -102,7 +103,19 @@ public class DefaultModelInterpolator implements ModelInterpolator {
     public Model interpolateModel(
             Model model, Path projectDir, ModelBuilderRequest request, ModelProblemCollector problems) {
         InnerInterpolator innerInterpolator = createInterpolator(model, projectDir, request, problems);
-        return new MavenTransformer(innerInterpolator::interpolate).visit(model);
+        return new MavenTransformer(innerInterpolator::interpolate) {
+            @Override
+            protected String transform(String value) {
+                // Fast path: skip the interpolation callback chain for strings
+                // that cannot contain variable references (the vast majority).
+                // This is safe here because this transformer is only used for
+                // interpolation (${...}), NOT for decryption ({...}).
+                if (value == null || value.indexOf('$') < 0) {
+                    return value;
+                }
+                return super.transform(value);
+            }
+        }.visit(model);
     }
 
     private InnerInterpolator createInterpolator(
@@ -113,9 +126,15 @@ public class DefaultModelInterpolator implements ModelInterpolator {
                 v -> Optional.ofNullable(callback(model, projectDir, request, problems, v));
         UnaryOperator<String> cb = v -> cache.computeIfAbsent(v, ucb).orElse(null);
         BinaryOperator<String> postprocessor = (e, v) -> postProcess(projectDir, request, e, v);
+        // Reuse a single HashSet for cycle detection across all strings in this model.
+        // The set is cleared after each substVars call returns, avoiding a new HashSet
+        // allocation per interpolated string (~550 allocations per Camel build).
+        HashSet<String> cycleMap = new HashSet<>();
+        DefaultInterpolator di = (DefaultInterpolator) interpolator;
         return value -> {
             try {
-                return interpolator.interpolate(value, cb, postprocessor, false);
+                cycleMap.clear();
+                return di.interpolate(value, null, cycleMap, cb, postprocessor, false);
             } catch (InterpolatorException e) {
                 problems.add(BuilderProblem.Severity.ERROR, ModelProblem.Version.BASE, e.getMessage(), e);
                 return null;

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
@@ -130,6 +130,10 @@ public class DefaultModelInterpolator implements ModelInterpolator {
         // The set is cleared after each substVars call returns, avoiding a new HashSet
         // allocation per interpolated string (~550 allocations per Camel build).
         HashSet<String> cycleMap = new HashSet<>();
+        // Downcast to access the package-private interpolate() overload that accepts
+        // an externally-managed cycleMap, allowing us to reuse the same HashSet across
+        // all strings in this model. Safe because DefaultInterpolator is the only
+        // implementation bound via DI in the Maven runtime.
         DefaultInterpolator di = (DefaultInterpolator) interpolator;
         return value -> {
             try {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1361,6 +1361,10 @@ public class DefaultModelValidator implements ModelValidator {
                             SourceHint.dependencyManagementKey(dependency),
                             dependency);
 
+                    /*
+                     * Extensions like Flex Mojos use custom scopes like "merged", "internal", "external", etc. In
+                     * order to not break backward-compat with those, only warn but don't error out.
+                     */
                     validateDependencyScope(
                             prefix,
                             "scope",

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1315,6 +1315,27 @@ public class DefaultModelValidator implements ModelValidator {
 
         String prefix = management ? "dependencyManagement.dependencies.dependency." : "dependencies.dependency.";
 
+        // Pre-compute scope validation data once before the loop instead of per-dependency.
+        // On Camel (676 modules, ~20+ deps each), this avoids thousands of redundant
+        // InternalSession.from() calls, stream pipelines, and array allocations.
+        String[] validScopes = null;
+        if (validationLevel >= ModelValidator.VALIDATION_LEVEL_MAVEN_2_0 && !dependencies.isEmpty()) {
+            ScopeManager scopeManager =
+                    InternalSession.from(session).getSession().getScopeManager();
+            if (management) {
+                Set<String> scopes = scopeManager.getDependencyScopeUniverse().stream()
+                        .map(org.eclipse.aether.scope.DependencyScope::getId)
+                        .collect(Collectors.toCollection(HashSet::new));
+                scopes.add("import");
+                validScopes = scopes.toArray(new String[0]);
+            } else {
+                validScopes = scopeManager.getDependencyScopeUniverse().stream()
+                        .map(org.eclipse.aether.scope.DependencyScope::getId)
+                        .distinct()
+                        .toArray(String[]::new);
+            }
+        }
+
         for (Dependency dependency : dependencies) {
             validateEffectiveDependency(problems, dependency, management, prefix, validationLevel);
 
@@ -1340,12 +1361,6 @@ public class DefaultModelValidator implements ModelValidator {
                             SourceHint.dependencyManagementKey(dependency),
                             dependency);
 
-                    /*
-                     * Extensions like Flex Mojos use custom scopes like "merged", "internal", "external", etc. In
-                     * order to not break backward-compat with those, only warn but don't error out.
-                     */
-                    ScopeManager scopeManager =
-                            InternalSession.from(session).getSession().getScopeManager();
                     validateDependencyScope(
                             prefix,
                             "scope",
@@ -1355,20 +1370,11 @@ public class DefaultModelValidator implements ModelValidator {
                             dependency.getScope(),
                             SourceHint.dependencyManagementKey(dependency),
                             dependency,
-                            scopeManager.getDependencyScopeUniverse().stream()
-                                    .map(org.eclipse.aether.scope.DependencyScope::getId)
-                                    .distinct()
-                                    .toArray(String[]::new),
+                            validScopes,
                             false);
 
                     validateEffectiveModelAgainstDependency(prefix, problems, model, dependency);
                 } else {
-                    ScopeManager scopeManager =
-                            InternalSession.from(session).getSession().getScopeManager();
-                    Set<String> scopes = scopeManager.getDependencyScopeUniverse().stream()
-                            .map(org.eclipse.aether.scope.DependencyScope::getId)
-                            .collect(Collectors.toCollection(HashSet::new));
-                    scopes.add("import");
                     validateDependencyScope(
                             prefix,
                             "scope",
@@ -1378,7 +1384,7 @@ public class DefaultModelValidator implements ModelValidator {
                             dependency.getScope(),
                             SourceHint.dependencyManagementKey(dependency),
                             dependency,
-                            scopes.toArray(new String[0]),
+                            validScopes,
                             true);
                 }
             }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
@@ -23,7 +23,6 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,6 +40,8 @@ import org.apache.maven.api.annotations.Nullable;
  */
 public class ReflectionValueExtractor {
     private static final Object[] OBJECT_ARGS = new Object[0];
+
+    private static final List<String> ACCESSOR_PREFIXES = List.of("get", "is", "to", "as");
 
     /**
      * Use a WeakHashMap here, so the keys (Class objects) can be garbage collected.
@@ -271,7 +272,7 @@ public class ReflectionValueExtractor {
         ClassMap classMap = getClassMap(value.getClass());
         String methodBase = Character.toTitleCase(property.charAt(0)) + property.substring(1);
         try {
-            for (String prefix : Arrays.asList("get", "is", "to", "as")) {
+            for (String prefix : ACCESSOR_PREFIXES) {
                 Method method = classMap.findMethod(prefix + methodBase);
                 if (method != null) {
                     return method.invoke(value, OBJECT_ARGS);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/type/TypeRegistryAdapter.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/type/TypeRegistryAdapter.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.impl.resolver.type;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.apache.maven.api.PathType;
 import org.apache.maven.api.Type;
 import org.apache.maven.api.services.TypeRegistry;
@@ -28,9 +31,12 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Adapter between Maven {@link TypeRegistry} and Resolver {@link ArtifactTypeRegistry}.
+ * <p>
+ * Results are cached per typeId since type definitions are immutable during a build.
  */
 public class TypeRegistryAdapter implements ArtifactTypeRegistry {
     private final TypeRegistry typeRegistry;
+    private final ConcurrentMap<String, ArtifactType> cache = new ConcurrentHashMap<>();
 
     public TypeRegistryAdapter(TypeRegistry typeRegistry) {
         this.typeRegistry = requireNonNull(typeRegistry, "typeRegistry");
@@ -38,6 +44,10 @@ public class TypeRegistryAdapter implements ArtifactTypeRegistry {
 
     @Override
     public ArtifactType get(String typeId) {
+        return cache.computeIfAbsent(typeId, this::doGet);
+    }
+
+    private ArtifactType doGet(String typeId) {
         Type type = typeRegistry.require(typeId);
         if (type instanceof ArtifactType artifactType) {
             return artifactType;

--- a/src/mdo/transformer.vm
+++ b/src/mdo/transformer.vm
@@ -71,7 +71,7 @@ public class ${className} {
      * The transformation function.
      */
     protected String transform(String value) {
-        return transformer.apply(value);
+        return value != null ? transformer.apply(value) : null;
     }
 
 #foreach ( $class in $model.allClasses )


### PR DESCRIPTION
## Summary

Forward port of #12540 (merged to `maven-4.0.x`) to `master`.

Cherry-picked from f5426bf5fa35 with conflict resolution in:
- `DefaultModelValidator.java` — adapted variable names (`session` vs `s`, `dependency` vs `d`) and FQN type references (`org.eclipse.aether.scope.DependencyScope`)
- `TypeRegistryAdapter.java` — kept `public` visibility (class moved to a different package on master)

See #12540 for the full description and JFR profiling results.

## Test plan

- [x] Compiles cleanly on `master`
- [ ] CI: full-build + integration-tests matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)