### PR TITLE
Remove workaround for creating site output directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1047,27 +1047,6 @@ under the License.
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>pre-site</phase>
-                <configuration>
-                  <target>
-                    <!-- directory should be created by org.eclipse.aether.tools.CollectConfiguration -->
-                    <!-- TODO: remove with next version of resolver-tools -->
-                    <mkdir dir="${project.build.directory}/generated-site/markdown" />
-                    <mkdir dir="${project.build.directory}/generated-site/resources" />
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>3.6.3</version>


### PR DESCRIPTION
fixed in resolver 2.0.11

(cherry picked from commit 77f52a42114d120b80c65ca4b4778cf72ece5e9d)

- https://github.com/apache/maven/pull/11481