### PR TITLE
[mvnup] Add maven-war-plugin and maven-ear-plugin to plugin upgrade list

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -144,7 +144,17 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     "org.codehaus.gmavenplus",
                     "gmavenplus-plugin",
                     "4.2.0",
-                    "Versions before 4.2.0 call mutating methods on immutable lists returned by Maven 4 API"));
+                    "Versions before 4.2.0 call mutating methods on immutable lists returned by Maven 4 API"),
+            new PluginUpgrade(
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID,
+                    "maven-war-plugin",
+                    "3.4.0",
+                    "Versions before 3.3.2 use reflection on java.util.Properties internals, blocked by JDK 17+ required by Maven 4"),
+            new PluginUpgrade(
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID,
+                    "maven-ear-plugin",
+                    "3.4.0",
+                    "Versions before 3.3.0 use reflection via plexus-archiver, blocked by JDK 17+ required by Maven 4"));
 
     private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
             "org.codehaus.mojo",


### PR DESCRIPTION
## Summary

- Add `maven-war-plugin` (min 3.4.0) to the `PLUGIN_UPGRADES` list in `PluginUpgradeStrategy`
- Add `maven-ear-plugin` (min 3.4.0) to the `PLUGIN_UPGRADES` list in `PluginUpgradeStrategy`

Both plugins use reflection on `java.util.Properties` internals (via XStream/plexus-archiver) in older versions, which is blocked by the JDK 17+ module system. Since Maven 4 requires JDK 17+, `mvnup` should upgrade these plugins to compatible versions.

### Affected versions

| Plugin | Broken versions | Fix version | Root cause |
|--------|----------------|-------------|------------|
| `maven-war-plugin` | < 3.3.2 | 3.4.0 | XStream `PropertiesConverter` reflects on `Properties.defaults` field |
| `maven-ear-plugin` | < 3.3.0 | 3.4.0 | `plexus-archiver` uses reflection blocked by JDK 17+ modules |

### Context

Discovered during [Maven 4 compatibility testing](https://github.com/gnodet/maven4-testing) — projects like `mina-vysper` using `maven-war-plugin:2.1.1` crash with:
```
java.lang.reflect.InaccessibleObjectException: Unable to make field protected volatile java.util.Properties java.util.Properties.defaults accessible
```

Running `mvnup apply` didn't fix this because `maven-war-plugin` wasn't in the upgrade list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)