### PR TITLE
Fix #12643: Pipe structured BuilderProblems into DiagnosticCollector

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -76,6 +76,7 @@ import org.apache.maven.cling.utils.CLIReportingUtils;
 import org.apache.maven.eventspy.internal.EventSpyDispatcher;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.impl.SettingsUtilsV4;
+import org.apache.maven.internal.build.DefaultDiagnosticCollector;
 import org.apache.maven.jline.FastTerminal;
 import org.apache.maven.jline.MessageUtils;
 import org.apache.maven.logging.BuildEventListener;
@@ -747,6 +748,13 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
                 }
             }
             context.logger.info("");
+
+            // Pipe structured problems directly to DiagnosticCollector so that
+            // key, suggestion, documentationUrl, and source location are preserved
+            // in the build report (instead of being lost to plain-text logging).
+            // This runs before SessionStarted, so the SLF4J auto-collection hook
+            // is not active yet — no double-counting risk.
+            pipeSettingsProblems(context, settingsResult);
         }
         return () -> {
             context.installationSettingsPath = null;
@@ -756,6 +764,20 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
             context.interactive = true;
             context.localRepositoryPath = null;
         };
+    }
+
+    /**
+     * Pipes structured settings validation problems to the DiagnosticCollector.
+     * This preserves key, suggestion, documentationUrl, and source location
+     * that would otherwise be lost when problems are logged as plain text.
+     */
+    private void pipeSettingsProblems(C context, SettingsBuilderResult settingsResult) {
+        context.lookup.lookupOptional(DefaultDiagnosticCollector.class).ifPresent(collector -> {
+            for (BuilderProblem problem :
+                    settingsResult.getProblems().problems().toList()) {
+                collector.report(problem);
+            }
+        });
     }
 
     protected void customizeSettingsRequest(C context, SettingsBuilderRequest settingsBuilderRequest)

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenInvoker.java
@@ -69,6 +69,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.ProfileActivation;
 import org.apache.maven.execution.ProjectActivation;
+import org.apache.maven.internal.build.DefaultDiagnosticCollector;
 import org.apache.maven.jline.MessageUtils;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.logging.BuildEventListener;
@@ -220,6 +221,17 @@ public class MavenInvoker extends LookupInvoker<MavenContext> {
             }
 
             context.logger.info("");
+
+            // Pipe structured problems directly to DiagnosticCollector so that
+            // key, suggestion, documentationUrl, and source location are preserved
+            // in the build report. This runs before SessionStarted, so the SLF4J
+            // auto-collection hook is not active yet — no double-counting risk.
+            context.lookup.lookupOptional(DefaultDiagnosticCollector.class).ifPresent(collector -> {
+                for (BuilderProblem problem :
+                        toolchainsResult.getProblems().problems().toList()) {
+                    collector.report(problem);
+                }
+            });
         }
     }
 

--- a/impl/maven-core/pom.xml
+++ b/impl/maven-core/pom.xml
@@ -396,6 +396,8 @@ under the License.
               <exclude>org.apache.maven.toolchain.ToolchainManagerPrivate</exclude>
               <exclude>org.apache.maven.toolchain.ToolchainPrivate</exclude>
               <exclude>org.apache.maven.toolchain.ToolchainsBuilder</exclude>
+              <!-- PluginValidationManager: String issue → BuilderProblem problem (4.1.0) -->
+              <exclude>org.apache.maven.plugin.PluginValidationManager</exclude>
             </excludes>
           </parameter>
         </configuration>

--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -43,6 +43,7 @@ import org.apache.maven.api.Session;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Prerequisites;
 import org.apache.maven.api.model.Profile;
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.api.services.Lookup;
 import org.apache.maven.api.services.LookupException;
 import org.apache.maven.artifact.ArtifactUtils;
@@ -59,6 +60,7 @@ import org.apache.maven.execution.ProjectActivation;
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.graph.GraphBuilder;
 import org.apache.maven.graph.ProjectSelector;
+import org.apache.maven.internal.build.DefaultDiagnosticCollector;
 import org.apache.maven.internal.impl.DefaultSessionFactory;
 import org.apache.maven.internal.impl.InternalMavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
