### PR TITLE
Prevent NPE in inheritance assembler

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultInheritanceAssembler.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultInheritanceAssembler.java
@@ -105,7 +105,8 @@ public class DefaultInheritanceAssembler implements InheritanceAssembler {
              * repository. In other words, modules where artifactId != moduleDirName will see different effective URLs
              * depending on how the model was constructed (from filesystem or from repository).
              */
-            if (child.getProjectDirectory() != null) {
+            if (child.getProjectDirectory() != null
+                    && child.getProjectDirectory().getFileName() != null) {
                 childName = child.getProjectDirectory().getFileName().toString();
             }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
@@ -18,81 +18,85 @@
  */
 package org.apache.maven.impl.model;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.apache.maven.api.model.Model;
-import org.apache.maven.api.services.xml.XmlReaderRequest;
-import org.apache.maven.api.services.xml.XmlWriterRequest;
-import org.apache.maven.impl.DefaultModelXmlFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xmlunit.builder.DiffBuilder;
-import org.xmlunit.diff.Diff;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DefaultInheritanceAssemblerTest {
-
-    private DefaultModelXmlFactory xmlFactory;
 
     private DefaultInheritanceAssembler assembler;
 
     @BeforeEach
     void setUp() {
-        xmlFactory = new DefaultModelXmlFactory();
         assembler = new DefaultInheritanceAssembler();
     }
 
-    private Path getPom(String name) {
-        return Paths.get("../../compat/maven-model-builder/src/test/resources/poms/inheritance/" + name + ".xml");
-    }
+    @Test
+    void testAssembleWithNullArtifactIdDoesNotThrowNpe() {
+        Model parent = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("test")
+                .artifactId("parent")
+                .version("1.0")
+                .build();
 
-    private Model getModel(String name) throws Exception {
-        return xmlFactory.read(XmlReaderRequest.builder().path(getPom(name)).build());
+        Model child = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("test")
+                .version("1.0")
+                .build();
+
+        assertNotNull(assembler);
+        assertDoesNotThrow(() -> assembler.assembleModelInheritance(child, parent, null, null));
     }
 
     @Test
-    void testPluginConfiguration() throws Exception {
-        testInheritance("plugin-configuration");
-    }
-
-    public void testInheritance(String baseName) throws Exception {
-        testInheritance(baseName, false);
-        testInheritance(baseName, true);
-    }
-
-    public void testInheritance(String baseName, boolean fromRepo) throws Exception {
-        Model parent = getModel(baseName + "-parent");
-        Model child = getModel(baseName + "-child");
-
-        if (!fromRepo) {
-            // when model is built from disk, pomFile is set
-            // (has consequences in inheritance algorithm since getProjectDirectory() returns non-null)
-            parent = parent.withPomFile(getPom(baseName + "-parent").toAbsolutePath());
-            child = child.withPomFile(getPom(baseName + "-child").toAbsolutePath());
-        }
-
-        Model assembled = assembler.assembleModelInheritance(child, parent, null, null);
-
-        // write baseName + "-actual"
-        Path actual = Paths.get(
-                "target/test-classes/poms/inheritance/" + baseName + (fromRepo ? "-build" : "-repo") + "-actual.xml");
-        Files.createDirectories(actual.getParent());
-        xmlFactory.write(XmlWriterRequest.<Model>builder()
-                .content(assembled)
-                .path(actual)
-                .build());
-
-        // check with getPom( baseName + "-expected" )
-        Path expected = getPom(baseName + "-expected");
-
-        Diff diff = DiffBuilder.compare(expected.toFile())
-                .withTest(actual.toFile())
-                .ignoreComments()
-                .ignoreWhitespace()
+    void testAssembleWithRootProjectDirectoryDoesNotThrowNpe() {
+        Model parent = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("test")
+                .artifactId("parent")
+                .version("1.0")
                 .build();
-        assertFalse(diff.hasDifferences(), "XML files should be identical: " + diff.toString());
+
+        // child has pomFile at root, so getProjectDirectory() returns root path
+        // and getFileName() on root path returns null
+        Model child = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("test")
+                .artifactId("child")
+                .version("1.0")
+                .pomFile(Paths.get("/pom.xml"))
+                .build();
+
+        assertNotNull(assembler);
+        assertDoesNotThrow(() -> assembler.assembleModelInheritance(child, parent, null, null));
+    }
+
+    @Test
+    void testAssembleWithNullArtifactIdAndRootProjectDirectoryDoesNotThrowNpe() {
+        Model parent = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("test")
+                .artifactId("parent")
+                .version("1.0")
+                .modules(List.of("../child/pom.xml"))
+                .build();
+
+        Model child = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("test")
+                .version("1.0")
+                .pomFile(Paths.get("/pom.xml"))
+                .build();
+
+        assertNotNull(assembler);
+        assertDoesNotThrow(() -> assembler.assembleModelInheritance(child, parent, null, null));
     }
 }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
@@ -60,26 +60,42 @@ class DefaultInheritanceAssemblerTest {
         testInheritance("plugin-configuration");
     }
 
+    /**
+     * Check most classical urls inheritance: directory structure where parent POM in parent directory
+     * and child directory == artifactId
+     */
     @Test
     void testUrls() throws Exception {
         testInheritance("urls");
     }
 
+    /**
+     * Flat directory structure: parent & child POMs in sibling directories, child directory == artifactId.
+     */
     @Test
     void testFlatUrls() throws Exception {
         testInheritance("flat-urls");
     }
 
+    /**
+     * MNG-5951 MNG-6059 child.x.y.inherit.append.path="false" test
+     */
     @Test
     void testNoAppendUrls() throws Exception {
         testInheritance("no-append-urls");
     }
 
+    /**
+     * MNG-5951 special case test: inherit with partial override
+     */
     @Test
     void testNoAppendUrls2() throws Exception {
         testInheritance("no-append-urls2");
     }
 
+    /**
+     * MNG-5951 special case test: child.x.y.inherit.append.path="true" in child should not reset content
+     */
     @Test
     void testNoAppendUrls3() throws Exception {
         testInheritance("no-append-urls3");

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
@@ -34,7 +34,6 @@ import org.xmlunit.diff.Diff;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DefaultInheritanceAssemblerTest {
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DefaultInheritanceAssemblerTest {
 
@@ -52,7 +51,6 @@ class DefaultInheritanceAssemblerTest {
                 .version("1.0")
                 .build();
 
-        assertNotNull(assembler);
         assertDoesNotThrow(() -> assembler.assembleModelInheritance(child, parent, null, null));
     }
 
@@ -75,7 +73,6 @@ class DefaultInheritanceAssemblerTest {
                 .pomFile(Paths.get("/pom.xml"))
                 .build();
 
-        assertNotNull(assembler);
         assertDoesNotThrow(() -> assembler.assembleModelInheritance(child, parent, null, null));
     }
 
@@ -96,7 +93,6 @@ class DefaultInheritanceAssemblerTest {
                 .pomFile(Paths.get("/pom.xml"))
                 .build();
 
-        assertNotNull(assembler);
         assertDoesNotThrow(() -> assembler.assembleModelInheritance(child, parent, null, null));
     }
 }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
@@ -140,12 +140,15 @@ class DefaultInheritanceAssemblerTest {
         Model child = getModel(baseName + "-child");
 
         if (!fromRepo) {
+            // when model is built from disk, pomFile is set
+            // (has consequences in inheritance algorithm since getProjectDirectory() returns non-null)
             parent = parent.withPomFile(getPom(baseName + "-parent").toAbsolutePath());
             child = child.withPomFile(getPom(baseName + "-child").toAbsolutePath());
         }
 
         Model assembled = assembler.assembleModelInheritance(child, parent, null, null);
 
+        // write baseName + "-actual"
         Path actual = Paths.get(
                 "target/test-classes/poms/inheritance/" + baseName + (fromRepo ? "-build" : "-repo") + "-actual.xml");
         Files.createDirectories(actual.getParent());
@@ -154,6 +157,7 @@ class DefaultInheritanceAssemblerTest {
                 .path(actual)
                 .build());
 
+        // check with getPom( baseName + "-expected" )
         Path expected = getPom(baseName + "-expected");
 
         Diff diff = DiffBuilder.compare(expected.toFile())

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultInheritanceAssemblerTest.java
@@ -18,22 +18,135 @@
  */
 package org.apache.maven.impl.model;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.maven.api.model.Model;
+import org.apache.maven.api.services.xml.XmlReaderRequest;
+import org.apache.maven.api.services.xml.XmlWriterRequest;
+import org.apache.maven.impl.DefaultModelXmlFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DefaultInheritanceAssemblerTest {
+
+    private DefaultModelXmlFactory xmlFactory;
 
     private DefaultInheritanceAssembler assembler;
 
     @BeforeEach
     void setUp() {
+        xmlFactory = new DefaultModelXmlFactory();
         assembler = new DefaultInheritanceAssembler();
+    }
+
+    private Path getPom(String name) {
+        return Paths.get("../../compat/maven-model-builder/src/test/resources/poms/inheritance/" + name + ".xml");
+    }
+
+    private Model getModel(String name) throws Exception {
+        return xmlFactory.read(XmlReaderRequest.builder().path(getPom(name)).build());
+    }
+
+    @Test
+    void testPluginConfiguration() throws Exception {
+        testInheritance("plugin-configuration");
+    }
+
+    @Test
+    void testUrls() throws Exception {
+        testInheritance("urls");
+    }
+
+    @Test
+    void testFlatUrls() throws Exception {
+        testInheritance("flat-urls");
+    }
+
+    @Test
+    void testNoAppendUrls() throws Exception {
+        testInheritance("no-append-urls");
+    }
+
+    @Test
+    void testNoAppendUrls2() throws Exception {
+        testInheritance("no-append-urls2");
+    }
+
+    @Test
+    void testNoAppendUrls3() throws Exception {
+        testInheritance("no-append-urls3");
+    }
+
+    @Test
+    void testWithEmptyUrl() throws Exception {
+        testInheritance("empty-urls", false);
+    }
+
+    @Test
+    void testModulePathNotArtifactId() throws Exception {
+        Model parent = getModel("module-path-not-artifactId-parent");
+        Model child = getModel("module-path-not-artifactId-child");
+
+        Model assembled = assembler.assembleModelInheritance(child, parent, null, null);
+
+        Path actual = Paths.get("target/test-classes/poms/inheritance/module-path-not-artifactId-actual.xml");
+        Files.createDirectories(actual.getParent());
+        xmlFactory.write(XmlWriterRequest.<Model>builder()
+                .content(assembled)
+                .path(actual)
+                .build());
+
+        Path expected = getPom("module-path-not-artifactId-expected");
+
+        Diff diff = DiffBuilder.compare(expected.toFile())
+                .withTest(actual.toFile())
+                .ignoreComments()
+                .ignoreWhitespace()
+                .build();
+        assertFalse(diff.hasDifferences(), "XML files should be identical: " + diff.toString());
+    }
+
+    public void testInheritance(String baseName) throws Exception {
+        testInheritance(baseName, false);
+        testInheritance(baseName, true);
+    }
+
+    public void testInheritance(String baseName, boolean fromRepo) throws Exception {
+        Model parent = getModel(baseName + "-parent");
+        Model child = getModel(baseName + "-child");
+
+        if (!fromRepo) {
+            parent = parent.withPomFile(getPom(baseName + "-parent").toAbsolutePath());
+            child = child.withPomFile(getPom(baseName + "-child").toAbsolutePath());
+        }
+
+        Model assembled = assembler.assembleModelInheritance(child, parent, null, null);
+
+        Path actual = Paths.get(
+                "target/test-classes/poms/inheritance/" + baseName + (fromRepo ? "-build" : "-repo") + "-actual.xml");
+        Files.createDirectories(actual.getParent());
+        xmlFactory.write(XmlWriterRequest.<Model>builder()
+                .content(assembled)
+                .path(actual)
+                .build());
+
+        Path expected = getPom(baseName + "-expected");
+
+        Diff diff = DiffBuilder.compare(expected.toFile())
+                .withTest(actual.toFile())
+                .ignoreComments()
+                .ignoreWhitespace()
+                .build();
+        assertFalse(diff.hasDifferences(), "XML files should be identical: " + diff.toString());
     }
 
     @Test
@@ -63,8 +176,6 @@ class DefaultInheritanceAssemblerTest {
                 .version("1.0")
                 .build();
 
-        // child has pomFile at root, so getProjectDirectory() returns root path
-        // and getFileName() on root path returns null
         Model child = Model.newBuilder()
                 .modelVersion("4.0.0")
                 .groupId("test")


### PR DESCRIPTION
fixes #12603 

## Bug

`DefaultInheritanceAssembler.getChildPathAdjustment()` throws NPE when:
1. `child.getProjectDirectory().getFileName()` returns null (root path like `/`)
2. `child.getArtifactId()` returns null

## Fix

- Added null check for `child.getProjectDirectory().getFileName()` before calling `.toString()`

## Testing

Added `DefaultInheritanceAssemblerTest` with three test cases:
- Null artifactId (no project directory)
- Root project directory (`getFileName()` returns null)
- Both null artifactId and root project directory

Co-authored-by: elharo