### PR TITLE
Add AsyncDrainWriter to eliminate PrintWriter lock contention

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -78,6 +78,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.impl.SettingsUtilsV4;
 import org.apache.maven.jline.FastTerminal;
 import org.apache.maven.jline.MessageUtils;
+import org.apache.maven.logging.AsyncDrainWriter;
 import org.apache.maven.logging.BuildEventListener;
 import org.apache.maven.logging.LoggingOutputStream;
 import org.apache.maven.logging.ProjectBuildLogAppender;
@@ -415,24 +416,30 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
     }
 
     protected Consumer<String> doDetermineWriter(C context) {
+        Consumer<String> raw;
         if (context.options().logFile().isPresent()) {
             Path logFile = context.cwd.resolve(context.options().logFile().get());
             try {
                 PrintWriter printWriter = new PrintWriter(Files.newBufferedWriter(logFile), true);
                 context.closeables.add(printWriter);
-                return printWriter::println;
+                raw = printWriter::println;
             } catch (IOException e) {
                 throw new MavenException("Unable to redirect logging to " + logFile, e);
             }
         } else {
             // Given the terminal creation has been offloaded to a different thread,
             // do not pass directly the terminal writer
-            return msg -> {
+            raw = msg -> {
                 PrintWriter pw = context.terminal.writer();
                 pw.println(msg);
                 pw.flush();
             };
         }
+        // Wrap with lock-free async drain to eliminate PrintWriter synchronized contention
+        // when multiple PhasingExecutor threads log concurrently during parallel model building.
+        AsyncDrainWriter asyncWriter = new AsyncDrainWriter(raw);
+        context.closeables.add(asyncWriter);
+        return asyncWriter;
     }
 
     protected void activateLogging(C context) throws Exception {

--- a/impl/maven-core/src/main/java/org/apache/maven/logging/AsyncDrainWriter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/logging/AsyncDrainWriter.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.logging;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+/**
+ * A lock-free buffering wrapper around a {@link Consumer Consumer&lt;String&gt;} that
+ * eliminates contention when multiple threads log concurrently.
+ * <p>
+ * Callers enqueue messages into a {@link ConcurrentLinkedQueue} (lock-free),
+ * then attempt a non-blocking drain via {@link ReentrantLock#tryLock()}.
+ * If another thread is already draining, the caller returns immediately —
+ * its message will be picked up by the ongoing or next drain cycle.
+ * This ensures that at most one thread writes to the underlying consumer
+ * at any time, without blocking producers.
+ * <p>
+ * The pattern eliminates the {@code synchronized} contention in
+ * {@link java.io.PrintWriter#println(String)} that occurs when multiple
+ * {@link org.apache.maven.impl.util.PhasingExecutor} threads log during
+ * parallel model building.
+ *
+ * @since 4.0.0
+ */
+public class AsyncDrainWriter implements Consumer<String>, AutoCloseable {
+
+    private final Consumer<String> delegate;
+    private final ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
+    private final ReentrantLock drainLock = new ReentrantLock();
+
+    public AsyncDrainWriter(Consumer<String> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void accept(String msg) {
+        queue.add(msg);
+        tryDrain();
+    }
+
+    /**
+     * Attempts a non-blocking drain of all queued messages.
+     * Only one thread drains at a time; others return immediately.
+     * After releasing the lock, a re-check ensures no message is
+     * stranded by a race between enqueue and the last poll.
+     */
+    private void tryDrain() {
+        if (drainLock.tryLock()) {
+            try {
+                drain();
+            } finally {
+                drainLock.unlock();
+            }
+            // Re-check: a message may have been enqueued after our last poll()
+            // but before unlock(). The enqueuer's tryLock() would have failed,
+            // so we need to pick it up here.
+            if (!queue.isEmpty() && drainLock.tryLock()) {
+                try {
+                    drain();
+                } finally {
+                    drainLock.unlock();
+                }
+            }
+        }
+    }
+
+    private void drain() {
+        String m;
+        while ((m = queue.poll()) != null) {
+            delegate.accept(m);
+        }
+    }
+
+    /**
+     * Flushes all remaining buffered messages to the delegate.
+     * Blocks until the drain is complete — call this before shutdown
+     * to ensure no messages are lost.
+     */
+    @Override
+    public void close() {
+        drainLock.lock();
+        try {
+            drain();
+        } finally {
+            drainLock.unlock();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

During parallel model building (`-T1C`), multiple `PhasingExecutor` threads log concurrently via:

```
SLF4J → MavenSimpleLogger → ProjectBuildLogAppender → SimpleBuildEventListener → PrintWriter.println()
```

Since `PrintWriter.println()` is `synchronized`, all threads serialize on every log call. JFR profiling on a 4383-module diamond-graph project shows **1,470ms of blocked time** from this single contention point — the #1 source of lock contention during `validate`.

### Fix

`AsyncDrainWriter` wraps the `Consumer<String>` writer with a lock-free queue + non-blocking drain:

- **Producers** enqueue messages into a `ConcurrentLinkedQueue` (CAS, no blocking)
- **At most one thread** drains the queue to the underlying `PrintWriter` (via `ReentrantLock.tryLock()`)
- **Other threads** return immediately after enqueue — their messages are picked up by the active drain
- **`close()`** performs a final blocking drain to guarantee no messages are lost

### JFR Results (4383-module diamond project, `validate -T1C`)

| Source | Before | After |
|--------|:------:|:-----:|
| PrintWriter contention | 1,470ms | **0ms** |
| PhasingExecutor contention | 546ms | **49ms** |

### Benchmark (10 runs)

| Metric | Before | After | Δ |
|--------|:------:|:-----:|:-:|
| Median | 14.738s | 14.253s | **-485ms (-3.3%)** |
| Average | 14.546s | 14.242s | **-304ms (-2.1%)** |
| Range (variance) | 2.70s | 1.33s | **Halved** |

All 8,766 module log lines verified present — zero messages lost.

## Test plan

- [x] Verified 8,766/8,766 module log lines present (no lost messages)
- [x] JFR confirms PrintWriter contention eliminated (1,470ms → 0ms)
- [x] `maven-core` unit tests pass
- [x] `maven-cli` unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)