### PR TITLE
Fix field cache to let child class fields take precedence over parent

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelper.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelper.java
@@ -229,7 +229,7 @@ public final class EnhancedCompositeBeanHelper {
         for (Object member : new DeclaredMembers(beanType, View.FIELDS)) {
             Field field = (Field) member;
             if (!Modifier.isStatic(field.getModifiers())) {
-                fieldMap.put(field.getName(), field);
+                fieldMap.putIfAbsent(field.getName(), field);
             }
         }
 

--- a/impl/maven-core/src/test/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelperTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/configuration/internal/EnhancedCompositeBeanHelperTest.java
@@ -209,6 +209,50 @@ class EnhancedCompositeBeanHelperTest {
     }
 
     /**
+     * Verifies that when a child class shadows a parent field with the same name,
+     * setting the property injects into the child's field (not the parent's).
+     * This is the scenario reported in apache/maven-resources-plugin#497:
+     * both ResourcesMojo and TestResourcesMojo declare {@code private boolean skip},
+     * and DeclaredMembers iterates child-first then parent. Using {@code putIfAbsent}
+     * in buildFieldCache ensures the child's field wins.
+     */
+    @Test
+    void testSetPropertyOnShadowedFieldInjectsIntoChildField() throws Exception {
+        ChildBean bean = new ChildBean();
+        PlexusConfiguration config = new XmlPlexusConfiguration("skip");
+        config.setValue("true");
+
+        when(evaluator.evaluate("true")).thenReturn("true");
+
+        helper.setProperty(bean, "skip", null, config);
+
+        // The child's field must receive the value
+        assertTrue(bean.isChildSkip(), "Child's shadowed 'skip' field should be true");
+    }
+
+    /**
+     * Verifies that the field cache resolves the child's field even after
+     * the cache has been populated by a prior lookup on the same class.
+     */
+    @Test
+    void testShadowedFieldCacheConsistency() throws Exception {
+        ChildBean bean1 = new ChildBean();
+        ChildBean bean2 = new ChildBean();
+        PlexusConfiguration config = new XmlPlexusConfiguration("skip");
+        config.setValue("true");
+
+        when(evaluator.evaluate("true")).thenReturn("true");
+
+        // First call populates the cache
+        helper.setProperty(bean1, "skip", null, config);
+        // Second call uses the cache
+        helper.setProperty(bean2, "skip", null, config);
+
+        assertTrue(bean1.isChildSkip(), "First bean: child's 'skip' field should be true");
+        assertTrue(bean2.isChildSkip(), "Second bean: child's 'skip' field should be true");
+    }
+
+    /**
      * Test bean class for testing property setting.
      */
     public static class TestBean {
@@ -234,6 +278,32 @@ class EnhancedCompositeBeanHelperTest {
 
         public void addItem(String item) {
             this.items.add(item);
+        }
+    }
+
+    /**
+     * Parent bean that declares a {@code skip} field — mirrors ResourcesMojo.
+     */
+    public static class ParentBean {
+        @SuppressWarnings("unused")
+        private boolean skip;
+
+        public boolean isParentSkip() {
+            return skip;
+        }
+    }
+
+    /**
+     * Child bean that shadows the parent's {@code skip} field — mirrors TestResourcesMojo.
+     * Both parent and child declare {@code private boolean skip}; only the child's
+     * field should receive the injected value.
+     */
+    public static class ChildBean extends ParentBean {
+        @SuppressWarnings("unused")
+        private boolean skip;
+
+        public boolean isChildSkip() {
+            return skip;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix `EnhancedCompositeBeanHelper.buildFieldCache()` to use `putIfAbsent()` instead of `put()`, so child class fields take precedence over parent fields with the same name
- Add regression tests for field-shadowing scenarios (`ParentBean`/`ChildBean` with same `skip` field)

## Problem

When a child Mojo class shadows a parent's field (e.g. both `ResourcesMojo` and `TestResourcesMojo` declare `private boolean skip`), the field cache incorrectly resolves to the **parent's** field. This causes POM `<configuration><skip>true</skip></configuration>` to inject into the parent's `skip` field but not the child's — breaking `TestResourcesMojo`'s skip behavior.

**Root cause:** `DeclaredMembers` iterates child-first then parent. The field cache used `put()` which overwrites the child entry with the parent's. The method cache already correctly uses `putIfAbsent()` — this was an asymmetry.

## Fix

One-line change: `fieldMap.put(...)` → `fieldMap.putIfAbsent(...)` in `buildFieldCache()`.

This matches the method cache behavior and ensures the first-seen field (from the child class) wins.

Reported in: https://github.com/apache/maven-resources-plugin/issues/497

## Test plan

- [x] New test `testSetPropertyOnShadowedFieldInjectsIntoChildField` — verifies child field receives the injected value
- [x] New test `testShadowedFieldCacheConsistency` — verifies cache reuse preserves correct field resolution
- [x] All 9 existing + new `EnhancedCompositeBeanHelperTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)