### PR TITLE
Move the core IT suite off the JUnit 4 assertions (4.0.x)

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
@@ -22,8 +22,10 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.Arrays;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is a test set for <a href="https://github.com/apache/maven/issues/10210">GH-10210</a>.
@@ -45,7 +47,7 @@ class MavenITgh10210SettingsXmlDecryptTest extends AbstractMavenIntegrationTestC
         verifier.addCliArgument("process-resources");
         verifier.execute();
 
-        Assert.assertEquals(
+        assertEquals(
                 Arrays.asList(
                         "prop1=%{foo}.txt",
                         "prop2=${foo}.txt",
@@ -69,7 +71,7 @@ class MavenITgh10210SettingsXmlDecryptTest extends AbstractMavenIntegrationTestC
         try {
             verifier.execute();
         } catch (VerificationException e) {
-            Assert.assertTrue(
+            assertTrue(
                     verifier.loadLogContent()
                             .contains(
                                     "Could not decrypt password (fix the corrupted password or remove it, if unused) {L6L/HbmrY+cH+sNkphn-this password is corrupted intentionally-q3fguYepTpM04WlIXb8nB1pk=}"));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7772CoreExtensionFoundTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7772CoreExtensionFoundTest.java
@@ -25,7 +25,7 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MavenITmng7772CoreExtensionFoundTest extends AbstractMavenIntegrationTestCase {
     public MavenITmng7772CoreExtensionFoundTest() {
@@ -66,7 +66,7 @@ public class MavenITmng7772CoreExtensionFoundTest extends AbstractMavenIntegrati
 
         Path jarPath = extensionBasedir.resolve("target").resolve("maven-it-core-extensions-0.1.jar");
 
-        assertTrue("Jar output path was not built", Files.isRegularFile(jarPath));
+        assertTrue(Files.isRegularFile(jarPath), "Jar output path was not built");
 
         verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setUserHomeDirectory(Paths.get(testDir.toPath().toString(), "home-lib-ext"));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8400CanonicalMavenHomeTest.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8400">MNG-8400</a>.

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8414ConsumerPomWithNewFeaturesTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8414ConsumerPomWithNewFeaturesTest.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.model.Model;
 import org.apache.maven.model.v4.MavenStaxReader;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8594AtFileTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8594AtFileTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8594">MNG-8594</a>.


### PR DESCRIPTION
Five classes in `its/core-it-suite` were already annotated with the Jupiter `@Test` but still called `org.junit.Assert`, which is the only thing still pulling JUnit 4 onto the IT classpath. They now use `org.junit.jupiter.api.Assertions`.

Four needed nothing but the static import swapped. The fifth is the one worth a second look:

```java
-        assertTrue("Jar output path was not built", Files.isRegularFile(jarPath));
+        assertTrue(Files.isRegularFile(jarPath), "Jar output path was not built");
```

The message is the **first** argument in JUnit 4 and the **last** in JUnit 5. Left as a plain import swap it would still compile — `assertTrue(String, boolean)` has no Jupiter overload, so that one actually fails to compile, but the equivalent `assertEquals(message, expected, actual)` form does not, and silently asserts the wrong thing. Worth watching for in similar cleanups.

### Verification — please read before merging

I could not run this suite. The `its` reactor needs the `0.1-stub-SNAPSHOT` plugin artifacts and `2.1-SNAPSHOT` it-support artifacts built first, and that build does not complete in my environment. What I did instead:

- a standalone `javac` compile check of the changed files against a classpath assembled from the cached `maven-it-helper` jar plus `junit-jupiter-api`/`opentest4j`/`apiguardian`, with **no JUnit 4 jar present** — clean
- confirmed no `org.junit.Assert` reference remains anywhere in `its/core-it-suite/src/test/java`
- confirmed no line exceeds 120 characters (the `its` reactor does not configure spotless, so there is no formatter to run)

So this is compile-checked, not test-run. Given the change is import-level plus one argument reorder, CI should settle it — but I would rather say that plainly than imply I ran the ITs.

The same change is on the 4.0.x line as a separate PR.

Generated-by: Claude Opus 5 (1M context)