### PR TITLE
Fix deprecated Maven testing API compatibility

### DIFF
--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoExtension.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/MojoExtension.java
@@ -315,9 +315,10 @@ public class MojoExtension extends MavenDIExtension implements ParameterResolver
 
         String pluginBasedir = MavenDIExtension.getBasedir();
 
-        String basedir = AnnotationSupport.findAnnotation(context.getElement().orElseThrow(), Basedir.class)
-                .map(Basedir::value)
-                .orElse(pluginBasedir);
+        String basedir = findBasedirValue(context.getElement().orElseThrow());
+        if (basedir == null) {
+            basedir = pluginBasedir;
+        }
         if (basedir.isEmpty()) {
             basedir = pluginBasedir + "/target/tests/"
                     + context.getRequiredTestClass().getSimpleName() + "/"
@@ -744,6 +745,18 @@ public class MojoExtension extends MavenDIExtension implements ParameterResolver
         requireNonNull(field, "Field " + variable + " not found");
         field.setAccessible(true);
         field.set(object, value);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static String findBasedirValue(AnnotatedElement element) {
+        Basedir a = AnnotationSupport.findAnnotation(element, Basedir.class).orElse(null);
+        if (a != null) {
+            return a.value();
+        }
+        org.apache.maven.api.plugin.testing.Basedir d = AnnotationSupport.findAnnotation(
+                        element, org.apache.maven.api.plugin.testing.Basedir.class)
+                .orElse(null);
+        return d != null ? d.value() : null;
     }
 
     @SuppressWarnings("deprecation")

--- a/impl/maven-testing/src/test/java/org/apache/maven/api/plugin/testing/ExpressionEvaluatorTest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/api/plugin/testing/ExpressionEvaluatorTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 
@@ -96,6 +97,17 @@ public class ExpressionEvaluatorTest {
         assertNotNull(mojo.workdir);
         assertEquals("paramValue", mojo.param);
         assertEquals("param2Value", mojo.param2);
+        assertDoesNotThrow(mojo::execute);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    @org.apache.maven.api.plugin.testing.InjectMojo(goal = COORDINATES, pom = CONFIG)
+    @org.apache.maven.api.plugin.testing.Basedir("${basedir}/target/test-classes")
+    @org.apache.maven.api.plugin.testing.MojoParameter(name = "param", value = "deprecatedParamValue")
+    public void testDeprecatedAnnotations(ExpressionEvaluatorMojo mojo) throws IllegalAccessException {
+        assertTrue(Paths.get(MojoExtension.getBasedir()).endsWith(Paths.get("target", "test-classes")));
+        assertEquals("deprecatedParamValue", MojoExtension.getVariableValueFromObject(mojo, "param"));
         assertDoesNotThrow(mojo::execute);
     }
 

--- a/impl/maven-testing/src/test/java/org/apache/maven/api/plugin/testing/stubs/ProducedArtifactStubTest.java
+++ b/impl/maven-testing/src/test/java/org/apache/maven/api/plugin/testing/stubs/ProducedArtifactStubTest.java
@@ -18,13 +18,21 @@
  */
 package org.apache.maven.api.plugin.testing.stubs;
 
-/** @deprecated Use {@link org.apache.maven.testing.plugin.stubs.ProducedArtifactStub} instead */
-@Deprecated(since = "4.0.0-rc-6", forRemoval = true)
-public class ProducedArtifactStub extends org.apache.maven.testing.plugin.stubs.ProducedArtifactStub {
-    public ProducedArtifactStub() {}
+import org.junit.jupiter.api.Test;
 
-    public ProducedArtifactStub(
-            String groupId, String artifactId, String classifier, String version, String extension) {
-        super(groupId, artifactId, classifier, version, extension);
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProducedArtifactStubTest {
+
+    @Test
+    @SuppressWarnings("removal")
+    void deprecatedConstructorRemainsSourceCompatible() {
+        ProducedArtifactStub artifact = new ProducedArtifactStub("group", "artifact", "tests", "1.0", "jar");
+
+        assertEquals("group", artifact.getGroupId());
+        assertEquals("artifact", artifact.getArtifactId());
+        assertEquals("tests", artifact.getClassifier());
+        assertEquals("1.0", artifact.getVersion().toString());
+        assertEquals("jar", artifact.getExtension());
     }
 }


### PR DESCRIPTION
## Summary

- recognize the deprecated `org.apache.maven.api.plugin.testing.Basedir` annotation while preserving precedence for the replacement annotation
- restore the five-argument constructor on the deprecated `ProducedArtifactStub` compatibility class
- add regression coverage for the deprecated annotation flow and constructor source compatibility

This keeps the deprecated testing API functional for its remaining lifetime instead of allowing existing plugin tests to compile but silently use the wrong base directory.

Fixes #12678.

## Verification

- `mvn --batch-mode verify`
- `mvn --batch-mode -pl impl/maven-testing -am verify`
- `mvn --batch-mode -pl impl/maven-testing -am -rf :maven-testing -Dtest=ExpressionEvaluatorTest,ProducedArtifactStubTest -Dsurefire.failIfNoSpecifiedTests=false test`

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/