### PR TITLE
Build and deploy through the wrapper on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
               withEnv(["JAVA_HOME=${tool "jdk_17_latest"}",
                        "PATH+MAVEN=${ tool "jdk_17_latest" }/bin:${tool "maven_3_latest"}/bin",
                        "MAVEN_OPTS=-Xms4G -Xmx4G -Djava.awt.headless=true"]) {
-                sh "mvn clean deploy -DdeployAtEnd=true -B"
+                sh "./mvnw clean deploy -DdeployAtEnd=true -B -V"
               }
             }
           }
@@ -67,7 +67,7 @@ def mavenBuild(jdk, extraArgs) {
       withEnv(["JAVA_HOME=${tool "$jdk"}",
                "PATH+MAVEN=${tool "$jdk"}/bin:${tool "maven_3_latest"}/bin",
                "MAVEN_OPTS=-Xms4G -Xmx4G -Djava.awt.headless=true"]) {
-        sh "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper -Dmaven=3.9.10"
+        sh "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=3.9.12"
         sh "echo run Its"
         sh "./mvnw -e -B -V install $extraArgs"
       }


### PR DESCRIPTION
Jenkins already provisions Maven with the wrapper for the build itself, but the deploy step still ran the `mvn` from the `maven_3_latest` Jenkins tool — so a release was published by a different Maven than the one that built it. `mavenBuild` runs first in the same workspace, so `./mvnw` is present by the time deploy runs.

Also moves the wrapper provisioning to `maven-wrapper-plugin` 3.3.4 and Maven 3.9.12, matching what `.github/workflows/maven.yml` already uses. Both are on Central (verified).

Same pattern as apache/maven-jenkins-lib#22, which applies it to the shared library. Part of apache/maven#12676.

No `master` companion is needed: `master` already has both of these — `./mvnw clean deploy -DdeployAtEnd=true -B -V` at `Jenkinsfile:41` and `maven-wrapper-plugin:3.3.4` with `-Dmaven=3.9.12` at `:70`. This brings `maven-4.0.x` up to the same state.

