### PR TITLE
[MNG-8709] Use active profile properties for consumer POM validation

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -265,7 +265,16 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         request.source(src);
         request.locationTracking(false);
         request.systemProperties(iSession.getSystemProperties());
-        request.userProperties(iSession.getUserProperties());
+        Map<String, String> userProperties = new LinkedHashMap<>();
+        // BUILD_CONSUMER does not reactivate project profiles, so expose properties from profiles
+        // that were already active when the project model was built.
+        if (project != null && project.getActiveProfiles() != null) {
+            for (org.apache.maven.model.Profile profile : project.getActiveProfiles()) {
+                userProperties.putAll(profile.getDelegate().getProperties());
+            }
+        }
+        userProperties.putAll(iSession.getUserProperties());
+        request.userProperties(userProperties);
         request.lifecycleBindingsInjector(lifecycleBindingsInjector::injectLifecycleBindings);
         // Pass remote repositories so that the model builder can resolve BOM imports
         // from non-central repositories (e.g., repositories defined in settings.xml profiles).

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.api.DependencyCoordinates;
 import org.apache.maven.api.Node;
@@ -275,5 +276,113 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
         boolean hasCustomRepo =
                 consumerRequest.getRepositories().stream().anyMatch(r -> "custom-repo".equals(r.getId()));
         assertTrue(hasCustomRepo, "Consumer POM model builder request should include the project's custom repository");
