### PR TITLE
Add validation for Plexus-based plugin dependency injection

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Verify that plugin descriptor does not contain Plexus Component requirements.
+ */
+@Singleton
+@Named
+class PluginDescriptorRequirementsValidator implements MavenPluginConfigurationValidator {
+
+    protected final PluginValidationManager pluginValidationManager;
+
+    @Inject
+    PluginDescriptorRequirementsValidator(PluginValidationManager pluginValidationManager) {
+        this.pluginValidationManager = requireNonNull(pluginValidationManager);
+    }
+
+    @Override
+    public void validate(
+            MavenSession mavenSession,
+            MojoDescriptor mojoDescriptor,
+            Class<?> mojoClass,
+            PlexusConfiguration pomConfiguration,
+            ExpressionEvaluator expressionEvaluator) {
+        if (!mojoDescriptor.getRequirements().isEmpty()) {
+            pluginValidationManager.reportPluginMojoValidationIssue(
+                    PluginValidationManager.IssueLocality.EXTERNAL,
+                    mavenSession,
+                    mojoDescriptor,
+                    mojoClass,
+                    "Plugin uses Plexus Component requirements (@Component annotation). "
+                            + "Use Maven 4 Dependency Injection (for v4 plugins) or JSR 330 annotations (for v3 plugins) to inject dependencies instead.");
+        }
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidator.java
@@ -32,12 +32,14 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Verify that plugin descriptor does not contain Plexus Component requirements.
+ *
+ * @since 3.10.0
  */
 @Singleton
 @Named
 class PluginDescriptorRequirementsValidator implements MavenPluginConfigurationValidator {
 
-    protected final PluginValidationManager pluginValidationManager;
+    private final PluginValidationManager pluginValidationManager;
 
     @Inject
     PluginDescriptorRequirementsValidator(PluginValidationManager pluginValidationManager) {

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDescriptorRequirementsValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.PluginValidationManager;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PluginDescriptorRequirementsValidatorTest {
+
+    @Mock
+    private PluginValidationManager pluginValidationManager;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private MojoDescriptor mojoDescriptor;
+
+    @InjectMocks
+    private PluginDescriptorRequirementsValidator validator;
+
+    private final Class<?> mojoClass = PluginDescriptorRequirementsValidatorTest.class;
+
+    @Test
+    void testValidateReportsIssueWhenMojoHasRequirements() {
+        when(mojoDescriptor.getRequirements()).thenReturn(List.of(new ComponentRequirement()));
+
+        validator.validate(mavenSession, mojoDescriptor, mojoClass, null, null);
+
+        verify(pluginValidationManager)
+                .reportPluginMojoValidationIssue(
+                        eq(PluginValidationManager.IssueLocality.EXTERNAL),
+                        eq(mavenSession),
+                        eq(mojoDescriptor),
+                        eq(mojoClass),
+                        contains("Plugin uses Plexus Component requirements"));
+    }
+
+    @Test
+    void testValidateDoesNotReportIssueWhenMojoHasNoRequirements() {
+        when(mojoDescriptor.getRequirements()).thenReturn(Collections.emptyList());
+
+        validator.validate(mavenSession, mojoDescriptor, mojoClass, null, null);
+
+        verify(pluginValidationManager, never())
+                .reportPluginMojoValidationIssue(
+                        any(PluginValidationManager.IssueLocality.class),
+                        any(MavenSession.class),
+                        any(MojoDescriptor.class),
+                        any(Class.class),
+                        any(String.class));
+    }
+}


### PR DESCRIPTION
* Add validation for Plexus-based plugin dependency injection

What changed

- Added a new validation that detects outdated dependency injection usage in plugins.
- Added a clear warning for plugin developers when this pattern is found.
- Pointed users to the recommended modern injection approach.

(cherry picked from commit 2a8b6b243ea1b87c76b5eec9bd8a375d5361706f)

