### PR TITLE
improve doc about deprecating plugin descriptor's requirement

### DIFF
--- a/maven-plugin-api/src/main/mdo/plugin.mdo
+++ b/maven-plugin-api/src/main/mdo/plugin.mdo
@@ -339,7 +339,10 @@ under the License.
         <field xdoc.separator="blank">
           <name>requirements</name>
           <version>1.0.0</version>
-          <description>Use Maven 4 Dependency Injection (for v4 plugins) or JSR 330 annotations (for v3 plugins) to inject dependencies instead.</description>
+          <description><![CDATA[
+            Deprecated: Component requirements (plugin tools {@code @Component} annotation), that will be injected to Mojo fields.
+            <a href="https://maven.apache.org/maven-jsr330.html">Use JSR 330 annotations</a> to inject components instead, without this descriptor.
+          ]]></description>
           <association>
             <type>Requirement</type>
             <multiplicity>*</multiplicity>
@@ -469,7 +472,10 @@ under the License.
     <class xdoc.anchorName="requirement">
       <name>Requirement</name>
       <version>1.0.0</version>
-      <description>Describes a component requirement.</description>
+      <description><![CDATA[
+        Deprecated: Describes a component requirement (plugin tools' {@code @Component} annotation), that will be injected to a Mojo field.
+        <a href="https://maven.apache.org/maven-jsr330.html">Use JSR 330 annotations</a> to inject components instead, without this descriptor.
+      ]]></description>
       <!-- see o.a.m.plugin.descriptor.Requirement -->
       <fields>
         <field>
@@ -477,7 +483,7 @@ under the License.
           <required>true</required>
           <version>1.0.0</version>
           <type>String</type>
-          <description></description>
+          <description>Plexus role of the component to inject.</description>
         </field>
         <field xml.tagName="role-hint">
           <name>roleHint</name>
@@ -490,7 +496,7 @@ under the License.
           <required>true</required>
           <version>1.0.0</version>
           <type>String</type>
-          <description>The field name which has this requirement.</description>
+          <description>The field name which has this component requirement.</description>
         </field>
       </fields>
     </class>


### PR DESCRIPTION
improve documentation of the deprecation in `plugin.xml`'s `<requirement>` https://maven.apache.org/ref/3.10.0-rc-1/maven-plugin-api/plugin.html#class_requirement ,
as recently we discovered that injection with `MavenPluginManager.getConfiguredMojo(...)` does not provide same result than direct JSR 330
= https://github.com/eclipse-tycho/tycho/pull/6195#issuecomment-5089230625
(notice: I still don't fully understand, but now it seems it's not only a question of "modern" style preference)

in parallel to Maven core documentation improvement, we should probably also:
1. help plugin writers: update Plugin Tools to warn when it generates a `plugin.xml` that contains such `<requirements>` (in general from [`@Component`](https://github.com/apache/maven-plugin-tools/blob/maven-plugin-tools-3.15.2/maven-plugin-annotations/src/main/java/org/apache/maven/plugins/annotations/Component.java) annotations)
2. help plugin consumers: once we help plugin writers, I suppose we can also warn plugin users with a new [plugin validation](https://maven.apache.org/guides/plugins/validation/index.html)