### PR TITLE
[ci][gh][workflow] explicit action hash and permissions

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -19,9 +19,15 @@ name: PR Automation
 on:
   pull_request_target:
     types:
+      # zizmor: ignore[dangerous-triggers]
       - closed
+
+permissions: {}
 
 jobs:
   pr-automation:
     name: PR Automation
-    uses: apache/maven-gh-actions-shared/.github/workflows/pr-automation.yml@v5
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: apache/maven-gh-actions-shared/.github/workflows/pr-automation.yml@8599b638c78a2bec146a98d75d4c8b4e8458324f # v5

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,6 +22,11 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-   update_release_draft:
-      uses: apache/maven-gh-actions-shared/.github/workflows/release-drafter.yml@v5
+  update_release_draft:
+    permissions:
+      contents: write
+      issues: write
+    uses: apache/maven-gh-actions-shared/.github/workflows/release-drafter.yml@8599b638c78a2bec146a98d75d4c8b4e8458324f # v5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,6 +23,11 @@ on:
   issue_comment:
     types: [ 'created' ]
 
+permissions: {}
+
 jobs:
   stale:
-    uses: 'apache/maven-gh-actions-shared/.github/workflows/stale.yml@v5'
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: apache/maven-gh-actions-shared/.github/workflows/stale.yml@8599b638c78a2bec146a98d75d4c8b4e8458324f # v5


### PR DESCRIPTION
Trying to harness more our workflows - but maven shared is designed to be too opened.
Audit mainly done by zizmor.