### PR TITLE
fix: interpolate properties in module/subproject path before filesystem resolution

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -933,24 +933,17 @@ public class DefaultModelBuilder implements ModelBuilder {
                         continue;
                     }
 
-                    // MNG-XXXX: interpolate properties in the subproject/module path (e.g.
+                    // #12729: interpolate properties in the subproject/module path (e.g.
                     // <module>./../module/pom${version-discriminator}.xml</module>) before
                     // resolving it against the filesystem. Model-wide interpolation happens
                     // later in the build, but module paths must be resolved here, so we
-                    // interpolate just the path against the model, user and system properties.
-                    String interpolated = interpolator.interpolate(subproject, key -> {
-                        String value = activated.getProperties().get(key);
-                        if (value == null) {
-                            value = request.getUserProperties().get(key);
-                        }
-                        if (value == null) {
-                            value = request.getSystemProperties().get(key);
-                        }
-                        return value;
-                    });
-                    if (interpolated != null) {
-                        subproject = interpolated;
-                    }
+                    // interpolate just the path against the user, model and system properties.
+                    subproject = interpolator.interpolate(
+                            subproject,
+                            Interpolator.chain(
+                                    request.getUserProperties()::get,
+                                    activated.getProperties()::get,
+                                    request.getSystemProperties()::get));
 
                     subproject = subproject.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -933,6 +933,25 @@ public class DefaultModelBuilder implements ModelBuilder {
                         continue;
                     }
 
+                    // MNG-XXXX: interpolate properties in the subproject/module path (e.g.
+                    // <module>./../module/pom${version-discriminator}.xml</module>) before
+                    // resolving it against the filesystem. Model-wide interpolation happens
+                    // later in the build, but module paths must be resolved here, so we
+                    // interpolate just the path against the model, user and system properties.
+                    String interpolated = interpolator.interpolate(subproject, key -> {
+                        String value = activated.getProperties().get(key);
+                        if (value == null) {
+                            value = request.getUserProperties().get(key);
+                        }
+                        if (value == null) {
+                            value = request.getSystemProperties().get(key);
+                        }
+                        return value;
+                    });
+                    if (interpolated != null) {
+                        subproject = interpolated;
+                    }
+
                     subproject = subproject.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 
                     Path rawSubprojectFile = modelProcessor.locateExistingPom(pomDirectory.resolve(subproject));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12729ModulePathPropertyInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12729ModulePathPropertyInterpolationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for <a href="https://github.com/apache/maven/issues/12729">#12729</a>.
+ * Verifies that properties in {@code <module>} (or {@code <subproject>}) paths of aggregator
+ * POMs are interpolated before filesystem resolution.
+ *
+ * <p>Maven 3 interpolated {@code ${property}} references in module paths, but Maven 4 lost
+ * this behaviour because the module path is resolved against the filesystem before model-wide
+ * interpolation runs. The fix performs a targeted early interpolation of the path string
+ * against user, model and system properties.
+ */
+class MavenITgh12729ModulePathPropertyInterpolationTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a POM-defined property in a {@code <module>} path is interpolated correctly.
+     */
+    @Test
+    void testModulePathWithPomProperty() throws Exception {
+        Path basedir = extractResources("/gh-12729-module-path-property-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+
+    /**
+     * Verify that a user property ({@code -D}) overrides a POM property in a module path,
+     * following Maven's user → model → system property precedence.
+     */
+    @Test
+    void testModulePathWithUserPropertyOverride() throws Exception {
+        Path basedir = extractResources("/gh-12729-module-path-property-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        // The POM defines child-dir=child; this override should also resolve to "child"
+        verifier.addCliArgument("-Dchild-dir=child");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/child/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12729</groupId>
+    <artifactId>module-path-interpolation-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-path-interpolation-child</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12729</groupId>
+  <artifactId>module-path-interpolation-parent</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <child-dir>child</child-dir>
+  </properties>
+
+  <modules>
+    <module>${child-dir}</module>
+  </modules>
+</project>


### PR DESCRIPTION
### Problem

Maven 4.0.0-rc6 does not interpolate properties in `<module>` (or `<subproject>`) paths of aggregator POMs. For example:

```xml
<properties>
    <version-discriminator>-v14</version-discriminator>
</properties>
<modules>
    <module>./../module/pom${version-discriminator}.xml</module>
</modules>
```

Maven 3 correctly interpolates `${version-discriminator}` to produce `./../module/pom-v14.xml`, but Maven 4 fails with:

```
[ERROR] Child subproject .../pom${version-discriminator}.xml of ... does not exist
```

### Root Cause

In `DefaultModelBuilder.loadFilePom()`, the subproject/module path strings are resolved against the filesystem **before** model-wide property interpolation runs. The path `${version-discriminator}` is never resolved, so Maven 4 treats it as a literal directory name.

### Fix

Interpolate each subproject path string against the model, user, and system properties before resolving it against the filesystem. This is a targeted interpolation of the path only — the full model interpolation still runs later in the build pipeline, unchanged.

### Testing

- Maven 3 behavior: module paths with `${property}` references are correctly interpolated
- This fix restores that behavior in Maven 4 by interpolating the path before the filesystem lookup
- Non-interpolated paths (the common case) pass through unchanged

Fixes #12729