### PR TITLE
Fail on misconfigured plugin-requested toolchains

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/toolchain/DefaultToolchainManager.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/DefaultToolchainManager.java
@@ -88,7 +88,8 @@ public class DefaultToolchainManager implements ToolchainManager {
                             toolchains.add(toolchain);
                         }
                     } catch (MisconfiguredToolchainException ex) {
-                        logger.error("Misconfigured toolchain.", ex);
+                        throw new IllegalStateException(
+                                "Misconfigured toolchain of type " + type + ": " + ex.getMessage(), ex);
                     }
                 }
             }

--- a/maven-core/src/main/java/org/apache/maven/toolchain/ToolchainManager.java
+++ b/maven-core/src/main/java/org/apache/maven/toolchain/ToolchainManager.java
@@ -44,6 +44,7 @@ public interface ToolchainManager {
      * @param type the type, must not be {@code null}
      * @param context the Maven session, must not be {@code null}
      * @return the toolchain selected by <code>maven-toolchains-plugin</code>
+     * @throws IllegalStateException if the configured toolchain cannot be created
      */
     Toolchain getToolchainFromBuildContext(String type, MavenSession context);
 
@@ -55,6 +56,7 @@ public interface ToolchainManager {
      * @param type the type, must not be {@code null}
      * @param requirements the requirements, may be {@code null}
      * @return the matching toolchains, never {@code null}
+     * @throws IllegalStateException if a configured toolchain cannot be created
      * @since 3.3.0
      */
     List<Toolchain> getToolchains(MavenSession session, String type, Map<String, String> requirements);

--- a/maven-core/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/toolchain/DefaultToolchainManagerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.toolchain;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,16 +28,22 @@ import java.util.Map;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.toolchain.java.JavaToolchainFactory;
 import org.apache.maven.toolchain.model.ToolchainModel;
 import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -143,5 +150,53 @@ public class DefaultToolchainManagerTest {
                 toolchainManager.getToolchains(session, "basic", Collections.singletonMap("key", "value"));
 
         assertEquals(1, toolchains.size());
+    }
+
+    @Test
+    public void testMatchingMisconfiguredJdkToolchain(@TempDir Path temporaryDirectory) {
+        Path invalidJdkHome = temporaryDirectory.resolve("non-existing-jdk");
+        ToolchainModel model = new ToolchainModel();
+        model.setType("jdk");
+        model.addProvide("version", "17");
+
+        Xpp3Dom jdkHome = new Xpp3Dom("jdkHome");
+        jdkHome.setValue(invalidJdkHome.toString());
+        Xpp3Dom configuration = new Xpp3Dom("configuration");
+        configuration.addChild(jdkHome);
+        model.setConfiguration(configuration);
+
+        MavenSession session = mock(MavenSession.class);
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        executionRequest.setToolchains(Collections.singletonMap("jdk", Collections.singletonList(model)));
+        when(session.getRequest()).thenReturn(executionRequest);
+        toolchainManager.factories.put("jdk", new JavaToolchainFactory());
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> toolchainManager.getToolchains(session, "jdk", Collections.singletonMap("version", "17")));
+
+        assertTrue(exception.getMessage().contains("Misconfigured toolchain of type jdk"));
+        assertTrue(exception.getMessage().contains(invalidJdkHome.toString()));
+        assertInstanceOf(MisconfiguredToolchainException.class, exception.getCause());
+    }
+
+    @Test
+    public void testValidNonmatchingToolchain() throws Exception {
+        ToolchainModel model = new ToolchainModel();
+        model.setType("basic");
+
+        MavenSession session = mock(MavenSession.class);
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        executionRequest.setToolchains(Collections.singletonMap("basic", Collections.singletonList(model)));
+        when(session.getRequest()).thenReturn(executionRequest);
+        ToolchainPrivate toolchain = mock(ToolchainPrivate.class);
+        when(toolchainFactoryBasicType.createToolchain(model)).thenReturn(toolchain);
+        when(toolchain.matchesRequirements(Collections.singletonMap("version", "21")))
+                .thenReturn(false);
+
+        List<Toolchain> toolchains =
+                toolchainManager.getToolchains(session, "basic", Collections.singletonMap("version", "21"));
+
+        assertEquals(0, toolchains.size());
     }
 }


### PR DESCRIPTION
Fixes apache/maven-compiler-plugin#618

Maven Compiler Plugin passes its `jdkToolchain` requirements to Maven Core's
public per-plugin `ToolchainManager#getToolchains(...)` API. Maven 3 previously
caught `MisconfiguredToolchainException`, logged it, and returned an empty list.
The compiler plugin consequently fell back to the JDK running Maven and could
report `BUILD SUCCESS` despite an explicitly requested malformed toolchain.

This change propagates an `IllegalStateException` with the toolchain type and
the original diagnostic, retaining `MisconfiguredToolchainException` as its
cause. An unchecked exception avoids changing the established Maven 3 public
method signature; adding a checked exception would break source compatibility
for plugin callers. Valid toolchains that do not match continue to produce an
empty selection, and missing toolchain factories retain their existing
log-and-empty-list behavior.

The regression test exercises the public per-plugin lookup with a real
`JavaToolchainFactory`, matching requirements, and a nonexistent `jdkHome`. A
separate control verifies that a valid nonmatching toolchain remains nonfatal.

Verification:

- `mvn -pl maven-core -Dtest=DefaultToolchainManagerTest test`
- `mvn -pl maven-core verify` — 366 tests, 1 skipped
- `mvn verify` — all 16 reactor modules successful
- Maven Core ITs `maven-3.10.x` at `70eabb0679`, run under JDK 8 against
  `apache-maven-3.10.0-SNAPSHOT-bin.zip` from this branch
  (`SHA-256 67b1c28163ecbf09417e262f3f1fc59ff8987fa076a5956b219cc0a97331a53a`):
  `mvn -B -V clean install -Prun-its -Dmaven.repo.local=/home/wilx/maven-sources/core/3.x/its-3/repo -DmavenDistro=/home/wilx/maven-sources/core/maven-issue-mcompiler-618-misconfigured-toolchain/apache-maven/target/apache-maven-3.10.0-SNAPSHOT-bin.zip`
  — 867 tests, 0 failures, 0 errors, 40 skipped; all 78 reactor modules
  successful.
- Maven Compiler Plugin 3.15.0 reproducer:
  - Maven 3.9.16 logged the malformed toolchain, compiled with its runtime JDK,
    and returned `BUILD SUCCESS`.
  - The patched Maven 3.10.0-SNAPSHOT returned `BUILD FAILURE` with the invalid
    JDK path and did not compile the source.
  - A valid JDK 17 toolchain requested as version 21 remained a normal
    nonmatch and the build proceeded normally.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
