### PR TITLE
Migrate legacy plugin Javadoc annotations in Maven Embedder tests

### DIFF
--- a/maven-embedder/src/test/error-reporting-projects/aggregate-mojo-failure/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/aggregate-mojo-failure/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/aggregate-mojo-failure/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/aggregate-mojo-failure/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -6,13 +6,12 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
 /**
- * @goal test
- * @aggregator
  *
  * @author jdcasey
  */
+@org.apache.maven.plugins.annotations.Mojo(name = "test", aggregator = true)
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/bad-build-plan/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/bad-build-plan/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/bad-build-plan/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/bad-build-plan/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -4,15 +4,16 @@ import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Execute;
 
 /**
- * @goal test
- * @execute goal="my:something:else:that:is:wrong"
  *
  * @author jdcasey
  */
+@Execute(goal = "my:something:else:that:is:wrong")
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-dep-ver/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-dep-ver/plugin/pom.xml
@@ -19,6 +19,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-dep-ver/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-dep-ver/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -5,11 +5,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-maven-ver/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-maven-ver/plugin/pom.xml
@@ -19,6 +19,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-maven-ver/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/bad-ext-plugin-maven-ver/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -5,11 +5,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/config-rdonly-mojo-param/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/config-rdonly-mojo-param/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/config-rdonly-mojo-param/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/config-rdonly-mojo-param/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -4,21 +4,16 @@ import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;
 
-    /**
-     * @parameter default-value="something"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "something", required = true, readonly = true)
     private String param;
 
     public void execute()

--- a/maven-embedder/src/test/error-reporting-projects/duplicated-attachments/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/duplicated-attachments/plugin/pom.xml
@@ -16,6 +16,12 @@
       <artifactId>maven-project</artifactId>
       <version>2.0.7</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/duplicated-attachments/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/duplicated-attachments/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -4,30 +4,26 @@ import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.MavenProject;
 
 /**
- * @goal test
  *
  * @author jdcasey
  */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;
 
-    /**
-     * @component
-     */
+    @Component
     private MavenProjectHelper mavenProjectHelper;
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     public void execute()

--- a/maven-embedder/src/test/error-reporting-projects/ext-plugin-realm-error/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/ext-plugin-realm-error/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/ext-plugin-realm-error/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/ext-plugin-realm-error/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -4,21 +4,20 @@ import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
 
 /**
- * @goal test
  *
  * @author jdcasey
  */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;
 
-    /**
-     * @component
-     */
+    @Component
     private ComponentOne one;
 
     public void execute()

--- a/maven-embedder/src/test/error-reporting-projects/ext-plugin-version-err/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/ext-plugin-version-err/plugin/pom.xml
@@ -19,6 +19,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/ext-plugin-version-err/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/ext-plugin-version-err/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -5,11 +5,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/missing-direct-invoke-mojo/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/missing-direct-invoke-mojo/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/missing-direct-invoke-mojo/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/missing-direct-invoke-mojo/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -6,13 +6,12 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
 /**
- * @goal test-unused
- * @aggregator
  *
  * @author jdcasey
  */
+@org.apache.maven.plugins.annotations.Mojo(name = "test-unused", aggregator = true)
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/missing-req-mojo-param/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/missing-req-mojo-param/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/missing-req-mojo-param/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/missing-req-mojo-param/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -4,20 +4,16 @@ import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;
 
-    /**
-     * @parameter
-     * @required
-     */
+    @Parameter(required = true)
     private String requiredParam;
 
     public void execute()

--- a/maven-embedder/src/test/error-reporting-projects/mojo-config-error/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/mojo-config-error/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/mojo-config-error/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/mojo-config-error/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -5,11 +5,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/mojo-exec-err/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/mojo-exec-err/plugin/pom.xml
@@ -11,6 +11,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/mojo-exec-err/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/mojo-exec-err/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -5,11 +5,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
-/**
- * @goal test
- */
+@org.apache.maven.plugins.annotations.Mojo(name = "test")
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;

--- a/maven-embedder/src/test/error-reporting-projects/mojo-lookup-err/plugin/pom.xml
+++ b/maven-embedder/src/test/error-reporting-projects/mojo-lookup-err/plugin/pom.xml
@@ -16,6 +16,12 @@
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/maven-embedder/src/test/error-reporting-projects/mojo-lookup-err/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/mojo-lookup-err/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -1,26 +1,24 @@
 package org.plugin;
 
 import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
 /**
- * @goal test
- * @requiresProject false
  *
  * @author jdcasey
  */
+@org.apache.maven.plugins.annotations.Mojo(name = "test", requiresProject = false)
 public class TestPlugin
-    implements Mojo
+        implements Mojo
 {
 
     private Log log;
 
-    /**
-     * @component role-hint="nonexistent"
-     */
+    @Component
     private MavenProject project;
 
     public void execute()

--- a/maven-embedder/src/test/error-reporting-projects/mojo-lookup-err/plugin/src/main/java/org/plugin/TestPlugin.java
+++ b/maven-embedder/src/test/error-reporting-projects/mojo-lookup-err/plugin/src/main/java/org/plugin/TestPlugin.java
@@ -18,7 +18,7 @@ public class TestPlugin
 
     private Log log;
 
-    @Component
+    @Component(hint = "nonexistent")
     private MavenProject project;
 
     public void execute()


### PR DESCRIPTION
## Summary

Migrate Maven Embedder error-reporting plugin fixtures from the legacy Javadoc-based plugin metadata to modern Maven plugin annotations on the Maven 3.x line.

The changes replace legacy tags such as `@goal`, `@phase`, and `@parameter` with annotations from `maven-plugin-annotations`. Each affected fixture declares that artifact as a provided dependency.

This supports the removal of Javadoc-based annotation processing tracked by [apache/maven-plugin-tools#651](https://github.com/apache/maven-plugin-tools/issues/651). The migration was performed with [maven-plugin-javadoc-openrewrite-recipes](https://github.com/wilx/maven-plugin-javadoc-openrewrite-recipes).

## Validation

- `JAVA_HOME=/opt/jdks/latest-21 /opt/maven/apache-maven-3.9.16/bin/mvn verify -e -B -V -DdistributionFileName=apache-maven`
- `JAVA_HOME=/opt/jdks/latest-21 /opt/maven/apache-maven-3.9.16/bin/mvn install -e -B -V -Prun-its,embedded -DmavenDistro=<built apache-maven-bin.zip>`

The complete Maven reactor passed, including RAT and distribution assembly. The Core IT suite passed with 867 tests, 0 failures, 0 errors, and 39 skips.

## Checklist

- [x] The pull request addresses one focused issue without unrelated changes.
- [x] The description explains what changed and why.
- [x] The commit has a meaningful subject and body.
- [x] Existing error-reporting fixtures cover the migrated plugin metadata.
- [x] The complete Maven reactor passes `verify`.
- [x] The Core IT suite has been run successfully.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0).
