### PR TITLE
[4.0.x] Bump Sisu to 1.1.0 and fix extension realm visibility for JSR330 filtering

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/PlexusContainerCapsuleFactory.java
@@ -252,6 +252,13 @@ public class PlexusContainerCapsuleFactory<C extends LookupContext> implements C
                     // sisu uses realm imports to establish component visibility
                     extRealm.importFrom(realm, realm.getId());
                 }
+                // Make the container realm (maven.ext) visible from extension realms.
+                // Beans discovered in the container are sourced from maven.ext, but extension
+                // realms have plexus.core as parent and cannot reach maven.ext through the parent
+                // chain alone. Without this import, Sisu 1.1.0's FilteredBeans (enabled by
+                // jsr330ComponentVisibilityFollowsPlexusVisibility) would hide container-sourced
+                // beans when TCCL is set to an extension realm during lifecycle callbacks.
+                realm.importFrom(extRealm, extRealm.getId());
             }
 
             return extRealm;

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.it;
 import java.io.File;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 /**
  * This is a test for <a href="https://github.com/apache/maven/issues/12522">GH-12522</a>.
@@ -58,6 +60,7 @@ class MavenITgh12522NonExtensionPluginTest extends AbstractMavenIntegrationTestC
      * is not visible from the container realm and should not be provisioned at all.
      */
     @Test
+    @EnabledForJreRange(min = JRE.JAVA_21, disabledReason = "tycho-bnd-plugin 5.0.3 requires Java 21")
     void testNonExtensionPluginComponentsNotPickedUp() throws Exception {
         File testDir = extractResources("/gh-12522-non-extension-plugin");
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12522NonExtensionPluginTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test for <a href="https://github.com/apache/maven/issues/12522">GH-12522</a>.
+ *
+ * Verifies that plugins that are NOT configured with {@code <extensions>true</extensions>}
+ * do not cause build failures when they ship JSR330 components whose internal dependencies
+ * cannot be resolved in Maven's container.
+ *
+ * <p>Prior to Sisu 1.1.0, {@code @Inject List<T>} produced an unfiltered live list backed
+ * by the global {@code BeanLocator}, so JSR330 components discovered from non-extension
+ * plugin realms would leak into core Maven injection points (e.g.
+ * {@code List<ProjectExecutionListener>} in {@code LifecycleModuleBuilder}). Lazy
+ * provisioning of such components would fail when their plugin-internal dependencies
+ * were not bound in Maven's container, aborting the build.</p>
+ *
+ * <p>Sisu 1.1.0's {@code jsr330ComponentVisibilityFollowsPlexusVisibility} feature applies
+ * realm-based filtering to JSR330 bean lookups, matching the filtering already applied
+ * by the Plexus compatibility layer. Non-extension plugin components are no longer
+ * visible from the container realm.</p>
+ *
+ * <p>The reproducer uses {@code tycho-bnd-plugin} which ships a
+ * {@code ProjectExecutionListener} ({@code BndProjectExecutionListener}) as a
+ * {@code @Named} JSR330 component but is not configured as an extension in the POM.</p>
+ */
+class MavenITgh12522NonExtensionPluginTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh12522NonExtensionPluginTest() {
+        super("[4.0.0-alpha-1,)");
+    }
+
+    /**
+     * Verify that a build using a plugin with JSR330 components (tycho-bnd-plugin)
+     * that is NOT marked as an extension completes successfully. With Sisu 1.1.0's
+     * realm-based JSR330 filtering, the plugin's {@code ProjectExecutionListener}
+     * is not visible from the container realm and should not be provisioned at all.
+     */
+    @Test
+    void testNonExtensionPluginComponentsNotPickedUp() throws Exception {
+        File testDir = extractResources("/gh-12522-non-extension-plugin");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath(), "remote");
+        verifier.addCliArgument("process-classes");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12522-non-extension-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12522-non-extension-plugin/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12522</groupId>
+  <artifactId>non-extension-plugin</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>GH-12522 Non-Extension Plugin Test</name>
+  <description>Test that plugins NOT marked with extensions=true do not have their
+    JSR330/Plexus components picked up as extensions. Reproducer from
+    https://github.com/apache/maven/issues/12522 using tycho-bnd-plugin.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-bnd-plugin</artifactId>
+        <version>5.0.3</version>
+        <executions>
+          <execution>
+            <id>bnd-process</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>process-classes</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ under the License.
     <plexusXmlVersion>4.1.1</plexusXmlVersion>
     <resolverVersion>2.0.21</resolverVersion>
     <securityDispatcherVersion>4.1.0</securityDispatcherVersion>
-    <sisuVersion>1.0.1</sisuVersion>
+    <sisuVersion>1.1.0</sisuVersion>
     <slf4jVersion>2.0.18</slf4jVersion>
     <stax2ApiVersion>4.3.0</stax2ApiVersion>
     <wagonVersion>3.5.3</wagonVersion>


### PR DESCRIPTION
## Summary

Backport of #12554 to `maven-4.0.x`.

- Bumps Eclipse Sisu from 1.0.1 to 1.1.0
- Fixes extension realm visibility so that Sisu 1.1.0's new JSR330 bean filtering works correctly with Maven's ClassRealm hierarchy

## Root Cause

Sisu 1.1.0 introduces `jsr330ComponentVisibilityFollowsPlexusVisibility` (on by default), which filters beans based on ClassRealm visibility via `RealmManager.computeVisibleNames()`. This BFS traversal walks parent and import realms from the current TCCL.

Extension realms have `plexus.core` as their parent, but beans discovered in the container are sourced from the `maven.ext` realm. Since extension realms had no import relationship to `maven.ext`, container-sourced beans were incorrectly filtered out when TCCL was set to an extension realm during lifecycle callbacks (e.g., Mimir extension).

## Fix

Adds a reverse import from each extension realm to the container realm (`maven.ext`), using the same `importFrom(realm, realm.getId())` pattern already used for the forward direction. This works **with** Sisu 1.1.0's filtering feature — the realm visibility graph is corrected to reflect the actual relationship between extension and container realms.

## Verified

- ✅ Clean cherry-pick from master (no conflicts)
- ✅ `mvn clean install -DskipTests` passes on 4.0.x
- ✅ `mvn verify -pl impl/maven-cli` passes (581 tests, 0 failures)
- ✅ Build succeeds with Mimir extension enabled
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)