### PR TITLE
Restore the Google Cloud mirror for CI resolution

### DIFF
--- a/.github/ci-mimir-session.properties
+++ b/.github/ci-mimir-session.properties
@@ -19,9 +19,5 @@
 
 # do not waste time on this; we maintain the version
 mimir.daemon.autoupdate=false
-# CI used the Google Cloud mirror of Central, but that mirror lags a fresh
-# release: apache-maven-4.0.0-rc-6 was still a 404 there days after Central
-# served it. Resolving from Central directly is the difference between a
-# build that works on release day and one that waits for a mirror we do not
-# control.
-# mimir.session.mirrors=central(https://maven-central.storage-download.googleapis.com/maven2/)
+# CI uses US Mirror
+mimir.session.mirrors=central(https://maven-central.storage-download.googleapis.com/maven2/)


### PR DESCRIPTION
Reverts b47bcec09c3906c71a8696e6ffb763c65f5f9a32, which commented out the `mimir.session.mirrors` line in `.github/ci-mimir-session.properties`.

### Why it was commented out

The Google Cloud mirror of Central lags a fresh release. `apache-maven-4.0.0-rc-6` was still a 404 there days after Central served it, which broke CI during the rc-6 rollout.

### Why restore it now

The mirror has caught up — both of these are 200 today:

| URL | status |
| --- | --- |
| `https://maven-central.storage-download.googleapis.com/maven2/.../apache-maven-4.0.0-rc-6.pom` | 200 |
| `https://repo1.maven.org/maven2/.../apache-maven-4.0.0-rc-6.pom` | 200 |

The mirror is cheaper for CI than hitting Central directly on every job, and the lag is a release-day problem rather than a steady-state one — so the mirror is the better default between releases.

### Caveat worth knowing

This does re-expose CI to the same 404 window when the next RC drops. If that happens, commenting the line out again is a one-line change.

A matching PR for `maven-4.0.x` follows, since that branch carries the same commit (c05b25dda5).