### PR TITLE
Add API dependency scope support

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/DependencyScope.java
@@ -43,6 +43,11 @@ import org.apache.maven.api.annotations.Nonnull;
 public enum DependencyScope {
 
     /**
+     * API scope. Compile, runtime and test, exported transitively.
+     */
+    API("api", true),
+
+    /**
      * None. Allows you to declare dependencies (for example to alter reactor build order) but in reality dependencies
      * in this scope are not part of any path scope.
      */
@@ -64,7 +69,7 @@ public enum DependencyScope {
     /**
      * Compile, runtime and test.
      */
-    COMPILE("compile", true),
+    COMPILE("compile", false),
 
     /**
      * Runtime and test.

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/PathScope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/PathScope.java
@@ -56,16 +56,18 @@ public interface PathScope extends ExtensibleEnum {
     PathScope MAIN_COMPILE = pathScope(
             "main-compile",
             ProjectScope.MAIN,
+            DependencyScope.API,
             DependencyScope.COMPILE_ONLY,
             DependencyScope.COMPILE,
             DependencyScope.PROVIDED);
 
     PathScope MAIN_RUNTIME =
-            pathScope("main-runtime", ProjectScope.MAIN, DependencyScope.COMPILE, DependencyScope.RUNTIME);
+            pathScope("main-runtime", ProjectScope.MAIN, DependencyScope.API, DependencyScope.COMPILE, DependencyScope.RUNTIME);
 
     PathScope TEST_COMPILE = pathScope(
             "test-compile",
             ProjectScope.TEST,
+            DependencyScope.API,
             DependencyScope.COMPILE,
             DependencyScope.PROVIDED,
             DependencyScope.TEST_ONLY,
@@ -74,6 +76,7 @@ public interface PathScope extends ExtensibleEnum {
     PathScope TEST_RUNTIME = pathScope(
             "test-runtime",
             ProjectScope.TEST,
+            DependencyScope.API,
             DependencyScope.COMPILE,
             DependencyScope.RUNTIME,
             DependencyScope.PROVIDED,

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/PathScope.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/PathScope.java
@@ -61,8 +61,8 @@ public interface PathScope extends ExtensibleEnum {
             DependencyScope.COMPILE,
             DependencyScope.PROVIDED);
 
-    PathScope MAIN_RUNTIME =
-            pathScope("main-runtime", ProjectScope.MAIN, DependencyScope.API, DependencyScope.COMPILE, DependencyScope.RUNTIME);
+    PathScope MAIN_RUNTIME = pathScope(
+            "main-runtime", ProjectScope.MAIN, DependencyScope.API, DependencyScope.COMPILE, DependencyScope.RUNTIME);
 
     PathScope TEST_COMPILE = pathScope(
             "test-compile",

--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/scopes/Maven4ScopeManagerConfiguration.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/scopes/Maven4ScopeManagerConfiguration.java
@@ -89,6 +89,8 @@ public final class Maven4ScopeManagerConfiguration implements ScopeManagerConfig
             InternalScopeManager internalScopeManager) {
         ArrayList<org.eclipse.aether.scope.DependencyScope> result = new ArrayList<>();
         result.add(internalScopeManager.createDependencyScope(
+                DependencyScope.API.id(), DependencyScope.API.isTransitive(), all()));
+        result.add(internalScopeManager.createDependencyScope(
                 DependencyScope.COMPILE.id(), DependencyScope.COMPILE.isTransitive(), all()));
         result.add(internalScopeManager.createDependencyScope(
                 DependencyScope.RUNTIME.id(),

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -1233,13 +1233,14 @@ public class DefaultModelValidator implements ModelValidator {
                 }
             }
 
-            // MNG-8750: New dependency scopes are only supported starting with modelVersion 4.1.0
+            // MNG-8750 / MNG-8099: New dependency scopes are only supported starting with modelVersion 4.1.0
             // When using modelVersion 4.0.0, fail validation if one of the new scopes is present
             if (!is41OrBeyond) {
                 String scope = dependency.getScope();
                 if (DependencyScope.COMPILE_ONLY.id().equals(scope)
                         || DependencyScope.TEST_ONLY.id().equals(scope)
-                        || DependencyScope.TEST_RUNTIME.id().equals(scope)) {
+                        || DependencyScope.TEST_RUNTIME.id().equals(scope)
+                        || DependencyScope.API.id().equals(scope)) {
                     addViolation(
                             problems,
                             Severity.ERROR,

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/resolver/scopes/Maven4ScopeManagerConfiguration.java
@@ -87,6 +87,8 @@ public final class Maven4ScopeManagerConfiguration implements ScopeManagerConfig
             InternalScopeManager internalScopeManager) {
         ArrayList<org.eclipse.aether.scope.DependencyScope> result = new ArrayList<>();
         result.add(internalScopeManager.createDependencyScope(
+                DependencyScope.API.id(), DependencyScope.API.isTransitive(), all()));
+        result.add(internalScopeManager.createDependencyScope(
                 DependencyScope.COMPILE.id(), DependencyScope.COMPILE.isTransitive(), all()));
         result.add(internalScopeManager.createDependencyScope(
                 DependencyScope.RUNTIME.id(),

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -119,6 +119,7 @@ class DefaultModelValidatorTest {
         validator = new DefaultModelValidator();
 
         Collection<DependencyScope> scopes = new ArrayList<>();
+        scopes.add(new DepScope("api"));
         scopes.add(new DepScope("compile"));
         scopes.add(new DepScope("runtime"));
         scopes.add(new DepScope("provided"));


### PR DESCRIPTION
## Summary

Adds support for the new `api` dependency scope and includes the corresponding validation updates.

## Changes

- Add `DependencyScope.API` and mark `COMPILE` as non-transitive
- Include the new scope in the resolver scope manager configuration
- Include it in the supported path scopes
- Update model validation for 4.0.0 compatibility checks
- Extend the validator test coverage for the new scope

## Verification

- Relevant Maven validation test was run for the modified area
- The branch was pushed to the fork and is ready for review