### PR TITLE
fix: synchronize ReflectionValueExtractor class-introspection cache for thread safety

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
@@ -23,6 +23,7 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,7 +49,8 @@ public class ReflectionValueExtractor {
      * This approach prevents permgen space overflows due to retention of discarded
      * classloaders.
      */
-    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS = new WeakHashMap<>();
+    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     static final int EOF = -1;
 


### PR DESCRIPTION
### Problem

`ReflectionValueExtractor` keeps a static `WeakHashMap` class-introspection cache that is read and written concurrently from multiple builder threads under `-T` (parallel builds). `WeakHashMap` is not thread-safe — concurrent `resize` from multiple threads can create circular bucket chains, causing the build to hang indefinitely at 100% CPU.

**Observed symptom**: `mvn -T1C` hangs with one core pinned at 100%, thread dump shows `WeakHashMap.transfer` in a RUNNABLE state inside `getClassMap()`.

### Fix

Wrap the `WeakHashMap` with `Collections.synchronizedMap()` to serialize all reads and writes. This preserves the weak-reference semantics (classloader GC is unaffected) while providing thread safety.

### Changes

- `ReflectionValueExtractor.java`: wrap `CLASS_MAPS` with `Collections.synchronizedMap()`, add `import java.util.Collections`

Fixes #12731