### PR TITLE
fix: keep all profile activation keys in the cache, including inactive ones

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileActivationContext.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileActivationContext.java
@@ -237,10 +237,7 @@ public class DefaultProfileActivationContext implements ProfileActivationContext
     }
 
     Record stop() {
-        // only keep keys for which the value is `true`
         Objects.requireNonNull(record, "start() must be called before stop()");
-        record.usedActiveProfiles.values().removeIf(value -> !value);
-        record.usedInactiveProfiles.values().removeIf(value -> !value);
         return new Record(record); // Return immutable copy for thread-safe caching
     }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/ParentProfileCacheTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/ParentProfileCacheTest.java
@@ -1,0 +1,57 @@
+package org.apache.maven.impl.model;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.api.model.Model;
+import org.apache.maven.impl.model.DefaultProfileActivationContext.Record;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ParentProfileCacheTest {
+
+    @Test
+    void recordOfAnUnactivatedProfileMustNotMatchAnActivatedContext() {
+        Record withoutRelease = record(List.of(), "release");
+        Record withRelease = record(List.of("release"), "release");
+
+        assertFalse(
+                withoutRelease.matches(context(List.of("release"))),
+                "a parent assembled without -Prelease must not be reused for a module built with -Prelease");
+        assertFalse(
+                withRelease.matches(context(List.of())),
+                "a parent assembled with -Prelease must not be reused for a module built without it");
+        assertTrue(withoutRelease.matches(context(List.of())));
+        assertTrue(withRelease.matches(context(List.of("release"))));
+    }
+
+    @Test
+    void recordOfAnUnsuppressedProfileMustNotMatchASuppressedContext() {
+        DefaultProfileActivationContext recording = context(List.of(), List.of()).start();
+        recording.isProfileInactive("release");
+        Record withoutSuppression = recording.stop();
+
+        assertFalse(
+                withoutSuppression.matches(context(List.of(), List.of("release"))),
+                "a parent assembled without -!release must not be reused for a module built with -!release");
+        assertTrue(withoutSuppression.matches(context(List.of(), List.of())));
+    }
+
+    /** Records the activation state of {@code profileId} as seen from a context with {@code activeIds}. */
+    private static Record record(List<String> activeIds, String profileId) {
+        DefaultProfileActivationContext recording = context(activeIds).start();
+        recording.isProfileActive(profileId);
+        return recording.stop();
+    }
+
+    private static DefaultProfileActivationContext context(List<String> activeIds) {
+        return context(activeIds, List.of());
+    }
+
+    private static DefaultProfileActivationContext context(List<String> activeIds, List<String> inactiveIds) {
+        return new DefaultProfileActivationContext(
+                null, null, null, activeIds, inactiveIds, Map.of(), Map.of(), Model.newInstance());
+    }
+}


### PR DESCRIPTION
### Problem

`DefaultProfileActivationContext.stop()` filters out `false`-valued entries from `usedActiveProfiles` and `usedInactiveProfiles` before freezing the `Record`. This means a parent POM assembled without `-Prelease` stores an empty map (`usedActiveProfiles = {}`), which matches ANY context — including one where `-Prelease` is active. The poisoned cache entry is then shared by every reactor module, causing profile-injected content (plugin executions, properties, dependencies) to silently vanish from a subset of modules.

Root cause: the cache key is too narrow — it only records profiles that were *active*, not profiles that were consulted but found *inactive*.

### Fix

Remove the two `removeIf` filters so every consulted profile key is retained, regardless of whether it evaluated to `true` or `false`. The `Record.matches()` method already correctly verifies keys it holds, so a `false`-valued entry correctly prevents a mis-match.

### Test

Added `ParentProfileCacheTest` with two assertions that fail on the unpatched code and pass with the fix:
- A parent assembled without `-Prelease` must not be reused for a module built with `-Prelease`
- A parent assembled without `-!release` must not be reused for a module built with `-!release`

### References

Full root-cause analysis: https://github.com/apache/maven/issues/12724