### PR TITLE
Add validation for Plexus-based plugin dependency injection

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
@@ -55,8 +55,8 @@ class PluginDescriptorRequirementsValidator implements MavenPluginConfigurationV
                     mavenSession,
                     mojoDescriptor,
                     mojoClass,
-                    "Plugin use Plexus Component (plugin tools {@code @Component} annotation). "
-                            + "Maven 4 Dependency Injection (for v4 plugins) or JSR 330 annotations (for v3 plugins) to inject dependencies should be used instead.");
+                    "Plugin uses Plexus Component requirements (@Component annotation). "
+                            + "Use Maven 4 Dependency Injection (for v4 plugins) or JSR 330 annotations (for v3 plugins) to inject dependencies instead.");
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+
+/**
+ * Verify that plugin descriptor does not contain Plexus Component requirements.
+ */
+@Singleton
+@Named
+class PluginDescriptorRequirementsValidator implements MavenPluginConfigurationValidator {
+
+    protected final PluginValidationManager pluginValidationManager;
+
+    @Inject
+    PluginDescriptorRequirementsValidator(PluginValidationManager pluginValidationManager) {
+        this.pluginValidationManager = pluginValidationManager;
+    }
+
+    @Override
+    public void validate(
+            MavenSession mavenSession,
+            MojoDescriptor mojoDescriptor,
+            Class<?> mojoClass,
+            PlexusConfiguration pomConfiguration,
+            ExpressionEvaluator expressionEvaluator) {
+        if (!mojoDescriptor.getRequirements().isEmpty()) {
+            pluginValidationManager.reportPluginMojoValidationIssue(
+                    PluginValidationManager.IssueLocality.EXTERNAL,
+                    mavenSession,
+                    mojoDescriptor,
+                    mojoClass,
+                    "Plugin use Plexus Component (plugin tools {@code @Component} annotation). "
+                            + "Maven 4 Dependency Injection (for v4 plugins) or JSR 330 annotations (for v3 plugins) to inject dependencies should be used instead.");
+        }
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
@@ -28,6 +28,8 @@ import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Verify that plugin descriptor does not contain Plexus Component requirements.
  */
@@ -39,7 +41,7 @@ class PluginDescriptorRequirementsValidator implements MavenPluginConfigurationV
 
     @Inject
     PluginDescriptorRequirementsValidator(PluginValidationManager pluginValidationManager) {
-        this.pluginValidationManager = pluginValidationManager;
+        this.pluginValidationManager = requireNonNull(pluginValidationManager);
     }
 
     @Override

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidatorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PluginDescriptorRequirementsValidatorTest {
+
+    @Mock
+    private PluginValidationManager pluginValidationManager;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private MojoDescriptor mojoDescriptor;
+
+    @InjectMocks
+    private PluginDescriptorRequirementsValidator validator;
+
+    private final Class<?> mojoClass = PluginDescriptorRequirementsValidatorTest.class;
+
+    @Test
+    void testValidateReportsIssueWhenMojoHasRequirements() {
+        when(mojoDescriptor.getRequirements()).thenReturn(List.of(new ComponentRequirement()));
+
+        validator.validate(mavenSession, mojoDescriptor, mojoClass, null, null);
+
+        verify(pluginValidationManager)
+                .reportPluginMojoValidationIssue(
+                        eq(PluginValidationManager.IssueLocality.EXTERNAL),
+                        eq(mavenSession),
+                        eq(mojoDescriptor),
+                        eq(mojoClass),
+                        contains("Plugin use Plexus Component"));
+    }
+
+    @Test
+    void testValidateDoesNotReportIssueWhenMojoHasNoRequirements() {
+        when(mojoDescriptor.getRequirements()).thenReturn(Collections.emptyList());
+
+        validator.validate(mavenSession, mojoDescriptor, mojoClass, null, null);
+
+        verify(pluginValidationManager, never())
+                .reportPluginMojoValidationIssue(
+                        any(PluginValidationManager.IssueLocality.class),
+                        any(MavenSession.class),
+                        any(MojoDescriptor.class),
+                        any(Class.class),
+                        any(String.class));
+    }
+}

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidatorTest.java
@@ -34,7 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,7 +67,7 @@ class PluginDescriptorRequirementsValidatorTest {
                         eq(mavenSession),
                         eq(mojoDescriptor),
                         eq(mojoClass),
-                        contains("Plugin use Plexus Component"));
+                        contains("Plugin uses Plexus Component requirements"));
     }
 
     @Test


### PR DESCRIPTION
What changed

- Added a new validation that detects outdated dependency injection usage in plugins.
- Added a clear warning for plugin developers when this pattern is found.
- Pointed users to the recommended modern injection approach.

