### PR TITLE
Replace custom `GraphLogger` with `DependencyGraphDumper` in dependency resolution

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -22,11 +22,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -34,7 +32,6 @@ import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.PluginResolutionException;
-import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -48,7 +45,6 @@ import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.collection.VersionFilterBuilder;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
-import org.eclipse.aether.graph.DependencyVisitor;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
@@ -61,8 +57,8 @@ import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.filter.AndDependencyFilter;
 import org.eclipse.aether.util.filter.ScopeDependencyFilter;
-import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.visitor.DependencyGraphDumper;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -254,7 +250,7 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                     repoSystem.collectDependencies(pluginSession, request).getRoot();
 
             if (logger.isDebugEnabled()) {
-                node.accept(new GraphLogger());
+                node.accept(new DependencyGraphDumper(logger::debug));
             }
 
             depRequest.setRoot(node);
@@ -271,81 +267,6 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
                                     .flatMap(r -> r.getExceptions().stream()))
                     .collect(Collectors.toList());
             throw new PluginResolutionException(plugin, exceptions, logger.isDebugEnabled() ? e : null);
-        }
-    }
-
-    // Keep this class in sync with org.apache.maven.project.DefaultProjectDependenciesResolver.GraphLogger
-    class GraphLogger implements DependencyVisitor {
-
-        private String indent = "";
-
-        public boolean visitEnter(DependencyNode node) {
-            StringBuilder buffer = new StringBuilder(128);
-            buffer.append(indent);
-            org.eclipse.aether.graph.Dependency dep = node.getDependency();
-            if (dep != null) {
-                org.eclipse.aether.artifact.Artifact art = dep.getArtifact();
-
-                buffer.append(art);
-                if (StringUtils.isNotEmpty(dep.getScope())) {
-                    buffer.append(':').append(dep.getScope());
-                }
-
-                if (dep.isOptional()) {
-                    buffer.append(" (optional)");
-                }
-
-                // TODO We currently cannot tell which <dependencyManagement> section contained the management
-                //      information. When the resolver provides this information, these log messages should be updated
-                //      to contain it.
-                if ((node.getManagedBits() & DependencyNode.MANAGED_SCOPE) == DependencyNode.MANAGED_SCOPE) {
-                    final String premanagedScope = DependencyManagerUtils.getPremanagedScope(node);
-                    buffer.append(" (scope managed from ");
-                    buffer.append(Objects.toString(premanagedScope, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_VERSION) == DependencyNode.MANAGED_VERSION) {
-                    final String premanagedVersion = DependencyManagerUtils.getPremanagedVersion(node);
-                    buffer.append(" (version managed from ");
-                    buffer.append(Objects.toString(premanagedVersion, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_OPTIONAL) == DependencyNode.MANAGED_OPTIONAL) {
-                    final Boolean premanagedOptional = DependencyManagerUtils.getPremanagedOptional(node);
-                    buffer.append(" (optionality managed from ");
-                    buffer.append(Objects.toString(premanagedOptional, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_EXCLUSIONS) == DependencyNode.MANAGED_EXCLUSIONS) {
-                    final Collection<org.eclipse.aether.graph.Exclusion> premanagedExclusions =
-                            DependencyManagerUtils.getPremanagedExclusions(node);
-
-                    buffer.append(" (exclusions managed from ");
-                    buffer.append(Objects.toString(premanagedExclusions, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_PROPERTIES) == DependencyNode.MANAGED_PROPERTIES) {
-                    final Map<String, String> premanagedProperties =
-                            DependencyManagerUtils.getPremanagedProperties(node);
-
-                    buffer.append(" (properties managed from ");
-                    buffer.append(Objects.toString(premanagedProperties, "default"));
-                    buffer.append(')');
-                }
-            }
-
-            logger.debug(buffer.toString());
-            indent += "   ";
-            return true;
-        }
-
-        public boolean visitLeave(DependencyNode node) {
-            indent = indent.substring(0, indent.length() - 3);
-            return true;
         }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/DefaultProjectDependenciesResolver.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
@@ -44,12 +43,12 @@ import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
-import org.eclipse.aether.graph.DependencyVisitor;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
+import org.eclipse.aether.util.graph.visitor.DependencyGraphDumper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,7 +179,7 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
         }
 
         if (logger.isDebugEnabled()) {
-            node.accept(new GraphLogger(project));
+            node.accept(new DependencyGraphDumper(logger::debug));
         }
 
         try {
@@ -205,92 +204,6 @@ public class DefaultProjectDependenciesResolver implements ProjectDependenciesRe
             } else {
                 result.setResolutionErrors(node.getDependency(), ar.getExceptions());
             }
-        }
-    }
-
-    // Keep this class in sync with org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver.GraphLogger
-    class GraphLogger implements DependencyVisitor {
-
-        private final MavenProject project;
-
-        private String indent = "";
-
-        GraphLogger(MavenProject project) {
-            this.project = project;
-        }
-
-        public boolean visitEnter(DependencyNode node) {
-            StringBuilder buffer = new StringBuilder(128);
-            buffer.append(indent);
-            org.eclipse.aether.graph.Dependency dep = node.getDependency();
-            if (dep != null) {
-                org.eclipse.aether.artifact.Artifact art = dep.getArtifact();
-
-                buffer.append(art);
-                if (StringUtils.isNotEmpty(dep.getScope())) {
-                    buffer.append(':').append(dep.getScope());
-                }
-
-                if (dep.isOptional()) {
-                    buffer.append(" (optional)");
-                }
-
-                // TODO We currently cannot tell which <dependencyManagement> section contained the management
-                //      information. When the resolver provides this information, these log messages should be updated
-                //      to contain it.
-                if ((node.getManagedBits() & DependencyNode.MANAGED_SCOPE) == DependencyNode.MANAGED_SCOPE) {
-                    final String premanagedScope = DependencyManagerUtils.getPremanagedScope(node);
-                    buffer.append(" (scope managed from ");
-                    buffer.append(Objects.toString(premanagedScope, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_VERSION) == DependencyNode.MANAGED_VERSION) {
-                    final String premanagedVersion = DependencyManagerUtils.getPremanagedVersion(node);
-                    buffer.append(" (version managed from ");
-                    buffer.append(Objects.toString(premanagedVersion, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_OPTIONAL) == DependencyNode.MANAGED_OPTIONAL) {
-                    final Boolean premanagedOptional = DependencyManagerUtils.getPremanagedOptional(node);
-                    buffer.append(" (optionality managed from ");
-                    buffer.append(Objects.toString(premanagedOptional, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_EXCLUSIONS) == DependencyNode.MANAGED_EXCLUSIONS) {
-                    final Collection<org.eclipse.aether.graph.Exclusion> premanagedExclusions =
-                            DependencyManagerUtils.getPremanagedExclusions(node);
-
-                    buffer.append(" (exclusions managed from ");
-                    buffer.append(Objects.toString(premanagedExclusions, "default"));
-                    buffer.append(')');
-                }
-
-                if ((node.getManagedBits() & DependencyNode.MANAGED_PROPERTIES) == DependencyNode.MANAGED_PROPERTIES) {
-                    final Map<String, String> premanagedProperties =
-                            DependencyManagerUtils.getPremanagedProperties(node);
-
-                    buffer.append(" (properties managed from ");
-                    buffer.append(Objects.toString(premanagedProperties, "default"));
-                    buffer.append(')');
-                }
-            } else {
-                buffer.append(project.getGroupId());
-                buffer.append(':').append(project.getArtifactId());
-                buffer.append(':').append(project.getPackaging());
-                buffer.append(':').append(project.getVersion());
-            }
-
-            logger.debug(buffer.toString());
-            indent += "   ";
-            return true;
-        }
-
-        public boolean visitLeave(DependencyNode node) {
-            indent = indent.substring(0, indent.length() - 3);
-            return true;
         }
     }
 }


### PR DESCRIPTION

Refactored the dependency graph logging by removing the custom `GraphLogger` implementation in both `DefaultProjectDependenciesResolver` and `DefaultPluginDependenciesResolver` and replacing it with `DependencyGraphDumper`.

Simplifies code and leverages existing utility for consistent logging.
