### PR TITLE
Make profile activation conditions locale-independent

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionFunctions.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionFunctions.java
@@ -19,6 +19,7 @@
 package org.apache.maven.impl.model.profile;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.maven.api.services.InterpolatorException;
 import org.apache.maven.api.services.ModelBuilderException;
@@ -65,6 +66,9 @@ public class ConditionFunctions {
 
     /**
      * Converts the given string to uppercase.
+     * <p>
+     * The conversion uses {@link Locale#ROOT} so that profile activation does not depend on the
+     * default locale of the machine running the build.
      *
      * @param args A list containing a single string argument
      * @return The uppercase version of the input string
@@ -75,11 +79,14 @@ public class ConditionFunctions {
             throw new IllegalArgumentException("upper function requires exactly one argument");
         }
         String s = ConditionParser.toString(args.get(0));
-        return s.toUpperCase();
+        return s.toUpperCase(Locale.ROOT);
     }
 
     /**
      * Converts the given string to lowercase.
+     * <p>
+     * The conversion uses {@link Locale#ROOT} so that profile activation does not depend on the
+     * default locale of the machine running the build.
      *
      * @param args A list containing a single string argument
      * @return The lowercase version of the input string
@@ -90,7 +97,7 @@ public class ConditionFunctions {
             throw new IllegalArgumentException("lower function requires exactly one argument");
         }
         String s = ConditionParser.toString(args.get(0));
-        return s.toLowerCase();
+        return s.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
@@ -20,6 +20,7 @@ package org.apache.maven.impl.model.profile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
@@ -554,6 +555,11 @@ public class ConditionParser {
      * Converts an object to a string representation.
      * If the object is a {@code Double}, it formats it without any decimal places.
      * Otherwise, it uses the {@code String.valueOf} method.
+     * <p>
+     * Formatting uses {@link Locale#ROOT} so that profile activation does not depend on the
+     * default locale of the machine running the build. Without it, a locale whose default
+     * numbering system is not latin (for example {@code hi-IN-u-nu-deva}) would render
+     * {@code 42} as {@code ४२}.
      *
      * @param value the object to convert to a string
      * @return the string representation of the object
@@ -562,7 +568,7 @@ public class ConditionParser {
         if (value instanceof Double || value instanceof Float) {
             double doubleValue = ((Number) value).doubleValue();
             if (doubleValue == Math.floor(doubleValue) && !Double.isInfinite(doubleValue)) {
-                return String.format("%.0f", doubleValue);
+                return String.format(Locale.ROOT, "%.0f", doubleValue);
             }
         }
         return String.valueOf(value);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.impl.model.profile;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
@@ -92,6 +93,49 @@ class ConditionParserTest {
     void testCaseConversionFunctions() {
         assertEquals("HELLO", parser.parse("upper('hello')"));
         assertEquals("world", parser.parse("lower('WORLD')"));
+    }
+
+    /**
+     * The result of {@code upper()} and {@code lower()} must not depend on the default locale of
+     * the machine running the build. In the Turkish locale the default case mapping turns
+     * {@code i} into the dotted {@code İ} and {@code I} into the dotless {@code ı}, which would
+     * silently change whether a profile is activated.
+     */
+    @Test
+    void testCaseConversionFunctionsAreLocaleIndependent() {
+        Locale orig = Locale.getDefault();
+        try {
+            Locale[] locales = {Locale.ENGLISH, new Locale("tr")};
+            for (Locale locale : locales) {
+                Locale.setDefault(locale);
+                assertEquals("WINDOWS", parser.parse("upper('windows')"), "upper() in " + locale);
+                assertEquals("LINUX", parser.parse("upper('linux')"), "upper() in " + locale);
+                assertEquals("linux", parser.parse("lower('LINUX')"), "lower() in " + locale);
+                assertEquals("ci", parser.parse("lower('CI')"), "lower() in " + locale);
+            }
+        } finally {
+            Locale.setDefault(orig);
+        }
+    }
+
+    /**
+     * Numbers must render with latin digits regardless of the default locale, otherwise a
+     * condition comparing against a string literal would evaluate differently on a machine
+     * whose locale uses a non-latin numbering system.
+     */
+    @Test
+    void testNumberFormattingIsLocaleIndependent() {
+        Locale orig = Locale.getDefault();
+        try {
+            // this locale's default numbering system is Devanagari rather than latin
+            Locale.setDefault(Locale.forLanguageTag("hi-IN-u-nu-deva"));
+            assertEquals("42", ConditionParser.toString(42.0));
+            assertEquals("42", ConditionParser.toString(42.0f));
+            assertEquals("The answer is 42", parser.parse("'The answer is ' + 42.0"));
+            assertEquals(2, parser.parse("length(42.0)"));
+        } finally {
+            Locale.setDefault(orig);
+        }
     }
 
     @Test


### PR DESCRIPTION
### What

Uses `Locale.ROOT` in the three places where profile activation condition evaluation was
implicitly relying on the JVM default locale:

- `ConditionFunctions.upper(..)` — `toUpperCase()` → `toUpperCase(Locale.ROOT)`
- `ConditionFunctions.lower(..)` — `toLowerCase()` → `toLowerCase(Locale.ROOT)`
- `ConditionParser.toString(..)` — `String.format("%.0f", ..)` → `String.format(Locale.ROOT, "%.0f", ..)`

### Why

Profile activation should not depend on the locale of the machine running the build, but today
it does. Turkish and Azeri map `i` to the dotted `İ` and `I` to the dotless `ı`, so this profile:

```xml
<profile>
  <activation>
    <condition>upper(${os.name}) == 'WINDOWS'</condition>
  </activation>
</profile>
```

silently fails to activate on a JVM started with `-Duser.language=tr`, because `upper('windows')`
returns `WİNDOWS`. Reproduction:

```
$ jshell -R-Duser.language=tr
jshell> "windows".toUpperCase()
$1 ==> "WİNDOWS"
jshell> "LINUX".toLowerCase()
$2 ==> "lınux"
```

`ConditionParser.toString(Object)` has the same class of problem: it formats whole doubles with
`String.format("%.0f", ..)` and no `Locale`, so under a locale whose default numbering system is
not latin (e.g. `hi-IN-u-nu-deva`) it renders `42` as `४२`.

This brings the three call sites in line with the rest of the codebase, which already passes an
explicit `Locale` in ~41 places — including `ExecutableFinder`, in this same package.

### Why the existing tests missed it

Every string the current tests convert (`hello`, `WORLD`, `success`, `HELLO WORLD`) happens to
contain no `i` or `I`, so `ConditionParserTest` passes unchanged under `-Duser.language=tr`.

### Tests

Two tests added to `ConditionParserTest`, both of which fail without the production change:

- `testCaseConversionFunctionsAreLocaleIndependent` — exercises `upper`/`lower` under `en` and `tr`
- `testNumberFormattingIsLocaleIndependent` — exercises number rendering under `hi-IN-u-nu-deva`

They follow the existing save/restore pattern from
`VersionTest.testCaseInsensitiveOrderingOfQualifiersIsLocaleIndependent` in the same module.

Reverting only the production change and re-running gives:

```
[ERROR] ConditionParserTest.testCaseConversionFunctionsAreLocaleIndependent
        upper() in tr ==> expected: <WINDOWS> but was: <WİNDOWS>
[ERROR] ConditionParserTest.testNumberFormattingIsLocaleIndependent
        expected: <42> but was: <४२>
```

With the change, the full `maven-impl` module suite passes: 552 tests, 0 failures, checkstyle /
spotless / rat clean.

If this is wanted on `maven-4.0.x` as well, happy for it to be backported.

---

## PR checklist

The template ships with this checklist. Tick these:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004

Leave UNTICKED unless you actually run it (see note below):

- [ ] You have run the Core IT successfully.

The ICLA line can stay unticked — the production change is ~20 lines, under the template's
"~20 lines of code" threshold.
