### PR TITLE
Resolve classified POM artifacts from the reactor in Maven 3.x

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/ReactorReader.java
+++ b/maven-core/src/main/java/org/apache/maven/ReactorReader.java
@@ -129,7 +129,8 @@ class ReactorReader implements MavenWorkspaceReader {
     //
 
     private File find(MavenProject project, Artifact artifact) {
-        if ("pom".equals(artifact.getExtension())) {
+        if ("pom".equals(artifact.getExtension())
+                && (artifact.getClassifier() == null || artifact.getClassifier().isEmpty())) {
             return project.getFile();
         }
 

--- a/maven-core/src/test/java/org/apache/maven/ReactorReaderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/ReactorReaderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ReactorReaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void classifiedPomShouldResolveToAttachedArtifact() throws Exception {
+        File projectPom = Files.createFile(tempDir.resolve("pom.xml")).toFile();
+        File attachedPom = Files.createFile(tempDir.resolve("custom.pom")).toFile();
+
+        MavenProject project = new MavenProject();
+        project.setGroupId("org.apache.maven.its.mdep590");
+        project.setArtifactId("producer");
+        project.setVersion("1.0-SNAPSHOT");
+        project.setFile(projectPom);
+        project.setArtifact(newArtifact(null, projectPom));
+        project.addAttachedArtifact(newArtifact("custom", attachedPom));
+
+        MavenSession session = mock(MavenSession.class);
+        when(session.getProjects()).thenReturn(Collections.singletonList(project));
+
+        ReactorReader reader = new ReactorReader(session);
+
+        assertEquals(
+                attachedPom,
+                reader.findArtifact(new org.eclipse.aether.artifact.DefaultArtifact(
+                        "org.apache.maven.its.mdep590:producer:pom:custom:1.0-SNAPSHOT")));
+    }
+
+    private static Artifact newArtifact(String classifier, File file) {
+        Artifact artifact = new DefaultArtifact(
+                "org.apache.maven.its.mdep590",
+                "producer",
+                "1.0-SNAPSHOT",
+                Artifact.SCOPE_COMPILE,
+                "pom",
+                classifier,
+                new DefaultArtifactHandler("pom"));
+        artifact.setFile(file);
+        return artifact;
+    }
+}


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Description

Maven 3's `ReactorReader` returns the reactor project's build POM for every artifact request whose extension is `pom`, before considering the classifier. Consequently, resolving an attached classified POM from the reactor returns `pom.xml` instead of the attached artifact.

This change limits the build-POM shortcut to unclassified POM requests. Classified POMs proceed through the existing artifact-matching path, which selects the attached artifact by extension and classifier. A focused unit test reproduces the incorrect path before the fix and verifies the attached POM afterward.

This is the Maven 3.10.x counterpart to apache/maven#12658.

Fixes apache/maven-dependency-plugin#1024

## Tests

- Regression test before the fix: expected `custom.pom`, but `ReactorReader` returned `pom.xml`.
- Full root `mvn verify`: all 16 modules passed with RAT, Checkstyle, Spotless, Animal Sniffer, and unit tests enabled.
- `maven-core`: 367 tests, 0 failures, 0 errors, 1 skipped.
- Complete unfiltered Maven 3.10.x Core IT suite with `run-its,embedded`: all 78 modules passed; 867 tests, 0 failures, 0 errors, 39 skipped.

[core-its]: https://maven.apache.org/core-its/core-it-suite/
