### PR TITLE
[4.0.x] Restore the Google Cloud mirror for CI resolution

### DIFF
--- a/.github/ci-mimir-session.properties
+++ b/.github/ci-mimir-session.properties
@@ -19,9 +19,5 @@
 
 # do not waste time on this; we maintain the version
 mimir.daemon.autoupdate=false
-# CI used the Google Cloud mirror of Central, but that mirror lags a fresh
-# release: apache-maven-4.0.0-rc-6 was still a 404 there days after Central
-# served it. Resolving from Central directly is the difference between a
-# build that works on release day and one that waits for a mirror we do not
-# control.
-# mimir.session.mirrors=central(https://maven-central.storage-download.googleapis.com/maven2/)
+# CI uses US Mirror
+mimir.session.mirrors=central(https://maven-central.storage-download.googleapis.com/maven2/)


### PR DESCRIPTION
Backport of #12700 to `maven-4.0.x`.

Reverts c05b25dda5, which commented out the `mimir.session.mirrors` line in `.github/ci-mimir-session.properties`.

The mirror was disabled because `apache-maven-4.0.0-rc-6` was still a 404 on the Google Cloud mirror days after Central served it. That URL returns 200 today, so the mirror has caught up, and it is cheaper for CI than resolving from Central on every job.

Re-exposes CI to the same 404 window when the next RC drops; commenting the line out again is a one-line change if that happens.