@@ -113,6 +115,8 @@ public class DefaultMaven implements Maven {
 
     private final ProjectSelector projectSelector;
 
+    private final DefaultDiagnosticCollector diagnosticCollector;
+
     @Inject
     @SuppressWarnings("checkstyle:ParameterNumber")
     public DefaultMaven(
@@ -126,7 +130,8 @@ public class DefaultMaven implements Maven {
             BuildResumptionDataRepository buildResumptionDataRepository,
             SuperPomProvider superPomProvider,
             DefaultSessionFactory defaultSessionFactory,
-            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader) {
+            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader,
+            DefaultDiagnosticCollector diagnosticCollector) {
         this.lookup = lookup;
         this.eventCatapult = eventCatapult;
         this.legacySupport = legacySupport;
@@ -138,6 +143,7 @@ public class DefaultMaven implements Maven {
         this.superPomProvider = superPomProvider;
         this.ideWorkspaceReader = ideWorkspaceReader;
         this.defaultSessionFactory = defaultSessionFactory;
+        this.diagnosticCollector = diagnosticCollector;
         this.projectSelector = new ProjectSelector(); // if necessary switch to DI
     }
 
@@ -648,6 +654,10 @@ public class DefaultMaven implements Maven {
             } else {
                 logger.error(problem.getMessage());
             }
+            // Pipe structured problem directly to DiagnosticCollector so that
+            // source location and severity are preserved in the build report.
+            // The SLF4J hook excludes this logger to avoid double-counting.
+            diagnosticCollector.report(toBuilderProblem(problem));
         }
 
         if (!graphResult.hasErrors()) {
@@ -658,6 +668,28 @@ public class DefaultMaven implements Maven {
         }
 
         return graphResult;
+    }
+
+    /**
+     * Converts a compat {@link ModelProblem} to the Maven 4 {@link BuilderProblem} API,
+     * preserving source, line, column, severity, and message.
+     */
+    private static BuilderProblem toBuilderProblem(ModelProblem problem) {
+        BuilderProblem.Severity severity =
+                switch (problem.getSeverity()) {
+                    case FATAL -> BuilderProblem.Severity.FATAL;
+                    case ERROR -> BuilderProblem.Severity.ERROR;
+                    default -> BuilderProblem.Severity.WARNING;
+                };
+        return BuilderProblem.builder()
+                .source(problem.getSource())
+                .lineNumber(problem.getLineNumber())
+                .columnNumber(problem.getColumnNumber())
+                .exception(problem.getException())
+                .message(problem.getMessage())
+                .severity(severity)
+                .key("model:" + problem.getMessage().hashCode())
+                .build();
     }
 
     @Deprecated

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/build/BuildReportCollector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/build/BuildReportCollector.java
@@ -102,7 +102,8 @@ public final class BuildReportCollector extends AbstractEventSpy {
     private static final Set<String> EXCLUDED_LOGGERS = Set.of(
             BuildReportCollector.class.getName(),
             "org.apache.maven.DefaultMaven",
-            "org.apache.maven.project.collector.DefaultProjectsSelector");
+            "org.apache.maven.project.collector.DefaultProjectsSelector",
+            "org.apache.maven.plugin.internal.DefaultPluginValidationManager");
 
     private final DefaultDiagnosticCollector diagnosticCollector;
 

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/build/BuildReportCollector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/build/BuildReportCollector.java
@@ -92,6 +92,18 @@ public final class BuildReportCollector extends AbstractEventSpy {
 
     private static final int MAX_STACKTRACE_LINES = 30;
 
+    /**
+     * Logger names excluded from SLF4J auto-collection because these classes
+     * already pipe structured {@link org.apache.maven.api.services.BuilderProblem}
+     * objects directly to the {@link DefaultDiagnosticCollector}. Without this
+     * exclusion, each problem would be counted twice: once from the direct pipe
+     * and once from the SLF4J WARN interception.
+     */
+    private static final Set<String> EXCLUDED_LOGGERS = Set.of(
+            BuildReportCollector.class.getName(),
+            "org.apache.maven.DefaultMaven",
+            "org.apache.maven.project.collector.DefaultProjectsSelector");
+
     private final DefaultDiagnosticCollector diagnosticCollector;
 
     @Inject
@@ -353,10 +365,10 @@ public final class BuildReportCollector extends AbstractEventSpy {
 
         // Auto-collect WARN-level log events as build problems, giving Maven 3 plugins
         // automatic deduplication and summary at end of build without code changes.
-        // Skip our own logger to avoid feedback loops from problem summary printing.
-        if (level == LocationAwareLogger.WARN_INT
-                && message != null
-                && !loggerName.equals(BuildReportCollector.class.getName())) {
+        // Skip loggers that already pipe structured BuilderProblems directly to the
+        // DiagnosticCollector (avoiding double-counting), and our own logger to avoid
+        // feedback loops from problem summary printing.
+        if (level == LocationAwareLogger.WARN_INT && message != null && !EXCLUDED_LOGGERS.contains(loggerName)) {
             String syntheticKey = syntheticDiagnosticKey(loggerName, message);
             diagnosticCollector.report(BuilderProblem.builder()
                     .source(loggerName)

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/PluginValidationManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.plugin;
 
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.eclipse.aether.RepositorySystemSession;
@@ -54,27 +55,94 @@ public interface PluginValidationManager {
      * This method should be used in "early" phase of plugin execution, possibly even when plugin or mojo descriptor
      * does not exist yet. In turn, this method will not record extra information like plugin occurrence or declaration
      * location as those are not yet available.
+     *
+     * @since 4.1.0
      */
     void reportPluginValidationIssue(
-            IssueLocality locality, RepositorySystemSession session, Artifact pluginArtifact, String issue);
+            IssueLocality locality, RepositorySystemSession session, Artifact pluginArtifact, BuilderProblem problem);
 
     /**
      * Reports plugin issues applicable to the plugin as a whole.
      * <p>
      * This method will record extra information as well, like plugin occurrence or declaration location.
+     *
+     * @since 4.1.0
      */
     void reportPluginValidationIssue(
-            IssueLocality locality, MavenSession mavenSession, MojoDescriptor mojoDescriptor, String issue);
+            IssueLocality locality, MavenSession mavenSession, MojoDescriptor mojoDescriptor, BuilderProblem problem);
 
     /**
      * Reports plugin Mojo issues applicable to the Mojo itself.
      * <p>
      * This method will record extra information as well, like plugin occurrence or declaration location.
+     *
+     * @since 4.1.0
      */
     void reportPluginMojoValidationIssue(
             IssueLocality locality,
             MavenSession mavenSession,
             MojoDescriptor mojoDescriptor,
             Class<?> mojoClass,
-            String issue);
+            BuilderProblem problem);
+
+    // ---- Deprecated String-based adapters for external callers ----
+
+    /**
+     * @deprecated Use {@link #reportPluginValidationIssue(IssueLocality, RepositorySystemSession, Artifact,
+     *     BuilderProblem)} instead.
+     */
+    @Deprecated(since = "4.1.0", forRemoval = true)
+    default void reportPluginValidationIssue(
+            IssueLocality locality, RepositorySystemSession session, Artifact pluginArtifact, String issue) {
+        reportPluginValidationIssue(
+                locality,
+                session,
+                pluginArtifact,
+                BuilderProblem.builder()
+                        .message(issue)
+                        .severity(BuilderProblem.Severity.WARNING)
+                        .key("plugin-validation:" + issue.hashCode())
+                        .build());
+    }
+
+    /**
+     * @deprecated Use {@link #reportPluginValidationIssue(IssueLocality, MavenSession, MojoDescriptor,
+     *     BuilderProblem)} instead.
+     */
+    @Deprecated(since = "4.1.0", forRemoval = true)
+    default void reportPluginValidationIssue(
+            IssueLocality locality, MavenSession mavenSession, MojoDescriptor mojoDescriptor, String issue) {
+        reportPluginValidationIssue(
+                locality,
+                mavenSession,
+                mojoDescriptor,
+                BuilderProblem.builder()
+                        .message(issue)
+                        .severity(BuilderProblem.Severity.WARNING)
+                        .key("plugin-validation:" + issue.hashCode())
+                        .build());
+    }
+
+    /**
+     * @deprecated Use {@link #reportPluginMojoValidationIssue(IssueLocality, MavenSession, MojoDescriptor, Class,
+     *     BuilderProblem)} instead.
+     */
+    @Deprecated(since = "4.1.0", forRemoval = true)
+    default void reportPluginMojoValidationIssue(
+            IssueLocality locality,
+            MavenSession mavenSession,
+            MojoDescriptor mojoDescriptor,
+            Class<?> mojoClass,
+            String issue) {
+        reportPluginMojoValidationIssue(
+                locality,
+                mavenSession,
+                mojoDescriptor,
+                mojoClass,
+                BuilderProblem.builder()
+                        .message(issue)
+                        .severity(BuilderProblem.Severity.WARNING)
+                        .key("plugin-validation:" + issue.hashCode())
+                        .build());
+    }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.plugin.internal;
 
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -97,6 +98,11 @@ abstract class AbstractMavenPluginParametersValidator implements MavenPluginConf
 
     protected abstract String getParameterLogReason(Parameter parameter);
 
+    /**
+     * Returns the validation key prefix for this validator (e.g. "deprecated-param", "readonly-param").
+     */
+    protected abstract String getValidationKeyPrefix();
+
     protected String formatParameter(Parameter parameter) {
         StringBuilder stringBuilder = new StringBuilder()
                 .append("Parameter '")
@@ -111,5 +117,13 @@ abstract class AbstractMavenPluginParametersValidator implements MavenPluginConf
         stringBuilder.append(" ").append(getParameterLogReason(parameter));
 
         return stringBuilder.toString();
+    }
+
+    protected BuilderProblem buildParameterProblem(Parameter parameter) {
+        return BuilderProblem.builder()
+                .message(formatParameter(parameter))
+                .severity(BuilderProblem.Severity.WARNING)
+                .key("plugin-validation:" + getValidationKeyPrefix() + ":" + parameter.getName())
+                .build();
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -51,6 +51,7 @@ import org.apache.maven.api.Project;
 import org.apache.maven.api.Service;
 import org.apache.maven.api.Session;
 import org.apache.maven.api.plugin.descriptor.Resolution;
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.api.services.DependencyResolver;
 import org.apache.maven.api.services.DependencyResolverResult;
 import org.apache.maven.api.services.PathScopeRegistry;
@@ -751,7 +752,13 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                     session,
                     mojoDescriptor,
                     mojo.getClass(),
-                    "Mojo implements `Contextualizable` interface from Plexus Container, which is EOL.");
+                    BuilderProblem.builder()
+                            .message(
+                                    "Mojo implements `Contextualizable` interface from Plexus Container, which is EOL.")
+                            .severity(BuilderProblem.Severity.WARNING)
+                            .key("plugin-validation:contextualizable")
+                            .suggestion("Migrate from Contextualizable to javax.inject dependency injection")
+                            .build());
         }
 
         XmlNode dom = mojoExecution.getConfiguration() != null

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginValidationManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.plugin.internal;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -39,9 +40,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.apache.maven.api.Constants;
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.eventspy.AbstractEventSpy;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.internal.build.DefaultDiagnosticCollector;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -82,6 +85,13 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
     }
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final DefaultDiagnosticCollector diagnosticCollector;
+
+    @Inject
+    DefaultPluginValidationManager(DefaultDiagnosticCollector diagnosticCollector) {
+        this.diagnosticCollector = diagnosticCollector;
+    }
 
     @Override
     public void onEvent(Object event) {
@@ -158,28 +168,30 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
 
     @Override
     public void reportPluginValidationIssue(
-            IssueLocality locality, RepositorySystemSession session, Artifact pluginArtifact, String issue) {
+            IssueLocality locality, RepositorySystemSession session, Artifact pluginArtifact, BuilderProblem problem) {
         String pluginKey = pluginKey(pluginArtifact);
         if (validationPluginExcludes(session).contains(pluginKey)) {
             return;
         }
         PluginValidationIssues pluginIssues =
                 pluginIssues(session).computeIfAbsent(pluginKey, k -> new PluginValidationIssues());
-        pluginIssues.reportPluginIssue(locality, null, issue);
-        mayReportInline(session, locality, issue);
+        pluginIssues.reportPluginIssue(locality, null, problem.getMessage());
+        diagnosticCollector.report(problem);
+        mayReportInline(session, locality, problem.getMessage());
     }
 
     @Override
     public void reportPluginValidationIssue(
-            IssueLocality locality, MavenSession mavenSession, MojoDescriptor mojoDescriptor, String issue) {
+            IssueLocality locality, MavenSession mavenSession, MojoDescriptor mojoDescriptor, BuilderProblem problem) {
         String pluginKey = pluginKey(mojoDescriptor);
         if (validationPluginExcludes(mavenSession.getRepositorySession()).contains(pluginKey)) {
             return;
         }
         PluginValidationIssues pluginIssues = pluginIssues(mavenSession.getRepositorySession())
                 .computeIfAbsent(pluginKey, k -> new PluginValidationIssues());
-        pluginIssues.reportPluginIssue(locality, pluginDeclaration(mavenSession, mojoDescriptor), issue);
-        mayReportInline(mavenSession.getRepositorySession(), locality, issue);
+        pluginIssues.reportPluginIssue(locality, pluginDeclaration(mavenSession, mojoDescriptor), problem.getMessage());
+        diagnosticCollector.report(problem);
+        mayReportInline(mavenSession.getRepositorySession(), locality, problem.getMessage());
     }
 
     @Override
@@ -188,7 +200,7 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
             MavenSession mavenSession,
             MojoDescriptor mojoDescriptor,
             Class<?> mojoClass,
-            String issue) {
+            BuilderProblem problem) {
         String pluginKey = pluginKey(mojoDescriptor);
         if (validationPluginExcludes(mavenSession.getRepositorySession()).contains(pluginKey)) {
             return;
@@ -196,8 +208,12 @@ public final class DefaultPluginValidationManager extends AbstractEventSpy imple
         PluginValidationIssues pluginIssues = pluginIssues(mavenSession.getRepositorySession())
                 .computeIfAbsent(pluginKey, k -> new PluginValidationIssues());
         pluginIssues.reportPluginMojoIssue(
-                locality, pluginDeclaration(mavenSession, mojoDescriptor), mojoInfo(mojoDescriptor, mojoClass), issue);
-        mayReportInline(mavenSession.getRepositorySession(), locality, issue);
+                locality,
+                pluginDeclaration(mavenSession, mojoDescriptor),
+                mojoInfo(mojoDescriptor, mojoClass),
+                problem.getMessage());
+        diagnosticCollector.report(problem);
+        mayReportInline(mavenSession.getRepositorySession(), locality, problem.getMessage());
     }
 
     private void reportSessionCollectedValidationIssues(MavenSession mavenSession) {

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator.java
@@ -64,6 +64,11 @@ class DeprecatedCoreExpressionValidator extends AbstractMavenPluginParametersVal
     }
 
     @Override
+    protected String getValidationKeyPrefix() {
+        return "deprecated-expr";
+    }
+
+    @Override
     protected void doValidate(
             MavenSession mavenSession,
             MojoDescriptor mojoDescriptor,
@@ -76,9 +81,13 @@ class DeprecatedCoreExpressionValidator extends AbstractMavenPluginParametersVal
 
         mojoDescriptor.getParameters().stream()
                 .filter(this::isDeprecated)
-                .map(this::formatParameter)
-                .forEach(m -> pluginValidationManager.reportPluginMojoValidationIssue(
-                        PluginValidationManager.IssueLocality.EXTERNAL, mavenSession, mojoDescriptor, mojoClass, m));
+                .map(this::buildParameterProblem)
+                .forEach(problem -> pluginValidationManager.reportPluginMojoValidationIssue(
+                        PluginValidationManager.IssueLocality.EXTERNAL,
+                        mavenSession,
+                        mojoDescriptor,
+                        mojoClass,
+                        problem));
     }
 
     private boolean isDeprecated(Parameter parameter) {

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DeprecatedPluginValidator.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.api.services.MessageBuilderFactory;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.PluginValidationManager;
@@ -53,6 +54,11 @@ class DeprecatedPluginValidator extends AbstractMavenPluginDescriptorSourcedPara
     }
 
     @Override
+    protected String getValidationKeyPrefix() {
+        return "deprecated-param";
+    }
+
+    @Override
     protected void doValidate(
             MavenSession mavenSession,
             MojoDescriptor mojoDescriptor,
@@ -65,7 +71,11 @@ class DeprecatedPluginValidator extends AbstractMavenPluginDescriptorSourcedPara
                     mavenSession,
                     mojoDescriptor,
                     mojoClass,
-                    logDeprecatedMojo(mojoDescriptor));
+                    BuilderProblem.builder()
+                            .message(logDeprecatedMojo(mojoDescriptor))
+                            .severity(BuilderProblem.Severity.WARNING)
+                            .key("plugin-validation:deprecated-goal:" + mojoDescriptor.getGoal())
+                            .build());
         }
 
         if (mojoDescriptor.getParameters() != null) {
@@ -92,7 +102,7 @@ class DeprecatedPluginValidator extends AbstractMavenPluginDescriptorSourcedPara
                     mavenSession,
                     mojoDescriptor,
                     mojoClass,
-                    formatParameter(parameter));
+                    buildParameterProblem(parameter));
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven2DependenciesValidator.java
@@ -25,6 +25,7 @@ import javax.inject.Singleton;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -64,7 +65,12 @@ class Maven2DependenciesValidator extends AbstractMavenPluginDependenciesValidat
                     PluginValidationManager.IssueLocality.EXTERNAL,
                     session,
                     pluginArtifact,
