### PR TITLE
Remove erroneous path normalization optimization + regression test

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
@@ -214,13 +214,6 @@ final class PathSelector implements PathMatcher {
     private final Path baseDirectory;
 
     /**
-     * Whether paths must be relativized before being given to a matcher. If {@code true}, then every paths
-     * will be made relative to {@link #baseDirectory} for allowing patterns like {@code "foo/bar/*.java"}
-     * to work. As a slight optimization, we can skip this step if all patterns start with {@code "**"}.
-     */
-    private final boolean needRelativize;
-
-    /**
      * Creates a new selector from the given includes and excludes.
      *
      * @param directory the base directory of the files to filter
@@ -240,7 +233,6 @@ final class PathSelector implements PathMatcher {
         FileSystem fileSystem = baseDirectory.getFileSystem();
         this.includes = matchers(fileSystem, includePatterns);
         this.excludes = matchers(fileSystem, excludePatterns);
-        needRelativize = needRelativize(includePatterns) || needRelativize(excludePatterns);
     }
 
     /**
@@ -473,21 +465,6 @@ final class PathSelector implements PathMatcher {
     }
 
     /**
-     * Returns {@code true} if at least one pattern requires path being relativized before to be matched.
-     *
-     * @param patterns include or exclude patterns
-     * @return whether at least one pattern require relativization
-     */
-    private static boolean needRelativize(String[] patterns) {
-        for (String pattern : patterns) {
-            if (!pattern.startsWith(DEFAULT_SYNTAX + WILDCARD_FOR_ANY_PREFIX)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Creates the path matchers for the given patterns.
      * The syntax (usually {@value #DEFAULT_SYNTAX}) must be specified for each pattern.
      */
@@ -504,16 +481,8 @@ final class PathSelector implements PathMatcher {
      */
     @SuppressWarnings("checkstyle:MissingSwitchDefault")
     private PathMatcher simplify() {
-        if (excludes.length == 0) {
-            switch (includes.length) {
-                case 0:
-                    return INCLUDES_ALL;
-                case 1:
-                    if (needRelativize) {
-                        break;
-                    }
-                    return includes[0];
-            }
+        if (excludes.length == 0 && includes.length == 0) {
+            return INCLUDES_ALL;
         }
         return this;
     }
@@ -527,9 +496,7 @@ final class PathSelector implements PathMatcher {
      */
     @Override
     public boolean matches(Path path) {
-        if (needRelativize) {
-            path = baseDirectory.relativize(path);
-        }
+        path = baseDirectory.relativize(path);
         return (includes.length == 0 || isMatched(path, includes))
                 && (excludes.length == 0 || !isMatched(path, excludes));
     }
@@ -648,9 +615,7 @@ final class PathSelector implements PathMatcher {
             if (baseDirectory.equals(directory)) {
                 return true;
             }
-            if (needRelativize) {
-                directory = baseDirectory.relativize(directory);
-            }
+            directory = baseDirectory.relativize(directory);
             if (isMatched(directory, dirExcludes)) {
                 return false;
             }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/PathSelectorTest.java
@@ -159,4 +159,42 @@ public class PathSelectorTest {
         assertTrue(explicitGlob.matches(mainFile));
         assertTrue(explicitGlob.matches(testFile));
     }
+
+    /**
+     * Regression test for <a href="https://github.com/apache/maven/pull/12617">#12617</a>.
+     * Verifies that when the base directory path itself contains a segment matching a {@code **} pattern,
+     * files that are not actually under a matching child directory are not falsely included.
+     *
+     * <p>The removed optimization skipped path relativization when all patterns started with {@code "**"},
+     * which caused the full (non-relativized) path to be matched against the pattern. If the base directory
+     * happened to contain the matching segment (e.g. base = {@code "something/target/test-classes"} with
+     * pattern <code>"**&sol;test-classes&sol;**"</code>), every file under the base directory would be
+     * falsely matched because the base directory itself satisfied the pattern.</p>
+     */
+    @Test
+    public void testNoFalsePositiveWhenBaseDirectoryMatchesPattern(@TempDir Path tempDir) throws IOException {
+        // Base directory path contains "test-classes" as a segment — this is the trigger for the false positive
+        Path baseDir = Files.createDirectories(tempDir.resolve("something/target/test-classes"));
+
+        // A child directory that also happens to be named "test-classes"
+        Path testClassesChild = Files.createDirectories(baseDir.resolve("test-classes"));
+        // Another child directory with a different name
+        Path otherChild = Files.createDirectories(baseDir.resolve("other"));
+
+        Path fileInTestClasses = Files.createFile(testClassesChild.resolve("MyTest.class"));
+        Path fileInOther = Files.createFile(otherChild.resolve("Other.class"));
+
+        // Include pattern: anything under a "test-classes" directory
+        PathMatcher matcher = PathSelector.of(baseDir, List.of("**/test-classes/**"), null, false);
+
+        // Should match: file is inside the test-classes/ child directory (relative: test-classes/MyTest.class)
+        assertTrue(matcher.matches(fileInTestClasses), "File inside test-classes/ child directory should be matched");
+
+        // Should NOT match: file is inside other/, not test-classes/.
+        // Before the fix, the non-relativized path "something/target/test-classes/other/Other.class"
+        // would satisfy "**/test-classes/**" because "test-classes" appears in the base directory path.
+        assertFalse(
+                matcher.matches(fileInOther),
+                "File in other/ should not be matched just because the base directory path contains 'test-classes'");
+    }
 }


### PR DESCRIPTION
## Summary

This PR incorporates the fix from #12617 (by @desruisseaux) and adds the regression test requested in the [review](https://github.com/apache/maven/pull/12617#pullrequestreview-4811043754).

- **Commit 1** (from #12617): Removes the `needRelativize` optimization in `PathSelector` that skipped path relativization when all patterns started with `**`. The optimization produced false positives when the base directory path itself contained a segment matching the pattern.
- **Commit 2**: Adds a regression test `testNoFalsePositiveWhenBaseDirectoryMatchesPattern` that constructs the exact scenario from the PR description — base directory `something/target/test-classes` with pattern `**/test-classes/**` falsely matching files in sibling directories.

Supersedes #12617 (maintainer push was disabled on the fork, so the test could not be added directly to that PR).

## Test plan

- [x] New test fails without the fix (false positive confirmed)
- [x] All 6 `PathSelectorTest` tests pass with the fix
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)