### PR TITLE
[MNG-6797] Remember if Maven model problems were encountered in Maven 4

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Session.java
@@ -32,6 +32,8 @@ import org.apache.maven.api.annotations.ThreadSafe;
 import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.services.ArtifactCoordinatesFactory;
 import org.apache.maven.api.services.DependencyCoordinatesFactory;
+import org.apache.maven.api.services.ModelProblem;
+import org.apache.maven.api.services.ProblemCollector;
 import org.apache.maven.api.services.VersionResolverException;
 import org.apache.maven.api.settings.Settings;
 import org.apache.maven.api.toolchain.ToolchainModel;
@@ -92,6 +94,25 @@ public interface Session extends ProtoSession {
      */
     @Nonnull
     SessionData getData();
+
+    /**
+     * Returns the model problems encountered while discovering the projects in this session's reactor.
+     *
+     * @return the session model problem collector, never {@code null}
+     */
+    @Nonnull
+    default ProblemCollector<ModelProblem> getModelProblemCollector() {
+        return SessionModelProblems.getProblemCollector(this);
+    }
+
+    /**
+     * Returns whether model problems were encountered while discovering the projects in this session's reactor.
+     *
+     * @return {@code true} if at least one model problem was encountered
+     */
+    default boolean hasModelProblems() {
+        return getModelProblemCollector().hasWarningProblems();
+    }
 
     /**
      * Default implementation at {@link ProtoSession} level, as the notion of project

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/SessionModelProblems.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/SessionModelProblems.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api;
+
+import org.apache.maven.api.services.ModelProblem;
+import org.apache.maven.api.services.ProblemCollector;
+
+final class SessionModelProblems {
+
+    private static final SessionData.Key<State> KEY = SessionData.key(State.class, SessionModelProblems.class);
+
+    private SessionModelProblems() {}
+
+    static ProblemCollector<ModelProblem> getProblemCollector(Session session) {
+        return session.getData()
+                .computeIfAbsent(KEY, () -> new State(ProblemCollector.create(session)))
+                .problemCollector;
+    }
+
+    private static final class State {
+
+        private final ProblemCollector<ModelProblem> problemCollector;
+
+        private State(ProblemCollector<ModelProblem> problemCollector) {
+            this.problemCollector = problemCollector;
+        }
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -34,6 +34,7 @@ import org.apache.maven.api.Session;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.RepositoryCache;
 import org.apache.maven.impl.SettingsUtilsV4;
+import org.apache.maven.internal.impl.SessionModelProblems;
 import org.apache.maven.model.Profile;
 import org.apache.maven.monitor.event.EventDispatcher;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -295,6 +296,8 @@ public class MavenSession implements Cloneable {
 
     private Session session;
 
+    private boolean modelProblems;
+
     @Deprecated
     /** @deprecated This appears not to be used anywhere within Maven itself. */
     public Map<String, MavenProject> getProjectMap() {
@@ -496,8 +499,34 @@ public class MavenSession implements Cloneable {
         return session;
     }
 
+    /**
+     * Returns whether the reactor projects had model problems.
+     *
+     * @return {@code true} if model problems were encountered
+     * @since 3.10.0
+     */
+    public boolean hasModelProblems() {
+        return modelProblems || (session != null && session.hasModelProblems());
+    }
+
+    /**
+     * Sets whether the reactor projects had model problems.
+     *
+     * @param modelProblems whether model problems were encountered
+     * @since 3.10.0
+     */
+    public void setModelProblems(boolean modelProblems) {
+        this.modelProblems = modelProblems;
+        if (session != null) {
+            SessionModelProblems.setLegacyFlag(session, modelProblems);
+        }
+    }
+
     public void setSession(Session session) {
         this.session = session;
+        if (session != null) {
+            SessionModelProblems.setLegacyFlag(session, modelProblems);
+        }
     }
     /*end[MAVEN4]*/
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/execution/MavenSession.java
@@ -34,7 +34,7 @@ import org.apache.maven.api.Session;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.RepositoryCache;
 import org.apache.maven.impl.SettingsUtilsV4;
-import org.apache.maven.internal.impl.SessionModelProblems;
+import org.apache.maven.internal.impl.SessionModelProblemsBridge;
 import org.apache.maven.model.Profile;
 import org.apache.maven.monitor.event.EventDispatcher;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -518,14 +518,14 @@ public class MavenSession implements Cloneable {
     public void setModelProblems(boolean modelProblems) {
         this.modelProblems = modelProblems;
         if (session != null) {
-            SessionModelProblems.setLegacyFlag(session, modelProblems);
+            SessionModelProblemsBridge.setLegacyFlag(session, modelProblems);
         }
     }
 
     public void setSession(Session session) {
         this.session = session;
         if (session != null) {
-            SessionModelProblems.setLegacyFlag(session, modelProblems);
+            SessionModelProblemsBridge.setLegacyFlag(session, modelProblems);
         }
     }
     /*end[MAVEN4]*/

--- a/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/graph/DefaultGraphBuilder.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.ProjectCycleException;
@@ -349,22 +350,48 @@ public class DefaultGraphBuilder implements GraphBuilder {
     private List<MavenProject> getProjectsForMavenReactor(MavenSession session) throws ProjectBuildingException {
         MavenExecutionRequest request = session.getRequest();
         request.getProjectBuildingRequest().setRepositorySession(session.getRepositorySession());
+        Consumer<org.apache.maven.model.building.ModelProblem> modelProblemConsumer = getModelProblemConsumer(session);
 
         // 1. Collect project for invocation without a POM.
         if (request.getPom() == null) {
-            return pomlessCollectionStrategy.collectProjects(request);
+            return pomlessCollectionStrategy.collectProjects(request, modelProblemConsumer);
         }
 
         // 2. Collect projects for all modules in the multi-module project.
         if (request.getMakeBehavior() != null || !request.getProjectActivation().isEmpty()) {
-            List<MavenProject> projects = multiModuleCollectionStrategy.collectProjects(request);
+            List<MavenProject> projects = multiModuleCollectionStrategy.collectProjects(request, modelProblemConsumer);
             if (!projects.isEmpty()) {
                 return projects;
             }
         }
 
         // 3. Collect projects for explicitly requested POM.
-        return requestPomCollectionStrategy.collectProjects(request);
+        return requestPomCollectionStrategy.collectProjects(request, modelProblemConsumer);
+    }
+
+    private Consumer<org.apache.maven.model.building.ModelProblem> getModelProblemConsumer(MavenSession session) {
+        org.apache.maven.api.Session apiSession = session.getSession();
+        if (apiSession == null) {
+            return problem -> session.setModelProblems(true);
+        }
+        return problem -> apiSession.getModelProblemCollector().reportProblem(toApiModelProblem(problem));
+    }
+
+    private org.apache.maven.api.services.ModelProblem toApiModelProblem(
+            org.apache.maven.model.building.ModelProblem problem) {
+        return new org.apache.maven.impl.model.DefaultModelProblem(
+                problem.getMessage(),
+                org.apache.maven.api.services.BuilderProblem.Severity.valueOf(
+                        problem.getSeverity().name()),
+                problem.getVersion() != null
+                        ? org.apache.maven.api.services.ModelProblem.Version.valueOf(
+                                problem.getVersion().name())
+                        : org.apache.maven.api.services.ModelProblem.Version.BASE,
+                problem.getSource(),
+                problem.getLineNumber(),
+                problem.getColumnNumber(),
+                problem.getModelId(),
+                problem.getException());
     }
 
     private void validateProjects(List<MavenProject> projects, MavenExecutionRequest request)

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
@@ -180,6 +180,11 @@ public class DefaultSession extends AbstractSession implements InternalMavenSess
         return getProjects(getMavenSession().getProjects());
     }
 
+    @Override
+    public boolean hasModelProblems() {
+        return SessionModelProblems.hasModelProblems(this);
+    }
+
     @Nonnull
     @Override
     public Map<String, Object> getPluginContext(Project project) {

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultSession.java
@@ -182,7 +182,7 @@ public class DefaultSession extends AbstractSession implements InternalMavenSess
 
     @Override
     public boolean hasModelProblems() {
-        return SessionModelProblems.hasModelProblems(this);
+        return SessionModelProblemsBridge.hasModelProblems(this);
     }
 
     @Nonnull

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/SessionModelProblems.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/SessionModelProblems.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.internal.impl;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.maven.api.Session;
+import org.apache.maven.api.SessionData;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Stores the legacy model-problem flag in session data so that derived sessions see the same state.
+ */
+public final class SessionModelProblems {
+
+    private static final SessionData.Key<State> KEY = SessionData.key(State.class, SessionModelProblems.class);
+
+    private SessionModelProblems() {}
+
+    public static boolean hasModelProblems(Session session) {
+        return getState(session).legacyFlag.get()
+                || session.getModelProblemCollector().hasWarningProblems();
+    }
+
+    public static void setLegacyFlag(Session session, boolean value) {
+        getState(session).legacyFlag.set(value);
+    }
+
+    private static State getState(Session session) {
+        requireNonNull(session, "session");
+        return session.getData().computeIfAbsent(KEY, State::new);
+    }
+
+    private static final class State {
+
+        private final AtomicBoolean legacyFlag = new AtomicBoolean();
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/SessionModelProblemsBridge.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/SessionModelProblemsBridge.java
@@ -28,11 +28,11 @@ import static java.util.Objects.requireNonNull;
 /**
  * Stores the legacy model-problem flag in session data so that derived sessions see the same state.
  */
-public final class SessionModelProblems {
+public final class SessionModelProblemsBridge {
 
-    private static final SessionData.Key<State> KEY = SessionData.key(State.class, SessionModelProblems.class);
+    private static final SessionData.Key<State> KEY = SessionData.key(State.class, SessionModelProblemsBridge.class);
 
-    private SessionModelProblems() {}
+    private SessionModelProblemsBridge() {}
 
     public static boolean hasModelProblems(Session session) {
         return getState(session).legacyFlag.get()

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/DefaultProjectsSelector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/DefaultProjectsSelector.java
@@ -25,6 +25,7 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.model.building.ModelProblem;
@@ -54,6 +55,13 @@ public class DefaultProjectsSelector implements ProjectsSelector {
     @Override
     public List<MavenProject> selectProjects(List<File> files, MavenExecutionRequest request)
             throws ProjectBuildingException {
+        return selectProjects(files, request, problem -> {});
+    }
+
+    @Override
+    public List<MavenProject> selectProjects(
+            List<File> files, MavenExecutionRequest request, Consumer<ModelProblem> problemConsumer)
+            throws ProjectBuildingException {
         ProjectBuildingRequest projectBuildingRequest = request.getProjectBuildingRequest();
 
         boolean hasProjectSelection = !request.getProjectActivation().isEmpty();
@@ -66,6 +74,7 @@ public class DefaultProjectsSelector implements ProjectsSelector {
 
         for (ProjectBuildingResult result : results) {
             projects.add(result.getProject());
+            result.getProblems().forEach(problemConsumer);
 
             int problemsCount = result.getProblems().size();
             totalProblemsCount += problemsCount;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/MultiModuleCollectionStrategy.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import org.apache.maven.api.services.model.ModelProcessor;
@@ -62,12 +63,19 @@ public class MultiModuleCollectionStrategy implements ProjectCollectionStrategy 
 
     @Override
     public List<MavenProject> collectProjects(MavenExecutionRequest request) throws ProjectBuildingException {
+        return collectProjects(request, problem -> {});
+    }
+
+    public List<MavenProject> collectProjects(MavenExecutionRequest request, Consumer<ModelProblem> problemConsumer)
+            throws ProjectBuildingException {
         File moduleProjectPomFile = getRootProject(request);
         List<File> files = Collections.singletonList(moduleProjectPomFile.getAbsoluteFile());
         try {
-            List<MavenProject> projects = projectsSelector.selectProjects(files, request);
+            List<ModelProblem> problems = new ArrayList<>();
+            List<MavenProject> projects = projectsSelector.selectProjects(files, request, problems::add);
             boolean isRequestedProjectCollected = isRequestedProjectCollected(request, projects);
             if (isRequestedProjectCollected) {
+                problems.forEach(problemConsumer);
                 return projects;
             } else {
                 LOGGER.debug(

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/PomlessCollectionStrategy.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/PomlessCollectionStrategy.java
@@ -24,15 +24,18 @@ import javax.inject.Singleton;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.maven.DefaultMaven;
 import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.model.building.UrlModelSource;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
 
 /**
  * Strategy to collect projects for building when the Maven invocation is not in a directory that contains a pom.xml.
@@ -49,10 +52,16 @@ public class PomlessCollectionStrategy implements ProjectCollectionStrategy {
 
     @Override
     public List<MavenProject> collectProjects(final MavenExecutionRequest request) throws ProjectBuildingException {
+        return collectProjects(request, problem -> {});
+    }
+
+    public List<MavenProject> collectProjects(MavenExecutionRequest request, Consumer<ModelProblem> problemConsumer)
+            throws ProjectBuildingException {
         ProjectBuildingRequest buildingRequest = request.getProjectBuildingRequest();
         ModelSource modelSource = new UrlModelSource(DefaultMaven.class.getResource("project/standalone.xml"));
-        MavenProject project =
-                projectBuilder.build(modelSource, buildingRequest).getProject();
+        ProjectBuildingResult result = projectBuilder.build(modelSource, buildingRequest);
+        result.getProblems().forEach(problemConsumer);
+        MavenProject project = result.getProject();
         project.setExecutionRoot(true);
         request.setProjectPresent(false);
 

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/ProjectsSelector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/ProjectsSelector.java
@@ -20,8 +20,10 @@ package org.apache.maven.project.collector;
 
 import java.io.File;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingException;
 
@@ -37,4 +39,19 @@ public interface ProjectsSelector {
      * @throws ProjectBuildingException In case the POMs are not used.
      */
     List<MavenProject> selectProjects(List<File> files, MavenExecutionRequest request) throws ProjectBuildingException;
+
+    /**
+     * Select Maven projects from a list of POM files and report model problems encountered while building them.
+     *
+     * @param files List of POM files.
+     * @param request The {@link MavenExecutionRequest}
+     * @param problemConsumer Consumer for model problems encountered while building the selected projects.
+     * @return A list of projects that have been found in the specified POM files.
+     * @throws ProjectBuildingException In case the POMs are not used.
+     */
+    default List<MavenProject> selectProjects(
+            List<File> files, MavenExecutionRequest request, Consumer<ModelProblem> problemConsumer)
+            throws ProjectBuildingException {
+        return selectProjects(files, request);
+    }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/RequestPomCollectionStrategy.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/RequestPomCollectionStrategy.java
@@ -25,8 +25,10 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingException;
 
@@ -45,7 +47,12 @@ public class RequestPomCollectionStrategy implements ProjectCollectionStrategy {
 
     @Override
     public List<MavenProject> collectProjects(MavenExecutionRequest request) throws ProjectBuildingException {
+        return collectProjects(request, problem -> {});
+    }
+
+    public List<MavenProject> collectProjects(MavenExecutionRequest request, Consumer<ModelProblem> problemConsumer)
+            throws ProjectBuildingException {
         List<File> files = Collections.singletonList(request.getPom().getAbsoluteFile());
-        return projectsSelector.selectProjects(files, request);
+        return projectsSelector.selectProjects(files, request, problemConsumer);
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
@@ -29,6 +29,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.MavenExecutionException;
+import org.apache.maven.api.Session;
+import org.apache.maven.api.services.BuilderProblem;
+import org.apache.maven.api.services.ModelProblem;
+import org.apache.maven.api.services.ProblemCollector;
 import org.apache.maven.api.services.model.ModelProcessor;
 import org.apache.maven.execution.BuildResumptionDataRepository;
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -65,6 +69,7 @@ import static org.apache.maven.execution.MavenExecutionRequest.REACTOR_MAKE_UPST
 import static org.apache.maven.graph.DefaultGraphBuilderTest.ScenarioBuilder.scenario;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -99,7 +104,9 @@ class DefaultGraphBuilderTest {
 
     private final ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
     private final MavenSession session = mock(MavenSession.class);
+    private final Session apiSession = mock(Session.class);
     private final MavenExecutionRequest mavenExecutionRequest = mock(MavenExecutionRequest.class);
+    private final ProblemCollector<ModelProblem> modelProblems = ProblemCollector.create(100);
 
     private final ProjectsSelector projectsSelector = new DefaultProjectsSelector(projectBuilder);
 
@@ -372,6 +379,123 @@ class DefaultGraphBuilderTest {
         assertEquals("pom", actualReactorProjects.get(1).getPackaging());
     }
 
+    @Test
+    void selectedReactorModelProblemsAreRetainedInSession() throws ProjectBuildingException {
+        Exception cause = new IllegalStateException("model problem cause");
+        org.apache.maven.model.building.ModelProblem legacyProblem =
+                new org.apache.maven.model.building.DefaultModelProblem(
+                        "model warning",
+                        org.apache.maven.model.building.ModelProblem.Severity.WARNING,
+                        org.apache.maven.model.building.ModelProblem.Version.V40,
+                        "module-parent/pom.xml",
+                        12,
+                        4,
+                        "unittest:module-parent:1.0",
+                        cause);
+        List<ProjectBuildingResult> projectBuildingResults =
+                createProjectBuildingResultMocks(artifactIdProjectMap.values());
+        when(projectBuildingResults.get(0).getProblems()).thenReturn(singletonList(legacyProblem));
+        when(projectBuilder.build(anyList(), anyBoolean(), any(ProjectBuildingRequest.class)))
+                .thenReturn(projectBuildingResults);
+        configureFullReactorRequest();
+
+        Result<ProjectDependencyGraph> result = graphBuilder.build(session);
+
+        assertFalse(result.hasErrors(), "Expected result not to have errors");
+        assertTrue(apiSession.hasModelProblems());
+        assertTrue(session.hasModelProblems());
+        assertEquals(1, modelProblems.totalProblemsReported());
+        ModelProblem problem = modelProblems.problems().findFirst().orElseThrow();
+        assertEquals("model warning", problem.getMessage());
+        assertEquals(BuilderProblem.Severity.WARNING, problem.getSeverity());
+        assertEquals(ModelProblem.Version.V40, problem.getVersion());
+        assertEquals("module-parent/pom.xml", problem.getSource());
+        assertEquals(12, problem.getLineNumber());
+        assertEquals(4, problem.getColumnNumber());
+        assertEquals("unittest:module-parent:1.0", problem.getModelId());
+        assertSame(cause, problem.getException());
+    }
+
+    @Test
+    void discardedMultiModuleCollectionProblemsAreNotRetained() throws ProjectBuildingException {
+        MavenProject requestedProject = artifactIdProjectMap.get(MODULE_A);
+        MavenProject unrelatedProject = artifactIdProjectMap.get(PARENT_MODULE);
+        ProjectBuildingResult discardedResult = createProjectBuildingResultMocks(singletonList(unrelatedProject))
+                .get(0);
+        when(discardedResult.getProblems())
+                .thenReturn(singletonList(new org.apache.maven.model.building.DefaultModelProblem(
+                        "discarded warning",
+                        org.apache.maven.model.building.ModelProblem.Severity.WARNING,
+                        org.apache.maven.model.building.ModelProblem.Version.V40,
+                        "pom.xml",
+                        1,
+                        1,
+                        "unittest:discarded:1.0",
+                        null)));
+        List<ProjectBuildingResult> selectedResults = createProjectBuildingResultMocks(singletonList(requestedProject));
+        when(projectBuilder.build(anyList(), anyBoolean(), any(ProjectBuildingRequest.class)))
+                .thenReturn(singletonList(discardedResult), selectedResults);
+        ModelProcessor testModelProcessor = mock(ModelProcessor.class);
+        when(testModelProcessor.locateExistingPom(Paths.get("reactor-root")))
+                .thenReturn(Paths.get("reactor-root/pom.xml"));
+        MultiModuleCollectionStrategy testMultiModuleCollectionStrategy =
+                new MultiModuleCollectionStrategy(testModelProcessor, projectsSelector);
+        graphBuilder = new DefaultGraphBuilder(
+                mock(BuildResumptionDataRepository.class),
+                pomlessCollectionStrategy,
+                testMultiModuleCollectionStrategy,
+                requestPomCollectionStrategy);
+        when(mavenExecutionRequest.getPom()).thenReturn(requestedProject.getFile());
+        when(mavenExecutionRequest.getRootDirectory()).thenReturn(Paths.get("reactor-root"));
+        when(mavenExecutionRequest.getMakeBehavior()).thenReturn(REACTOR_MAKE_UPSTREAM);
+        when(mavenExecutionRequest.getProjectActivation()).thenReturn(new ProjectActivation());
+        when(mavenExecutionRequest.isRecursive()).thenReturn(true);
+
+        Result<ProjectDependencyGraph> result = graphBuilder.build(session);
+
+        assertFalse(result.hasErrors(), "Expected result not to have errors");
+        assertFalse(apiSession.hasModelProblems());
+        assertFalse(session.hasModelProblems());
+        assertEquals(0, modelProblems.totalProblemsReported());
+    }
+
+    @Test
+    void problemsFromProjectsRemovedAfterDiscoveryAreRetained() throws ProjectBuildingException {
+        List<ProjectBuildingResult> projectBuildingResults =
+                createProjectBuildingResultMocks(artifactIdProjectMap.values());
+        ProjectBuildingResult removedProjectResult = projectBuildingResults.stream()
+                .filter(projectResult ->
+                        MODULE_B.equals(projectResult.getProject().getArtifactId()))
+                .findFirst()
+                .orElseThrow();
+        when(removedProjectResult.getProblems())
+                .thenReturn(singletonList(new org.apache.maven.model.building.DefaultModelProblem(
+                        "warning from project removed after discovery",
+                        org.apache.maven.model.building.ModelProblem.Severity.WARNING,
+                        org.apache.maven.model.building.ModelProblem.Version.V40,
+                        "module-b/pom.xml",
+                        1,
+                        1,
+                        "unittest:module-b:1.0",
+                        null)));
+        when(projectBuilder.build(anyList(), anyBoolean(), any(ProjectBuildingRequest.class)))
+                .thenReturn(projectBuildingResults);
+        ProjectActivation projectActivation = new ProjectActivation();
+        projectActivation.activateRequiredProject(":" + MODULE_A);
+        when(mavenExecutionRequest.getPom()).thenReturn(new File(PARENT_MODULE, "pom.xml"));
+        when(mavenExecutionRequest.getRootDirectory()).thenReturn(Paths.get(PARENT_MODULE));
+        when(mavenExecutionRequest.getProjectActivation()).thenReturn(projectActivation);
+        when(mavenExecutionRequest.isRecursive()).thenReturn(true);
+
+        Result<ProjectDependencyGraph> result = graphBuilder.build(session);
+
+        assertFalse(result.hasErrors(), "Expected result not to have errors");
+        assertEquals(
+                singletonList(artifactIdProjectMap.get(MODULE_A)), result.get().getSortedProjects());
+        assertTrue(apiSession.hasModelProblems());
+        assertEquals(1, modelProblems.totalProblemsReported());
+    }
+
     @BeforeEach
     void before() throws Exception {
         graphBuilder = new DefaultGraphBuilder(
@@ -413,6 +537,10 @@ class DefaultGraphBuilderTest {
 
         // Set up needed mocks
         when(session.getRequest()).thenReturn(mavenExecutionRequest);
+        when(session.getSession()).thenReturn(apiSession);
+        when(apiSession.getModelProblemCollector()).thenReturn(modelProblems);
+        when(apiSession.hasModelProblems()).thenAnswer(invocation -> modelProblems.hasWarningProblems());
+        when(session.hasModelProblems()).thenAnswer(invocation -> apiSession.hasModelProblems());
         when(session.getProjects()).thenReturn(null); // needed, otherwise it will be an empty list by default
         when(mavenExecutionRequest.getProjectBuildingRequest()).thenReturn(mock(ProjectBuildingRequest.class));
         List<ProjectBuildingResult> projectBuildingResults =
@@ -420,6 +548,12 @@ class DefaultGraphBuilderTest {
         when(projectBuilder.build(anyList(), anyBoolean(), any(ProjectBuildingRequest.class)))
                 .thenReturn(projectBuildingResults);
         when(mavenExecutionRequest.getRootDirectory()).thenReturn(null);
+    }
+
+    private void configureFullReactorRequest() {
+        when(mavenExecutionRequest.getPom()).thenReturn(new File(PARENT_MODULE, "pom.xml"));
+        when(mavenExecutionRequest.getProjectActivation()).thenReturn(new ProjectActivation());
+        when(mavenExecutionRequest.isRecursive()).thenReturn(true);
     }
 
     private MavenProject getMavenProject(String artifactId, MavenProject parentProject) {

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultSessionTest.java
@@ -21,8 +21,12 @@ package org.apache.maven.internal.impl;
 import java.nio.file.Paths;
 import java.util.Collections;
 
+import org.apache.maven.api.Session;
+import org.apache.maven.api.services.BuilderProblem;
+import org.apache.maven.api.services.ModelProblem;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.impl.model.DefaultModelProblem;
 import org.apache.maven.model.root.RootLocator;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
@@ -30,7 +34,10 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class DefaultSessionTest {
@@ -59,5 +66,57 @@ public class DefaultSessionTest {
                 new DefaultSession(ms, mock(RepositorySystem.class), Collections.emptyList(), null, null, null);
 
         assertEquals(Paths.get("myRootDirectory"), session.getRootDirectory());
+    }
+
+    @Test
+    void modelProblemsAreSharedWithDerivedAndLegacySessions() {
+        RepositorySystemSession rss = new DefaultRepositorySystemSession(h -> false);
+        MavenSession legacySession = new MavenSession(null, rss, new DefaultMavenExecutionRequest(), null);
+        DefaultSession session = new DefaultSession(
+                legacySession, mock(RepositorySystem.class), Collections.emptyList(), null, null, null);
+        legacySession.setSession(session);
+
+        ModelProblem problem = new DefaultModelProblem(
+                "model warning",
+                BuilderProblem.Severity.WARNING,
+                ModelProblem.Version.BASE,
+                "pom.xml",
+                12,
+                4,
+                "org.example:project:1",
+                null);
+        session.getModelProblemCollector().reportProblem(problem);
+
+        Session derivedSession = session.withRemoteRepositories(Collections.emptyList());
+
+        assertTrue(session.hasModelProblems());
+        assertTrue(derivedSession.hasModelProblems());
+        assertTrue(legacySession.hasModelProblems());
+        assertSame(session.getModelProblemCollector(), derivedSession.getModelProblemCollector());
+        assertSame(
+                problem,
+                session.getModelProblemCollector().problems().findFirst().orElseThrow());
+    }
+
+    @Test
+    void legacyModelProblemSetterIsVisibleThroughNativeSession() {
+        RepositorySystemSession rss = new DefaultRepositorySystemSession(h -> false);
+        MavenSession legacySession = new MavenSession(null, rss, new DefaultMavenExecutionRequest(), null);
+        DefaultSession session = new DefaultSession(
+                legacySession, mock(RepositorySystem.class), Collections.emptyList(), null, null, null);
+        legacySession.setSession(session);
+
+        assertFalse(session.hasModelProblems());
+        assertFalse(legacySession.hasModelProblems());
+
+        legacySession.setModelProblems(true);
+
+        assertTrue(session.hasModelProblems());
+        assertTrue(legacySession.hasModelProblems());
+
+        legacySession.setModelProblems(false);
+
+        assertFalse(session.hasModelProblems());
+        assertFalse(legacySession.hasModelProblems());
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -347,6 +347,10 @@ public class DefaultModelBuilder implements ModelBuilder {
             return derive(request, new DefaultModelBuilderResult(request, ProblemCollector.create(session)));
         }
 
+        ModelBuilderSessionState deriveWithProblemCollector(ModelBuilderRequest request) {
+            return derive(request, new DefaultModelBuilderResult(request, getProblemCollector()));
+        }
+
         ModelBuilderSessionState derive(ModelBuilderRequest request, DefaultModelBuilderResult result) {
             if (session != request.getSession()) {
                 throw new IllegalArgumentException("Session mismatch");
@@ -1195,7 +1199,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             }
 
             try {
-                ModelBuilderSessionState derived = derive(
+                ModelBuilderSessionState derived = deriveWithProblemCollector(
                         request.getRequestType() == ModelBuilderRequest.RequestType.BUILD_CONSUMER
                                 ? ModelBuilderRequest.builder(request)
                                         .requestType(ModelBuilderRequest.RequestType.CONSUMER_PARENT)
@@ -1369,7 +1373,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                     .source(modelSource)
                     .build();
 
-            ModelBuilderSessionState derived = derive(lenientRequest);
+            ModelBuilderSessionState derived = deriveWithProblemCollector(lenientRequest);
             Model parentModel = derived.readAsParentModel(profileActivationContext, parentChain);
             // Add profiles from parent, preserving model ID tracking
             for (Map.Entry<String, List<Profile>> entry :
@@ -2218,7 +2222,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                         .source(importSource)
                         .repositories(repositories)
                         .build();
-                ModelBuilderSessionState modelBuilderSession = derive(importRequest);
+                ModelBuilderSessionState modelBuilderSession = deriveWithProblemCollector(importRequest);
                 // build the effective model
                 modelBuilderSession.buildEffectiveModel(importIds);
                 importResult = modelBuilderSession.result;

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -27,6 +27,8 @@ import java.util.Map;
 
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.Model;
@@ -35,8 +37,10 @@ import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.services.ModelBuilder;
 import org.apache.maven.api.services.ModelBuilderRequest;
 import org.apache.maven.api.services.ModelBuilderResult;
+import org.apache.maven.api.services.ModelProblem;
 import org.apache.maven.api.services.Sources;
 import org.apache.maven.impl.standalone.ApiRunner;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +75,48 @@ class DefaultModelBuilderTest {
         ModelBuilderResult result = builder.newSession().build(request);
         assertNotNull(result);
         assertEquals("21", result.getEffectiveModel().getProperties().get("maven.compiler.release"));
+    }
+
+    @Test
+    void defaultSessionModelProblemCollectorIsWritable() {
+        ModelProblem problem = new DefaultModelProblem(
+                "model warning",
+                org.apache.maven.api.services.BuilderProblem.Severity.WARNING,
+                ModelProblem.Version.BASE,
+                "pom.xml",
+                -1,
+                -1,
+                "org.apache.maven.tests:project:1.0",
+                null);
+
+        session.getModelProblemCollector().reportProblem(problem);
+
+        assertTrue(session.hasModelProblems());
+        assertEquals(1, session.getModelProblemCollector().totalProblemsReported());
+    }
+
+    @Test
+    void externalParentProblemsAreRetainedInProjectResult() {
+        ModelBuilderResult result = buildWithTestRepository("model-problems-external-parent-child");
+
+        assertTrue(
+                result.getProblemCollector()
+                        .problems()
+                        .anyMatch(
+                                problem -> problem.getMessage().contains("Duplicate activation for profile duplicate")),
+                "The project result should contain problems encountered while building its external parent");
+    }
+
+    @Test
+    void importedBomProblemsAreRetainedInProjectResult() {
+        ModelBuilderResult result = buildWithTestRepository("model-problems-imported-bom");
+
+        assertTrue(
+                result.getProblemCollector()
+                        .problems()
+                        .anyMatch(
+                                problem -> problem.getMessage().contains("Duplicate activation for profile duplicate")),
+                "The project result should contain problems encountered while building an imported BOM");
     }
 
     @Test
@@ -520,5 +566,29 @@ class DefaultModelBuilderTest {
 
     private Path getPom(String name) {
         return Paths.get("src/test/resources/poms/factory/" + name + ".xml").toAbsolutePath();
+    }
+
+    private ModelBuilderResult buildWithTestRepository(String pom) {
+        Path basedir = Paths.get(System.getProperty("basedir", "")).toAbsolutePath();
+        Session repositorySession = ApiRunner.createSession(
+                injector -> injector.bindInstance(DefaultModelBuilderTest.class, this),
+                basedir.resolve("target/model-problems-test-repository"));
+        RemoteRepository testRepository = repositorySession.createRemoteRepository(
+                RemoteRepository.CENTRAL_ID,
+                basedir.resolve("src/test/remote-repo").toUri().toString());
+        repositorySession = repositorySession.withRemoteRepositories(List.of(testRepository));
+        ModelBuilder repositoryBuilder = repositorySession.getService(ModelBuilder.class);
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(repositorySession)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(getPom(pom)))
+                .build();
+        return repositoryBuilder.newSession().build(request);
+    }
+
+    @Provides
+    @Named(FileTransporterFactory.NAME)
+    static FileTransporterFactory newFileTransporterFactory() {
+        return new FileTransporterFactory();
     }
 }

--- a/impl/maven-impl/src/test/remote-repo/org/apache/maven/tests/model-problems-bom/1.0/model-problems-bom-1.0.pom
+++ b/impl/maven-impl/src/test/remote-repo/org/apache/maven/tests/model-problems-bom/1.0/model-problems-bom-1.0.pom
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.tests</groupId>
+    <artifactId>model-problems-bom</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+    <profiles>
+        <profile>
+            <id>duplicate</id>
+        </profile>
+        <profile>
+            <id>duplicate</id>
+        </profile>
+    </profiles>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.tests</groupId>
+                <artifactId>managed-dependency</artifactId>
+                <version>1.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/remote-repo/org/apache/maven/tests/model-problems-parent/1.0/model-problems-parent-1.0.pom
+++ b/impl/maven-impl/src/test/remote-repo/org/apache/maven/tests/model-problems-parent/1.0/model-problems-parent-1.0.pom
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.tests</groupId>
+    <artifactId>model-problems-parent</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+    <profiles>
+        <profile>
+            <id>duplicate</id>
+        </profile>
+        <profile>
+            <id>duplicate</id>
+        </profile>
+    </profiles>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/model-problems-external-parent-child.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/model-problems-external-parent-child.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.tests</groupId>
+        <artifactId>model-problems-parent</artifactId>
+        <version>1.0</version>
+        <relativePath/>
+    </parent>
+    <artifactId>model-problems-external-parent-child</artifactId>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/model-problems-imported-bom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/model-problems-imported-bom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.tests</groupId>
+    <artifactId>model-problems-imported-bom</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.tests</groupId>
+                <artifactId>model-problems-bom</artifactId>
+                <version>1.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITRememberModelProblemsTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITRememberModelProblemsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that model problems encountered during reactor discovery remain available from the build session.
+ */
+public class MavenITRememberModelProblemsTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    public void testModelProblemStateInNativeAndLegacySessions() throws Exception {
+        Path testDir = extractResources("remember-model-problems");
+
+        Properties warningProperties = execute(testDir.resolve("warning"));
+
+        assertEquals("true", warningProperties.getProperty("session.hasModelProblems"));
+        assertEquals("true", warningProperties.getProperty("session.session.hasModelProblems"));
+        assertTrue(
+                Integer.parseInt(warningProperties.getProperty(
+                                "session.session.modelProblemCollector.totalProblemsReported"))
+                        > 0,
+                "Expected at least one retained model problem");
+
+        Properties cleanProperties = execute(testDir.resolve("clean"));
+
+        assertEquals("false", cleanProperties.getProperty("session.hasModelProblems"));
+        assertEquals("false", cleanProperties.getProperty("session.session.hasModelProblems"));
+        assertEquals(
+                "0",
+                cleanProperties.getProperty("session.session.modelProblemCollector.totalProblemsReported"));
+    }
+
+    private Properties execute(Path testDir) throws Exception {
+        Verifier verifier = newVerifier(testDir);
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        return verifier.loadProperties("target/session.properties");
+    }
+}

--- a/its/core-it-suite/src/test/resources/remember-model-problems/clean/pom.xml
+++ b/its/core-it-suite/src/test/resources/remember-model-problems/clean/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>remember-model-problems-clean</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <configuration>
+          <outputFile>target/session.properties</outputFile>
+          <expressions>
+            <expression>session/hasModelProblems</expression>
+            <expression>session/session/hasModelProblems</expression>
+            <expression>session/session/modelProblemCollector/totalProblemsReported</expression>
+          </expressions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>inspect-session</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/remember-model-problems/warning/pom.xml
+++ b/its/core-it-suite/src/test/resources/remember-model-problems/warning/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>remember-model-problems-warning</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its</groupId>
+      <artifactId>system-dependency</artifactId>
+      <version>1.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/system-dependency.jar</systemPath>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <configuration>
+          <outputFile>target/session.properties</outputFile>
+          <expressions>
+            <expression>session/hasModelProblems</expression>
+            <expression>session/session/hasModelProblems</expression>
+            <expression>session/session/modelProblemCollector/totalProblemsReported</expression>
+          </expressions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>inspect-session</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This ports the model-problem retention feature from Maven 3 PR #298 to Maven 4.

Maven 4 retains the model problems reported while discovering the reactor. The
native `Session.getModelProblemCollector()` exposes a
`ProblemCollector` with problem
details, severity counts, and overflow information. ~~Its default implementation
uses `SessionData`, so sessions sharing that data, including derived sessions,
share a writable collector without depending on Maven Core&#39;s `DefaultSession`.~~

`Session.getModelProblemCollector()` is now abstract. Core's `DefaultSession`
and the standalone `ApiRunner.DefaultSession` each explicitly allocate a
writable collector lazily through `SessionData`. Sessions sharing that data
within either implementation, including derived sessions, share the collector
and preserve its configured limits, counts, and overflow information. The
`SessionModelProblems` helper has been removed from the API module.
No model-problem accessors or bridge are added to the legacy `MavenSession` API.

Problems encountered while constructing an external parent or imported BOM are
part of the owning project&#39;s model result. Derived model-builder requests
share that result&#39;s collector, preserving its limits, counts, and causes
rather than copying problems afterward.

Project-collection problems are retained from the selected discovery result
before `-pl` and related project trimming, matching Maven 3 behavior. Problems
from a speculative multi-module collection attempt are buffered until that
attempt is selected; if Maven falls back to the explicitly requested POM,
those unrelated problems are discarded. Later, unrelated model-building
operations remain outside the session collector&#39;s scope.

~~Binary compatibility is preserved by adding default methods to the native
`Session` and `ProjectsSelector` interfaces and retaining existing project
collection entry points.~~

The new Maven 4.1.0 `Session.getModelProblemCollector()` method is abstract,
so existing `Session` implementations must implement it; adding this method
does not preserve binary compatibility for callers invoking it on older
implementations. Basic stubs can return `ProblemCollector.empty()`, as
`SessionStub` now does. The `ProjectsSelector` default overload and existing
project-collection entry points are retained for compatibility.

The new `ProjectsSelector` overload delegates to the
original two-argument method by default and does not invoke the problem
consumer. Custom implementations must override the new overload to report
model problems; Maven&#39;s `DefaultProjectsSelector` does so.

Fixes #8485.

## Verification

- Latest validation of the changes committed as `6fbc2a4fc9`, using JDK 21 and Maven 3.9.16:
  - All 90 reactor modules passed `clean verify` with `-Prun-its` and
    `-Dits.test=MavenITRememberModelProblemsTest,MavenITmng2199ParentVersionRangeTest`.
  - Unit-test reports recorded 3,224 tests, with 0 failures, 0 errors, and
    16 skipped, including collector sharing, isolation, and overflow coverage.
  - All 11 selected Core ITs passed against the newly built distribution.
  - Checkstyle, RAT, Spotless, and Japicmp passed.
  - The packaged API declares the collector accessor abstract and contains
    no `SessionModelProblems` helper.
- ~~Latest~~ Earlier post-rebase validation on `31dae90c23`, using JDK 21:
  - 130 selected unit tests passed, covering model building, iterative parent
    traversal, project building, graph collection, and session storage.
  - 11 Core ITs passed: `MavenITRememberModelProblemsTest` and
    `MavenITmng2199ParentVersionRangeTest`.
  - The reactor `verify` build passed with those test selections.
- Earlier full-suite validation, before the latest rebase:
  - `mvn -e -B -V -Prun-its clean install` passed all 90 reactor modules.
  - 1,049 Core ITs completed with 0 failures, 0 errors, and 43 skipped.
  - Checkstyle, RAT, Spotless, and Japicmp passed.
  - This full-suite run has not been repeated after the latest rebase.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don&#39;t need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/


