### PR TITLE
[MNG-8708] Fix Maven 4 parent inference

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -608,9 +608,11 @@ public class DefaultModelBuilder implements ModelBuilder {
 
         //
         // Transform raw model to build pom.
-        // Infer inner reactor dependencies version
+        // Infer missing coordinates from models in the reactor
         //
         Model transformFileToRaw(Model model) {
+            Parent newParent = inferParentVersion(model);
+
             List<Dependency> newDeps = null;
             boolean depsChanged = false;
             if (!model.getDependencies().isEmpty()) {
@@ -626,10 +628,13 @@ public class DefaultModelBuilder implements ModelBuilder {
                 managedDepsChanged = inferDependencies(model, depMgmt.getDependencies(), newManagedDeps);
             }
 
-            if (!depsChanged && !managedDepsChanged) {
+            if (newParent == null && !depsChanged && !managedDepsChanged) {
                 return model;
             }
             Model.Builder builder = Model.newBuilder(model);
+            if (newParent != null) {
+                builder.parent(newParent);
+            }
             if (depsChanged) {
                 builder.dependencies(newDeps);
             }
@@ -637,6 +642,34 @@ public class DefaultModelBuilder implements ModelBuilder {
                 builder.dependencyManagement(depMgmt.withDependencies(newManagedDeps));
             }
             return builder.build();
+        }
+
+        private Parent inferParentVersion(Model model) {
+            Parent parent = model.getParent();
+            if (parent == null
+                    || parent.getVersion() != null
+                    || parent.getGroupId() == null
+                    || parent.getArtifactId() == null) {
+                return null;
+            }
+
+            Model parentModel = getRawModel(model.getPomFile(), parent.getGroupId(), parent.getArtifactId());
+            if (parentModel == null) {
+                return null;
+            }
+
+            String version = parentModel.getVersion();
+            InputLocation versionLocation = parentModel.getLocation("version");
+            if (version == null && parentModel.getParent() != null) {
+                version = parentModel.getParent().getVersion();
+                versionLocation = parentModel.getParent().getLocation("version");
+            }
+            return version != null
+                    ? parent.with()
+                            .version(version)
+                            .location("version", versionLocation)
+                            .build()
+                    : null;
         }
 
         /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -661,6 +661,9 @@ public class DefaultModelBuilder implements ModelBuilder {
             String version = parentModel.getVersion();
             InputLocation versionLocation = parentModel.getLocation("version");
             if (version == null && parentModel.getParent() != null) {
+                // Parent model inherits its version from its own parent (grandparent).
+                // versionLocation may be null if the grandparent has no explicit <version>;
+                // Builder.location() silently ignores null values, which is safe here.
                 version = parentModel.getParent().getVersion();
                 versionLocation = parentModel.getParent().getLocation("version");
             }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -339,9 +339,7 @@ public class DefaultModelValidator implements ModelValidator {
 
             if (parent.getRelativePath() != null
                     && !parent.getRelativePath().isEmpty()
-                    && (parent.getGroupId() != null && !parent.getGroupId().isEmpty()
-                            || parent.getArtifactId() != null
-                                    && !parent.getArtifactId().isEmpty())
+                    && (parent.getLocation("groupId") != null || parent.getLocation("artifactId") != null)
                     && validationLevel >= ModelValidator.VALIDATION_LEVEL_MAVEN_4_0
                     && ModelBuilder.KNOWN_MODEL_VERSIONS.contains(model.getModelVersion())
                     && !Objects.equals(model.getModelVersion(), ModelBuilder.MODEL_VERSION_4_0_0)) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -373,9 +373,7 @@ public class DefaultModelValidator implements ModelValidator {
             for (Parent mixin : model.getMixins()) {
                 if (mixin.getRelativePath() != null
                         && !mixin.getRelativePath().isEmpty()
-                        && (mixin.getGroupId() != null && !mixin.getGroupId().isEmpty()
-                                || mixin.getArtifactId() != null
-                                        && !mixin.getArtifactId().isEmpty())
+                        && (mixin.getLocation("groupId") != null || mixin.getLocation("artifactId") != null)
                         && validationLevel >= ModelValidator.VALIDATION_LEVEL_MAVEN_4_0
                         && ModelBuilder.KNOWN_MODEL_VERSIONS.contains(model.getModelVersion())
                         && !Objects.equals(model.getModelVersion(), ModelBuilder.MODEL_VERSION_4_0_0)) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8708">MNG-8708</a>.
+ *
+ * @since 4.1.0
+ */
+class MavenITmng8708ParentInferenceTest extends AbstractMavenIntegrationTestCase {
+
+    private static final String PARENT_DECLARATION_WARNING =
+            "'parent.relativePath' only specify relativePath or groupId/artifactId in modelVersion 4.1.0";
+
+    @Test
+    void testSupportedParentInference() throws Exception {
+        Path testDir = extractResources("mng-8708-parent-inference/supported");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextNotInLog(PARENT_DECLARATION_WARNING);
+    }
+
+    @Test
+    void testExplicitPathAndCoordinatesStillWarn() throws Exception {
+        Path testDir = extractResources("mng-8708-parent-inference/explicit-both");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog(PARENT_DECLARATION_WARNING);
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
@@ -43,6 +43,23 @@ class MavenITmng8708ParentInferenceTest extends AbstractMavenIntegrationTestCase
         verifier.verifyTextNotInLog(PARENT_DECLARATION_WARNING);
     }
 
+    /**
+     * Three-level hierarchy: grandparent (with version) → versionless mid parent → child.
+     * The child specifies only groupId/artifactId for the mid parent, which itself
+     * inherits its version from the grandparent. Exercises the fallback path in
+     * {@code inferParentVersion} where the parent model's version comes from its own parent.
+     */
+    @Test
+    void testThreeLevelParentInference() throws Exception {
+        Path testDir = extractResources("mng-8708-parent-inference/three-level");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextNotInLog(PARENT_DECLARATION_WARNING);
+    }
+
     @Test
     void testExplicitPathAndCoordinatesStillWarn() throws Exception {
         Path testDir = extractResources("mng-8708-parent-inference/explicit-both");

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/modules/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/modules/child/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng8708</groupId>
+    <artifactId>parent</artifactId>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>child</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8708</groupId>
+  <artifactId>parent</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/child</subproject>
+  </subprojects>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/gav-only/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/gav-only/pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng8708</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+
+  <artifactId>gav-only</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/path-only/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/path-only/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>path-only</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8708</groupId>
+  <artifactId>parent</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/path-only</subproject>
+    <subproject>modules/gav-only</subproject>
+  </subprojects>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/modules/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/modules/child/pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng8708</groupId>
+    <artifactId>mid</artifactId>
+  </parent>
+
+  <artifactId>child</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>mid</artifactId>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/child</subproject>
+  </subprojects>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8708</groupId>
+  <artifactId>grandparent</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/mid</subproject>
+  </subprojects>
+</project>


### PR DESCRIPTION
Fixes #10377.

This fixes Maven 4.1.0 parent inference for reactor projects when parent coordinates are partially omitted.

The file-to-raw model transformation now:

- infers a missing parent version from the matching reactor model before raw-model validation;
- preserves the inferred version's source location.

Parent validation now checks whether `groupId` or `artifactId` was explicitly declared before warning about combining coordinates with `relativePath`. Values inferred from a relative parent POM no longer trigger the warning.

The existing warning remains in place when a POM explicitly declares both a non-empty `relativePath` and parent coordinates.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

### Tests

- `mvn verify`
- `MavenITmng8708ParentInferenceTest`: 2 tests passed
- `MavenITmng8708ParentInferenceTest,MavenITmng8294ParentChecksTest`: 8 tests passed
- `maven-impl`: 550 tests passed, 4 skipped
- Reporter reproduction: all three reactor projects build, and only the explicitly combined parent declaration emits the warning
- `mvn -Prun-its verify`: source modules passed; the broad Core IT suite reported two unrelated DI fixture errors because `org.apache.maven:maven-testing:4.1.0-SNAPSHOT` was unavailable

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/