### PR TITLE
Fix #12704: Do not report an independent, built module as skipped

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/event/ExecutionEventLogger.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/event/ExecutionEventLogger.java
@@ -316,10 +316,32 @@ public class ExecutionEventLogger extends AbstractExecutionListener {
             infoLine('-');
             String name = event.getProject().getName();
             infoMain("Skipping " + name);
-            logger.info("{} was not built because a module it depends on failed to build.", name);
+            if (dependsOnFailedProject(event)) {
+                logger.info("{} was not built because a module it depends on failed to build.", name);
+            } else {
+                logger.info("{} was not built because the build was stopped after an earlier failure.", name);
+            }
 
             infoLine('-');
         }
+    }
+
+    /**
+     * A project can be skipped for two different reasons: one of the modules it depends on failed,
+     * or the reactor was stopped after an unrelated module failed. Only the first one lets us blame
+     * a dependency, so tell them apart instead of always reporting the same cause.
+     * When the answer cannot be established, the dependency wording is kept.
+     */
+    private boolean dependsOnFailedProject(ExecutionEvent event) {
+        MavenSession session = event.getSession();
+        MavenProject project = event.getProject();
+        if (session == null || project == null || session.getProjectDependencyGraph() == null) {
+            return true;
+        }
+        MavenExecutionResult result = session.getResult();
+        return result == null
+                || session.getProjectDependencyGraph().getUpstreamProjects(project, true).stream()
+                        .anyMatch(upstream -> result.getBuildSummary(upstream) instanceof BuildFailure);
     }
 
     @Override

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/event/ExecutionEventLoggerTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/event/ExecutionEventLoggerTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.cling.event;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.execution.BuildFailure;
@@ -444,6 +445,66 @@ class ExecutionEventLoggerTest {
         inOrder.verify(logger).info(eq("Total time:  {}{}"), anyString(), anyString());
         inOrder.verify(logger).info(eq("Finished at: {}"), anyString());
         inOrder.verify(logger).info("------------------------------------------------------------------------");
+    }
+
+    @Test
+    void testProjectSkippedBecauseADependencyFailed() {
+        // prepare
+        MavenProject failed = generateMavenProject("Maven Project artifact1");
+        MavenProject skipped = generateMavenProject("Maven Project artifact2");
+
+        DefaultMavenExecutionResult executionResult = new DefaultMavenExecutionResult();
+        executionResult.addBuildSummary(new BuildFailure(failed, 1000, new Exception("Failure")));
+
+        ExecutionEvent event = skipEvent(skipped, executionResult, Arrays.asList(failed));
+
+        // execute
+        executionEventLogger.projectSkipped(event);
+
+        // verify
+        InOrder inOrder = inOrder(logger);
+        inOrder.verify(logger).info("Skipping Maven Project artifact2");
+        inOrder.verify(logger)
+                .info("{} was not built because a module it depends on failed to build.", "Maven Project artifact2");
+    }
+
+    @Test
+    void testProjectSkippedBecauseTheBuildWasStopped() {
+        // prepare
+        MavenProject unrelated = generateMavenProject("Maven Project artifact1");
+        MavenProject skipped = generateMavenProject("Maven Project artifact2");
+
+        DefaultMavenExecutionResult executionResult = new DefaultMavenExecutionResult();
+        executionResult.addBuildSummary(new BuildFailure(unrelated, 1000, new Exception("Failure")));
+
+        // the skipped project has no upstream projects at all, so the failure cannot be blamed on one
+        ExecutionEvent event = skipEvent(skipped, executionResult, Collections.emptyList());
+
+        // execute
+        executionEventLogger.projectSkipped(event);
+
+        // verify
+        InOrder inOrder = inOrder(logger);
+        inOrder.verify(logger).info("Skipping Maven Project artifact2");
+        inOrder.verify(logger)
+                .info(
+                        "{} was not built because the build was stopped after an earlier failure.",
+                        "Maven Project artifact2");
+    }
+
+    private ExecutionEvent skipEvent(
+            MavenProject skipped, MavenExecutionResult executionResult, List<MavenProject> upstream) {
+        ProjectDependencyGraph projectDependencyGraph = mock(ProjectDependencyGraph.class);
+        when(projectDependencyGraph.getUpstreamProjects(skipped, true)).thenReturn(upstream);
+
+        MavenSession mavenSession = mock(MavenSession.class);
+        when(mavenSession.getResult()).thenReturn(executionResult);
+        when(mavenSession.getProjectDependencyGraph()).thenReturn(projectDependencyGraph);
+
+        ExecutionEvent event = mock(ExecutionEvent.class);
+        when(event.getProject()).thenReturn(skipped);
+        when(event.getSession()).thenReturn(mavenSession);
+        return event;
     }
 
     private static MavenProject generateMavenProject(String projectName) {

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -523,7 +523,7 @@ public class BuildPlanExecutor {
 
                     // Check if there are any stored exceptions for this project
                     List<Throwable> failures = null;
-                    boolean allStepsExecuted = true;
+                    boolean allWorkExecuted = true;
                     for (BuildStep projectStep : plan.steps(step.project).toList()) {
                         Exception exception = projectStep.exception;
                         if (exception != null) {
@@ -532,8 +532,23 @@ public class BuildPlanExecutor {
                             }
                             failures.add(exception);
                         }
-                        allStepsExecuted &= step == projectStep || projectStep.status.get() == EXECUTED;
+                        // Only steps that carry mojo executions represent work that was asked for.
+                        // The plan holds a step for every phase of the lifecycle, so a project that
+                        // has run everything requested of it still has empty steps left over for the
+                        // phases beyond the requested tasks. Those get skipped as soon as the reactor
+                        // is halted, and must not turn a completed project into a skipped one.
+                        if (projectStep != step
+                                && projectStep.status.get() != EXECUTED
+                                && projectStep.hasExecutions()) {
+                            allWorkExecuted = false;
+                        }
                     }
+
+                    // A project whose setup never ran was never started at all: it is genuinely skipped,
+                    // even when it has no work of its own (an aggregator, for instance).
+                    boolean projectStarted = plan.step(step.project, SETUP)
+                            .map(setup -> setup.status.get() == EXECUTED)
+                            .orElse(false);
 
                     if (failures != null) {
                         // Handle the stored exception
@@ -546,7 +561,7 @@ public class BuildPlanExecutor {
                             failures.forEach(failure::addSuppressed);
                         }
                         handleBuildError(reactorContext, session, step.project, failure);
-                    } else if (allStepsExecuted) {
+                    } else if (projectStarted && allWorkExecuted) {
                         // If there were no failures, report success
                         projectExecutionListener.afterProjectExecutionSuccess(
                                 new ProjectExecutionEvent(session, step.project, Collections.emptyList()));

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildStep.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildStep.java
@@ -130,6 +130,16 @@ public class BuildStep {
         return mojos.values().stream().flatMap(m -> m.values().stream());
     }
 
+    /**
+     * Indicates whether executing this step performs any actual work.
+     * Steps without mojo executions are pure ordering nodes: this is the case for the
+     * {@code before:} and {@code after:} steps of a phase, and for every phase that lies
+     * outside the scope of the tasks the user requested.
+     */
+    public boolean hasExecutions() {
+        return !mojos.isEmpty();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildStepTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/concurrent/BuildStepTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.internal.concurrent;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuildStepTest {
+
+    @Test
+    void stepWithoutMojosDoesNoWork() {
+        BuildStep step = new BuildStep("compile", new MavenProject(), null);
+
+        assertFalse(step.hasExecutions());
+    }
+
+    @Test
+    void stepCarryingAMojoDoesWork() {
+        BuildStep step = new BuildStep("compile", new MavenProject(), null);
+        step.addMojo(mojoExecution("compile"), 0);
+
+        assertTrue(step.hasExecutions());
+    }
+
+    @Test
+    void skippedStepDoesNoWork() {
+        BuildStep step = new BuildStep("compile", new MavenProject(), null);
+        step.addMojo(mojoExecution("compile"), 0);
+        step.skip();
+
+        assertFalse(step.hasExecutions());
+    }
+
+    private static MojoExecution mojoExecution(String goal) {
+        MojoDescriptor descriptor = new MojoDescriptor();
+        descriptor.setGoal(goal);
+        return new MojoExecution(descriptor, "default-" + goal);
+    }
+}


### PR DESCRIPTION
Fixes #12704.

### 1. The event

`BuildPlanExecutor`'s `TEARDOWN` decided between `ProjectSucceeded` and `ProjectSkipped` on `allStepsExecuted`, which required *every* step of the project's plan to have reached `EXECUTED`. The plan holds a step for every phase of the lifecycle regardless of the requested tasks, so for `mvn compile` a project keeps empty `package`, `install` and `deploy` steps that normally run as no-ops. As soon as the reactor is halted those get skipped, `allStepsExecuted` turns false, and a project that had already finished everything asked of it is reported as skipped.

The outcome is now based on the steps that actually carry mojo executions. A project that ran all of its work is reported as succeeded; one that still had mojo-bearing steps pending stays skipped. A project whose `SETUP` step never ran was never started at all, so it stays skipped too — this keeps aggregators and other modules with no work of their own from being reported as succeeded when they were genuinely never built.

`BuildStep.hasExecutions()` is added for that predicate. (`BuildStep.skip()` looks like it was meant for this, but it has no callers, so out-of-scope phases are distinguishable only by having no mojos.)

### 2. The message

`ExecutionEventLogger.projectSkipped` always printed:

```
X was not built because a module it depends on failed to build.
```

That is the only reason the legacy builder ever produced, because `LifecycleModuleBuilder` fires `ProjectSkipped` before `ProjectStarted` and only for projects that never started. The concurrent builder also fires it for projects stopped by an unrelated failure, where the sentence is simply untrue. The logger now checks whether any upstream project actually failed and says which of the two happened; when the answer cannot be established the existing wording is kept.

### Before / after

Two sibling modules with no dependency between them, plus one that does depend on the failing module. `slow` has 4000 generated sources so it is still compiling when `fails` breaks:

```
$ mvn compile -b concurrent -T5
```

before:

```
[INFO] Skipping dependent
[INFO] dependent was not built because a module it depends on failed to build.
[INFO] Skipping slow
[INFO] slow was not built because a module it depends on failed to build.
```

after:

```
[INFO] Skipping dependent
[INFO] dependent was not built because a module it depends on failed to build.
```

`slow` compiles its 4001 sources, writes its 4000 class files and is reported as succeeded; `dependent` is still skipped, with the reason that is true for it. Reproduced 5 runs out of 5 in both directions.

### Testing

- Two new cases in `ExecutionEventLoggerTest` covering both skip reasons.
- `MavenITmng8648ProjectEventsTest` passes against the patched distribution — `subproject-a` and `subproject-b` succeed, `subproject-c` fails, `subproject-d` is skipped and keeps the dependency message.
- Unit tests of `impl/maven-core` and `impl/maven-cli` are green (635 tests).

### Not addressed here

`MavenITmng8648ProjectEventsTest` remains timing-sensitive: if `subproject-c` fails before `subproject-b`'s steps are scheduled at all, `b` is legitimately skipped and the assertion on `ProjectSucceeded` still fails. That needs an ordering guarantee in the test rather than a change in core, so I left it out of this PR. It is the flake described in #12704.