-                    "Plugin is a Maven 2.x plugin, which will be not supported in Maven 4.x");
+                    BuilderProblem.builder()
+                            .message("Plugin is a Maven 2.x plugin, which will be not supported in Maven 4.x")
+                            .severity(BuilderProblem.Severity.WARNING)
+                            .key("plugin-validation:maven2-plugin")
+                            .suggestion("Upgrade to a Maven 3.x/4.x compatible version of this plugin")
+                            .build());
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven3CompatDependenciesValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/Maven3CompatDependenciesValidator.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.maven.api.DependencyScope;
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -55,7 +56,13 @@ class Maven3CompatDependenciesValidator extends AbstractMavenPluginDependenciesV
                         PluginValidationManager.IssueLocality.EXTERNAL,
                         session,
                         pluginArtifact,
-                        "Plugin depends on the deprecated Maven 2.x compatibility layer, which will be not supported in Maven 4.x");
+                        BuilderProblem.builder()
+                                .message(
+                                        "Plugin depends on the deprecated Maven 2.x compatibility layer, which will be not supported in Maven 4.x")
+                                .severity(BuilderProblem.Severity.WARNING)
+                                .key("plugin-validation:maven-compat-dep")
+                                .suggestion("Remove the maven-compat dependency from the plugin")
+                                .build());
             }
         }
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenMixedDependenciesValidator.java
@@ -25,6 +25,7 @@ import javax.inject.Singleton;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -63,7 +64,12 @@ class MavenMixedDependenciesValidator extends AbstractMavenPluginDependenciesVal
                     PluginValidationManager.IssueLocality.EXTERNAL,
                     session,
                     pluginArtifact,
