### PR TITLE
fix: make stdout/stderr log level follow -q/--quiet option (#12730)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -396,8 +396,13 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
     protected void doConfigureWithTerminalWithRawStreamsDisabled(C context) {
         MavenSimpleLogger stdout = (MavenSimpleLogger) context.loggerFactory.getLogger("stdout");
         MavenSimpleLogger stderr = (MavenSimpleLogger) context.loggerFactory.getLogger("stderr");
-        stdout.setLogLevel(LocationAwareLogger.INFO_INT);
-        stderr.setLogLevel(LocationAwareLogger.INFO_INT);
+        int streamLogLevel = switch (context.loggerLevel) {
+            case DEBUG -> LocationAwareLogger.DEBUG_INT;
+            case INFO -> LocationAwareLogger.INFO_INT;
+            case ERROR -> LocationAwareLogger.ERROR_INT;
+        };
+        stdout.setLogLevel(streamLogLevel);
+        stderr.setLogLevel(streamLogLevel);
         PrintStream psOut = new LoggingOutputStream(s -> stdout.info("[stdout] " + s)).printStream();
         context.closeables.add(() -> LoggingOutputStream.forceFlush(psOut));
         PrintStream psErr = new LoggingOutputStream(s -> stderr.warn("[stderr] " + s)).printStream();


### PR DESCRIPTION
## Summary
Fixes #12730 — `mvn --quiet` does not honor the `-q`/`--quiet` option.

## Root cause
In `LookupInvoker.doConfigureWithTerminalWithRawStreamsDisabled()`, the `stdout` and `stderr` loggers were hardcoded to `LocationAwareLogger.INFO_INT`, ignoring the active log level set by the `-q`/`--quiet` option. When `-q` is passed, `context.loggerLevel` is set to `ERROR`, but the stdout logger remains at INFO, so `[INFO] [stdout] ...` lines still appear (e.g. from `help:evaluate -DforceStdout`).

## Fix
Derive the stdout/stderr log level from `context.loggerLevel` instead of hardcoding INFO:
- `-q`/`--quiet` → ERROR (suppresses `[INFO] [stdout]` prefix)
- default → INFO (unchanged behavior)
- `-X`/`--debug` → DEBUG

## Impact
- `mvn --quiet help:evaluate -Dexpression=X -DforceStdout` now prints just the value, without the `[INFO] [stdout] ` prefix.
- No behavior change for non-quiet invocations.