### PR TITLE
Migrate legacy plugin Javadoc annotations in Core ITs

### DIFF
--- a/its/core-it-suite/src/test/resources/mng-0612/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-0612/plugin/pom.xml
@@ -18,5 +18,11 @@
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/its/core-it-suite/src/test/resources/mng-0612/plugin/src/main/java/org/apache/maven/its/it0125/DependenciesMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-0612/plugin/src/main/java/org/apache/maven/its/it0125/DependenciesMojo.java
@@ -48,23 +48,21 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Simple mojo to write the project's resolved dependencies to a file.
  *
  * @author <a href="mailto:markhobson@gmail.com">Mark Hobson</a>
- * @goal dependencies
- * @requiresDependencyResolution test
  */
+@Mojo(name = "dependencies", requiresDependencyResolution = ResolutionScope.TEST)
 public class DependenciesMojo extends AbstractMojo {
-    /**
-     * @parameter expression="${project.artifacts}"
-     */
+    @Parameter(defaultValue = "${project.artifacts}")
     private Set artifacts;
 
-    /**
-     * @parameter expression="${project.build.directory}"
-     */
+    @Parameter(defaultValue = "${project.build.directory}")
     private String buildDirectory;
 
     /*

--- a/its/core-it-suite/src/test/resources/mng-0870/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-0870/plugin/pom.xml
@@ -54,6 +54,12 @@ under the License.
       <artifactId>dep</artifactId>
       <version>0.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-0870/plugin/src/main/java/org/apache/maven/plugin/coreit/LoadMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-0870/plugin/src/main/java/org/apache/maven/plugin/coreit/LoadMojo.java
@@ -44,23 +44,23 @@ import java.net.URL;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Creates a touch file if and only if a resource from the plugin dependency was successfully loaded, fails otherwise.
  *
- * @goal load
- * @phase validate
  *
  * @author Benjamin Bentmann
- *
  */
+@Mojo(name = "load", defaultPhase = LifecyclePhase.VALIDATE)
 public class LoadMojo extends AbstractMojo {
 
     /**
      * The path to the output file, relative to the project base directory.
-     *
-     * @parameter expression="${touch.file}" default-value="target/touch.txt"
      */
+    @Parameter(property = "touch.file", defaultValue = "target/touch.txt")
     private File file;
 
     /**

--- a/its/core-it-suite/src/test/resources/mng-1088/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-1088/plugin/pom.xml
@@ -48,6 +48,12 @@ under the License.
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-1088/plugin/src/main/java/org/apache/maven/plugin/coreit/TouchMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-1088/plugin/src/main/java/org/apache/maven/plugin/coreit/TouchMojo.java
@@ -42,22 +42,23 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Creates a text file.
  *
- * @goal touch
- * @phase validate
  *
  * @author Benjamin Bentmann
  */
+@Mojo(name = "touch", defaultPhase = LifecyclePhase.VALIDATE)
 public class TouchMojo extends AbstractMojo {
 
     /**
      * The path to the output file, relative to the project base directory.
-     *
-     * @parameter expression="${touch.file}" default-value="target/touch.txt"
      */
+    @Parameter(property = "touch.file", defaultValue = "target/touch.txt")
     private File file;
 
     /**

--- a/its/core-it-suite/src/test/resources/mng-11796-default-phases-standard-lifecycle/extension-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-11796-default-phases-standard-lifecycle/extension-plugin/pom.xml
@@ -15,6 +15,12 @@
       <version>3.2.5</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-11796-default-phases-standard-lifecycle/extension-plugin/src/main/java/org/apache/maven/its/mng11796/TouchMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-11796-default-phases-standard-lifecycle/extension-plugin/src/main/java/org/apache/maven/its/mng11796/TouchMojo.java
@@ -23,15 +23,15 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Creates a marker file to prove the goal was executed.
- * @goal touch
  */
+@Mojo(name = "touch")
 public class TouchMojo extends AbstractMojo {
-    /**
-     * @parameter default-value="${project.build.directory}"
-     */
+    @Parameter(defaultValue = "${project.build.directory}")
     private File outputDirectory;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-2135/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-2135/plugin/pom.xml
@@ -38,6 +38,12 @@ under the License.
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-2135/plugin/src/main/java/coreit/ItMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-2135/plugin/src/main/java/coreit/ItMojo.java
@@ -42,15 +42,13 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * @goal it
- */
+@Mojo(name = "it")
 public class ItMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project.build.directory}/touch.txt"
-     */
+    @Parameter(defaultValue = "${project.build.directory}/touch.txt")
     private File outputFile;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-2771/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-2771/plugin/pom.xml
@@ -18,5 +18,17 @@
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/its/core-it-suite/src/test/resources/mng-2771/plugin/src/main/java/org/apache/maven/its/it0124/LookupMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-2771/plugin/src/main/java/org/apache/maven/its/it0124/LookupMojo.java
@@ -46,22 +46,21 @@ import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import javax.inject.Inject;
 
 /**
  * Simple mojo to write the injected artifact factory implementation to a file.
  *
  * @author <a href="mailto:markhobson@gmail.com">Mark Hobson</a>
- * @goal lookup
  */
+@Mojo(name = "lookup")
 public class LookupMojo extends AbstractMojo {
-    /**
-     * @component
-     */
     private ArtifactFactory artifactFactory;
 
-    /**
-     * @parameter expression="${project.build.directory}"
-     */
+    @Parameter(defaultValue = "${project.build.directory}")
     private String buildDirectory;
 
     /*
@@ -84,5 +83,10 @@ public class LookupMojo extends AbstractMojo {
         } catch (IOException exception) {
             throw new MojoExecutionException("Cannot create lookup.log", exception);
         }
+    }
+
+    @Inject
+    public LookupMojo(ArtifactFactory artifactFactory) {
+        this.artifactFactory = artifactFactory;
     }
 }

--- a/its/core-it-suite/src/test/resources/mng-3372/direct-using-prefix/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3372/direct-using-prefix/plugin/pom.xml
@@ -12,5 +12,11 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/its/core-it-suite/src/test/resources/mng-3372/direct-using-prefix/plugin/src/main/java/org/plugin/TestMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3372/direct-using-prefix/plugin/src/main/java/org/plugin/TestMojo.java
@@ -26,19 +26,14 @@ import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestMojo implements Mojo {
 
     private Log log;
 
-    /**
-     * @parameter default-value="${project.build.directory}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project.build.directory}", required = true, readonly = true)
     private File buildDir;
 
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/its/core-it-suite/src/test/resources/mng-3396/plugin/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3396/plugin/plugin/pom.xml
@@ -31,6 +31,12 @@
       <artifactId>B</artifactId>
       <version>1.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3396/plugin/plugin/src/main/java/org/apache/maven/its/mng3396/NoopMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3396/plugin/plugin/src/main/java/org/apache/maven/its/mng3396/NoopMojo.java
@@ -35,12 +35,11 @@ package org.apache.maven.its.mng3396;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
-/**
- * @goal noop
- * @phase compile
- * @requiresDependencyResolution test
- */
+@Mojo(name = "noop", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyResolution = ResolutionScope.TEST)
 public class NoopMojo extends AbstractMojo {
 
     public void execute() throws MojoExecutionException, MojoFailureException {}

--- a/its/core-it-suite/src/test/resources/mng-3498/maven-mng3498-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3498/maven-mng3498-plugin/pom.xml
@@ -37,6 +37,12 @@ under the License.
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3498/maven-mng3498-plugin/src/main/java/plugin/CheckMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3498/maven-mng3498-plugin/src/main/java/plugin/CheckMojo.java
@@ -24,18 +24,15 @@ import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * @goal check
- * @phase validate
- * @execute goal="touch"
- */
+@Execute(goal = "touch")
+@org.apache.maven.plugins.annotations.Mojo(name = "check", defaultPhase = LifecyclePhase.VALIDATE)
 public class CheckMojo implements Mojo {
 
-    /**
-     * @parameter default-value="${project.build.directory}/touch.txt"
-     * @required
-     */
+    @Parameter(defaultValue = "${project.build.directory}/touch.txt", required = true)
     private File touchFile;
 
     private Log log;

--- a/its/core-it-suite/src/test/resources/mng-3498/maven-mng3498-plugin/src/main/java/plugin/TouchMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3498/maven-mng3498-plugin/src/main/java/plugin/TouchMojo.java
@@ -40,18 +40,18 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which touches a timestamp file.
- *
- * @goal touch
  */
+@Mojo(name = "touch")
 public class TouchMojo extends AbstractMojo {
     /**
      * Location of the file.
-     * @parameter expression="${project.build.directory}"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
     private File outputDirectory;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3536/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3536/plugin/pom.xml
@@ -35,6 +35,12 @@ under the License.
       <artifactId>maven-project</artifactId>
       <version>2.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3536/plugin/src/main/java/plugin/Mojo3563.java
+++ b/its/core-it-suite/src/test/resources/mng-3536/plugin/src/main/java/plugin/Mojo3563.java
@@ -28,24 +28,19 @@ import org.apache.maven.model.Model;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.IOUtil;
 
-/**
- * @goal validate
- * @phase validate
- */
+@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE)
 public class Mojo3563 extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     */
+    @Parameter(defaultValue = "${project}")
     private MavenProject project;
 
-    /**
-     * @parameter
-     * @required
-     */
+    @Parameter(required = true)
     private File foo;
 
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/its/core-it-suite/src/test/resources/mng-3536/project/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3536/project/pom.xml
@@ -27,6 +27,14 @@ under the License.
   <properties>
     <test>file:${project.build.sourceDirectory}/plugin/Mojo3563.java</test>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/its/core-it-suite/src/test/resources/mng-3536/project/src/main/java/plugin/Mojo3563.java
+++ b/its/core-it-suite/src/test/resources/mng-3536/project/src/main/java/plugin/Mojo3563.java
@@ -24,19 +24,18 @@ import org.apache.maven.model.Model;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
  * Maven Mojo for executing nunit tests
- *
- * @goal validate
- * @phase validate
  */
+@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE)
 public class Mojo3563 extends AbstractMojo {
 
-    /**
-     * @parameter expression="${project}"
-     */
+    @Parameter(defaultValue = "${project}")
     private MavenProject project;
 
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/its/core-it-suite/src/test/resources/mng-3652/test-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3652/test-plugin/pom.xml
@@ -31,6 +31,18 @@
       <artifactId>plexus-utils</artifactId>
       <version>3.4.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3652/test-plugin/src/main/java/org/apache/maven/its/mng3652/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3652/test-plugin/src/main/java/org/apache/maven/its/mng3652/MyMojo.java
@@ -35,70 +35,40 @@ import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.execution.RuntimeInformation;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
+
+import javax.inject.Inject;
 
 /**
  * Goal which attempts to download a dummy artifact from a repository on localhost
  * at the specified port. This is used to allow the unit test class to record the
  * User-Agent HTTP header in use. It will also write the maven version in use to
  * a file in the output directory, for comparison in the unit tests assertions.
- *
- * @goal touch
- *
- * @phase validate
  */
+@Mojo(name = "touch", defaultPhase = LifecyclePhase.VALIDATE)
 public class MyMojo extends AbstractMojo {
 
     private static final String LS = System.getProperty("line.separator");
 
-    /**
-     * @parameter default-value="${project.build.directory}/touch.txt"
-     */
+    @Parameter(defaultValue = "${project.build.directory}/touch.txt")
     private File touchFile;
-
-    /**
-     * @component
-     */
     private ArtifactResolver resolver;
-
-    /**
-     * @component
-     */
     private ArtifactFactory artifactFactory;
-
-    /**
-     * @component
-     */
     private ArtifactRepositoryFactory repositoryFactory;
-
-    /**
-     * @component
-     */
     private ArtifactRepositoryLayout layout;
-
-    /**
-     * @component
-     */
     private RuntimeInformation runtimeInformation;
 
-    /**
-     * @parameter expression="${testProtocol}" default-value="http"
-     * @required
-     */
+    @Parameter(property = "testProtocol", defaultValue = "http", required = true)
     private String testProtocol;
 
-    /**
-     * @parameter expression="${testPort}"
-     * @required
-     */
+    @Parameter(property = "testPort", required = true)
     private String testPort;
 
-    /**
-     * @parameter default-value="${project.build.directory}/local-repo"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project.build.directory}/local-repo", required = true, readonly = true)
     private File localRepoDir;
 
     public void execute() throws MojoExecutionException {
@@ -179,5 +149,19 @@ public class MyMojo extends AbstractMojo {
         } finally {
             IOUtil.close(w);
         }
+    }
+
+    @Inject
+    public MyMojo(
+            ArtifactResolver resolver,
+            ArtifactFactory artifactFactory,
+            ArtifactRepositoryFactory repositoryFactory,
+            ArtifactRepositoryLayout layout,
+            RuntimeInformation runtimeInformation) {
+        this.resolver = resolver;
+        this.artifactFactory = artifactFactory;
+        this.repositoryFactory = repositoryFactory;
+        this.layout = layout;
+        this.runtimeInformation = runtimeInformation;
     }
 }

--- a/its/core-it-suite/src/test/resources/mng-3684/maven-mng3684-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3684/maven-mng3684-plugin/pom.xml
@@ -34,6 +34,12 @@
       <artifactId>maven-reporting-impl</artifactId>
       <version>2.0.4.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3684/maven-mng3684-plugin/src/main/java/plugin/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3684/maven-mng3684-plugin/src/main/java/plugin/MyMojo.java
@@ -43,24 +43,16 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal check
- */
+@Mojo(name = "check")
 public class MyMojo extends AbstractMojo {
-    /**
-     * @parameter default-value="${project.build}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project.build}", required = true, readonly = true)
     private Build build;
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3684/maven-mng3684-plugin/src/main/java/plugin/MyReport.java
+++ b/its/core-it-suite/src/test/resources/mng-3684/maven-mng3684-plugin/src/main/java/plugin/MyReport.java
@@ -43,26 +43,18 @@ import java.util.Map;
 import org.apache.maven.doxia.siterenderer.Renderer;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Resource;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 
-/**
- * @goal check-report
- */
+@Mojo(name = "check-report")
 public class MyReport extends AbstractMavenReport {
-    /**
-     * @parameter default-value="${project.build}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project.build}", required = true, readonly = true)
     private Build build;
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     private void runChecks() throws MavenReportException {

--- a/its/core-it-suite/src/test/resources/mng-3693/maven-mng3693-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3693/maven-mng3693-plugin/pom.xml
@@ -24,6 +24,12 @@
       <artifactId>maven-project</artifactId>
       <version>2.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3693/maven-mng3693-plugin/src/main/java/plugin/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3693/maven-mng3693-plugin/src/main/java/plugin/MyMojo.java
@@ -39,18 +39,15 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 
-/**
- * @goal move-pom
- * @phase package
- */
+@Mojo(name = "move-pom", defaultPhase = LifecyclePhase.PACKAGE)
 public class MyMojo extends AbstractMojo {
-    /**
-     * @parameter expression="${project}"
-     * @required
-     */
+    @Parameter(defaultValue = "${project}", required = true)
     private MavenProject project;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3694/maven-mng3694-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3694/maven-mng3694-plugin/pom.xml
@@ -24,6 +24,12 @@
       <artifactId>maven-project</artifactId>
       <version>2.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3694/maven-mng3694-plugin/src/main/java/plugin/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3694/maven-mng3694-plugin/src/main/java/plugin/MyMojo.java
@@ -39,30 +39,27 @@ import java.util.List;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal check
- * @phase validate
- */
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VALIDATE)
 public class MyMojo extends AbstractMojo {
 
     /**
      * Not used, just an offset to place reactorProjects in the middle.
-     * @parameter default-value="${project.build.directory}"
      */
+    @Parameter(defaultValue = "${project.build.directory}")
     private String outputDirectory;
 
-    /**
-     * @parameter expression="${reactorProjects}"
-     * @required
-     */
+    @Parameter(defaultValue = "${reactorProjects}", required = true)
     private List reactorProjects;
 
     /**
      * Not used, just an offset to place reactorProjects in the middle.
-     * @parameter default-value="${project.build.directory}"
      */
+    @Parameter(defaultValue = "${project.build.directory}")
     private String outputDirectory2;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/pom.xml
@@ -29,6 +29,12 @@
       <artifactId>maven-reporting-impl</artifactId>
       <version>2.0.4.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/AbstractCheckMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/AbstractCheckMojo.java
@@ -41,24 +41,17 @@ import java.util.Map;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 public abstract class AbstractCheckMojo extends AbstractMojo {
 
     protected static boolean forkHasRun = false;
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * @parameter default-value="${executedProject}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${executedProject}", required = true, readonly = true)
     private MavenProject executionProject;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/CheckMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/CheckMojo.java
@@ -34,12 +34,13 @@ package jar;
  * limitations under the License.
  */
 
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal check
- * @execute phase="compile"
- */
+@Execute(phase = LifecyclePhase.COMPILE)
+@Mojo(name = "check")
 public class CheckMojo extends AbstractCheckMojo {
 
     @Override

--- a/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/CheckReport.java
+++ b/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/CheckReport.java
@@ -42,34 +42,25 @@ import java.util.Map;
 
 import org.apache.maven.doxia.siterenderer.DefaultSiteRenderer;
 import org.apache.maven.doxia.siterenderer.Renderer;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 
-/**
- * @goal check-report
- * @execute phase="compile"
- */
+@Execute(phase = LifecyclePhase.COMPILE)
+@Mojo(name = "check-report")
 public class CheckReport extends AbstractMavenReport {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * @parameter default-value="${executedProject}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${executedProject}", required = true, readonly = true)
     private MavenProject executionProject;
 
-    /**
-     * @parameter default-value="${project.build.directory}/generated-site/mng3703"
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project.build.directory}/generated-site/mng3703", readonly = true)
     private String outputDirectory;
 
     protected void executeReport(Locale locale) throws MavenReportException {

--- a/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/RunMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3703/maven-mng3703-plugin/src/main/java/jar/RunMojo.java
@@ -35,12 +35,11 @@ package jar;
  */
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal run
- * @phase validate
- */
+@Mojo(name = "run", defaultPhase = LifecyclePhase.VALIDATE)
 public class RunMojo extends AbstractCheckMojo {
 
     @Override

--- a/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-directInvoke-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-directInvoke-plugin/pom.xml
@@ -18,6 +18,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-directInvoke-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-directInvoke-plugin/src/main/java/jar/MyMojo.java
@@ -36,10 +36,9 @@ package jar;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
 
-/**
- * @goal run
- */
+@Mojo(name = "run")
 public class MyMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         getLog().info("Direct-invoke mojo executed.");

--- a/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-originalModel-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-originalModel-plugin/pom.xml
@@ -23,6 +23,12 @@
       <artifactId>maven-project</artifactId>
       <version>2.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-originalModel-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3710/original-model/plugins/maven-mng3710-originalModel-plugin/src/main/java/jar/MyMojo.java
@@ -41,17 +41,13 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal check
- */
+@Mojo(name = "check")
 public class MyMojo extends AbstractMojo {
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3710/pom-inheritance/maven-mng3710-pomInheritance-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3710/pom-inheritance/maven-mng3710-pomInheritance-plugin/pom.xml
@@ -18,6 +18,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3710/pom-inheritance/maven-mng3710-pomInheritance-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3710/pom-inheritance/maven-mng3710-pomInheritance-plugin/src/main/java/jar/MyMojo.java
@@ -40,20 +40,19 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which touches a timestamp file.
- *
- * @goal touch
- *
- * @phase process-sources
  */
+@Mojo(name = "touch", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class MyMojo extends AbstractMojo {
     /**
      * Location of the file.
-     * @parameter expression="${project.build.directory}/touch.txt"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}/touch.txt", required = true)
     private File touchFile;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3716/maven-mng3716-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3716/maven-mng3716-plugin/pom.xml
@@ -19,6 +19,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3716/maven-mng3716-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3716/maven-mng3716-plugin/src/main/java/jar/MyMojo.java
@@ -36,12 +36,12 @@ package jar;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
-/**
- * @goal run
- * @aggregator
- * @execute phase="package"
- */
+@Execute(phase = LifecyclePhase.PACKAGE)
+@Mojo(name = "run", aggregator = true)
 public class MyMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         getLog().info("Aggregator mojo executed.");

--- a/its/core-it-suite/src/test/resources/mng-3723/maven-mng3723-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3723/maven-mng3723-plugin/pom.xml
@@ -24,6 +24,12 @@
       <artifactId>maven-project</artifactId>
       <version>2.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3723/maven-mng3723-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3723/maven-mng3723-plugin/src/main/java/jar/MyMojo.java
@@ -36,18 +36,16 @@ package jar;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal run
- */
+@Mojo(name = "run")
 public class MyMojo extends AbstractMojo {
     /**
      * Location of the file.
-     * @parameter expression="${project}"
-     * @required
-     * @readonly
      */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/pom.xml
@@ -24,6 +24,12 @@
       <artifactId>maven-project</artifactId>
       <version>2.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/AbstractMng2734Mojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/AbstractMng2734Mojo.java
@@ -21,14 +21,14 @@ package jar;
 import java.io.File;
 
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractMng2734Mojo extends AbstractMojo {
 
     /**
      * Location of the file.
-     * @parameter expression="${project.build.directory}/generated/src/main/java"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}/generated/src/main/java", required = true)
     private File generatorTargetDir;
 
     protected final File getGeneratorTargetDir() {

--- a/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/Phase1ForkingMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/Phase1ForkingMojo.java
@@ -36,11 +36,12 @@ package jar;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
-/**
- * @goal phase1
- * @execute phase="validate"
- */
+@Execute(phase = LifecyclePhase.VALIDATE)
+@Mojo(name = "phase1")
 public class Phase1ForkingMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {}
 }

--- a/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/Phase2GeneratorMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/Phase2GeneratorMojo.java
@@ -39,17 +39,13 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal phase2
- */
+@Mojo(name = "phase2")
 public class Phase2GeneratorMojo extends AbstractMng2734Mojo {
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/Phase3ForkVerifierMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3724/maven-mng3724-plugin/src/main/java/jar/Phase3ForkVerifierMojo.java
@@ -38,17 +38,16 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * @goal phase3
- * @execute phase="validate"
- */
+@Execute(phase = LifecyclePhase.VALIDATE)
+@Mojo(name = "phase3")
 public class Phase3ForkVerifierMojo extends AbstractMng2734Mojo {
-    /**
-     * @parameter expression="${executedProject}"
-     * @required
-     */
+    @Parameter(defaultValue = "${executedProject}", required = true)
     private MavenProject executedProject;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/pom.xml
@@ -19,6 +19,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/src/main/java/jar/Fork1Mojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/src/main/java/jar/Fork1Mojo.java
@@ -36,12 +36,12 @@ package jar;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
-/**
- * @goal fork1
- * @aggregator
- * @execute phase="compile"
- */
+@Execute(phase = LifecyclePhase.COMPILE)
+@Mojo(name = "fork1", aggregator = true)
 public class Fork1Mojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {}
 }

--- a/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/src/main/java/jar/Fork2Mojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/src/main/java/jar/Fork2Mojo.java
@@ -36,12 +36,12 @@ package jar;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
-/**
- * @goal fork2
- * @aggregator
- * @execute phase="compile"
- */
+@Execute(phase = LifecyclePhase.COMPILE)
+@Mojo(name = "fork2", aggregator = true)
 public class Fork2Mojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {}
 }

--- a/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/src/main/java/jar/Plain1Mojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3729/maven-mng3729-plugin/src/main/java/jar/Plain1Mojo.java
@@ -36,11 +36,10 @@ package jar;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
-/**
- * @goal plain1
- * @requiresDependencyResolution compile
- */
+@Mojo(name = "plain1", requiresDependencyResolution = ResolutionScope.COMPILE)
 public class Plain1Mojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {}
 }

--- a/its/core-it-suite/src/test/resources/mng-3740/projects.v1/maven-mng3740-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3740/projects.v1/maven-mng3740-plugin/pom.xml
@@ -17,6 +17,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3740/projects.v1/maven-mng3740-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3740/projects.v1/maven-mng3740-plugin/src/main/java/jar/MyMojo.java
@@ -40,20 +40,19 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which touches a timestamp file.
- *
- * @goal touch
- *
- * @phase process-sources
  */
+@Mojo(name = "touch", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class MyMojo extends AbstractMojo {
     /**
      * Location of the file.
-     * @parameter expression="${project.build.directory}"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
     private File outputDirectory;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3740/projects.v2/maven-mng3740-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3740/projects.v2/maven-mng3740-plugin/pom.xml
@@ -17,6 +17,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3740/projects.v2/maven-mng3740-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3740/projects.v2/maven-mng3740-plugin/src/main/java/jar/MyMojo.java
@@ -40,20 +40,19 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which touches a timestamp file.
- *
- * @goal touch
- *
- * @phase process-sources
  */
+@Mojo(name = "touch", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class MyMojo extends AbstractMojo {
     /**
      * Location of the file.
-     * @parameter expression="${project.build.directory}"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
     private File outputDirectory;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-3746/maven-mng3746-plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-3746/maven-mng3746-plugin/pom.xml
@@ -19,6 +19,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-3746/maven-mng3746-plugin/src/main/java/jar/MyMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-3746/maven-mng3746-plugin/src/main/java/jar/MyMojo.java
@@ -38,31 +38,21 @@ import java.util.Properties;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * @goal test
- */
+@Mojo(name = "test")
 public class MyMojo extends AbstractMojo {
-    /**
-     * @parameter
-     * @required
-     */
+    @Parameter(required = true)
     private String check;
 
-    /**
-     * @parameter expression="${test.verification}"
-     */
+    @Parameter(property = "test.verification")
     private String verification;
 
-    /**
-     * @parameter expression="${test.usingCliValue}" default-value="false"
-     */
+    @Parameter(property = "test.usingCliValue", defaultValue = "false")
     private boolean usingCliValue;
 
-    /**
-     * @parameter default-value="${project.properties}"
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project.properties}", readonly = true)
     private Properties properties;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-4091/invalid/maven-it-plugin-invalid-descriptor/src/main/java/org/apache/maven/plugin/coreit/CoreItMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-4091/invalid/maven-it-plugin-invalid-descriptor/src/main/java/org/apache/maven/plugin/coreit/CoreItMojo.java
@@ -20,13 +20,10 @@ package org.apache.maven.plugin.coreit;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
-/**
- *
- * @phase process-sources
- */
-@Mojo(name = "test")
+@Mojo(name = "test", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class CoreItMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         throw new MojoExecutionException("Should not be run");

--- a/its/core-it-suite/src/test/resources/mng-6127-plugin-execution-configuration-interference/plugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-6127-plugin-execution-configuration-interference/plugin/pom.xml
@@ -48,6 +48,12 @@ under the License.
       <version>${maven-version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-6127-plugin-execution-configuration-interference/plugin/src/main/java/org/apache/maven/its/mng6127/plugin/TestMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-6127-plugin-execution-configuration-interference/plugin/src/main/java/org/apache/maven/its/mng6127/plugin/TestMojo.java
@@ -45,33 +45,31 @@ import java.io.Writer;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
  * Test mojo.
- *
- * @goal test
  */
+@Mojo(name = "test")
 public class TestMojo extends AbstractMojo {
     /**
      * The Maven project.
-     *
-     * @parameter expression="${project}"
      */
+    @Parameter(defaultValue = "${project}")
     private MavenProject project;
 
     /**
      * The name to write.
-     *
-     * @parameter
      */
+    @Parameter
     private String name;
 
     /**
      * The second name to write.
-     *
-     * @parameter
      */
+    @Parameter
     private String secondName;
 
     public void execute() throws MojoExecutionException {

--- a/its/core-it-suite/src/test/resources/mng-6240-plugin-extension-aether-provider/plugin-extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-6240-plugin-extension-aether-provider/plugin-extension/pom.xml
@@ -39,6 +39,12 @@ under the License.
       <artifactId>maven-resolver-provider</artifactId>
       <version>${maven-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-6240-plugin-extension-aether-provider/plugin-extension/src/main/java/org/apache/maven/its/plugin/TestMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-6240-plugin-extension-aether-provider/plugin-extension/src/main/java/org/apache/maven/its/plugin/TestMojo.java
@@ -40,10 +40,9 @@ package org.apache.maven.its.mng6209.multiple.build.extensions.pluginb;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
 
-/**
- * @goal test
- */
+@Mojo(name = "test")
 public class TestMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {}
 }

--- a/its/core-it-suite/src/test/resources/mng-8299-custom-lifecycle/CustomLifecyclePlugin/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8299-custom-lifecycle/CustomLifecyclePlugin/pom.xml
@@ -15,6 +15,12 @@
       <version>3.2.5</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/core-it-suite/src/test/resources/mng-8299-custom-lifecycle/CustomLifecyclePlugin/src/main/java/com/nextmetaphor/plugin/mojo/CustomLifecyclePluginPhase1Mojo.java
+++ b/its/core-it-suite/src/test/resources/mng-8299-custom-lifecycle/CustomLifecyclePlugin/src/main/java/com/nextmetaphor/plugin/mojo/CustomLifecyclePluginPhase1Mojo.java
@@ -20,11 +20,12 @@ package com.nextmetaphor.plugin.mojo;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Forks a zip lifecycle.
- * @goal phase1Goal
  */
+@Mojo(name = "phase1Goal")
 public class CustomLifecyclePluginPhase1Mojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         getLog().info("Doing Phase 1 stuff. Oh yeah baby.");

--- a/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/NoOpMojo.java
+++ b/its/core-it-suite/src/test/resources/mng-8572-di-type-handler/extension/src/main/java/org/apache/maven/its/mng8572/extension/NoOpMojo.java
@@ -26,8 +26,6 @@ import org.apache.maven.api.plugin.annotations.Parameter;
 /**
  * A no-operation Mojo that does nothing. This is just to make the plugin valid.
  * The real functionality is in the TypeProvider.
- *
- * @goal noop
  */
 @org.apache.maven.api.plugin.annotations.Mojo(name = "noop")
 public class NoOpMojo implements Mojo {

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-project-interpolation/src/main/java/org/apache/maven/plugin/coreit/PropertyInterpolationMojo.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-project-interpolation/src/main/java/org/apache/maven/plugin/coreit/PropertyInterpolationMojo.java
@@ -22,15 +22,12 @@ import java.io.File;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- *
- * @phase validate
- */
-@Mojo(name = "check-property")
+@Mojo(name = "check-property", defaultPhase = LifecyclePhase.VALIDATE)
 public class PropertyInterpolationMojo extends AbstractMojo {
 
     /**

--- a/its/core-it-support/core-it-plugins/maven-it-plugin-site/src/main/java/org/apache/maven/plugin/coreit/InfoReport.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-site/src/main/java/org/apache/maven/plugin/coreit/InfoReport.java
@@ -29,6 +29,7 @@ import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.reporting.MavenReport;
 import org.apache.maven.reporting.MavenReportException;
@@ -36,11 +37,10 @@ import org.apache.maven.reporting.MavenReportException;
 /**
  * Creates a properties file in the site output directory.
  *
- * @goal info
  *
  * @author Benjamin Bentmann
- *
  */
+@Mojo(name = "info")
 public class InfoReport extends AbstractMojo implements MavenReport {
 
     /**


### PR DESCRIPTION
## Summary

Migrate Maven Core integration-test plugin fixtures from the legacy Javadoc-based plugin metadata to modern Maven plugin annotations.

The changes replace tags such as `@goal`, `@phase`, `@parameter`, and `@component` with `@Mojo`, `@Execute`, and `@Parameter`. Legacy component field injection is replaced with JSR-330 constructor injection where necessary.

This supports the removal of Javadoc-based annotation processing tracked by [apache/maven-plugin-tools#651](https://github.com/apache/maven-plugin-tools/issues/651). The migration was performed with [maven-plugin-javadoc-openrewrite-recipes](https://github.com/wilx/maven-plugin-javadoc-openrewrite-recipes).

## Validation

- `mvn clean verify`

## Checklist

- [x] The pull request addresses one focused issue without unrelated changes.
- [x] The description explains what changed and why.
- [x] The commit has a meaningful subject and body.
- [x] Existing integration-test fixtures cover the migrated plugin metadata.
- [x] `mvn clean verify` passes.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0).