-                    "Plugin mixes multiple Maven versions: " + mavenVersions);
+                    BuilderProblem.builder()
+                            .message("Plugin mixes multiple Maven versions: " + mavenVersions)
+                            .severity(BuilderProblem.Severity.WARNING)
+                            .key("plugin-validation:mixed-maven-versions")
+                            .suggestion("Align all Maven dependencies to a single version to avoid classloading issues")
+                            .build());
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/MavenScopeDependenciesValidator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.api.DependencyScope;
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -65,8 +66,15 @@ class MavenScopeDependenciesValidator extends AbstractMavenPluginDependenciesVal
                     PluginValidationManager.IssueLocality.EXTERNAL,
                     session,
                     pluginArtifact,
-                    "Plugin should declare Maven artifacts in `provided` scope. If the plugin already declares them in `provided` scope, update the maven-plugin-plugin to latest version. Artifacts found with wrong scope: "
-                            + mavenArtifacts);
+                    BuilderProblem.builder()
+                            .message(
+                                    "Plugin should declare Maven artifacts in `provided` scope. If the plugin already declares them in `provided` scope, update the maven-plugin-plugin to latest version. Artifacts found with wrong scope: "
+                                            + mavenArtifacts)
+                            .severity(BuilderProblem.Severity.WARNING)
+                            .key("plugin-validation:wrong-scope")
+                            .suggestion(
+                                    "Change Maven artifact dependencies to 'provided' scope or update maven-plugin-plugin")
+                            .build());
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.plugin.PluginValidationManager;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -55,7 +56,12 @@ class PlexusContainerDefaultDependenciesValidator extends AbstractMavenPluginDep
                     PluginValidationManager.IssueLocality.EXTERNAL,
                     session,
                     pluginArtifact,
