### PR TITLE
Resolve classified POM artifacts from the reactor [4.x]

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -159,8 +159,9 @@ class ReactorReader implements MavenWorkspaceReader {
     //
 
     private File findArtifact(MavenProject project, Artifact artifact, boolean checkUptodate) {
-        // POMs are always returned from the file system
-        if ("pom".equals(artifact.getExtension())) {
+        // Unclassified POMs are always returned from the file system
+        if ("pom".equals(artifact.getExtension())
+                && (artifact.getClassifier() == null || artifact.getClassifier().isEmpty())) {
             return project.getFile();
         }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmdep0590ClassifiedPomArtifactFromReactorTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmdep0590ClassifiedPomArtifactFromReactorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for <a href="https://github.com/apache/maven-dependency-plugin/issues/1024">MDEP-590</a>.
+ */
+class MavenITmdep0590ClassifiedPomArtifactFromReactorTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void classifiedPomShouldResolveToAttachedArtifact() throws Exception {
+        Path testDir = extractResources("mdep-590");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("consumer/target");
+        verifier.deleteArtifacts("org.apache.maven.its.mdep590");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties properties = verifier.loadProperties("consumer/target/artifact.properties");
+        ItUtils.assertCanonicalFileEquals(
+                testDir.resolve("producer/custom.pom"),
+                Path.of(properties.getProperty(
+                        "org.apache.maven.its.mdep590:producer:pom:custom:1.0-SNAPSHOT")));
+    }
+}

--- a/its/core-it-suite/src/test/resources/mdep-590/consumer/pom.xml
+++ b/its/core-it-suite/src/test/resources/mdep-590/consumer/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.mdep590</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>consumer</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: MDEP-590 :: Consumer</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-artifact</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>resolve-classified-pom</id>
+            <goals>
+              <goal>resolve</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <propertiesFile>target/artifact.properties</propertiesFile>
+              <dependencies>
+                <dependency>
+                  <groupId>org.apache.maven.its.mdep590</groupId>
+                  <artifactId>producer</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <type>pom</type>
+                  <classifier>custom</classifier>
+                </dependency>
+              </dependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mdep-590/pom.xml
+++ b/its/core-it-suite/src/test/resources/mdep-590/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mdep590</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: MDEP-590</name>
+  <description>Test that a classified POM artifact resolves from the reactor to the attached artifact.</description>
+
+  <modules>
+    <module>producer</module>
+    <module>consumer</module>
+  </modules>
+</project>

--- a/its/core-it-suite/src/test/resources/mdep-590/producer/custom.pom
+++ b/its/core-it-suite/src/test/resources/mdep-590/producer/custom.pom
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<custom>classified POM artifact</custom>

--- a/its/core-it-suite/src/test/resources/mdep-590/producer/pom.xml
+++ b/its/core-it-suite/src/test/resources/mdep-590/producer/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.mdep590</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>producer</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: MDEP-590 :: Producer</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-artifact</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>attach-classified-pom</id>
+            <goals>
+              <goal>attach</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <attachedFile>custom.pom</attachedFile>
+              <artifactType>pom</artifactType>
+              <artifactClassifier>custom</artifactClassifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Description

`ReactorReader` currently returns the reactor project's build POM for every artifact whose extension is `pom`, without considering its classifier. Consequently, resolving an attached classified POM from the reactor returns `pom.xml` instead of the attached artifact.

This change limits the build-POM shortcut to unclassified POM requests. Classified POMs proceed through the existing artifact matching path, which selects the attached artifact by extension and classifier. Ordinary reactor POM and consumer-POM resolution remain unchanged.

Fixes apache/maven-dependency-plugin#1024

## Tests

- Full root `mvn verify`: all 38 modules passed with RAT enabled (2:01).
- Complete unfiltered Core IT suite: 1,052 tests, 0 failures, 0 errors, 43 skipped (3:37).
- Maven Core dependency reactor tests: 580 tests in `maven-core`, with no failures.
- `MavenITmdep0590ClassifiedPomArtifactFromReactorTest`
- `MavenITmng8293BomImportFromReactor`
- `MavenITgh11084ReactorReaderPreferConsumerPomTest`

[core-its]: https://maven.apache.org/core-its/core-it-suite/
