### PR TITLE
fix configuration page generation

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -333,7 +333,9 @@ public final class Constants {
      * so even plugins will get relocated artifacts) relocation.
      * <br/>
      * For example,
-     * <pre>maven.relocations.entries = org.foo:*:*>, \\<br/>    org.here:*:*>org.there:*:*, \\<br/>    javax.inject:javax.inject:1>>jakarta.inject:jakarta.inject:1.0.5</pre>
+     * <pre>maven.relocations.entries = org.foo:*:*>,\
+     *     org.here:*:*>org.there:*:*,\
+     *     javax.inject:javax.inject:1>>jakarta.inject:jakarta.inject:1.0.5</pre>
      * means: 3 entries, ban <code>org.foo group</code> (exactly, so <code>org.foo.bar</code> is allowed),
      * relocate <code>org.here</code> to <code>org.there</code> and finally globally relocate (see <code>&gt;&gt;</code> above)
      * <code>javax.inject:javax.inject:1</code> to <code>jakarta.inject:jakarta.inject:1.0.5</code>.
@@ -428,7 +430,7 @@ public final class Constants {
      * dependency management entries in transitive dependency POMs. Maven 4 enables "transitivity" by default, hence
      * unlike Maven2, obeys dependency management entries deep in dependency graph as well.
      * <br/>
-     * Default: <code>"true"</code>.
+     * Default: <code>true</code>.
      *
      * @since 4.0.0
      */
@@ -490,10 +492,12 @@ public final class Constants {
 
     /**
      * User property for controlling consumer POM flattening behavior.
-     * When set to <code>true</code>, consumer POMs are flattened by removing
-     * dependency management and keeping only direct dependencies with transitive scopes.
-     * When set to <code>false</code> (default), consumer POMs preserve dependency management
-     * like parent POMs, allowing dependency management to be inherited by consumers.
+     * <ul>
+     *     <li>When set to <code>true</code>, consumer POMs are flattened by removing
+     * dependency management and keeping only direct dependencies with transitive scopes.</li>
+     *     <li>When set to <code>false</code> (default), consumer POMs preserve dependency management
+     * like parent POMs, allowing dependency management to be inherited by consumers.</li>
+     * </ul>
      *
      * @since 4.1.0
      */
@@ -502,12 +506,14 @@ public final class Constants {
 
     /**
      * User property for controlling removal of unused managed dependencies during consumer POM flattening.
-     * When set to {@code true} (default), managed dependencies that do not appear in the resolved
+     * <ul>
+     *     <li>When set to <code>true</code> (default), managed dependencies that do not appear in the resolved
      * dependency tree are removed from the consumer POM to keep it lean. This is important when using
-     * BOMs like Spring Boot or Quarkus that contain hundreds of managed dependency entries.
-     * When set to {@code false}, all managed dependencies are preserved in the consumer POM,
+     * BOMs like Spring Boot or Quarkus that contain hundreds of managed dependency entries.</li>
+     *     <li>When set to <code>false</code>, all managed dependencies are preserved in the consumer POM,
      * which may be needed in rare cases where downstream consumers override transitive dependency
-     * versions and rely on the original managed dependencies for alignment.
+     * versions and rely on the original managed dependencies for alignment.</li>
+     * </ul>
      *
      * @since 4.1.0
      */
@@ -573,7 +579,7 @@ public final class Constants {
      *     <li>"snapshot" - query only snapshot repositories to discover versions</li>
      * </ul>
      * Default (when unset) is using request carried nature. Hence, this configuration really makes sense with value
-     * {@code "auto"}, while ideally callers needs update and use newly added method on version range request to
+     * <code>auto</code>, while ideally callers needs update and use newly added method on version range request to
      * express preference.
      *
      * @since 4.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -1058,14 +1058,11 @@ under the License.
                 <version>${resolverVersion}</version>
               </dependency>
               <dependency>
+                <!-- we need a dependency on maven-api-annotations to be able to load org.apache.maven.api.annotations.Config class -->
                 <groupId>org.apache.maven</groupId>
-                <artifactId>maven-core</artifactId>
-                <version>${project.version}</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-compat</artifactId>
-                <version>${project.version}</version>
+                <artifactId>maven-api-annotations</artifactId>
+                <!-- use previous version to avoid dependency cycles -->
+                <version>4.0.0-rc-6</version>
               </dependency>
             </dependencies>
             <executions>
@@ -1089,7 +1086,8 @@ under the License.
                     hence template is renamed to maven-configuration.md.vm, to avoid conflict (and picking up resolver template)
                     -->
                     <argument>--templates=maven-configuration.md</argument>
-                    <argument>${project.basedir}</argument>
+                    <!-- only look at maven-api-core, as it only contains configuration class org.apache.maven.api.Constants  -->
+                    <argument>${project.basedir}/api/maven-api-core</argument>
                     <argument>${project.build.directory}/generated-site/markdown</argument>
                   </arguments>
                 </configuration>
@@ -1113,7 +1111,7 @@ under the License.
                     to avoid double execution
                     -->
                     <argument>--templates=configuration.properties,configuration.yaml</argument>
-                    <argument>${project.basedir}</argument>
+                    <argument>${project.basedir}/api/maven-api-core</argument>
                     <argument>${project.build.directory}/generated-site/resources</argument>
                   </arguments>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1079,14 +1079,11 @@ under the License.
                 <version>${resolverVersion}</version>
               </dependency>
               <dependency>
+                <!-- we need a dependency on maven-api-annotations to be able to load org.apache.maven.api.annotations.Config class -->
                 <groupId>org.apache.maven</groupId>
-                <artifactId>maven-core</artifactId>
-                <version>${project.version}</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-compat</artifactId>
-                <version>${project.version}</version>
+                <artifactId>maven-api-annotations</artifactId>
+                <!-- use previous version to avoid dependency cycles -->
+                <version>4.0.0-rc-6</version>
               </dependency>
             </dependencies>
             <executions>
@@ -1110,7 +1107,8 @@ under the License.
                     hence template is renamed to maven-configuration.md.vm, to avoid conflict (and picking up resolver template)
                     -->
                     <argument>--templates=maven-configuration.md</argument>
-                    <argument>${project.basedir}</argument>
+                    <!-- only look at maven-api-core, as it only contains configuration class org.apache.maven.api.Constants  -->
+                    <argument>${project.basedir}/api/maven-api-core</argument>
                     <argument>${project.build.directory}/generated-site/markdown</argument>
                   </arguments>
                 </configuration>
@@ -1134,7 +1132,7 @@ under the License.
                     to avoid double execution
                     -->
                     <argument>--templates=configuration.properties,configuration.yaml</argument>
-                    <argument>${project.basedir}</argument>
+                    <argument>${project.basedir}/api/maven-api-core</argument>
                     <argument>${project.build.directory}/generated-site/resources</argument>
                   </arguments>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1054,7 +1054,7 @@ under the License.
       <activation>
         <property>
           <name>skipConfiguration</name>
-          <value>!false</value>
+          <value>!true</value>
         </property>
       </activation>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1046,12 +1046,34 @@ under the License.
               </execution>
             </executions>
           </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>maven-configuration</id>
+      <activation>
+        <property>
+          <name>skipConfiguration</name>
+          <value>!false</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>3.6.3</version>
             <inherited>false</inherited>
+            <configuration>
+              <additionalClasspathElements>
+                <additionalClasspathElement>${project.basedir}/src/configuration-templates</additionalClasspathElement>
+              </additionalClasspathElements>
+              <includePluginDependencies>true</includePluginDependencies>
+              <!-- https://maven.apache.org/resolver/maven-resolver-tools/apidocs/org/eclipse/aether/tools/CollectConfiguration.html -->
+              <mainClass>org.eclipse.aether.tools.CollectConfiguration</mainClass>
+            </configuration>
             <dependencies>
+              <!-- https://maven.apache.org/resolver/maven-resolver-tools/ that contains the invoked class -->
               <dependency>
                 <groupId>org.apache.maven.resolver</groupId>
                 <artifactId>maven-resolver-tools</artifactId>
@@ -1067,17 +1089,12 @@ under the License.
             </dependencies>
             <executions>
               <execution>
-                <id>render-configuration-page</id>
+                <id>render-maven-configuration-md</id>
                 <goals>
                   <goal>java</goal>
                 </goals>
                 <phase>pre-site</phase>
                 <configuration>
-                  <additionalClasspathElements>
-                    <additionalClasspathElement>${project.basedir}/src/configuration-templates</additionalClasspathElement>
-                  </additionalClasspathElements>
-                  <includePluginDependencies>true</includePluginDependencies>
-                  <mainClass>org.eclipse.aether.tools.CollectConfiguration</mainClass>
                   <arguments>
                     <argument>--mode=maven</argument>
                     <!--
@@ -1093,17 +1110,12 @@ under the License.
                 </configuration>
               </execution>
               <execution>
-                <id>render-configuration-properties</id>
+                <id>render-configuration-properties+yaml</id>
                 <goals>
                   <goal>java</goal>
                 </goals>
                 <phase>pre-site</phase>
                 <configuration>
-                  <additionalClasspathElements>
-                    <additionalClasspathElement>${project.basedir}/src/configuration-templates</additionalClasspathElement>
-                  </additionalClasspathElements>
-                  <includePluginDependencies>true</includePluginDependencies>
-                  <mainClass>org.eclipse.aether.tools.CollectConfiguration</mainClass>
                   <arguments>
                     <argument>--mode=maven</argument>
                     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1122,7 +1122,7 @@ under the License.
                     TODO: add feature to resolver-tools to allow multiple output directory for different templates
                     to avoid double execution
                     -->
-                    <argument>--templates=configuration.properties,configuration.yaml</argument>
+                    <argument>--templates=configuration.yaml</argument>
                     <argument>${project.basedir}/api/maven-api-core</argument>
                     <argument>${project.build.directory}/generated-site/resources</argument>
                   </arguments>

--- a/pom.xml
+++ b/pom.xml
@@ -1100,12 +1100,12 @@ under the License.
                     <!--
                     TODO: templates are loaded from classpath, in "normal" JAR project local template would override docgen one,
                     but in this case the packaging=pom all I could do is use additionalClasspathElement that APPENDS classpath,
-                    hence template is renamed to maven-configuration.md.vm, to avoid conflict (and picking up resolver template)
+                    hence template is renamed to configuration.xml.vm, to avoid conflict (and picking up resolver template)
                     -->
-                    <argument>--templates=maven-configuration.md</argument>
+                    <argument>--templates=configuration.xml</argument>
                     <!-- only look at maven-api-core, as it only contains configuration class org.apache.maven.api.Constants  -->
                     <argument>${project.basedir}/api/maven-api-core</argument>
-                    <argument>${project.build.directory}/generated-site/markdown</argument>
+                    <argument>${project.build.directory}/generated-site/xdoc</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1057,6 +1057,16 @@ under the License.
                 <artifactId>maven-resolver-tools</artifactId>
                 <version>${resolverVersion}</version>
               </dependency>
+              <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${project.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
+                <version>${project.version}</version>
+              </dependency>
             </dependencies>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1078,6 +1078,16 @@ under the License.
                 <artifactId>maven-resolver-tools</artifactId>
                 <version>${resolverVersion}</version>
               </dependency>
+              <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${project.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
+                <version>${project.version}</version>
+              </dependency>
             </dependencies>
             <executions>
               <execution>

--- a/src/configuration-templates/configuration.xml.vm
+++ b/src/configuration-templates/configuration.xml.vm
@@ -51,7 +51,7 @@ under the License.
 #end
 
 <p>These parameters don't configure plugins, but Maven itself. The parameters's list is also available as
-<a href="./configuration.properties">properties</a> or <a href="./configuration.yaml">yaml</a>.</p>
+<a href="./configuration.yaml">yaml file</a>.</p>
 
 <table>
   <thead>

--- a/src/configuration-templates/configuration.xml.vm
+++ b/src/configuration-templates/configuration.xml.vm
@@ -50,6 +50,9 @@ under the License.
 #if ($val) <code>$val</code> #else - #end
 #end
 
+<p>These parameters don't configure plugins, but Maven itself. The parameters's list is also available as
+<a href="./configuration.properties">properties</a> or <a href="./configuration.yaml">yaml</a>.</p>
+
 <table>
   <thead>
     <tr><th>Key</th><th>Type</th><th>Description</th><th>Default Value</th><th>Since</th><th>Source</th></tr>

--- a/src/configuration-templates/configuration.xml.vm
+++ b/src/configuration-templates/configuration.xml.vm
@@ -16,8 +16,8 @@
 ## specific language governing permissions and limitations
 ## under the License.
 ##
-#[[
-# Maven Configuration Options
+<?xml version="1.0"?>
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -27,7 +27,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -37,15 +37,30 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-]]#
+<document>
 
+  <properties>
+    <title>Maven Configuration Options</title>
+  </properties>
+
+  <body>
+
+    <section name="Maven Configuration Options">
 #macro(value $val)
-#if ($val) `$val` #else - #end
+#if ($val) <code>$val</code> #else - #end
 #end
 
-| Key | Type | Description | Default Value | Since | Source |
-| --- | --- | --- | --- | --- | --- |
+<table>
+  <thead>
+    <tr><th>Key</th><th>Type</th><th>Description</th><th>Default Value</th><th>Since</th><th>Source</th></tr>
+  </thead>
 #foreach($key in $keys)
-| `$key.key` | `$key.configurationType` | $key.description | #value( $key.defaultValue ) | $key.since | $key.configurationSource |
+<tr><td><code>$key.key</code></td><td><code>$key.configurationType</code></td>
+   <td>$key.description</td>
+   <td>#value( $key.defaultValue )</td><td>$key.since</td><td>$key.configurationSource</td>
+</tr>
 #end
-
+</table>
+    </section>
+  </body>
+</document>

--- a/src/configuration-templates/maven-configuration.md.vm
+++ b/src/configuration-templates/maven-configuration.md.vm
@@ -17,7 +17,7 @@
 ## under the License.
 ##
 #[[
-# Configuration Options
+# Maven Configuration Options
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -37,17 +37,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<!--
-THIS FILE IS GENERATED - DO NOT EDIT
-Generated from: apache-maven/src/test/resources/maven-configuration.md.vm
-To modify this file, edit the template and regenerate.
--->
-
 ]]#
-
-#macro(yesno $val)
-  #if ($val) Yes #else No #end
-#end
 
 #macro(value $val)
 #if ($val) `$val` #else - #end

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -41,7 +41,7 @@ under the License.
     number of other development tools for reporting or the build
     process.</p>
 
-      <p>Learn more about <a href="configuring.html">configuring Maven</a> and <a href="maven-configuration.html">Maven's configuration</a>.</p>
+      <p>Learn more about <a href="configuring.html">configuring Maven</a> and <a href="configuration.html">Maven's configuration</a>.</p>
 
       <p>
         <object data="images/maven-deps.svg"></object>


### PR DESCRIPTION
discovered while working on #12635 that lead to fixing #10961
it worked in RC5 https://maven.apache.org/ref/4.0.0-rc-5/maven-configuration.html 
but is broken in RC6 https://maven.apache.org/ref/4.0.0-rc-6/maven-configuration.html

first PR adds necessary dependencies to have the generation step work
(notice: it requires `mvn install` before `mvn site`...)

sadly, the rendering done after has issues: multi-line documentation breaks markdown table
need more rework