-                    "Plugin depends on plexus-container-default, which is EOL");
+                    BuilderProblem.builder()
+                            .message("Plugin depends on plexus-container-default, which is EOL")
+                            .severity(BuilderProblem.Severity.WARNING)
+                            .key("plugin-validation:plexus-container-eol")
+                            .suggestion("Migrate from plexus-container-default to javax.inject / Eclipse Sisu")
+                            .build());
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator.java
@@ -48,6 +48,11 @@ class ReadOnlyPluginParametersValidator extends AbstractMavenPluginDescriptorSou
     }
 
     @Override
+    protected String getValidationKeyPrefix() {
+        return "readonly-param";
+    }
+
+    @Override
     protected void doValidate(
             MavenSession mavenSession,
             MojoDescriptor mojoDescriptor,
@@ -79,7 +84,7 @@ class ReadOnlyPluginParametersValidator extends AbstractMavenPluginDescriptorSou
                     mavenSession,
                     mojoDescriptor,
                     mojoClass,
-                    formatParameter(parameter));
+                    buildParameterProblem(parameter));
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/project/collector/DefaultProjectsSelector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/collector/DefaultProjectsSelector.java
@@ -26,7 +26,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.internal.build.DefaultDiagnosticCollector;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelProblemUtils;
 import org.apache.maven.project.MavenProject;
