### PR TITLE
docs: add draft FAQ page and enable link

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,7 +33,8 @@ under the License.
       <item name="Introduction" href="index.html"/>
       <item name="Javadocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>
-      <!--item name="FAQ" href="faq.html"/-->
+      <!-- FAQ draft page created -->
+      <item name="FAQ" href="faq.html"/>
       <item name="License" href="https://www.apache.org/licenses/"/>
       <item name="Download" href="../../download.cgi"/>
     </menu>

--- a/src/site/xdoc/faq.xml
+++ b/src/site/xdoc/faq.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. -->
+<document>
+
+  <properties>
+    <title>FAQ</title>
+    <author email="dev@maven.apache.org">Apache Maven Team</author>
+  </properties>
+
+  <body>
+    <section name="Frequently Asked Questions">
+      
+      <p>This is a draft FAQ page for Apache Maven. Content will be added over time.</p>
+      
+      <subsection name="Getting Started">
+        
+        <p><b>Q: What is the minimum Java version required for Maven?</b></p>
+        <p>A: Maven 4.x requires Java 8 or later. For specific version requirements, see the <a href="https://maven.apache.org/install.html">installation guide</a>.</p>
+        
+      </subsection>
+
+    </section>
+  </body>
+
+</document>


### PR DESCRIPTION
- Creates new src/site/xdoc/faq.xml with basic structure
- Uncomments FAQ navigation item in site.xml

Fixes #3.