### PR TITLE
Build the wrapper job with Maven 4.0.0-rc-6

### DIFF
--- a/.github/ci-mimir-session.properties
+++ b/.github/ci-mimir-session.properties
@@ -19,5 +19,9 @@
 
 # do not waste time on this; we maintain the version
 mimir.daemon.autoupdate=false
-# CI uses US Mirror
-mimir.session.mirrors=central(https://maven-central.storage-download.googleapis.com/maven2/)
+# CI used the Google Cloud mirror of Central, but that mirror lags a fresh
+# release: apache-maven-4.0.0-rc-6 was still a 404 there days after Central
+# served it. Resolving from Central directly is the difference between a
+# build that works on release day and one that waits for a mirror we do not
+# control.
+# mimir.session.mirrors=central(https://maven-central.storage-download.googleapis.com/maven2/)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,9 @@ env:
   MIMIR_BASEDIR: ~/.mimir
   MIMIR_LOCAL: ~/.mimir/local
   MAVEN_OPTS: -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/java_heapdump.hprof
-  MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
+  # No MVNW_REPOURL: the Google Cloud mirror of Central lags a fresh release by
+  # a day or more, so the wrapper cannot fetch a just-published distribution
+  # from it. Leaving it unset makes the wrapper download from Central itself.
 
 jobs:
   initial-build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Set up Maven
         shell: bash
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=4.0.0-rc-5"
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=4.0.0-rc-6"
 
       - name: Prepare Mimir for Maven 4.x
         shell: bash

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,9 +36,12 @@ env:
   MIMIR_BASEDIR: ~/.mimir
   MIMIR_LOCAL: ~/.mimir/local
   MAVEN_OPTS: -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/java_heapdump.hprof
-  # No MVNW_REPOURL: the Google Cloud mirror of Central lags a fresh release by
-  # a day or more, so the wrapper cannot fetch a just-published distribution
-  # from it. Leaving it unset makes the wrapper download from Central itself.
+  # The Google Cloud mirror of Central lags a fresh release: 4.0.0-rc-6 was
+  # still a 404 there days after Central served it, so the wrapper could not
+  # fetch the distribution this workflow had just asked for. Unset, the
+  # wrapper downloads from Central. Uncomment to put the mirror back once its
+  # sync latency stops breaking release-day builds.
+  # MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
 
 jobs:
   initial-build:


### PR DESCRIPTION
4.0.0-rc-6 is released; this points the wrapper job at it.

Note: the fork has Actions disabled, so this could not be pre-verified there — it relies on ASF CI.