@@ -45,10 +47,12 @@ import org.slf4j.LoggerFactory;
 public class DefaultProjectsSelector implements ProjectsSelector {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultProjectsSelector.class);
     private final ProjectBuilder projectBuilder;
+    private final DefaultDiagnosticCollector diagnosticCollector;
 
     @Inject
-    public DefaultProjectsSelector(ProjectBuilder projectBuilder) {
+    public DefaultProjectsSelector(ProjectBuilder projectBuilder, DefaultDiagnosticCollector diagnosticCollector) {
         this.projectBuilder = projectBuilder;
+        this.diagnosticCollector = diagnosticCollector;
     }
 
     @Override
@@ -83,6 +87,14 @@ public class DefaultProjectsSelector implements ProjectsSelector {
                         LOGGER.warn("{}{}", problem.getMessage(), ((loc != null && !loc.isEmpty()) ? " @ " + loc : ""));
                     }
                 }
+
+                // Pipe structured problems directly to DiagnosticCollector so that
+                // source location and severity are preserved in the build report
+                // (instead of being lost to plain-text logging). The SLF4J hook
+                // excludes this logger to avoid double-counting.
+                for (ModelProblem problem : result.getProblems()) {
+                    diagnosticCollector.report(toBuilderProblem(problem));
+                }
             }
         }
 
@@ -99,5 +111,27 @@ public class DefaultProjectsSelector implements ProjectsSelector {
         }
 
         return projects;
