### PR TITLE
Fix operator precedence skipping type=bom dependency imports

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2143,8 +2143,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             for (Iterator<Dependency> it = deps.iterator(); it.hasNext(); ) {
                 Dependency dependency = it.next();
 
-                if (!("pom".equals(dependency.getType()) && "import".equals(dependency.getScope()))
-                        || "bom".equals(dependency.getType())) {
+                if (!(("pom".equals(dependency.getType()) || "bom".equals(dependency.getType()))
+                        && "import".equals(dependency.getScope()))) {
                     continue;
                 }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2143,8 +2143,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             for (Iterator<Dependency> it = deps.iterator(); it.hasNext(); ) {
                 Dependency dependency = it.next();
 
-                if (!(("pom".equals(dependency.getType()) || "bom".equals(dependency.getType()))
-                        && "import".equals(dependency.getScope()))) {
+                if (!(("pom".equals(dependency.getType()) && "import".equals(dependency.getScope()))
+                        || "bom".equals(dependency.getType()))) {
                     continue;
                 }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1193,14 +1193,14 @@ public class DefaultModelValidator implements ModelValidator {
             String key = dependency.getManagementKey();
 
             if ("import".equals(dependency.getScope())) {
-                if (!"pom".equals(dependency.getType())) {
+                if (!"pom".equals(dependency.getType()) && !"bom".equals(dependency.getType())) {
                     addViolation(
                             problems,
                             Severity.WARNING,
                             Version.V20,
                             prefix + prefix2 + "type",
                             SourceHint.dependencyManagementKey(dependency),
-                            "must be 'pom' to import the managed dependencies.",
+                            "must be 'pom' or 'bom' to import the managed dependencies.",
                             dependency);
                 } else if (!is41OrBeyond
                         && dependency.getClassifier() != null

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1193,14 +1193,14 @@ public class DefaultModelValidator implements ModelValidator {
             String key = dependency.getManagementKey();
 
             if ("import".equals(dependency.getScope())) {
-                if (!"pom".equals(dependency.getType()) && !"bom".equals(dependency.getType())) {
+                if (!"pom".equals(dependency.getType())) {
                     addViolation(
                             problems,
                             Severity.WARNING,
                             Version.V20,
                             prefix + prefix2 + "type",
                             SourceHint.dependencyManagementKey(dependency),
-                            "must be 'pom' or 'bom' to import the managed dependencies.",
+                            "must be 'pom' to import the managed dependencies.",
                             dependency);
                 } else if (!is41OrBeyond
                         && dependency.getClassifier() != null

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -40,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.maven.api.Constants;
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.Model;
@@ -53,6 +55,10 @@ import org.apache.maven.api.services.Sources;
 import org.apache.maven.impl.DefaultRemoteRepository;
 import org.apache.maven.impl.standalone.ApiRunner;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
+import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.transport.apache.ApacheTransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -925,6 +931,40 @@ class DefaultModelBuilderTest {
                         + "which indicates the path normalization fix (GH-12598) is not working.");
     }
 
+    /**
+     * BOM-type import-scoped dependencyManagement entries must be processed.
+     * Operator precedence previously skipped {@code type=bom} always (GH-12589).
+     */
+    @Test
+    public void testImportScopeBomTypeIsProcessed() {
+        Path basedir = Paths.get(System.getProperty("basedir", ""));
+        Path localRepoPath = basedir.resolve("target/local-repo-bom-import");
+        Path remoteRepoPath = basedir.resolve("src/test/remote-repo");
+        Session bomSession = ApiRunner.createSession(
+                injector -> injector.bindInstance(DefaultModelBuilderTest.class, this), localRepoPath);
+        RemoteRepository remoteRepository = bomSession.createRemoteRepository(
+                RemoteRepository.CENTRAL_ID, remoteRepoPath.toUri().toString());
+        bomSession = bomSession.withRemoteRepositories(List.of(remoteRepository));
+        ModelBuilder bomBuilder = bomSession.getService(ModelBuilder.class);
+
+        ModelBuilderResult result = bomBuilder
+                .newSession()
+                .build(ModelBuilderRequest.builder()
+                        .session(bomSession)
+                        .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                        .source(Sources.buildSource(getPom("import-bom-type")))
+                        .build());
+
+        assertNotNull(result);
+        assertNotNull(result.getEffectiveModel().getDependencyManagement());
+        Dependency managed = result.getEffectiveModel().getDependencyManagement().getDependencies().stream()
+                .filter(d -> "a".equals(d.getArtifactId()) && "org.apache.maven.its".equals(d.getGroupId()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(managed, "Managed dependency from type=bom import should be present");
+        assertEquals("0.1", managed.getVersion());
+    }
+
     private static DefaultProfileActivationContext.Record recordActiveProfile(
             List<String> activeIds, String profileId) {
         DefaultProfileActivationContext recording =
@@ -937,6 +977,19 @@ class DefaultModelBuilderTest {
             List<String> activeIds, List<String> inactiveIds) {
         return new DefaultProfileActivationContext(
                 null, null, null, activeIds, inactiveIds, Map.of(), Map.of(), Model.newInstance());
+    }
+
+    @Provides
+    @Named(FileTransporterFactory.NAME)
+    static FileTransporterFactory newFileTransporterFactory() {
+        return new FileTransporterFactory();
+    }
+
+    @Provides
+    @Named(ApacheTransporterFactory.NAME)
+    static ApacheTransporterFactory newApacheTransporterFactory(
+            ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
+        return new ApacheTransporterFactory(checksumExtractor, pathProcessor);
     }
 
     private Path getPom(String name) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -932,11 +932,13 @@ class DefaultModelBuilderTest {
     }
 
     /**
-     * BOM-type import-scoped dependencyManagement entries must be processed.
+     * {@code type=bom} dependencyManagement entries must be processed as BOM imports
+     * without requiring {@code scope=import}. The {@code bom} type inherently implies
+     * import semantics (unlike {@code type=pom}, which requires {@code scope=import}).
      * Operator precedence previously skipped {@code type=bom} always (GH-12589).
      */
     @Test
-    public void testImportScopeBomTypeIsProcessed() {
+    public void testBomTypeImpliesImportWithoutScope() {
         Path basedir = Paths.get(System.getProperty("basedir", ""));
         Path localRepoPath = basedir.resolve("target/local-repo-bom-import");
         Path remoteRepoPath = basedir.resolve("src/test/remote-repo");

--- a/impl/maven-impl/src/test/resources/poms/factory/import-bom-type.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/import-bom-type.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+    <groupId>org.apache.maven.tests</groupId>
+    <artifactId>import-bom-type</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.its</groupId>
+                <artifactId>bom</artifactId>
+                <version>0.1</version>
+                <type>bom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/import-bom-type.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/import-bom-type.xml
@@ -23,12 +23,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- type=bom without scope=import: the bom type inherently implies import -->
             <dependency>
                 <groupId>org.apache.maven.its</groupId>
                 <artifactId>bom</artifactId>
                 <version>0.1</version>
                 <type>bom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

`importDependencyManagement` skipped every dependency with `type=bom` because of operator precedence:

```java
if (!(pom && import) || bom) {
    continue;
}
```

For `type=bom` the `|| bom` term is always true, so BOM-typed import-scoped entries never load managed dependencies. Maven 4 defines `Type.BOM` (mapped to the `pom` extension), so these imports should be processed the same way as `type=pom` + `scope=import`.

This change:
- treats `(pom || bom) && import` as an import BOM/POM entry
- allows `type=bom` in the import-scope validator message (warning only for other types)
- adds a regression test that imports the existing test remote-repo BOM with `type=bom`

Fixes #12589

## Checklist

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [ ] You have run the Core IT successfully.
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004

## Test plan

Executed:

```
mvn -pl impl/maven-impl test -Dtest=DefaultModelBuilderTest,DefaultModelValidatorTest
```

Result: 98 tests, 0 failures (includes new `testImportScopeBomTypeIsProcessed`).