### PR TITLE
Support the logical not operator in profile activation conditions

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
@@ -288,11 +288,21 @@ public class ConditionParser {
     }
 
     /**
-     * Parses unary operations (negation).
+     * Parses unary operations: logical not ({@code !}) and arithmetic negation ({@code -}).
+     * <p>
+     * {@code !} is equivalent to the {@code not()} function and uses the same {@link #toBoolean}
+     * coercion. Being handled here gives both operators a higher precedence than multiplication,
+     * addition, comparison and the logical operators, so {@code !a && b} parses as
+     * {@code (!a) && b}.
      *
      * @return the result of parsing unary operations
      */
     private Object parseUnary() {
+        if (current < tokens.size() && tokens.get(current).equals("!")) {
+            current++;
+            Object value = parseUnary();
+            return !toBoolean(value);
+        }
         if (current < tokens.size() && tokens.get(current).equals("-")) {
             current++;
             Object value = parseUnary();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
@@ -159,6 +159,71 @@ class ConditionParserTest {
         assertEquals("SUCCESS!", parser.parse(expression));
     }
 
+    /**
+     * The tokenizer emits a bare {@code !} token, so the parser has to be able to consume it.
+     * The {@code contains(..)} cases also cover a {@code !} inside a string literal, which the
+     * tokenizer must leave alone.
+     */
+    @Test
+    void testLogicalNotOperator() {
+        assertFalse((Boolean) parser.parse("!true"));
+        assertTrue((Boolean) parser.parse("!false"));
+        assertTrue((Boolean) parser.parse("!!true"));
+        assertFalse((Boolean) parser.parse("!!!true"));
+        assertTrue((Boolean) parser.parse("!contains('Hello, World!', 'OpenAI')"));
+        assertFalse((Boolean) parser.parse("!contains('Hello, World!', 'World')"));
+    }
+
+    /**
+     * {@code !x} is sugar for the {@code not(x)} function and must agree with it.
+     */
+    @Test
+    void testLogicalNotOperatorMatchesNotFunction() {
+        assertEquals(
+                parser.parse("not(contains('Hello, World!', 'OpenAI'))"),
+                parser.parse("!contains('Hello, World!', 'OpenAI')"));
+        assertEquals(
+                parser.parse("not(contains('Hello, World!', 'World'))"),
+                parser.parse("!contains('Hello, World!', 'World')"));
+        assertEquals(parser.parse("not(true)"), parser.parse("!true"));
+    }
+
+    /**
+     * {@code !} binds tighter than comparison and the logical operators, as it does in Java.
+     */
+    @Test
+    void testLogicalNotOperatorPrecedence() {
+        assertTrue((Boolean) parser.parse("!false && true"));
+        assertFalse((Boolean) parser.parse("!true && false"));
+        assertTrue((Boolean) parser.parse("!true || true"));
+        assertTrue((Boolean) parser.parse("!(true && false)"));
+        assertTrue((Boolean) parser.parse("!(1 > 2)"));
+        assertFalse((Boolean) parser.parse("!('a' != 'b')"));
+    }
+
+    /**
+     * Coercion of non-boolean operands must match what the {@code not()} function does.
+     */
+    @Test
+    void testLogicalNotOperatorCoercion() {
+        assertFalse((Boolean) parser.parse("!'abc'"));
+        assertTrue((Boolean) parser.parse("!''"));
+        assertFalse((Boolean) parser.parse("!length('ab')"));
+        assertTrue((Boolean) parser.parse("!0"));
+        assertFalse((Boolean) parser.parse("!1"));
+    }
+
+    /**
+     * A bare {@code !} must not disturb the {@code !=} operator, which the tokenizer emits as a
+     * single token.
+     */
+    @Test
+    void testNotEqualsStillParsesAsOneOperator() {
+        assertTrue((Boolean) parser.parse("1 != 2"));
+        assertFalse((Boolean) parser.parse("'abc' != 'abc'"));
+        assertTrue((Boolean) parser.parse("'abc' != 'cdf'"));
+    }
+
     @Test
     void testStringComparison() {
         assertTrue((Boolean) parser.parse("'abc' != 'cdf'"));


### PR DESCRIPTION
Fixes #12736

### What

Adds handling for the `!` operator to `ConditionParser.parseUnary()`.

### Why

The tokenizer already treats `!` as an operator and emits a bare `!` token, but no parser rule
consumes it. Writing the natural form of a negated condition:

```xml
<condition>!exists('some/path')</condition>
```

fails with `Unknown variable: !`, which is confusing — nothing in the expression is a variable.

`!` is defined here as sugar for the `not()` function that already exists, using the same
`toBoolean()` coercion, so this adds no new capability and no new semantics. It is handled in
`parseUnary()`, giving it the same precedence as in Java: tighter than arithmetic, comparison,
`&&` and `||`.

`!=` is unaffected — the tokenizer emits it as a single token before a bare `!` can be produced.

### Tests

Four tests added to `ConditionParserTest`, all failing before the change:

- `testLogicalNotOperator` — basic negation, stacking (`!!`, `!!!`), and negating a function call
- `testLogicalNotOperatorMatchesNotFunction` — pins `!x` to the same result as `not(x)`
- `testLogicalNotOperatorPrecedence` — precedence against `&&`, `||` and parenthesised groups
- `testLogicalNotOperatorCoercion` — string/number coercion matches `not()`

The negation tests deliberately use `contains('Hello, World!', ..)`, which puts a `!` inside a
string literal, to confirm the tokenizer still leaves quoted `!` alone.

---

## Out of scope — a separate bug found while testing this

`compare()` handles `Number` vs `Number` and `String` vs `String`, but has no `Boolean` branch, so
comparing two booleans throws on the **unmodified** parser:

```
true == true    => RuntimeException: Cannot compare true and true with operator ==
true != false   => RuntimeException: Cannot compare true and false with operator !=
```

This is pre-existing and independent of `!`. It is deliberately NOT fixed in this PR, and the
tests here avoid boolean-to-boolean comparison. Candidate for a fourth PR.

---

## PR checklist — APPEND THIS TO THE END OF THE PR DESCRIPTION

This is the repo's `pull_request_template.md` checklist. Paste it below the body above.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT](https://maven.apache.org/core-its/core-it-suite/) successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
