### PR TITLE
Migrate the embedder-test-project fixture to JUnit 5

### DIFF
--- a/maven-embedder/src/test/embedder-test-project/pom.xml
+++ b/maven-embedder/src/test/embedder-test-project/pom.xml
@@ -20,9 +20,9 @@
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -41,7 +41,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.5.6</version>
       </plugin>
     </plugins>
   </build>

--- a/maven-embedder/src/test/embedder-test-project/src/test/java/org/apache/maven/AppTest.java
+++ b/maven-embedder/src/test/embedder-test-project/src/test/java/org/apache/maven/AppTest.java
@@ -1,36 +1,18 @@
 package org.apache.maven;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for simple App.
  */
 public class AppTest
-    extends TestCase
 {
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public AppTest( String testName )
-    {
-        super( testName );
-    }
-
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite()
-    {
-        return new TestSuite( AppTest.class );
-    }
-
     /**
      * Rigorous Test :-)
      */
+    @Test
     public void testApp()
     {
         assertTrue( true );


### PR DESCRIPTION
The `embedder-test-project` sample under `maven-embedder/src/test` is a standalone, un-parented fixture project (its own groupId/artifactId/version) that exists as filesystem input data. It is not part of the reactor and no test code references it, so nothing in the build compiles or runs it.

This converts its archetype-generated `AppTest` from JUnit 3.8.1 to JUnit 5 Jupiter and bumps its pinned surefire-plugin from 2.4.3, so the fixture still builds and runs standalone if someone invokes it by hand.

**Scope, stated plainly:** this is deliberately narrow. Roughly 20 other fixture projects under `maven-embedder/src/test` and `maven-core/src/test` still declare `junit:junit`, and `maven-compat` still has real JUnit 4 test code. This PR does not touch any of them. If the preference is to do the fixtures in one sweep rather than piecemeal, say so and I will fold this into a single change instead.

`maven-embedder/src/test` no longer exists on `master`, so this applies to the 3.x line only.

<!-- Generated with assistance from Claude Opus 5; see the Generated-by trailer on the commit. -->