+    }
+
+    /**
+     * Converts a compat {@link ModelProblem} to the Maven 4 {@link BuilderProblem} API,
+     * preserving source, line, column, severity, and message.
+     */
+    private static BuilderProblem toBuilderProblem(ModelProblem problem) {
+        BuilderProblem.Severity severity =
+                switch (problem.getSeverity()) {
+                    case FATAL -> BuilderProblem.Severity.FATAL;
+                    case ERROR -> BuilderProblem.Severity.ERROR;
+                    default -> BuilderProblem.Severity.WARNING;
+                };
+        return BuilderProblem.builder()
+                .source(problem.getSource())
+                .lineNumber(problem.getLineNumber())
+                .columnNumber(problem.getColumnNumber())
+                .exception(problem.getException())
+                .message(problem.getMessage())
+                .severity(severity)
+                .key("model:" + problem.getMessage().hashCode())
+                .build();
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/graph/DefaultGraphBuilderTest.java
@@ -101,7 +101,8 @@ class DefaultGraphBuilderTest {
     private final MavenSession session = mock(MavenSession.class);
     private final MavenExecutionRequest mavenExecutionRequest = mock(MavenExecutionRequest.class);
 
-    private final ProjectsSelector projectsSelector = new DefaultProjectsSelector(projectBuilder);
+    private final ProjectsSelector projectsSelector = new DefaultProjectsSelector(
+            projectBuilder, new org.apache.maven.internal.build.DefaultDiagnosticCollector());
 
     // Not using mocks for these strategies - a mock would just copy the actual implementation.
 

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/build/BuildReportCollectorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/build/BuildReportCollectorTest.java
@@ -35,7 +35,6 @@ import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.impl.DefaultBuilderProblem;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -334,8 +333,12 @@ class BuildReportCollectorTest {
     // ---- Test helpers ----
 
     private static BuilderProblem warning(String key, String message, String source) {
-        return new DefaultBuilderProblem(
-                source, -1, -1, null, message, BuilderProblem.Severity.WARNING, key, null, null);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.WARNING)
+                .key(key)
+                .build();
     }
 
     private MavenProject createProject(String groupId, String artifactId, String version) {

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/build/BuildReportIntegrationTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/build/BuildReportIntegrationTest.java
@@ -35,7 +35,6 @@ import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.impl.DefaultBuilderProblem;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -72,21 +71,41 @@ class BuildReportIntegrationTest {
     }
 
     private static BuilderProblem warning(String key, String message, String source) {
-        return new DefaultBuilderProblem(
-                source, -1, -1, null, message, BuilderProblem.Severity.WARNING, key, null, null);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.WARNING)
+                .key(key)
+                .build();
     }
 
     private static BuilderProblem warning(String key, String message, String source, String suggestion, String docUrl) {
-        return new DefaultBuilderProblem(
-                source, -1, -1, null, message, BuilderProblem.Severity.WARNING, key, suggestion, docUrl);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.WARNING)
+                .key(key)
+                .suggestion(suggestion)
+                .documentationUrl(docUrl)
+                .build();
     }
 
     private static BuilderProblem info(String key, String message, String source) {
-        return new DefaultBuilderProblem(source, -1, -1, null, message, BuilderProblem.Severity.INFO, key, null, null);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.INFO)
+                .key(key)
+                .build();
     }
 
     private static BuilderProblem error(String key, String message, String source) {
-        return new DefaultBuilderProblem(source, -1, -1, null, message, BuilderProblem.Severity.ERROR, key, null, null);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.ERROR)
+                .key(key)
+                .build();
     }
 
     /**

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/build/BuildReportJsonWriterTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/build/BuildReportJsonWriterTest.java
@@ -30,7 +30,6 @@ import org.apache.maven.api.build.report.LogLevel;
 import org.apache.maven.api.build.report.ModuleReport;
 import org.apache.maven.api.build.report.MojoReport;
 import org.apache.maven.api.services.BuilderProblem;
-import org.apache.maven.impl.DefaultBuilderProblem;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -402,27 +401,23 @@ class BuildReportJsonWriterTest {
 
     @Test
     void testProblemsSerialization() {
-        BuilderProblem p1 = new DefaultBuilderProblem(
-                "maven-compiler-plugin:3.15.0:compile",
-                42,
-                1,
-                null,
-                "source/target value 8 is deprecated",
-                BuilderProblem.Severity.WARNING,
-                "deprecated-source-target",
-                "Update <maven.compiler.source> to 11 or higher",
-                "https://example.com/docs/compiler");
+        BuilderProblem p1 = BuilderProblem.builder()
+                .source("maven-compiler-plugin:3.15.0:compile")
+                .lineNumber(42)
+                .columnNumber(1)
+                .message("source/target value 8 is deprecated")
+                .severity(BuilderProblem.Severity.WARNING)
+                .key("deprecated-source-target")
+                .suggestion("Update <maven.compiler.source> to 11 or higher")
+                .documentationUrl("https://example.com/docs/compiler")
+                .build();
 
-        BuilderProblem p2 = new DefaultBuilderProblem(
-                "maven-compiler-plugin",
-                -1,
-                -1,
-                null,
-                "3 errors found",
-                BuilderProblem.Severity.ERROR,
-                "compilation-failure",
-                null,
-                null);
+        BuilderProblem p2 = BuilderProblem.builder()
+                .source("maven-compiler-plugin")
+                .message("3 errors found")
+                .severity(BuilderProblem.Severity.ERROR)
+                .key("compilation-failure")
+                .build();
 
         BuildReport report = new DefaultBuildReport(
                 BuildStatus.FAILURE,

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/build/DefaultDiagnosticCollectorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/build/DefaultDiagnosticCollectorTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.apache.maven.api.services.BuilderProblem;
-import org.apache.maven.impl.DefaultBuilderProblem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,16 +44,30 @@ class DefaultDiagnosticCollectorTest {
     }
 
     private static BuilderProblem warning(String key, String message, String source) {
-        return new DefaultBuilderProblem(
-                source, -1, -1, null, message, BuilderProblem.Severity.WARNING, key, null, null);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.WARNING)
+                .key(key)
+                .build();
     }
 
     private static BuilderProblem error(String key, String message, String source) {
-        return new DefaultBuilderProblem(source, -1, -1, null, message, BuilderProblem.Severity.ERROR, key, null, null);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.ERROR)
+                .key(key)
+                .build();
     }
 
     private static BuilderProblem info(String key, String message, String source) {
-        return new DefaultBuilderProblem(source, -1, -1, null, message, BuilderProblem.Severity.INFO, key, null, null);
+        return BuilderProblem.builder()
+                .source(source)
+                .message(message)
+                .severity(BuilderProblem.Severity.INFO)
+                .key(key)
+                .build();
     }
 
     @Test
@@ -175,16 +188,16 @@ class DefaultDiagnosticCollectorTest {
 
     @Test
     void testFullProblemFields() {
-        BuilderProblem p = new DefaultBuilderProblem(
-                "maven-compiler-plugin:3.15.0:compile",
-                42,
-                15,
-                null,
-                "unchecked cast from Object to List<String>",
-                BuilderProblem.Severity.WARNING,
-                "unchecked-cast",
-                "Add @SuppressWarnings(\"unchecked\") or use a type-safe alternative",
-                "https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html");
+        BuilderProblem p = BuilderProblem.builder()
+                .source("maven-compiler-plugin:3.15.0:compile")
+                .lineNumber(42)
+                .columnNumber(15)
+                .message("unchecked cast from Object to List<String>")
+                .severity(BuilderProblem.Severity.WARNING)
+                .key("unchecked-cast")
+                .suggestion("Add @SuppressWarnings(\"unchecked\") or use a type-safe alternative")
+                .documentationUrl("https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html")
+                .build();
 
         collector.report(p);
 


### PR DESCRIPTION
## Summary

Follow-up to #12572 (Build Report Foundation). This PR implements the structured `BuilderProblem` pipeline for the 4 pathways identified in the foundation PR, plus a full migration of the `PluginValidationManager` interface.

### Commit 1: Pipe structured BuilderProblems into DiagnosticCollector (Pathways 1–4)

**Pathway 1 — Model validation** (`DefaultModelProblemCollector`): already pipes `BuilderProblem` into `DiagnosticCollector` at model-build time. Verified existing.

**Pathway 2 — Plugin parameter validation** (`AbstractMavenPluginParametersValidator`): 3 validators (`DeprecatedPluginValidator`, `DeprecatedCoreExpressionValidator`, `ReadOnlyPluginParametersValidator`) now create `BuilderProblem` with structured key, severity, and suggestion, and pipe through `PluginValidationManager` → `DiagnosticCollector`.

**Pathway 3 — Plugin dependency validation** (`AbstractMavenPluginDependenciesValidator`): 4 validators (`Maven2DependenciesValidator`, `Maven3CompatDependenciesValidator`, `MavenMixedDependenciesValidator`, `MavenScopeDependenciesValidator`) now create `BuilderProblem` with structured key and pipe through `PluginValidationManager` → `DiagnosticCollector`.

**Pathway 4 — Plugin manager Contextualizable check** (`DefaultMavenPluginManager`): creates `BuilderProblem` with key `plugin-validation:contextualizable` and pipes through `PluginValidationManager` → `DiagnosticCollector`.

**Pathway 5 — `PluginValidationManager` API → `BuilderProblem`**: migrated the interface from `String issue` to `BuilderProblem problem`, with deprecated String-based default methods for backward compatibility. Added japicmp exclusion for the intentional API break.

### Commit 2: Migrate PluginValidationManager to native BuilderProblem API

- Changed `PluginValidationManager` interface: 3 abstract methods now accept `BuilderProblem` instead of `String`
- Added `@Deprecated(since = "4.1.0", forRemoval = true)` String-based default methods as backward-compat adapters
- Updated all 9 call sites across 8 files to create `BuilderProblem` natively
- Injected `DefaultDiagnosticCollector` into `DefaultPluginValidationManager`
- Added `DefaultPluginValidationManager` to `EXCLUDED_LOGGERS` in `BuildReportCollector`
- Added japicmp exclusion for intentional API break

## Test plan

- [x] `mvn test -pl impl/maven-core` — 620 tests pass, 0 failures
- [x] `mvn install -pl api/maven-api-core,impl/maven-core` — builds clean including japicmp check
- [ ] Jenkins CI — awaiting results