### PR TITLE
Fix SubList.get() accepting an index equal to its own size

### DIFF
--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
@@ -297,7 +297,7 @@ class ImmutableCollections {
 
             @Override
             public E get(int index) {
-                if (index < 0 || index > size()) {
+                if (index < 0 || index >= size()) {
                     throw outOfBounds(index);
                 }
                 return AbstractImmutableList.this.get(fromIndex + index);

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/ImmutableCollections.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/ImmutableCollections.java
@@ -297,7 +297,7 @@ class ImmutableCollections {
 
             @Override
             public E get(int index) {
-                if (index < 0 || index > size()) {
+                if (index < 0 || index >= size()) {
                     throw outOfBounds(index);
                 }
                 return AbstractImmutableList.this.get(fromIndex + index);

--- a/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/ImmutableCollectionsTest.java
+++ b/impl/maven-xml/src/test/java/org/apache/maven/internal/xml/ImmutableCollectionsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.internal.xml;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ImmutableCollectionsTest {
+
+    private static List<String> abc() {
+        return ImmutableCollections.copy(Arrays.asList("a", "b", "c"));
+    }
+
+    @Test
+    void subListRejectsIndexEqualToItsSize() {
+        List<String> sub = abc().subList(0, 1);
+
+        assertEquals(1, sub.size());
+        assertEquals("a", sub.get(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> sub.get(1));
+    }
+
+    @Test
+    void subListDoesNotReachPastItsEnd() {
+        // A sub list that stops before the end of the backing list is the case that used to
+        // read past its own bounds instead of failing: the parent list resolves the index
+        // and hands back an element the sub list does not contain.
+        List<String> sub = abc().subList(1, 2);
+
+        assertEquals(List.of("b"), sub);
+        assertThrows(IndexOutOfBoundsException.class, () -> sub.get(1));
+        assertThrows(IndexOutOfBoundsException.class, () -> sub.get(-1));
+    }
+
+    @Test
+    void subListIterationStaysWithinBounds() {
+        List<String> sub = abc().subList(0, 2);
+
+        assertEquals(List.of("a", "b"), sub);
+        assertEquals(List.of("a", "b"), List.copyOf(sub));
+    }
+
+    @Test
+    void listIteratorStillAcceptsIndexEqualToSize() {
+        // List.listIterator(int) is specified to accept size() as a valid cursor position,
+        // so that bound is deliberately not the same as the one for get(int).
+        List<String> list = abc();
+
+        assertEquals(3, list.size());
+        assertEquals(false, list.listIterator(3).hasNext());
+        assertThrows(IndexOutOfBoundsException.class, () -> list.listIterator(4));
+    }
+}

--- a/src/mdo/java/ImmutableCollections.java
+++ b/src/mdo/java/ImmutableCollections.java
@@ -300,7 +300,7 @@ class ImmutableCollections {
 
             @Override
             public E get(int index) {
-                if (index < 0 || index > size()) {
+                if (index < 0 || index >= size()) {
                     throw outOfBounds(index);
                 }
                 return AbstractImmutableList.this.get(fromIndex + index);


### PR DESCRIPTION
`SubList.get()` checked `index > size()`, so an index equal to the sub list's size passed and reached `AbstractImmutableList.this.get(fromIndex + index)`.

The issue describes this as surfacing an `IndexOutOfBoundsException` from the parent instead of a clear one from the sub list. That is what happens when the sub list reaches the end of its parent, and the exception is an `ArrayIndexOutOfBoundsException` from the backing array. When the sub list stops earlier there is no exception at all: the parent resolves the index and returns an element the sub list does not contain.

```java
List<String> list = ImmutableCollections.copy(List.of("a", "b", "c"));
list.subList(0, 1).get(1);   // "b"   before
list.subList(0, 1).get(1);   // IndexOutOfBoundsException: Index: 1, Size: 1   after
list.subList(2, 3).get(1);   // ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3   before
```

`ListN.get()` indexes the array directly and has no bounds check of its own, which is why a read past the sub list is silent.

The same class is checked in three times: the mdo template plus the two copies generated from it under `api/maven-api-xml` and `impl/maven-xml`. All three are fixed, since changing only the copies would let the next regeneration bring it back.

`listIterator(int)` a few lines above keeps `index > size()`. That bound is correct there because `List.listIterator(int)` accepts `size()` as a cursor position, so one of the added tests pins it to prevent the two being aligned later by mistake.

Tests: four cases in a new `ImmutableCollectionsTest` in `impl/maven-xml`, covering the equal-to-size index, the read past a sub list that ends early, negative indices, and the `listIterator` bound. Two of them fail on `maven-4.0.x` and pass with this change; the module suite is green at 75 tests with checkstyle and spotless enabled.

Fixes #12595
