### PR TITLE
Ignore logback >= 1.3.0 on Maven 3.x branches in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
     labels:
       - "mvn3"
       - "dependencies"
+    ignore:
+      - dependency-name: "ch.qos.logback:*"
+        versions: [ "[1.3.0,)" ]
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -51,6 +54,8 @@ updates:
     ignore:
       - dependency-name: "org.jline:*"
         versions: [ "[4.0.0,)" ]
+      - dependency-name: "ch.qos.logback:*"
+        versions: [ "[1.3.0,)" ]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Logback 1.3+ requires Java 11+ bytecode (and 1.6+ requires Java 21+), which causes  check in  to fail on Maven 3.x branches (which target Java 8 bytecode compatibility).

This PR configures  to ignore  version  for  and  target branches.