### PR TITLE
Fix modello velocity phase for concurrent builder compatibility

### DIFF
--- a/api/maven-api-settings/pom.xml
+++ b/api/maven-api-settings/pom.xml
@@ -76,6 +76,12 @@ under the License.
             <id>modello</id>
             <goals>
               <goal>velocity</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+          <execution>
+            <id>modello-docs</id>
+            <goals>
               <goal>xdoc</goal>
               <goal>xsd</goal>
             </goals>

--- a/api/maven-api-toolchain/pom.xml
+++ b/api/maven-api-toolchain/pom.xml
@@ -67,6 +67,12 @@ under the License.
             <id>modello</id>
             <goals>
               <goal>velocity</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+          <execution>
+            <id>modello-docs</id>
+            <goals>
               <goal>xdoc</goal>
               <goal>xsd</goal>
             </goals>


### PR DESCRIPTION
## Summary

- Split modello plugin executions in `maven-api-settings` and `maven-api-toolchain` so the `velocity` goal (Java source generation) runs at `generate-sources` instead of `generate-resources`, while `xdoc`/`xsd` (documentation) remain at `generate-resources`
- Fixes a race condition in the concurrent builder (`-b concurrent`) where `COMPILE` could start before `velocity` finished generating Java source files, causing `"package does not exist"` compilation errors
- Aligns with the pattern already used by `maven-api-model`

## Details

In Maven 4's graph lifecycle model, `SOURCES` and `RESOURCES` are parallel siblings under `BUILD`, and `COMPILE` is ordered `after(SOURCES)` but **not** `after(RESOURCES)`:

```
phase(BUILD,
    phase(SOURCES),
    phase(RESOURCES),                                            ← parallel with SOURCES
    phase(COMPILE, after(SOURCES), dependencies(..., READY)),    ← waits for SOURCES, not RESOURCES
    phase(READY, after(COMPILE), after(RESOURCES)),
    phase(PACKAGE, after(READY), ...))
```

The modello `velocity` goal generates **Java source files**, but was bound to `generate-resources` (→ `RESOURCES` phase). This created a race: `COMPILE` could start while `velocity` was still running, missing the generated sources.

The race manifested deterministically as `mvn build -T1C -b concurrent` failing without `clean` (upstream incremental builds finished fast → `COMPILE` started before modello), while `mvn clean build -T1C -b concurrent` worked (upstream full rebuilds took longer → modello finished first).

## Test plan

- [x] `mvn clean build -T1C -b concurrent -DskipTests` → BUILD SUCCESS
- [x] `mvn build -T1C -b concurrent -DskipTests` (without clean) → BUILD SUCCESS (previously failed with `package org.apache.maven.api.settings does not exist`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)