### PR TITLE
Log API enhancements and mojo MDC

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
@@ -38,8 +38,13 @@ import org.apache.maven.api.annotations.Provider;
 public interface Log {
     /**
      * {@return true if the <b>trace</b> error level is enabled}
+     * <p>
+     * The default implementation returns {@code false} for backward
+     * compatibility with existing {@code Log} implementations.
      */
-    boolean isTraceEnabled();
+    default boolean isTraceEnabled() {
+        return false;
+    }
 
     /**
      * Sends a message to the user in the <b>trace</b> error level.
@@ -49,44 +54,54 @@ public interface Log {
      * ordering details.  Use {@link #debug(CharSequence)} instead for
      * messages that help <em>users</em> investigate their build
      * (e.g. why a module was recompiled).
+     * <p>
+     * The default implementation is a no-op for backward compatibility.
      *
      * @param content the message to log
      */
-    void trace(CharSequence content);
+    default void trace(CharSequence content) {}
 
     /**
      * Sends a message (and accompanying exception) to the user at the <b>trace</b> error level.
      * The error's stacktrace will be output when this error level is enabled.
+     * <p>
+     * The default implementation is a no-op for backward compatibility.
      *
      * @param content the message to log
      * @param error the error that caused this log
      */
-    void trace(CharSequence content, Throwable error);
+    default void trace(CharSequence content, Throwable error) {}
 
     /**
      * Sends an exception to the user in the <b>trace</b> error level.
      * The stack trace for this exception will be output when this error level is enabled.
+     * <p>
+     * The default implementation is a no-op for backward compatibility.
      *
      * @param error the error that caused this log
      */
-    void trace(Throwable error);
+    default void trace(Throwable error) {}
 
     /**
      * Sends a lazily-computed message in the <b>trace</b> error level.
      * The supplier is only evaluated if trace is enabled.
+     * <p>
+     * The default implementation is a no-op for backward compatibility.
      *
      * @param content the message supplier
      */
-    void trace(Supplier<String> content);
+    default void trace(Supplier<String> content) {}
 
     /**
      * Sends a lazily-computed message (and accompanying exception) in the <b>trace</b> error level.
      * The supplier is only evaluated if trace is enabled.
+     * <p>
+     * The default implementation is a no-op for backward compatibility.
      *
      * @param content the message supplier
      * @param error the error that caused this log
      */
-    void trace(Supplier<String> content, Throwable error);
+    default void trace(Supplier<String> content, Throwable error) {}
 
     /**
      * {@return true if the <b>debug</b> error level is enabled}

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/plugin/Log.java
@@ -37,12 +37,69 @@ import org.apache.maven.api.annotations.Provider;
 @Provider
 public interface Log {
     /**
+     * {@return true if the <b>trace</b> error level is enabled}
+     */
+    boolean isTraceEnabled();
+
+    /**
+     * Sends a message to the user in the <b>trace</b> error level.
+     * <p>
+     * Trace is the most verbose level, intended for Maven core internals
+     * such as resolver negotiation, model interpolation, and lifecycle
+     * ordering details.  Use {@link #debug(CharSequence)} instead for
+     * messages that help <em>users</em> investigate their build
+     * (e.g. why a module was recompiled).
+     *
+     * @param content the message to log
+     */
+    void trace(CharSequence content);
+
+    /**
+     * Sends a message (and accompanying exception) to the user at the <b>trace</b> error level.
+     * The error's stacktrace will be output when this error level is enabled.
+     *
+     * @param content the message to log
+     * @param error the error that caused this log
+     */
+    void trace(CharSequence content, Throwable error);
+
+    /**
+     * Sends an exception to the user in the <b>trace</b> error level.
+     * The stack trace for this exception will be output when this error level is enabled.
+     *
+     * @param error the error that caused this log
+     */
+    void trace(Throwable error);
+
+    /**
+     * Sends a lazily-computed message in the <b>trace</b> error level.
+     * The supplier is only evaluated if trace is enabled.
+     *
+     * @param content the message supplier
+     */
+    void trace(Supplier<String> content);
+
+    /**
+     * Sends a lazily-computed message (and accompanying exception) in the <b>trace</b> error level.
+     * The supplier is only evaluated if trace is enabled.
+     *
+     * @param content the message supplier
+     * @param error the error that caused this log
+     */
+    void trace(Supplier<String> content, Throwable error);
+
+    /**
      * {@return true if the <b>debug</b> error level is enabled}
      */
     boolean isDebugEnabled();
 
     /**
      * Sends a message to the user in the <b>debug</b> error level.
+     * <p>
+     * Debug is intended for messages that help <em>users</em> investigate
+     * their build — for example, why a module was recompiled or what
+     * classpath was resolved.  For Maven core internals, use
+     * {@link #trace(CharSequence)} instead.
      *
      * @param content the message to log
      */
@@ -167,4 +224,27 @@ public interface Log {
     void error(Supplier<String> content);
 
     void error(Supplier<String> content, Throwable error);
+
+    /**
+     * Returns a child logger whose name is derived from this logger's name
+     * by appending a dot and the given suffix.
+     *
+     * <p>For example, if a plugin's logger is named
+     * {@code "org.apache.maven.plugins.compiler.CompilerMojo"},
+     * then {@code child("diagnostics")} returns a logger named
+     * {@code "org.apache.maven.plugins.compiler.CompilerMojo.diagnostics"}.
+     * This lets sub-components log under an independently filterable name
+     * without requiring a separate injection point.</p>
+     *
+     * <p>The default implementation returns {@code this}, so existing
+     * {@code Log} implementations continue to work without changes.
+     * Implementations that wrap a hierarchical logging backend (such as
+     * SLF4J) should override this to create a real child logger.</p>
+     *
+     * @param name the suffix to append (must not be {@code null} or blank)
+     * @return a child logger — never {@code null}
+     */
+    default Log child(String name) {
+        return this;
+    }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLog.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLog.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import org.apache.maven.api.plugin.Log;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,6 +31,44 @@ public class DefaultLog implements Log {
 
     public DefaultLog(Logger logger) {
         this.logger = requireNonNull(logger);
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(CharSequence content) {
+        if (isTraceEnabled()) {
+            logger.trace(toString(content));
+        }
+    }
+
+    @Override
+    public void trace(CharSequence content, Throwable error) {
+        if (isTraceEnabled()) {
+            logger.trace(toString(content), error);
+        }
+    }
+
+    @Override
+    public void trace(Throwable error) {
+        logger.trace("", error);
+    }
+
+    @Override
+    public void trace(Supplier<String> content) {
+        if (isTraceEnabled()) {
+            logger.trace(content.get());
+        }
+    }
+
+    @Override
+    public void trace(Supplier<String> content, Throwable error) {
+        if (isTraceEnabled()) {
+            logger.trace(content.get(), error);
+        }
     }
 
     @Override
@@ -127,7 +166,7 @@ public class DefaultLog implements Log {
     @Override
     public void warn(Supplier<String> content, Throwable error) {
         if (isWarnEnabled()) {
-            logger.info(content.get(), error);
+            logger.warn(content.get(), error);
         }
     }
 
@@ -182,6 +221,12 @@ public class DefaultLog implements Log {
     @Override
     public boolean isErrorEnabled() {
         return logger.isErrorEnabled();
+    }
+
+    @Override
+    public Log child(String name) {
+        requireNonNull(name, "name");
+        return new DefaultLog(LoggerFactory.getLogger(logger.getName() + "." + name));
     }
 
     private String toString(CharSequence content) {

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLog.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLog.java
@@ -54,7 +54,9 @@ public class DefaultLog implements Log {
 
     @Override
     public void trace(Throwable error) {
-        logger.trace("", error);
+        if (isTraceEnabled()) {
+            logger.trace("", error);
+        }
     }
 
     @Override
@@ -87,7 +89,9 @@ public class DefaultLog implements Log {
 
     @Override
     public void debug(Throwable error) {
-        logger.debug("", error);
+        if (isDebugEnabled()) {
+            logger.debug("", error);
+        }
     }
 
     @Override
@@ -120,7 +124,9 @@ public class DefaultLog implements Log {
 
     @Override
     public void info(Throwable error) {
-        logger.info("", error);
+        if (isInfoEnabled()) {
+            logger.info("", error);
+        }
     }
 
     @Override
@@ -153,7 +159,9 @@ public class DefaultLog implements Log {
 
     @Override
     public void warn(Throwable error) {
-        logger.warn("", error);
+        if (isWarnEnabled()) {
+            logger.warn("", error);
+        }
     }
 
     @Override
@@ -186,7 +194,9 @@ public class DefaultLog implements Log {
 
     @Override
     public void error(Throwable error) {
-        logger.error("", error);
+        if (isErrorEnabled()) {
+            logger.error("", error);
+        }
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingExecutionListener.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingExecutionListener.java
@@ -129,15 +129,15 @@ public class LoggingExecutionListener implements ExecutionListener, ProjectExecu
     @Override
     public void mojoSucceeded(ExecutionEvent event) {
         setMdc(event);
-        ProjectBuildLogAppender.setMojoId(null);
         delegate.mojoSucceeded(event);
+        ProjectBuildLogAppender.setMojoId(null);
     }
 
     @Override
     public void mojoFailed(ExecutionEvent event) {
         setMdc(event);
-        ProjectBuildLogAppender.setMojoId(null);
         delegate.mojoFailed(event);
+        ProjectBuildLogAppender.setMojoId(null);
     }
 
     @Override
@@ -151,18 +151,22 @@ public class LoggingExecutionListener implements ExecutionListener, ProjectExecu
         setMdc(event);
         delegate.forkStarted(event);
         ProjectBuildLogAppender.setForkingProjectId(event.getProject().getArtifactId());
+        // Save the forking mojo's ID so it can be restored when the fork completes
+        ProjectBuildLogAppender.setForkingMojoId(ProjectBuildLogAppender.getMojoId());
     }
 
     @Override
     public void forkSucceeded(ExecutionEvent event) {
         delegate.forkSucceeded(event);
         ProjectBuildLogAppender.setForkingProjectId(null);
+        ProjectBuildLogAppender.setForkingMojoId(null);
     }
 
     @Override
     public void forkFailed(ExecutionEvent event) {
         delegate.forkFailed(event);
         ProjectBuildLogAppender.setForkingProjectId(null);
+        ProjectBuildLogAppender.setForkingMojoId(null);
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingExecutionListener.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingExecutionListener.java
@@ -144,6 +144,7 @@ public class LoggingExecutionListener implements ExecutionListener, ProjectExecu
     public void mojoSkipped(ExecutionEvent event) {
         setMdc(event);
         delegate.mojoSkipped(event);
+        ProjectBuildLogAppender.setMojoId(null);
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingExecutionListener.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/logging/LoggingExecutionListener.java
@@ -121,6 +121,7 @@ public class LoggingExecutionListener implements ExecutionListener, ProjectExecu
     @Override
     public void mojoStarted(ExecutionEvent event) {
         setMdc(event);
+        setMojoMdc(event);
         buildEventListener.mojoStarted(event);
         delegate.mojoStarted(event);
     }
@@ -128,12 +129,14 @@ public class LoggingExecutionListener implements ExecutionListener, ProjectExecu
     @Override
     public void mojoSucceeded(ExecutionEvent event) {
         setMdc(event);
+        ProjectBuildLogAppender.setMojoId(null);
         delegate.mojoSucceeded(event);
     }
 
     @Override
     public void mojoFailed(ExecutionEvent event) {
         setMdc(event);
+        ProjectBuildLogAppender.setMojoId(null);
         delegate.mojoFailed(event);
     }
 
@@ -185,6 +188,14 @@ public class LoggingExecutionListener implements ExecutionListener, ProjectExecu
     private void setMdc(ExecutionEvent event) {
         if (event.getProject() != null) {
             ProjectBuildLogAppender.setProjectId(event.getProject().getArtifactId());
+        }
+    }
+
+    private void setMojoMdc(ExecutionEvent event) {
+        if (event.getMojoExecution() != null) {
+            String mojoId = event.getMojoExecution().getMojoDescriptor().getFullGoalName() + "@"
+                    + event.getMojoExecution().getExecutionId();
+            ProjectBuildLogAppender.setMojoId(mojoId);
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/logging/ProjectBuildLogAppender.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/logging/ProjectBuildLogAppender.java
@@ -31,6 +31,7 @@ public class ProjectBuildLogAppender implements AutoCloseable {
     private static final ThreadLocal<String> PROJECT_ID = new InheritableThreadLocal<>();
     private static final ThreadLocal<String> MOJO_ID = new InheritableThreadLocal<>();
     private static final ThreadLocal<String> FORKING_PROJECT_ID = new InheritableThreadLocal<>();
+    private static final ThreadLocal<String> FORKING_MOJO_ID = new InheritableThreadLocal<>();
 
     public static String getProjectId() {
         return PROJECT_ID.get();
@@ -60,9 +61,8 @@ public class ProjectBuildLogAppender implements AutoCloseable {
 
     /**
      * Sets or clears the mojo execution identifier in both the thread-local
-     * and the SLF4J MDC.  The value is available to any SLF4J appender via
-     * the MDC key {@code maven.mojo.id} and to JUL-bridged messages through
-     * the same MDC path.
+     * and the SLF4J MDC.  When clearing ({@code null}), if a forking mojo ID
+     * was saved, it is restored — mirroring the fork-aware project ID pattern.
      * <p>
      * Format: {@code "prefix:goal@executionId"}
      * (e.g. {@code "compiler:compile@default-compile"}).
@@ -74,8 +74,15 @@ public class ProjectBuildLogAppender implements AutoCloseable {
             MOJO_ID.set(mojoId);
             MDC.put(KEY_MOJO_ID, mojoId);
         } else {
-            MOJO_ID.remove();
-            MDC.remove(KEY_MOJO_ID);
+            // Restore the forking mojo's ID if one was saved
+            String forkingMojoId = FORKING_MOJO_ID.get();
+            if (forkingMojoId != null) {
+                MOJO_ID.set(forkingMojoId);
+                MDC.put(KEY_MOJO_ID, forkingMojoId);
+            } else {
+                MOJO_ID.remove();
+                MDC.remove(KEY_MOJO_ID);
+            }
         }
     }
 
@@ -84,6 +91,21 @@ public class ProjectBuildLogAppender implements AutoCloseable {
             FORKING_PROJECT_ID.set(forkingProjectId);
         } else {
             FORKING_PROJECT_ID.remove();
+        }
+    }
+
+    /**
+     * Saves or clears the mojo ID of the forking mojo, so it can be
+     * restored when the fork completes. Mirrors the {@link #setForkingProjectId}
+     * pattern for project IDs.
+     *
+     * @param forkingMojoId the forking mojo identifier, or {@code null} to clear
+     */
+    public static void setForkingMojoId(String forkingMojoId) {
+        if (forkingMojoId != null) {
+            FORKING_MOJO_ID.set(forkingMojoId);
+        } else {
+            FORKING_MOJO_ID.remove();
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/logging/ProjectBuildLogAppender.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/logging/ProjectBuildLogAppender.java
@@ -27,7 +27,9 @@ import org.slf4j.MDC;
 public class ProjectBuildLogAppender implements AutoCloseable {
 
     private static final String KEY_PROJECT_ID = "maven.project.id";
+    private static final String KEY_MOJO_ID = "maven.mojo.id";
     private static final ThreadLocal<String> PROJECT_ID = new InheritableThreadLocal<>();
+    private static final ThreadLocal<String> MOJO_ID = new InheritableThreadLocal<>();
     private static final ThreadLocal<String> FORKING_PROJECT_ID = new InheritableThreadLocal<>();
 
     public static String getProjectId() {
@@ -49,6 +51,31 @@ public class ProjectBuildLogAppender implements AutoCloseable {
         } else {
             PROJECT_ID.remove();
             MDC.remove(KEY_PROJECT_ID);
+        }
+    }
+
+    public static String getMojoId() {
+        return MOJO_ID.get();
+    }
+
+    /**
+     * Sets or clears the mojo execution identifier in both the thread-local
+     * and the SLF4J MDC.  The value is available to any SLF4J appender via
+     * the MDC key {@code maven.mojo.id} and to JUL-bridged messages through
+     * the same MDC path.
+     * <p>
+     * Format: {@code "prefix:goal@executionId"}
+     * (e.g. {@code "compiler:compile@default-compile"}).
+     *
+     * @param mojoId the mojo identifier, or {@code null} to clear
+     */
+    public static void setMojoId(String mojoId) {
+        if (mojoId != null) {
+            MOJO_ID.set(mojoId);
+            MDC.put(KEY_MOJO_ID, mojoId);
+        } else {
+            MOJO_ID.remove();
+            MDC.remove(KEY_MOJO_ID);
         }
     }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultBuildPluginManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultBuildPluginManager.java
@@ -125,7 +125,7 @@ public class DefaultBuildPluginManager implements BuildPluginManager {
             scope.seed(
                     org.apache.maven.api.plugin.Log.class,
                     new DefaultLog(LoggerFactory.getLogger(
-                            mojoExecution.getMojoDescriptor().getFullGoalName())));
+                            mojoExecution.getMojoDescriptor().getImplementation())));
             InternalMavenSession sessionV4 = InternalMavenSession.from(session.getSession());
             scope.seed(Project.class, sessionV4.getProject(project));
             scope.seed(org.apache.maven.api.MojoExecution.class, new DefaultMojoExecution(sessionV4, mojoExecution));

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -555,7 +555,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
 
         org.apache.maven.api.MojoExecution execution = new DefaultMojoExecution(sessionV4, mojoExecution);
         org.apache.maven.api.plugin.Log log = new DefaultLog(
-                LoggerFactory.getLogger(mojoExecution.getMojoDescriptor().getFullGoalName()));
+                LoggerFactory.getLogger(mojoExecution.getMojoDescriptor().getImplementation()));
         try {
             Injector injector = Injector.create();
             injector.discover(pluginRealm);

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultLogTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/impl/DefaultLogTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.internal.impl;
+
+import org.apache.maven.api.plugin.Log;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DefaultLog}.
+ */
+class DefaultLogTest {
+
+    /**
+     * Regression test: {@code warn(Supplier, Throwable)} was incorrectly
+     * calling {@code logger.info()} instead of {@code logger.warn()}.
+     */
+    @Test
+    void warnWithSupplierAndThrowableDelegatesToWarn() {
+        Logger mockLogger = mock(Logger.class);
+        when(mockLogger.isWarnEnabled()).thenReturn(true);
+
+        DefaultLog log = new DefaultLog(mockLogger);
+        RuntimeException ex = new RuntimeException("test");
+        log.warn(() -> "warning message", ex);
+
+        verify(mockLogger).warn("warning message", ex);
+    }
+
+    /**
+     * Verify trace methods delegate to the SLF4J logger correctly.
+     */
+    @Test
+    void traceMethodsDelegateToSlf4jTrace() {
+        Logger mockLogger = mock(Logger.class);
+        when(mockLogger.isTraceEnabled()).thenReturn(true);
+
+        DefaultLog log = new DefaultLog(mockLogger);
+        log.trace("trace message");
+
+        verify(mockLogger).trace("trace message");
+    }
+
+    /**
+     * Verify that trace methods are no-ops when trace is disabled.
+     */
+    @Test
+    void traceIsNoOpWhenDisabled() {
+        Logger mockLogger = mock(Logger.class);
+        when(mockLogger.isTraceEnabled()).thenReturn(false);
+
+        DefaultLog log = new DefaultLog(mockLogger);
+        log.trace("should not be logged");
+
+        verify(mockLogger).isTraceEnabled();
+        verifyNoMoreInteractions(mockLogger);
+    }
+
+    /**
+     * Verify that {@code child()} creates a new logger with the
+     * expected hierarchical name.
+     */
+    @Test
+    void childCreatesSubLogger() {
+        Logger mockLogger = mock(Logger.class);
+        when(mockLogger.getName()).thenReturn("org.apache.maven.plugins.compiler.CompilerMojo");
+
+        DefaultLog parent = new DefaultLog(mockLogger);
+        Log child = parent.child("diagnostics");
+
+        assertNotSame(parent, child);
+        assertTrue(child instanceof DefaultLog, "child should be a DefaultLog");
+    }
+
+    /**
+     * Verify that the default {@code Log.isTraceEnabled()} returns false,
+     * preventing {@code AbstractMethodError} for third-party implementors.
+     */
+    @Test
+    void defaultTraceIsDisabled() {
+        // Use a minimal Log implementation that relies on defaults
+        Log minimal = new Log() {
+            @Override
+            public boolean isDebugEnabled() {
+                return false;
+            }
+
+            @Override
+            public void debug(CharSequence c) {}
+
+            @Override
+            public void debug(CharSequence c, Throwable e) {}
+
+            @Override
+            public void debug(Throwable e) {}
+
+            @Override
+            public void debug(java.util.function.Supplier<String> c) {}
+
+            @Override
+            public void debug(java.util.function.Supplier<String> c, Throwable e) {}
+
+            @Override
+            public boolean isInfoEnabled() {
+                return false;
+            }
+
+            @Override
+            public void info(CharSequence c) {}
+
+            @Override
+            public void info(CharSequence c, Throwable e) {}
+
+            @Override
+            public void info(Throwable e) {}
+
+            @Override
+            public void info(java.util.function.Supplier<String> c) {}
+
+            @Override
+            public void info(java.util.function.Supplier<String> c, Throwable e) {}
+
+            @Override
+            public boolean isWarnEnabled() {
+                return false;
+            }
+
+            @Override
+            public void warn(CharSequence c) {}
+
+            @Override
+            public void warn(CharSequence c, Throwable e) {}
+
+            @Override
+            public void warn(Throwable e) {}
+
+            @Override
+            public void warn(java.util.function.Supplier<String> c) {}
+
+            @Override
+            public void warn(java.util.function.Supplier<String> c, Throwable e) {}
+
+            @Override
+            public boolean isErrorEnabled() {
+                return false;
+            }
+
+            @Override
+            public void error(CharSequence c) {}
+
+            @Override
+            public void error(CharSequence c, Throwable e) {}
+
+            @Override
+            public void error(Throwable e) {}
+
+            @Override
+            public void error(java.util.function.Supplier<String> c) {}
+
+            @Override
+            public void error(java.util.function.Supplier<String> c, Throwable e) {}
+        };
+
+        // These should NOT throw AbstractMethodError — they use defaults
+        assertEquals(false, minimal.isTraceEnabled());
+        minimal.trace("should be a no-op");
+        minimal.trace("no-op", new RuntimeException());
+        minimal.trace(new RuntimeException());
+        minimal.trace(() -> "no-op");
+        minimal.trace(() -> "no-op", new RuntimeException());
+    }
+}


### PR DESCRIPTION
## Summary

Four Log-related improvements for 4.0.x:

- **`Log.trace()`** — new trace level (SLF4J TRACE / JUL FINEST) to separate Maven core internals from user-facing debug messages. Currently `-X` floods debug output with resolver/interpolation details that drown user-relevant diagnostics. All 6 trace methods have `default` implementations (no-ops) to prevent `AbstractMethodError` for existing third-party `Log` implementors.
- **`Log.child(name)`** — creates a sub-logger with an independently filterable name (e.g. `CompilerMojo.diagnostics`), letting plugin sub-components log under their own namespace.
- **Logger name alignment** — Maven 4 `Log` now uses the mojo implementation class name (e.g. `org.apache.maven.plugins.compiler.CompilerMojo`) instead of the goal name (`compiler:compile`). This matches what Maven 3 mojos already use and enables standard SLF4J hierarchical level configuration.
- **Mojo MDC propagation** — sets `maven.mojo.id` (`prefix:goal@executionId`) in the SLF4J MDC during mojo execution. All log messages — including those arriving through the JUL-to-SLF4J bridge — now carry mojo context, available to any SLF4J appender via `%X{maven.mojo.id}`. Fork-aware: saves and restores the forking mojo's ID across forked lifecycles.

Also fixes a pre-existing bug where `DefaultLog.warn(Supplier, Throwable)` delegated to `logger.info()` instead of `logger.warn()`, and adds `isXxxEnabled()` guards to the existing `debug(Throwable)`, `info(Throwable)`, `warn(Throwable)`, and `error(Throwable)` methods.

## Files changed

| File | Change |
|---|---|
| `Log.java` | Add `trace()` default methods + `child()` default method |
| `DefaultLog.java` | Implement trace + child + fix warn bug + isXxxEnabled guards |
| `DefaultMavenPluginManager.java` | `getFullGoalName()` → `getImplementation()` |
| `DefaultBuildPluginManager.java` | `getFullGoalName()` → `getImplementation()` |
| `ProjectBuildLogAppender.java` | Add `maven.mojo.id` MDC key + fork-aware `setMojoId()` / `setForkingMojoId()` |
| `LoggingExecutionListener.java` | Set/clear mojoId MDC on mojo start/end, save/restore across forks |

## Related

- #12694 (logging foundation on master — superset including structured LogEvent, JUL handler, LogSink)

## Test plan

- [x] `mvn test -pl impl/maven-core` — 562 tests pass
- [ ] CI on maven-4.0.x branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)