### PR TITLE
[backport maven-4.0.x] fix #12583: Inverted file existence check in DefaultTransport.put()

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultTransport.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultTransport.java
@@ -98,7 +98,7 @@ public class DefaultTransport implements Transport {
     public void put(Path source, URI relativeTarget) {
         requireNonNull(source, "source is null");
         requireNonNull(relativeTarget, "relativeTarget is null");
-        if (Files.isRegularFile(source)) {
+        if (!Files.isRegularFile(source)) {
             throw new IllegalArgumentException("source file does not exist or is not a file");
         }
         if (relativeTarget.isAbsolute()) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultTransportTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultTransportTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class DefaultTransportTest {
+
+    @Test
+    void testPutWithNonExistentFileThrows(@TempDir Path tempDir) {
+        Transporter transporter = mock(Transporter.class);
+        DefaultTransport transport = new DefaultTransport(URI.create("http://example.com/test/"), transporter);
+        Path nonExistentFile = tempDir.resolve("missing.txt");
+        assertThrows(IllegalArgumentException.class, () -> transport.put(nonExistentFile, URI.create("dest.txt")));
+    }
+
+    @Test
+    void testPutWithExistingFileSucceeds(@TempDir Path tempDir) throws Exception {
+        Path sourceFile = tempDir.resolve("source.txt");
+        Files.writeString(sourceFile, "test content");
+
+        Transporter transporter = mock(Transporter.class);
+        DefaultTransport transport = new DefaultTransport(URI.create("http://example.com/test/"), transporter);
+        URI dest = URI.create("dest.txt");
+        transport.put(sourceFile, dest);
+        verify(transporter).put(any(PutTask.class));
+    }
+
+    @Test
+    void testPutBytesSucceeds() throws Exception {
+        Transporter transporter = mock(Transporter.class);
+        DefaultTransport transport = new DefaultTransport(URI.create("http://example.com/test/"), transporter);
+        URI dest = URI.create("dest.txt");
+        transport.putBytes("test content".getBytes(), dest);
+        verify(transporter).put(any(PutTask.class));
+    }
+}


### PR DESCRIPTION
## Backport of #12612

Cherry-pick of #12612 onto `maven-4.0.x`.

**Original PR:** #12612 - fix #12583: Inverted file existence check in DefaultTransport.put()
**Original author:** @elharo
**Target branch:** `maven-4.0.x`

### Original description

The condition `Files.isRegularFile(source)` in `DefaultTransport.put()` was inverted — it should have been `!Files.isRegularFile(source)`. This caused `put()` to reject valid existing files and silently accept non-existent ones, which broke `putBytes()` and `putString()` transitively.

**Fix:** Added the missing `!` negation operator.

**Tests:** Added `DefaultTransportTest` with tests for non-existent file rejection, valid file acceptance, and the `putBytes()` -> `put()` delegation chain.

Closes #12583

---

🤖 Generated with [Claude Code](https://claude.ai/code)