### PR TITLE
Migrate internal plumbing DEBUG statements to TRACE level

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CliUtils.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CliUtils.java
@@ -115,7 +115,7 @@ public final class CliUtils {
     public static int toMavenExecutionRequestLoggingLevel(Slf4jConfiguration.Level level) {
         requireNonNull(level, "level");
         return switch (level) {
-            case DEBUG -> MavenExecutionRequest.LOGGING_LEVEL_DEBUG;
+            case TRACE, DEBUG -> MavenExecutionRequest.LOGGING_LEVEL_DEBUG;
             case INFO -> MavenExecutionRequest.LOGGING_LEVEL_INFO;
             case ERROR -> MavenExecutionRequest.LOGGING_LEVEL_ERROR;
         };
@@ -124,7 +124,7 @@ public final class CliUtils {
     public static int toPlexusLoggingLevel(Slf4jConfiguration.Level level) {
         requireNonNull(level, "level");
         return switch (level) {
-            case DEBUG -> Logger.LEVEL_DEBUG;
+            case TRACE, DEBUG -> Logger.LEVEL_DEBUG;
             case INFO -> Logger.LEVEL_INFO;
             case ERROR -> Logger.LEVEL_ERROR;
         };

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/logging/Slf4jConfiguration.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/logging/Slf4jConfiguration.java
@@ -29,6 +29,7 @@ public interface Slf4jConfiguration {
      * Level
      */
     enum Level {
+        TRACE,
         DEBUG,
         INFO,
         ERROR

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/logging/impl/MavenSimpleConfiguration.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/logging/impl/MavenSimpleConfiguration.java
@@ -37,6 +37,7 @@ public class MavenSimpleConfiguration extends BaseSlf4jConfiguration {
     public void setRootLoggerLevel(Level level) {
         String value =
                 switch (level) {
+                    case TRACE -> "trace";
                     case DEBUG -> "debug";
                     case INFO -> "info";
                     case ERROR -> "error";

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/LookupInvokerLoggingTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/LookupInvokerLoggingTest.java
@@ -158,6 +158,7 @@ class LookupInvokerLoggingTest {
             // Simulate what MavenSimpleConfiguration does
             String value =
                     switch (level) {
+                        case TRACE -> "trace";
                         case DEBUG -> "debug";
                         case INFO -> "info";
                         case ERROR -> "error";

--- a/impl/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/classrealm/DefaultClassRealmManager.java
@@ -131,7 +131,7 @@ public class DefaultClassRealmManager implements ClassRealmManager {
                 try {
                     ClassRealm classRealm = world.newRealm(realmId, null);
 
-                    logger.debug("Created new class realm {}", realmId);
+                    logger.trace("Created new class realm {}", realmId);
 
                     return classRealm;
                 } catch (DuplicateRealmException e) {
@@ -177,8 +177,8 @@ public class DefaultClassRealmManager implements ClassRealmManager {
             for (Artifact artifact : artifacts) {
                 if (!isProvidedArtifact(artifact, v4api) && artifact.getFile() != null) {
                     constituents.add(new ArtifactClassRealmConstituent(artifact));
-                } else if (logger.isDebugEnabled()) {
-                    logger.debug("  Excluded: {}", getId(artifact));
+                } else if (logger.isTraceEnabled()) {
+                    logger.trace("  Excluded: {}", getId(artifact));
                 }
             }
         }
@@ -314,14 +314,14 @@ public class DefaultClassRealmManager implements ClassRealmManager {
     }
 
     private void populateRealm(ClassRealm classRealm, List<ClassRealmConstituent> constituents) {
-        logger.debug("Populating class realm {}", classRealm.getId());
+        logger.trace("Populating class realm {}", classRealm.getId());
 
         for (ClassRealmConstituent constituent : constituents) {
             File file = constituent.getFile();
 
-            if (logger.isDebugEnabled()) {
+            if (logger.isTraceEnabled()) {
                 String id = getId(constituent);
-                logger.debug("  Included: {}", id);
+                logger.trace("  Included: {}", id);
             }
 
             try {
@@ -335,23 +335,23 @@ public class DefaultClassRealmManager implements ClassRealmManager {
 
     private void wireRealm(ClassRealm classRealm, List<String> parentImports, Map<String, ClassLoader> foreignImports) {
         if (foreignImports != null && !foreignImports.isEmpty()) {
-            logger.debug("Importing foreign packages into class realm {}", classRealm.getId());
+            logger.trace("Importing foreign packages into class realm {}", classRealm.getId());
 
             for (Map.Entry<String, ClassLoader> entry : foreignImports.entrySet()) {
                 ClassLoader importedRealm = entry.getValue();
                 String imp = entry.getKey();
 
-                logger.debug("  Imported: {} < {}", imp, getId(importedRealm));
+                logger.trace("  Imported: {} < {}", imp, getId(importedRealm));
 
                 classRealm.importFrom(importedRealm, imp);
             }
         }
 
         if (parentImports != null && !parentImports.isEmpty()) {
-            logger.debug("Importing parent packages into class realm {}", classRealm.getId());
+            logger.trace("Importing parent packages into class realm {}", classRealm.getId());
 
             for (String imp : parentImports) {
-                logger.debug("  Imported: {} < {}", imp, getId(classRealm.getParentClassLoader()));
+                logger.trace("  Imported: {} < {}", imp, getId(classRealm.getParentClassLoader()));
 
                 classRealm.importFromParent(imp);
             }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDebugLogger.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleDebugLogger.java
@@ -49,7 +49,7 @@ public class LifecycleDebugLogger {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public void debug(String s) {
-        logger.debug(s);
+        logger.trace(s);
     }
 
     public void info(String s) {
@@ -57,45 +57,45 @@ public class LifecycleDebugLogger {
     }
 
     public void debugReactorPlan(ProjectBuildList projectBuilds) {
-        if (!logger.isDebugEnabled()) {
+        if (!logger.isTraceEnabled()) {
             return;
         }
 
-        logger.debug("=== REACTOR BUILD PLAN ================================================");
+        logger.trace("=== REACTOR BUILD PLAN ================================================");
 
         for (Iterator<ProjectSegment> it = projectBuilds.iterator(); it.hasNext(); ) {
             ProjectSegment projectBuild = it.next();
 
-            logger.debug("Project: " + projectBuild.getProject().getId());
-            logger.debug("Tasks:   " + projectBuild.getTaskSegment().getTasks());
-            logger.debug("Style:   " + (projectBuild.getTaskSegment().isAggregating() ? "Aggregating" : "Regular"));
+            logger.trace("Project: " + projectBuild.getProject().getId());
+            logger.trace("Tasks:   " + projectBuild.getTaskSegment().getTasks());
+            logger.trace("Style:   " + (projectBuild.getTaskSegment().isAggregating() ? "Aggregating" : "Regular"));
 
             if (it.hasNext()) {
-                logger.debug("-----------------------------------------------------------------------");
+                logger.trace("-----------------------------------------------------------------------");
             }
         }
 
-        logger.debug("=======================================================================");
+        logger.trace("=======================================================================");
     }
 
     public void debugProjectPlan(MavenProject currentProject, MavenExecutionPlan executionPlan) {
-        if (!logger.isDebugEnabled()) {
+        if (!logger.isTraceEnabled()) {
             return;
         }
 
-        logger.debug("=== PROJECT BUILD PLAN ================================================");
-        logger.debug("Project:       " + BuilderCommon.getKey(currentProject));
+        logger.trace("=== PROJECT BUILD PLAN ================================================");
+        logger.trace("Project:       " + BuilderCommon.getKey(currentProject));
 
         debugDependencyRequirements(executionPlan.getMojoExecutions());
 
-        logger.debug("Repositories (dependencies): " + currentProject.getRemoteProjectRepositories());
-        logger.debug("Repositories (plugins)     : " + currentProject.getRemotePluginRepositories());
+        logger.trace("Repositories (dependencies): " + currentProject.getRemoteProjectRepositories());
+        logger.trace("Repositories (plugins)     : " + currentProject.getRemotePluginRepositories());
 
         for (ExecutionPlanItem mojoExecution : executionPlan) {
             debugMojoExecution(mojoExecution.getMojoExecution());
         }
 
-        logger.debug("=======================================================================");
+        logger.trace("=======================================================================");
     }
 
     private void debugMojoExecution(MojoExecution mojoExecution) {
@@ -106,7 +106,7 @@ public class LifecycleDebugLogger {
         Map<String, List<MojoExecution>> forkedExecutions = mojoExecution.getForkedExecutions();
         if (!forkedExecutions.isEmpty()) {
             for (Map.Entry<String, List<MojoExecution>> fork : forkedExecutions.entrySet()) {
-                logger.debug("--- init fork of " + fork.getKey() + " for " + mojoExecId + " ---");
+                logger.trace("--- init fork of " + fork.getKey() + " for " + mojoExecId + " ---");
 
                 debugDependencyRequirements(fork.getValue());
 
@@ -114,15 +114,15 @@ public class LifecycleDebugLogger {
                     debugMojoExecution(forkedExecution);
                 }
 
-                logger.debug("--- exit fork of " + fork.getKey() + " for " + mojoExecId + " ---");
+                logger.trace("--- exit fork of " + fork.getKey() + " for " + mojoExecId + " ---");
             }
         }
 
-        logger.debug("-----------------------------------------------------------------------");
-        logger.debug("Goal:          " + mojoExecId);
-        logger.debug(
+        logger.trace("-----------------------------------------------------------------------");
+        logger.trace("Goal:          " + mojoExecId);
+        logger.trace(
                 "Style:         " + (mojoExecution.getMojoDescriptor().isAggregator() ? "Aggregating" : "Regular"));
-        logger.debug("Configuration: " + mojoExecution.getConfiguration());
+        logger.trace("Configuration: " + mojoExecution.getConfiguration());
     }
 
     private void debugDependencyRequirements(List<MojoExecution> mojoExecutions) {
@@ -143,7 +143,7 @@ public class LifecycleDebugLogger {
             }
         }
 
-        logger.debug("Dependencies (collect): " + scopesToCollect);
-        logger.debug("Dependencies (resolve): " + scopesToResolve);
+        logger.trace("Dependencies (collect): " + scopesToCollect);
+        logger.trace("Dependencies (resolve): " + scopesToResolve);
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/multithreaded/MultiThreadedBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/builder/multithreaded/MultiThreadedBuilder.java
@@ -135,7 +135,7 @@ public class MultiThreadedBuilder implements Builder {
         // schedule independent projects (ordered by critical path priority)
         for (MavenProject mavenProject : analyzer.getRootSchedulableBuilds()) {
             ProjectSegment projectSegment = projectBuildList.get(mavenProject);
-            logger.debug("Scheduling: {}", projectSegment.getProject());
+            logger.trace("Scheduling: {}", projectSegment.getProject());
             Callable<ProjectSegment> cb =
                     createBuildCallable(rootSession, projectSegment, reactorContext, taskSegment, duplicateArtifactIds);
             service.submit(cb);
@@ -155,7 +155,7 @@ public class MultiThreadedBuilder implements Builder {
                             analyzer.markAsFinished(projectBuild.getProject());
                     for (MavenProject mavenProject : newItemsThatCanBeBuilt) {
                         ProjectSegment scheduledDependent = projectBuildList.get(mavenProject);
-                        logger.debug("Scheduling: {}", scheduledDependent);
+                        logger.trace("Scheduling: {}", scheduledDependent);
                         Callable<ProjectSegment> cb = createBuildCallable(
                                 rootSession, scheduledDependent, reactorContext, taskSegment, duplicateArtifactIds);
                         service.submit(cb);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -395,7 +395,7 @@ public class BuildPlanExecutor {
                 if (shouldExecute && anyPredecessorFailed) {
                     // We'll run the step but mark it as SKIPPED instead of SCHEDULED
                     if (step.status.compareAndSet(CREATED, SKIPPED)) {
-                        logger.debug(
+                        logger.trace(
                                 "Running after:* step {} for cleanup but marking it as SKIPPED because a predecessor failed",
                                 step);
                         executor.execute(() -> {
@@ -406,7 +406,7 @@ public class BuildPlanExecutor {
                                 step.status.compareAndSet(SKIPPED, FAILED);
                                 // Store the exception in the step for handling in the TEARDOWN phase
                                 step.exception = e;
-                                logger.debug("Stored exception for step {} to be handled in TEARDOWN phase", step, e);
+                                logger.trace("Stored exception for step {} to be handled in TEARDOWN phase", step, e);
                                 // Let the scheduler handle after:* phases and TEARDOWN in the next cycle
                                 executePlan();
                             }
@@ -444,7 +444,7 @@ public class BuildPlanExecutor {
 
                         // Store the exception in the step for handling in the TEARDOWN phase
                         step.exception = e;
-                        logger.debug("Stored exception for step {} to be handled in TEARDOWN phase", step, e);
+                        logger.trace("Stored exception for step {} to be handled in TEARDOWN phase", step, e);
 
                         // Let the scheduler handle after:* phases and TEARDOWN in the next cycle
                         executePlan();
@@ -454,18 +454,18 @@ public class BuildPlanExecutor {
                 // Skip the step and provide a specific reason
                 if (!shouldExecute) {
                     if (status.isHalted()) {
-                        logger.debug("Skipping step {} because the build is halted", step);
+                        logger.trace("Skipping step {} because the build is halted", step);
                     } else if (status.isBlackListed(step.project)) {
-                        logger.debug("Skipping step {} because the project is blacklisted", step);
+                        logger.trace("Skipping step {} because the project is blacklisted", step);
                     } else if (TEARDOWN.equals(step.name)) {
                         // This should never happen given we always process TEARDOWN steps
                         logger.warn("Unexpected skipping of TEARDOWN step {}", step);
                     } else {
-                        logger.debug("Skipping step {} because a dependency has failed", step);
+                        logger.trace("Skipping step {} because a dependency has failed", step);
                     }
                 } else {
                     // Skip because predecessors failed or were skipped
-                    logger.debug(
+                    logger.trace(
                             "Skipping step {} because one or more predecessors did not execute successfully", step);
                 }
                 // Recursively call executePlan to process steps that depend on this one

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
@@ -95,7 +95,7 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
 
     @Override
     public PluginPrefixResult resolve(PluginPrefixRequest request) throws NoPluginFoundForPrefixException {
-        logger.debug("Resolving plugin prefix {} from {}", request.getPrefix(), request.getPluginGroups());
+        logger.trace("Resolving plugin prefix {} from {}", request.getPrefix(), request.getPluginGroups());
 
         Model pom = request.getPom();
         Build build = pom != null ? pom.getBuild() : null;
@@ -139,7 +139,7 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
                     request.getRepositorySession().getLocalRepository(),
                     request.getRepositories());
         } else {
-            logger.debug(
+            logger.trace(
                     "Resolved plugin prefix {} to {}:{} from repository {}",
                     request.getPrefix(),
                     result.getGroupId(),

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver.java
@@ -107,7 +107,7 @@ public class DefaultPluginVersionResolver implements PluginVersionResolver {
             if (result == null) {
                 result = resolveFromRepository(request);
 
-                logger.debug(
+                logger.trace(
                         "Resolved plugin version for {}:{} to {} from repository {}",
                         request.getGroupId(),
                         request.getArtifactId(),
@@ -116,7 +116,7 @@ public class DefaultPluginVersionResolver implements PluginVersionResolver {
 
                 cache.putIfAbsent(key, result);
             } else {
-                logger.debug(
+                logger.trace(
                         "Reusing cached resolved plugin version for {}:{} to {} from POM {}",
                         request.getGroupId(),
                         request.getArtifactId(),
@@ -124,7 +124,7 @@ public class DefaultPluginVersionResolver implements PluginVersionResolver {
                         request.getPom());
             }
         } else {
-            logger.debug(
+            logger.trace(
                     "Reusing cached resolved plugin version for {}:{} to {} from POM {}",
                     request.getGroupId(),
                     request.getArtifactId(),
@@ -348,7 +348,7 @@ public class DefaultPluginVersionResolver implements PluginVersionResolver {
             pluginDescriptor = pluginManager.getPluginDescriptor(
                     plugin, request.getRepositories(), request.getRepositorySession());
         } catch (PluginResolutionException e) {
-            logger.debug("Ignoring unresolvable plugin version {}", version, e);
+            logger.trace("Ignoring unresolvable plugin version {}", version, e);
             return false;
         } catch (Exception e) {
             // ignore for now and delay failure to higher level processing

--- a/impl/maven-core/src/test/java/org/apache/maven/classrealm/DefaultClassRealmManagerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/classrealm/DefaultClassRealmManagerTest.java
@@ -95,9 +95,9 @@ class DefaultClassRealmManagerTest {
     }
 
     @Test
-    void testDebugEnabled() throws PlexusContainerException {
+    void testTraceEnabled() throws PlexusContainerException {
         Logger logger = mock(Logger.class);
-        when(logger.isDebugEnabled()).thenReturn(true);
+        when(logger.isTraceEnabled()).thenReturn(true);
 
         DefaultClassRealmManager classRealmManager;
         ClassRealm classRealm;
@@ -122,18 +122,18 @@ class DefaultClassRealmManagerTest {
                 classRealm.getURLs()[0].getPath().endsWith("local/repository/some/path"),
                 "ClassRealm URL should end with local repository path");
 
-        verifier.verify(logger, calls(1)).debug("Importing foreign packages into class realm {}", "maven.api");
-        verifier.verify(logger, calls(1)).debug("  Imported: {} < {}", "group1:artifact1", "test");
-        verifier.verify(logger, calls(1)).debug("  Excluded: {}", "group1:artifact2:ext:classifier1:null");
+        verifier.verify(logger, calls(1)).trace("Importing foreign packages into class realm {}", "maven.api");
+        verifier.verify(logger, calls(1)).trace("  Imported: {} < {}", "group1:artifact1", "test");
+        verifier.verify(logger, calls(1)).trace("  Excluded: {}", "group1:artifact2:ext:classifier1:null");
         verifier.verify(logger, calls(1))
-                .debug("Populating class realm {}", "project>modelGroup1:modelArtifact1:modelVersion1");
-        verifier.verify(logger, calls(1)).debug("  Included: {}", "group1:artifact1:ext:classifier1:null");
+                .trace("Populating class realm {}", "project>modelGroup1:modelArtifact1:modelVersion1");
+        verifier.verify(logger, calls(1)).trace("  Included: {}", "group1:artifact1:ext:classifier1:null");
     }
 
     @Test
-    void testDebugDisabled() throws PlexusContainerException {
+    void testTraceDisabled() throws PlexusContainerException {
         Logger logger = mock(Logger.class);
-        when(logger.isDebugEnabled()).thenReturn(false);
+        when(logger.isTraceEnabled()).thenReturn(false);
 
         DefaultClassRealmManager classRealmManager;
         ClassRealm classRealm;
@@ -158,11 +158,11 @@ class DefaultClassRealmManagerTest {
                 classRealm.getURLs()[0].getPath().endsWith("local/repository/some/path"),
                 "ClassRealm URL should end with local repository path");
 
-        verifier.verify(logger, calls(1)).debug("Importing foreign packages into class realm {}", "maven.api");
-        verifier.verify(logger, calls(1)).debug("  Imported: {} < {}", "group1:artifact1", "test");
+        verifier.verify(logger, calls(1)).trace("Importing foreign packages into class realm {}", "maven.api");
+        verifier.verify(logger, calls(1)).trace("  Imported: {} < {}", "group1:artifact1", "test");
         verifier.verify(logger, calls(1))
-                .debug("Populating class realm {}", "project>modelGroup1:modelArtifact1:modelVersion1");
-        verifier.verify(logger, never()).debug("  Included: {}", "group1:artifact1:ext:classifier1:null");
-        verifier.verify(logger, never()).debug("  Excluded: {}", "group1:artifact2:ext:classifier1:null");
+                .trace("Populating class realm {}", "project>modelGroup1:modelArtifact1:modelVersion1");
+        verifier.verify(logger, never()).trace("  Included: {}", "group1:artifact1:ext:classifier1:null");
+        verifier.verify(logger, never()).trace("  Excluded: {}", "group1:artifact2:ext:classifier1:null");
     }
 }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/CacheConfigurationResolver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/CacheConfigurationResolver.java
@@ -103,7 +103,7 @@ public class CacheConfigurationResolver {
             if (selector.matches(req)) {
                 if (mergedConfig == null) {
                     mergedConfig = selector.config();
-                    LOGGER.debug(
+                    LOGGER.trace(
                             "Cache config for {}: matched selector '{}' with config {}",
                             req.getClass().getSimpleName(),
                             selector,
@@ -111,7 +111,7 @@ public class CacheConfigurationResolver {
                 } else {
                     PartialCacheConfig previousConfig = mergedConfig;
                     mergedConfig = mergedConfig.mergeWith(selector.config());
-                    LOGGER.debug(
+                    LOGGER.trace(
                             "Cache config for {}: merged selector '{}' with previous config {} -> {}",
                             req.getClass().getSimpleName(),
                             selector,
@@ -134,7 +134,7 @@ public class CacheConfigurationResolver {
                 finalConfig =
                         new CacheConfig(finalConfig.scope(), finalConfig.referenceType(), keyRefType, valueRefType);
             }
-            LOGGER.debug("Final cache config for {}: {}", req.getClass().getSimpleName(), finalConfig);
+            LOGGER.trace("Final cache config for {}: {}", req.getClass().getSimpleName(), finalConfig);
             return finalConfig;
         }
 
@@ -142,7 +142,7 @@ public class CacheConfigurationResolver {
         if (legacyRetention != null) {
             CacheConfig config = new CacheConfig(
                     legacyRetention, getDefaultReferenceType(legacyRetention), keyRefType, valueRefType);
-            LOGGER.debug(
+            LOGGER.trace(
                     "Cache config for {}: {} (legacy CacheMetadata)",
                     req.getClass().getSimpleName(),
                     config);
@@ -152,14 +152,14 @@ public class CacheConfigurationResolver {
         if (keyRefType != null && valueRefType != null) {
             CacheConfig config = new CacheConfig(
                     CacheConfig.DEFAULT.scope(), CacheConfig.DEFAULT.referenceType(), keyRefType, valueRefType);
-            LOGGER.debug(
+            LOGGER.trace(
                     "Cache config for {}: {} (with key/value refs)",
                     req.getClass().getSimpleName(),
                     config);
             return config;
         }
 
-        LOGGER.debug("Cache config for {}: {} (default)", req.getClass().getSimpleName(), CacheConfig.DEFAULT);
+        LOGGER.trace("Cache config for {}: {} (default)", req.getClass().getSimpleName(), CacheConfig.DEFAULT);
         return CacheConfig.DEFAULT;
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/DefaultRequestCache.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/DefaultRequestCache.java
@@ -215,8 +215,8 @@ public class DefaultRequestCache extends AbstractRequestCache {
         // Debug logging to verify reference types (disabled)
         // System.err.println("DEBUG: Cache config for " + req.getClass().getSimpleName() + ": retention=" + retention
         //         + ", keyRef=" + keyReferenceType + ", valueRef=" + valueReferenceType);
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace(
                     "Cache config for {}: retention={}, keyRef={}, valueRef={}",
                     req.getClass().getSimpleName(),
                     retention,
@@ -240,7 +240,7 @@ public class DefaultRequestCache extends AbstractRequestCache {
             Cache<Object, Cache<Object, CachingSupplier<?, ?>>> caches = session.getData()
                     .computeIfAbsent(KEY, () -> {
                         if (config.hasSeparateKeyValueReferenceTypes()) {
-                            LOGGER.debug(
+                            LOGGER.trace(
                                     "Creating SESSION_SCOPED parent cache with key={}, value={}",
                                     keyReferenceType,
                                     valueReferenceType);
@@ -253,7 +253,7 @@ public class DefaultRequestCache extends AbstractRequestCache {
             // Use separate key/value reference types if configured
             if (config.hasSeparateKeyValueReferenceTypes()) {
                 cache = caches.computeIfAbsent(ROOT, k -> {
-                    LOGGER.debug(
+                    LOGGER.trace(
                             "Creating SESSION_SCOPED cache with key={}, value={}",
                             keyReferenceType,
                             valueReferenceType);
@@ -283,8 +283,8 @@ public class DefaultRequestCache extends AbstractRequestCache {
             }
             cacheType = "SESSION_SCOPED";
             // Debug logging for cache sizes
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace(
                         "Cache access: type={}, request={}, cacheSize={}, totalCaches={}, key={}",
                         cacheType,
                         req.getClass().getSimpleName(),
@@ -297,7 +297,7 @@ public class DefaultRequestCache extends AbstractRequestCache {
             Cache<Object, Cache<Object, CachingSupplier<?, ?>>> caches = session.getData()
                     .computeIfAbsent(KEY, () -> {
                         if (config.hasSeparateKeyValueReferenceTypes()) {
-                            LOGGER.debug(
+                            LOGGER.trace(
                                     "Creating REQUEST_SCOPED parent cache with key={}, value={}",
                                     keyReferenceType,
                                     valueReferenceType);
@@ -310,7 +310,7 @@ public class DefaultRequestCache extends AbstractRequestCache {
             // Use separate key/value reference types if configured
             if (config.hasSeparateKeyValueReferenceTypes()) {
                 cache = caches.computeIfAbsent(key, k -> {
-                    LOGGER.debug(
+                    LOGGER.trace(
                             "Creating REQUEST_SCOPED cache with key={}, value={}",
                             keyReferenceType,
                             valueReferenceType);
@@ -333,8 +333,8 @@ public class DefaultRequestCache extends AbstractRequestCache {
             cacheType = "REQUEST_SCOPED";
 
             // Debug logging for cache sizes
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace(
                         "Cache access: type={}, request={}, cacheSize={}, totalCaches={}, key={}",
                         cacheType,
                         req.getClass().getSimpleName(),
@@ -347,7 +347,7 @@ public class DefaultRequestCache extends AbstractRequestCache {
             Cache<Object, Cache<Object, CachingSupplier<?, ?>>> caches = session.getData()
                     .computeIfAbsent(KEY, () -> {
                         if (config.hasSeparateKeyValueReferenceTypes()) {
-                            LOGGER.debug(
+                            LOGGER.trace(
                                     "Creating PERSISTENT parent cache with key={}, value={}",
                                     keyReferenceType,
                                     valueReferenceType);
@@ -361,7 +361,7 @@ public class DefaultRequestCache extends AbstractRequestCache {
             // Use separate key/value reference types if configured
             if (config.hasSeparateKeyValueReferenceTypes()) {
                 cache = caches.computeIfAbsent(KEY, k -> {
-                    LOGGER.debug(
+                    LOGGER.trace(
                             "Creating PERSISTENT cache with key={}, value={}", keyReferenceType, valueReferenceType);
                     Cache<Object, CachingSupplier<?, ?>> newCache =
                             Cache.newCache(keyReferenceType, valueReferenceType, "RequestCache-PERSISTENT");
@@ -381,8 +381,8 @@ public class DefaultRequestCache extends AbstractRequestCache {
             }
             cacheType = "PERSISTENT";
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace(
                         "Cache access: type={}, request={}, cacheSize={}",
                         cacheType,
                         req.getClass().getSimpleName(),

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -255,7 +255,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                         clearRequestScopedCache(request);
                     } catch (Exception e) {
                         // Log but don't fail the build due to cache cleanup issues
-                        logger.debug("Failed to clear REQUEST_SCOPED cache for request: {}", request, e);
+                        logger.trace("Failed to clear REQUEST_SCOPED cache for request: {}", request, e);
                     }
                 }
                 RequestTraceHelper.exit(trace);
@@ -863,7 +863,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 // If profile activation fails, log a warning but continue with base properties
                 // This ensures that CI-friendly versions still work even if profile activation has issues
                 logger.warn("Failed to activate profiles for CI-friendly version processing: {}", e.getMessage());
-                logger.debug("Profile activation failure details", e);
+                logger.trace("Profile activation failure details", e);
             }
 
             // System and user properties override everything (use request properties
@@ -1399,8 +1399,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                 var previousRepositories = repositories;
                 mergeRepositories(childModel, false);
                 if (!Objects.equals(previousRepositories, repositories)) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Merging repositories from " + childModel.getId() + "\n"
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Merging repositories from " + childModel.getId() + "\n"
                                 + repositories.stream()
                                         .map(Object::toString)
                                         .collect(Collectors.joining("\n", "    ", "")));
@@ -1622,7 +1622,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 List<String> newRepos =
                         repositories.stream().map(Object::toString).toList();
                 if (!Objects.equals(oldRepos, newRepos)) {
-                    logger.debug("Replacing repositories from " + resultModel.getId() + "\n"
+                    logger.trace("Replacing repositories from " + resultModel.getId() + "\n"
                             + newRepos.stream().map(s -> "    " + s).collect(Collectors.joining("\n")));
                 }
             }
@@ -1664,7 +1664,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             Path rootDirectory;
             boolean rootDirectoryFromSession = false;
             setSource(modelSource.getLocation());
-            logger.debug("Reading file model from " + modelSource.getLocation());
+            logger.trace("Reading file model from " + modelSource.getLocation());
             Path sourcePath = modelSource.getPath();
             // Use toAbsolutePath().normalize() for consistent path identity in activeModelReads.
             // This must match the normalization used in getEnhancedProperties() guard check
@@ -1882,7 +1882,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                                                     : null)
                                     .build();
                         } catch (ModelBuilderException e) {
-                            logger.debug(
+                            logger.trace(
                                     "Could not read root model properties for CI-friendly version interpolation", e);
                         }
                     }
@@ -2454,7 +2454,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 clearRequestScopedCache(request);
             } catch (Exception e) {
                 // Log but don't fail the build due to cache cleanup issues
-                logger.debug("Failed to clear REQUEST_SCOPED cache for raw model request: {}", request, e);
+                logger.trace("Failed to clear REQUEST_SCOPED cache for raw model request: {}", request, e);
             }
             RequestTraceHelper.exit(trace);
         }
@@ -2804,8 +2804,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                     int beforeSize = map.size();
                     map.removeIf((k, v) -> !(k instanceof RgavCacheKey) && !(k instanceof SourceCacheKey));
                     int afterSize = map.size();
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
+                    if (logger.isTraceEnabled()) {
+                        logger.trace(
                                 "Cleared REQUEST_SCOPED cache for request: {}, removed {} entries, remaining entries: {}",
                                 outerRequestKey.getClass().getSimpleName(),
                                 afterSize - beforeSize,

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/DefaultArtifactDescriptorReader.java
@@ -352,7 +352,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
 
         for (org.apache.maven.api.model.Dependency dependency : model.getDependencies()) {
             if (hasUninterpolatedExpression(dependency)) {
-                logger.debug("Filtered dependency with uninterpolated expression: {}", dependency);
+                logger.trace("Filtered dependency with uninterpolated expression: {}", dependency);
                 continue;
             }
             result.addDependency(convert(dependency, stereotypes));
@@ -362,7 +362,7 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
         if (dependencyManagement != null) {
             for (org.apache.maven.api.model.Dependency dependency : dependencyManagement.getDependencies()) {
                 if (hasUninterpolatedExpression(dependency)) {
-                    logger.debug("Filtered managed dependency with uninterpolated expression: {}", dependency);
+                    logger.trace("Filtered managed dependency with uninterpolated expression: {}", dependency);
                     continue;
                 }
                 result.addManagedDependency(convert(dependency, stereotypes));
@@ -440,21 +440,21 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
     private void filterUninterpolated(ArtifactDescriptorResult result) {
         result.getRepositories().removeIf(repo -> {
             if (containsPlaceholder(repo.getId()) || containsPlaceholder(repo.getUrl())) {
-                logger.debug("Filtered repository with uninterpolated expression: {}", repo);
+                logger.trace("Filtered repository with uninterpolated expression: {}", repo);
                 return true;
             }
             return false;
         });
         result.getDependencies().removeIf(dep -> {
             if (hasUninterpolatedExpression(dep.getArtifact())) {
-                logger.debug("Filtered dependency with uninterpolated expression: {}", dep);
+                logger.trace("Filtered dependency with uninterpolated expression: {}", dep);
                 return true;
             }
             return false;
         });
         result.getManagedDependencies().removeIf(dep -> {
             if (hasUninterpolatedExpression(dep.getArtifact())) {
-                logger.debug("Filtered managed dependency with uninterpolated expression: {}", dep);
+                logger.trace("Filtered managed dependency with uninterpolated expression: {}", dep);
                 return true;
             }
             return false;

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/DistributionManagementArtifactRelocationSource.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/DistributionManagementArtifactRelocationSource.java
@@ -62,7 +62,7 @@ public final class DistributionManagementArtifactRelocationSource implements Mav
                         null,
                         relocation.getVersion(),
                         relocation.getMessage());
-                LOGGER.debug(
+                LOGGER.trace(
                         "The artifact {} has been relocated to {}: {}",
                         artifactDescriptorResult.getRequest().getArtifact(),
                         result,

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/UserPropertiesArtifactRelocationSource.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/relocation/UserPropertiesArtifactRelocationSource.java
@@ -69,7 +69,7 @@ public final class UserPropertiesArtifactRelocationSource implements MavenArtifa
                 if (relocation.target == SENTINEL) {
                     String message = "The artifact " + original + " has been banned from resolution: "
                             + (relocation.global ? "User global ban" : "User project ban");
-                    LOGGER.debug(message);
+                    LOGGER.trace(message);
                     throw new ArtifactDescriptorException(artifactDescriptorResult, message);
                 }
                 Artifact result = new RelocatedArtifact(
@@ -80,7 +80,7 @@ public final class UserPropertiesArtifactRelocationSource implements MavenArtifa
                         isAny(relocation.target.getExtension()) ? null : relocation.target.getExtension(),
                         isAny(relocation.target.getVersion()) ? null : relocation.target.getVersion(),
                         relocation.global ? "User global relocation" : "User project relocation");
-                LOGGER.debug(
+                LOGGER.trace(
                         "The artifact {} has been relocated to {}: {}",
                         original,
                         result,

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/type/TypeDeriver.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/type/TypeDeriver.java
@@ -60,13 +60,13 @@ public class TypeDeriver implements DependencyGraphTransformer {
     @Override
     public DependencyNode transformGraph(DependencyNode root, DependencyGraphTransformationContext context) {
         ArtifactTypeRegistry registry = context.getSession().getArtifactTypeRegistry();
-        if (logger.isDebugEnabled()) {
+        if (logger.isTraceEnabled()) {
             StringBuilder sb = new StringBuilder();
             root.accept(new DependencyGraphDumper(
                     l -> sb.append(l).append("\n"),
                     DependencyGraphDumper.defaultsWith(
                             List.of(DependencyGraphDumper.artifactProperties(List.of(ArtifactProperties.TYPE))))));
-            logger.debug("TYPES: Before transform:\n {}", sb);
+            logger.trace("TYPES: Before transform:\n {}", sb);
         }
         root.accept(new TypeDeriverVisitor(registry));
         // Apply processor type info collected by TypeCollector before conflict resolution.
@@ -78,13 +78,13 @@ public class TypeDeriver implements DependencyGraphTransformer {
         if (collectedProcessorTypes != null) {
             root.accept(new ProcessorTypeMerger(collectedProcessorTypes));
         }
-        if (logger.isDebugEnabled()) {
+        if (logger.isTraceEnabled()) {
             StringBuilder sb = new StringBuilder();
             root.accept(new DependencyGraphDumper(
                     l -> sb.append(l).append("\n"),
                     DependencyGraphDumper.defaultsWith(
                             List.of(DependencyGraphDumper.artifactProperties(List.of(ArtifactProperties.TYPE))))));
-            logger.debug("TYPES: After transform:\n {}", sb);
+            logger.trace("TYPES: After transform:\n {}", sb);
         }
         return root;
     }


### PR DESCRIPTION
## Summary
- Migrates 70+ DEBUG log statements to TRACE in 6 areas that produce excessive noise under `-X`: lifecycle engine (reactor plan dumps, step scheduling), classrealm (realm creation/population/imports), cache internals (config resolution, access stats), resolver (descriptor filtering, relocation), model builder (cache clearing, profile activation), and plugin resolution (version/prefix tracing)
- Adds `TRACE` to `Slf4jConfiguration.Level` enum so the logging system supports `-Dmaven.logger.defaultLogLevel=trace` as a system property for Maven core developers
- `DEBUG` (`-X`) remains the right level for plugin development; `TRACE` is for Maven core developers diagnosing framework internals

## Motivation

The TRACE level was added in the logging-foundation PR to separate two audiences:
- **DEBUG** — plugin developers and power users diagnosing plugin behavior
- **TRACE** — Maven core developers tracing internal framework mechanics

Without this migration, TRACE exists but nothing emits at it, making the distinction theoretical. This PR populates it with the noisiest internal plumbing output that dominates `-X` today and drowns out the signal plugin developers actually want.

## What stays at DEBUG
- Plugin parameter resolution, mojo configuration/loading (useful for plugin devs)
- `mvnup` upgrade diagnostics
- CLI bootstrap messages (uses `o.a.m.api.cli.Logger` which doesn't have TRACE)

## Files changed (18 files, +108/-105)

| Area | Files | Changes |
|---|---|---|
| Lifecycle engine | `LifecycleDebugLogger`, `BuildPlanExecutor`, `MultiThreadedBuilder` | 32 statements |
| Cache internals | `DefaultRequestCache`, `CacheConfigurationResolver` | 22 statements |
| Classrealm | `DefaultClassRealmManager` | 8 statements |
| Resolver | `DefaultArtifactDescriptorReader`, relocation sources, `TypeDeriver` | 8 statements |
| Model builder | `DefaultModelBuilder` | 8 statements |
| Plugin resolution | `DefaultPluginVersionResolver`, `DefaultPluginPrefixResolver` | 6 statements |
| Infrastructure | `Slf4jConfiguration`, `MavenSimpleConfiguration`, `CliUtils` | TRACE level support |
| Tests | `DefaultClassRealmManagerTest`, `LookupInvokerLoggingTest` | Updated mocks |

## PR chain

| # | PR | Feature |
|---|---|---|
| 1 | #12694 | Logging foundation |
| 2 | #12695 | Build report |
| 3 | #13180 | Console modes |
| 4 | #12698 | Warning mode + diagnostics |
| 5 | #12699 | `mvnlog` viewer |
| 6 | #12702 | Structured problems pipeline |
| 7 | **This PR** | TRACE level migration |

## Test plan
- [x] All modified modules compile cleanly
- [x] `DefaultClassRealmManagerTest` updated to verify `trace()` calls instead of `debug()`
- [x] `LookupInvokerLoggingTest` updated for new TRACE enum value
- [x] All tests pass in isolation (batch-mode flakiness in `MavenInvokerTest` is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
