### PR TITLE
Fix #12605: DefaultProjectBuildingHelper synchronized bottleneck in parallel builds

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
@@ -143,7 +143,7 @@ public class DefaultProjectBuildingHelper implements ProjectBuildingHelper {
     }
 
     @Override
-    public synchronized ProjectRealmCache.CacheRecord createProjectRealm(
+    public ProjectRealmCache.CacheRecord createProjectRealm(
             MavenProject project, Model model, ProjectBuildingRequest request)
             throws PluginResolutionException, PluginVersionResolutionException, PluginManagerException {
         ClassRealm projectRealm;

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectRealmCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectRealmCache.java
@@ -94,13 +94,13 @@ public class DefaultProjectRealmCache implements ProjectRealmCache, Disposable {
     public CacheRecord put(Key key, ClassRealm projectRealm, DependencyFilter extensionArtifactFilter) {
         Objects.requireNonNull(projectRealm, "projectRealm cannot be null");
 
-        if (cache.containsKey(key)) {
-            throw new IllegalStateException("Duplicate project realm for extensions " + key);
-        }
-
         CacheRecord record = new CacheRecord(projectRealm, extensionArtifactFilter);
 
-        cache.put(key, record);
+        CacheRecord existing = cache.putIfAbsent(key, record);
+
+        if (existing != null) {
+            throw new IllegalStateException("Duplicate project realm for extensions " + key);
+        }
 
         return record;
     }

--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectRealmCacheTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectRealmCacheTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.eclipse.aether.graph.DependencyFilter;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +38,6 @@ class DefaultProjectRealmCacheTest {
     void testConcurrentPutWithSameKey() throws Exception {
         DefaultProjectRealmCache cache = new DefaultProjectRealmCache();
         ClassRealm realm = mock(ClassRealm.class);
-        DependencyFilter filter = mock(DependencyFilter.class);
         ProjectRealmCache.Key key = cache.createKey(List.of(realm));
 
         int threadCount = 10;
@@ -53,15 +51,15 @@ class DefaultProjectRealmCacheTest {
                 try {
                     cache.put(key, mock(ClassRealm.class), mock(DependencyFilter.class));
                     return true;
-                } catch (IllegalStateException e) {
+                } catch (IllegalStateException ex) {
                     return false;
                 }
             }));
         }
 
         int successCount = 0;
-        for (Future<Boolean> f : futures) {
-            if (f.get()) {
+        for (Future<Boolean> futre : futures) {
+            if (futre.get()) {
                 successCount++;
             }
         }

--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectRealmCacheTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectRealmCacheTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.project;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+class DefaultProjectRealmCacheTest {
+
+    @Test
+    void testConcurrentPutWithSameKey() throws Exception {
+        DefaultProjectRealmCache cache = new DefaultProjectRealmCache();
+        ClassRealm realm = mock(ClassRealm.class);
+        DependencyFilter filter = mock(DependencyFilter.class);
+        ProjectRealmCache.Key key = cache.createKey(List.of(realm));
+
+        int threadCount = 10;
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Future<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                barrier.await();
+                try {
+                    cache.put(key, mock(ClassRealm.class), mock(DependencyFilter.class));
+                    return true;
+                } catch (IllegalStateException e) {
+                    return false;
+                }
+            }));
+        }
+
+        int successCount = 0;
+        for (Future<Boolean> f : futures) {
+            if (f.get()) {
+                successCount++;
+            }
+        }
+        executor.shutdown();
+
+        assertEquals(1, successCount, "Only one put should succeed");
+        assertNotNull(cache.get(key));
+    }
+}


### PR DESCRIPTION
Fixes #12605

## Problem
`DefaultProjectBuildingHelper.createProjectRealm()` was declared `synchronized`, making it a global lock during multi-module parallel builds. Every project needing extension realm setup had to acquire this lock serially.

Additionally, `DefaultProjectRealmCache.put()` had a check-then-act race condition: `containsKey()` followed by `put()` are not atomic, allowing two threads to both pass the check and overwrite each other's entry.

## Fix
1. **Removed `synchronized`** from `createProjectRealm()` — the `projectRealmCache` uses `ConcurrentHashMap` and is already thread-safe for `get`/`createKey`.
2. **Fixed `put()` race** — replaced the non-atomic `containsKey()` + `put()` with `putIfAbsent()`, which atomically inserts only if absent and throws `IllegalStateException` if the key already exists.

## Testing
Added `DefaultProjectRealmCacheTest` that verifies concurrent `put()` calls with the same key result in exactly one successful insertion.