### PR TITLE
Fix #12604: DefaultSettingsBuilder dead Windows drive-relative path handling

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsBuilder.java
@@ -21,7 +21,6 @@ package org.apache.maven.impl;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -128,11 +127,13 @@ public class DefaultSettingsBuilder implements SettingsBuilder {
                     .build();
         }
 
-        // for the special case of a drive-relative Windows path, make sure it's absolute to save plugins from trouble
+        // resolve relative local repository paths to absolute to save plugins from trouble.
+        // paths containing property placeholders like ${user.home} must be left as-is
+        // so that later interpolation can resolve them.
         String localRepository = effective.getLocalRepository();
         if (localRepository != null && !localRepository.isEmpty()) {
             Path file = Paths.get(localRepository);
-            if (!file.isAbsolute() && file.toString().startsWith(File.separator)) {
+            if (!file.isAbsolute() && !localRepository.contains("${")) {
                 effective = effective.withLocalRepository(file.toAbsolutePath().toString());
             }
         }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsBuilderFactoryTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsBuilderFactoryTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -158,6 +159,17 @@ class DefaultSettingsBuilderFactoryTest {
         assertEquals(
                 "'servers.server[0].aliases[0]' for server-1 must be unique across all server ids and aliases but found duplicate alias server-2",
                 problems.problems().findFirst().orElseThrow().getMessage());
+    }
+
+    @Test
+    void testRelativeLocalRepositoryIsResolvedToAbsolute() {
+        Settings settings = execute("settings-relative-local-repo").getEffectiveSettings();
+
+        String localRepository = settings.getLocalRepository();
+        assertNotNull(localRepository);
+        assertFalse(localRepository.isEmpty());
+        Path repoPath = Paths.get(localRepository);
+        assertTrue(repoPath.isAbsolute(), "Relative local repository should be resolved to absolute");
     }
 
     private Path getSettings(String name) {

--- a/impl/maven-impl/src/test/resources/settings/settings-relative-local-repo.xml
+++ b/impl/maven-impl/src/test/resources/settings/settings-relative-local-repo.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<settings xmlns='http://maven.apache.org/SETTINGS/1.0.0'>
+  <localRepository>relative/repo</localRepository>
+</settings>


### PR DESCRIPTION
Fixes #12604

## Problem

The condition `!file.isAbsolute() && file.toString().startsWith(File.separator)` is **always false** on all platforms:

- On Unix: any path starting with `/` is absolute, so `!file.isAbsolute()` is false
- On Windows: any path starting with `\` is absolute (drive-relative), so `!file.isAbsolute()` is false

This made the entire local repository path resolution block dead code.

## Fix

Replace the impossible condition with `!file.isAbsolute()` (skipping paths containing `${` placeholders that need later interpolation). This correctly resolves relative paths like `relative/repo` to absolute.

## Testing

Added `testRelativeLocalRepositoryIsResolvedToAbsolute` which loads a settings file with `<localRepository>relative/repo</localRepository>` and verifies the output path is absolute.

Existing test `testSettingsWithServersAndAliases` continues to pass because paths containing `${user.home}` placeholders are left untouched.