+    }
+
+    /**
+     * Verifies that the consumer POM builder injects properties from the project's
+     * active profiles into the BUILD_CONSUMER request's user properties.
+     * <p>
+     * Without the fix in {@code DefaultConsumerPomBuilder.buildModel()}, the
+     * {@code ModelBuilderRequest} only carries session user properties. When a
+     * dependency version is defined via a profile property (e.g.
+     * {@code <version>${my.version}</version>}), model validation would reject the
+     * unresolved expression as an invalid version.
+     * <p>
+     * Session user properties ({@code -D} flags) must still take precedence over
+     * profile-defined properties.
+     */
+    @Test
+    void testConsumerPomIncludesActiveProfileProperties() throws Exception {
+        setRootDirectory("trivial");
+        Path file = Paths.get("src/test/resources/consumer/trivial/child/pom.xml");
+
+        MavenProject project = getEffectiveModel(file);
+
+        // Create an active profile with a property, simulating a profile that defines
+        // a dependency version (the scenario fixed by MNG-8709).
+        org.apache.maven.api.model.Profile apiProfile = org.apache.maven.api.model.Profile.newBuilder()
+                .id("version-profile")
+                .properties(Map.of("dep.version", "1.0.0"))
+                .build();
+        org.apache.maven.model.Profile modelProfile = new org.apache.maven.model.Profile(apiProfile);
+        project.setActiveProfiles(List.of(modelProfile));
+
+        // Spy on the ModelBuilderSession to capture the ModelBuilderRequest
+        ModelBuilder.ModelBuilderSession originalMbs = modelBuilder.newSession();
+        ModelBuilder.ModelBuilderSession spyMbs = Mockito.spy(originalMbs);
+        InternalSession.from(session).getData().set(SessionData.key(ModelBuilder.ModelBuilderSession.class), spyMbs);
+
+        // Build the consumer POM
+        builder.build(session, project, Sources.buildSource(file));
+
+        // Capture the ModelBuilderRequest passed to the ModelBuilderSession
+        ArgumentCaptor<ModelBuilderRequest> requestCaptor = ArgumentCaptor.forClass(ModelBuilderRequest.class);
+        Mockito.verify(spyMbs, Mockito.atLeastOnce()).build(requestCaptor.capture());
+
+        // Find the BUILD_CONSUMER request
+        ModelBuilderRequest consumerRequest = requestCaptor.getAllValues().stream()
+                .filter(r -> r.getRequestType() == ModelBuilderRequest.RequestType.BUILD_CONSUMER)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(consumerRequest, "Expected a BUILD_CONSUMER request to be made");
+
+        // Verify that user properties contain the profile property
+        Map<String, String> userProps = consumerRequest.getUserProperties();
+        assertNotNull(userProps, "User properties should not be null");
+        assertTrue(
+                userProps.containsKey("dep.version"), "User properties should contain properties from active profiles");
+        assertTrue(
+                "1.0.0".equals(userProps.get("dep.version")),
+                "Profile property 'dep.version' should have value '1.0.0'");
+    }
+
+    /**
+     * Verifies that session user properties ({@code -D} flags) take precedence
+     * over profile-defined properties in the BUILD_CONSUMER request.
+     */
+    @Test
+    void testConsumerPomSessionPropertiesOverrideProfileProperties() throws Exception {
+        MavenExecutionRequest execRequest = setRootDirectory("trivial");
+        Path file = Paths.get("src/test/resources/consumer/trivial/child/pom.xml");
+
+        MavenProject project = getEffectiveModel(file);
+
+        // Create an active profile with a property
+        org.apache.maven.api.model.Profile apiProfile = org.apache.maven.api.model.Profile.newBuilder()
+                .id("version-profile")
+                .properties(Map.of("dep.version", "1.0.0"))
+                .build();
+        org.apache.maven.model.Profile modelProfile = new org.apache.maven.model.Profile(apiProfile);
+        project.setActiveProfiles(List.of(modelProfile));
+
+        // Set the same property as a session user property (simulating -Ddep.version=2.0.0)
+        execRequest.getUserProperties().setProperty("dep.version", "2.0.0");
+
+        // Spy on the ModelBuilderSession to capture the ModelBuilderRequest
+        ModelBuilder.ModelBuilderSession originalMbs = modelBuilder.newSession();
+        ModelBuilder.ModelBuilderSession spyMbs = Mockito.spy(originalMbs);
+        InternalSession.from(session).getData().set(SessionData.key(ModelBuilder.ModelBuilderSession.class), spyMbs);
+
+        // Build the consumer POM
+        builder.build(session, project, Sources.buildSource(file));
+
+        // Capture the BUILD_CONSUMER request
+        ArgumentCaptor<ModelBuilderRequest> requestCaptor = ArgumentCaptor.forClass(ModelBuilderRequest.class);
+        Mockito.verify(spyMbs, Mockito.atLeastOnce()).build(requestCaptor.capture());
+
+        ModelBuilderRequest consumerRequest = requestCaptor.getAllValues().stream()
+                .filter(r -> r.getRequestType() == ModelBuilderRequest.RequestType.BUILD_CONSUMER)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(consumerRequest, "Expected a BUILD_CONSUMER request to be made");
+
+        // Session user properties must override profile properties
+        Map<String, String> userProps = consumerRequest.getUserProperties();
+        assertTrue(
+                "2.0.0".equals(userProps.get("dep.version")),
+                "Session user property should override profile property; expected '2.0.0' but got '"
+                        + userProps.get("dep.version") + "'");
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8709ProfileDependencyVersionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8709ProfileDependencyVersionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MavenITmng8709ProfileDependencyVersionTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8709ProfileDependencyVersionTest() {
+        super("[4.0.0-rc-6,)");
+    }
+
+    @Test
+    void dependencyVersionFromActiveProfileIsValidForConsumerPom() throws Exception {
+        Path basedir = extractResources("/mng-8709-profile-dependency-version")
+                .getAbsoluteFile()
+                .toPath();
+
+        Verifier verifier = newVerifier(basedir.toString());
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Path consumerPom = Path.of(verifier.getArtifactPath(
+                "org.apache.maven.its.mng8709", "profile-version", "1.0", "pom"));
+        String content = Files.readString(consumerPom);
+        assertTrue(content.contains("<activeByDefault>true</activeByDefault>"));
+        assertTrue(content.contains("<version>${junit.version}</version>"));
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8709ProfileDependencyVersionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8709ProfileDependencyVersionTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MavenITmng8709ProfileDependencyVersionTest extends AbstractMavenIntegrationTestCase {
 
     MavenITmng8709ProfileDependencyVersionTest() {
-        super("[4.0.0-rc-6,)");
+        super("[4.0.0-rc-7,)");
     }
 
     @Test

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -116,6 +116,7 @@ public class TestSuiteOrdering implements ClassOrderer {
         suite.addTestSuite(MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.class);
         suite.addTestSuite(MavenITgh10937QuotedPipesInMavenOptsTest.class);
         suite.addTestSuite(MavenITgh2532DuplicateDependencyEffectiveModelTest.class);
+        suite.addTestSuite(MavenITmng8709ProfileDependencyVersionTest.class);
         suite.addTestSuite(MavenITmng8736ConcurrentFileActivationTest.class);
         suite.addTestSuite(MavenITmng8744CIFriendlyTest.class);
         suite.addTestSuite(MavenITmng8572DITypeHandlerTest.class);

--- a/its/core-it-suite/src/test/resources/mng-8709-profile-dependency-version/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8709-profile-dependency-version/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng8709</groupId>
+  <artifactId>profile-version</artifactId>
+  <version>1.0</version>
+
+  <profiles>
+    <profile>
+      <id>default-versions</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <junit.version>5.11.0</junit.version>
+      </properties>
+    </profile>
+  </profiles>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
Fixes #10379.

When Maven rebuilds a consumer POM, `BUILD_CONSUMER` does not reactivate the profiles that were active while building the project. As a result, model validation can see unresolved dependency versions when their values come from an active profile.

This change makes properties from the project's already-active profiles available while rebuilding the consumer model. Session user properties are applied afterward so their existing precedence is preserved. The change does not activate additional profiles or replace profile-backed expressions in the generated consumer POM.

A Core IT covers an `activeByDefault` profile that supplies a dependency version and verifies that installation succeeds while the generated consumer POM retains both the profile and the property expression.

### Tests

- `mvn -pl impl/maven-core -Dtest=ConsumerPomBuilderTest test`
- `mvn -Prun-its -DmavenHome=<maven-under-test> -Dtest=MavenITmng8709ProfileDependencyVersionTest -Dsurefire.failIfNoSpecifiedTests=false verify`
- `mvn -Prun-its -DmavenHome=<maven-under-test> verify -rf :core-it-suite` on JDK 21
  - 1,037 tests ran and the MNG-8709 regression passed. One unrelated existing test failed because it expected the legacy Central URL `https://repo1.maven.org` while the local environment used `https://repo.maven.apache.org`.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/