### PR TITLE
Fix #12609: ProtoSession.Builder.newBuilder() NPE on unset property maps

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ProtoSession.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ProtoSession.java
@@ -116,8 +116,8 @@ public interface ProtoSession {
     }
 
     class Builder {
-        private Map<String, String> userProperties;
-        private Map<String, String> systemProperties;
+        private Map<String, String> userProperties = Map.of();
+        private Map<String, String> systemProperties = Map.of();
         private Instant startTime;
         private Path topDirectory;
         private Path rootDirectory;

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api;
+
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ProtoSessionTest {
+
+    @Test
+    void testNewBuilderWithUnsetPropertyMaps() {
+        ProtoSession session = ProtoSession.newBuilder()
+                .withTopDirectory(Paths.get("."))
+                .withRootDirectory(Paths.get("."))
+                .build();
+        assertNotNull(session);
+        assertNotNull(session.getUserProperties());
+        assertNotNull(session.getSystemProperties());
+    }
+}

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
@@ -35,11 +35,8 @@ class ProtoSessionTest {
                 .build();
         assertNotNull(session);
         assertNotNull(session.getUserProperties());
-        assertNotNull(session.getUserProperties());
-        assertTrue(session.getUserProperties().isEmpty());
-        assertNotNull(session.getSystemProperties());
-        assertTrue(session.getSystemProperties().isEmpty());
         assertTrue(session.getUserProperties().isEmpty(), "User properties should default to empty");
+        assertNotNull(session.getSystemProperties());
         assertTrue(session.getSystemProperties().isEmpty(), "System properties should default to empty");
     }
 }

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProtoSessionTest {
 
@@ -35,5 +36,7 @@ class ProtoSessionTest {
         assertNotNull(session);
         assertNotNull(session.getUserProperties());
         assertNotNull(session.getSystemProperties());
+        assertTrue(session.getUserProperties().isEmpty(), "User properties should default to empty");
+        assertTrue(session.getSystemProperties().isEmpty(), "System properties should default to empty");
     }
 }

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/ProtoSessionTest.java
@@ -35,7 +35,10 @@ class ProtoSessionTest {
                 .build();
         assertNotNull(session);
         assertNotNull(session.getUserProperties());
+        assertNotNull(session.getUserProperties());
+        assertTrue(session.getUserProperties().isEmpty());
         assertNotNull(session.getSystemProperties());
+        assertTrue(session.getSystemProperties().isEmpty());
         assertTrue(session.getUserProperties().isEmpty(), "User properties should default to empty");
         assertTrue(session.getSystemProperties().isEmpty(), "System properties should default to empty");
     }


### PR DESCRIPTION
Fixes #12609

Initialize `userProperties` and `systemProperties` to `Map.of()` in `Builder` to prevent `NullPointerException` when `build()` is called without setting these properties via `newBuilder()`.

Also adds a test that verifies building a session without setting properties does not throw NPE.