### PR TITLE
docs: Remove broken link

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -43,29 +43,26 @@ under the License.
     </menu>
 
     <menu inherit="bottom" name="Descriptors Reference">
-    <!-- API documentation must be built separately with javadoc:javadoc -->
-      <!--item name="POM" href="./api/maven-api-model/maven.html"/-->
-      <!--item name="Settings" href="./api/maven-api-settings/settings.html"/-->
-      <!--item name="Toolchains" href="./api/maven-api-toolchain/toolchains.html"/-->
-      <!--item name="Core Extensions" href="./api/maven-api-cli/core-extensions.html"/-->
-      <!--item name="Repository Metadata" href="./api/maven-api-metadata/repository-metadata.html"/-->
-      <!--item name="Plugin Descriptor" href="./api/maven-api-plugin/plugin.html"/-->
-      <!--item name="Lifecycle Descriptor" href="./api/maven-api-plugin/lifecycle.html"/-->
+      <item name="POM" href="./api/maven-api-model/maven.html"/>
+      <item name="Settings" href="./api/maven-api-settings/settings.html"/>
+      <item name="Toolchains" href="./api/maven-api-toolchain/toolchains.html"/>
+      <item name="Core Extensions" href="./api/maven-api-cli/core-extensions.html"/>
+      <item name="Repository Metadata" href="./api/maven-api-metadata/repository-metadata.html"/>
+      <item name="Plugin Descriptor" href="./api/maven-api-plugin/plugin.html"/>
+      <item name="Lifecycle Descriptor" href="./api/maven-api-plugin/lifecycle.html"/>
     </menu>
 
     <menu inherit="bottom" name="Reference">
-    <!-- Implementation modules documentation must be built separately -->
-      <!--item name="Lifecycles" href="./impl/maven-core/lifecycles.html"/-->
-      <!--item name="Plugin Bindings to Default Lifecycle" href="./impl/maven-core/default-bindings.html"/-->
-      <!--item name="Artifact Handlers" href="./impl/maven-core/artifact-handlers.html"/-->
-      <!--item name="CLI options" href="./compat/maven-embedder/cli.html"/-->
-      <!--item name="Super POM" href="./compat/maven-model-builder/super-pom.html"/-->
+      <item name="Lifecycles" href="./impl/maven-core/lifecycles.html"/>
+      <item name="Plugin Bindings to Default Lifecycle" href="./impl/maven-core/default-bindings.html"/>
+      <item name="Artifact Handlers" href="./impl/maven-core/artifact-handlers.html"/>
+      <item name="CLI options" href="./compat/maven-embedder/cli.html"/>
+      <item name="Super POM" href="./compat/maven-model-builder/super-pom.html"/>
     </menu>
 
     <menu inherit="bottom" name="Development">
-      <!-- Developer documentation exists in separate repositories -->
-      <!--item name="Maven Developer Centre" href="../../developers/index.html"/-->
-      <!--item name="Maven Core ITs" href="../../core-its/index.html"/-->
+      <item name="Maven Developer Centre" href="../../developers/index.html"/>
+      <item name="Maven Core ITs" href="../../core-its/index.html"/>
     </menu>
 
     <menu inherit="bottom" ref="modules"/>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -43,26 +43,29 @@ under the License.
     </menu>
 
     <menu inherit="bottom" name="Descriptors Reference">
-      <item name="POM" href="./api/maven-api-model/maven.html"/>
-      <item name="Settings" href="./api/maven-api-settings/settings.html"/>
-      <item name="Toolchains" href="./api/maven-api-toolchain/toolchains.html"/>
-      <item name="Core Extensions" href="./api/maven-api-cli/core-extensions.html"/>
-      <item name="Repository Metadata" href="./api/maven-api-metadata/repository-metadata.html"/>
-      <item name="Plugin Descriptor" href="./api/maven-api-plugin/plugin.html"/>
-      <item name="Lifecycle Descriptor" href="./api/maven-api-plugin/lifecycle.html"/>
+    <!-- API documentation must be built separately with javadoc:javadoc -->
+      <!--item name="POM" href="./api/maven-api-model/maven.html"/-->
+      <!--item name="Settings" href="./api/maven-api-settings/settings.html"/-->
+      <!--item name="Toolchains" href="./api/maven-api-toolchain/toolchains.html"/-->
+      <!--item name="Core Extensions" href="./api/maven-api-cli/core-extensions.html"/-->
+      <!--item name="Repository Metadata" href="./api/maven-api-metadata/repository-metadata.html"/-->
+      <!--item name="Plugin Descriptor" href="./api/maven-api-plugin/plugin.html"/-->
+      <!--item name="Lifecycle Descriptor" href="./api/maven-api-plugin/lifecycle.html"/-->
     </menu>
 
     <menu inherit="bottom" name="Reference">
-      <item name="Lifecycles" href="./impl/maven-core/lifecycles.html"/>
-      <item name="Plugin Bindings to Default Lifecycle" href="./impl/maven-core/default-bindings.html"/>
-      <item name="Artifact Handlers" href="./impl/maven-core/artifact-handlers.html"/>
-      <item name="CLI options" href="./compat/maven-embedder/cli.html"/>
-      <item name="Super POM" href="./compat/maven-model-builder/super-pom.html"/>
+    <!-- Implementation modules documentation must be built separately -->
+      <!--item name="Lifecycles" href="./impl/maven-core/lifecycles.html"/-->
+      <!--item name="Plugin Bindings to Default Lifecycle" href="./impl/maven-core/default-bindings.html"/-->
+      <!--item name="Artifact Handlers" href="./impl/maven-core/artifact-handlers.html"/-->
+      <!--item name="CLI options" href="./compat/maven-embedder/cli.html"/-->
+      <!--item name="Super POM" href="./compat/maven-model-builder/super-pom.html"/-->
     </menu>
 
     <menu inherit="bottom" name="Development">
-      <item name="Maven Developer Centre" href="../../developers/index.html"/>
-      <item name="Maven Core ITs" href="../../core-its/index.html"/>
+      <!-- Developer documentation exists in separate repositories -->
+      <!--item name="Maven Developer Centre" href="../../developers/index.html"/-->
+      <!--item name="Maven Core ITs" href="../../core-its/index.html"/-->
     </menu>
 
     <menu inherit="bottom" ref="modules"/>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -41,7 +41,7 @@ under the License.
     number of other development tools for reporting or the build
     process.</p>
 
-      <p>Learn more about <a href="configuring.html">configuring Maven</a> and <a href="maven-configuration.html">Maven's configuration</a>.</p>
+      <p>Learn more about <a href="configuring.html">configuring Maven</a>.</p>
 
       <p>
         <object data="images/maven-deps.svg"></object>


### PR DESCRIPTION
- Remove reference to maven-configuration.html which doesn't exist
- Comment out API/impl/compat navigation links with explanatory comments
- Comment out developer docs and Core ITs links

