### PR TITLE
remove commented out link

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,7 +33,6 @@ under the License.
       <item name="Introduction" href="index.html"/>
       <item name="Javadocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>
-      
       <item name="License" href="https://www.apache.org/licenses/"/>
       <item name="Download" href="../../download.cgi"/>
     </menu>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,7 +33,7 @@ under the License.
       <item name="Introduction" href="index.html"/>
       <item name="Javadocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>
-      <!--item name="FAQ" href="faq.html"/-->
+      
       <item name="License" href="https://www.apache.org/licenses/"/>
       <item name="Download" href="../../download.cgi"/>
     </menu>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,6 +33,7 @@ under the License.
       <item name="Introduction" href="index.html"/>
       <item name="Javadocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>
+      <!-- FAQ page not yet created -->
       <!--item name="FAQ" href="faq.html"/-->
       <item name="License" href="https://www.apache.org/licenses/"/>
       <item name="Download" href="../../download.cgi"/>


### PR DESCRIPTION
- Updates the FAQ comment to explain Why it's commented out

Fixes #9.