### PR TITLE
Remove an optimization on PathSelector producing false negatives

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/PathSelector.java
@@ -537,13 +537,6 @@ final class PathSelector implements PathMatcher {
         private final PathMatcher[] dirExcludes;
 
         /**
-         * Whether to ignore the includes defined by the enclosing class.
-         * This flag can be {@code false} if we determined that all includes are applicable to directories.
-         * This flag should be {@code true} in case of doubt since directory filtering is only an optimization.
-         */
-        private final boolean ignoreIncludes;
-
-        /**
          * Creates a new matcher for directories.
          */
         @SuppressWarnings("StringEquality")
@@ -558,17 +551,9 @@ final class PathSelector implements PathMatcher {
             if (excludeDirPatterns.contains(DEFAULT_SYNTAX)) {
                 // A pattern was something like "glob:{/**,}", which exclude everything.
                 dirExcludes = new PathMatcher[] {INCLUDES_ALL};
-                ignoreIncludes = true;
-                return;
+            } else {
+                dirExcludes = matchers(baseDirectory.getFileSystem(), excludeDirPatterns.toArray(String[]::new));
             }
-            dirExcludes = matchers(baseDirectory.getFileSystem(), excludeDirPatterns.toArray(String[]::new));
-            for (String pattern : includePatterns) {
-                if (trimSuffixes(pattern) == pattern) { // Identity comparison is sufficient here.
-                    ignoreIncludes = true;
-                    return;
-                }
-            }
-            ignoreIncludes = (includes.length == 0);
         }
 
         /**
@@ -593,12 +578,7 @@ final class PathSelector implements PathMatcher {
          */
         PathMatcher simplify() {
             if (dirExcludes.length == 0) {
-                if (ignoreIncludes) {
-                    return INCLUDES_ALL;
-                }
-                if (includes.length == 1) {
-                    return includes[0];
-                }
+                return INCLUDES_ALL;
             }
             return this;
         }
@@ -619,7 +599,7 @@ final class PathSelector implements PathMatcher {
             if (isMatched(directory, dirExcludes)) {
                 return false;
             }
-            return ignoreIncludes || isMatched(directory, includes);
+            return true;
         }
     }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
@@ -259,9 +259,16 @@ public class DefaultPathMatcherFactoryTest {
         assertTrue(anyMatcher.matches(dir.resolve(Path.of("org", "foo", "more"))));
         assertTrue(dirMatcher.matches(dir.resolve(Path.of("org", "0foo0", "more"))));
         assertTrue(anyMatcher.matches(dir.resolve(Path.of("org", "0foo0", "more"))));
-        assertFalse(dirMatcher.matches(dir.resolve(Path.of("org", "bar", "more"))));
+
+        // Before to match an "org/foo" directory, a `FileVisitor` will need to traverse the "org" directory first.
+        assertTrue(dirMatcher.matches(dir.resolve(Path.of("org"))));
+
+        // Ideally, `dirMatcher` would return false. But it is hard to implement without false negative on "org".
+        assertTrue(dirMatcher.matches(dir.resolve(Path.of("org", "bar", "more"))));
         assertFalse(anyMatcher.matches(dir.resolve(Path.of("org", "bar", "more"))));
-        assertFalse(dirMatcher.matches(dir.resolve(Path.of("bar"))));
+
+        // Same reason than above.
+        assertTrue(dirMatcher.matches(dir.resolve(Path.of("bar"))));
         assertFalse(anyMatcher.matches(dir.resolve(Path.of("bar"))));
     }
 }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultPathMatcherFactoryTest.java
@@ -260,14 +260,14 @@ public class DefaultPathMatcherFactoryTest {
         assertTrue(dirMatcher.matches(dir.resolve(Path.of("org", "0foo0", "more"))));
         assertTrue(anyMatcher.matches(dir.resolve(Path.of("org", "0foo0", "more"))));
 
-        // Before to match an "org/foo" directory, a `FileVisitor` will need to traverse the "org" directory first.
+        // Before matching an "org/foo" directory, a `FileVisitor` will need to traverse the "org" directory first.
         assertTrue(dirMatcher.matches(dir.resolve(Path.of("org"))));
 
         // Ideally, `dirMatcher` would return false. But it is hard to implement without false negative on "org".
         assertTrue(dirMatcher.matches(dir.resolve(Path.of("org", "bar", "more"))));
         assertFalse(anyMatcher.matches(dir.resolve(Path.of("org", "bar", "more"))));
 
-        // Same reason than above.
+        // Same reason as above.
         assertTrue(dirMatcher.matches(dir.resolve(Path.of("bar"))));
         assertFalse(anyMatcher.matches(dir.resolve(Path.of("bar"))));
     }


### PR DESCRIPTION
Remove an optimization on `PathSelector` which was sometime producing false negatives. It is safe to use an exclude filter for directories during `FileVisitor` transversal, but it is unsafe to use an include filter because of the need to traverse parents first.