### PR TITLE
[MNG-8129] Handle InvalidPathException for broken relativePath on Windows

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/Sources.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/Sources.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Objects;
 
@@ -228,7 +229,12 @@ public final class Sources {
         @Nullable
         public ModelSource resolve(@Nonnull ModelLocator locator, @Nonnull String relative) {
             String norm = relative.replace('\\', File.separatorChar).replace('/', File.separatorChar);
-            Path path = getPath().getParent().resolve(norm);
+            Path path;
+            try {
+                path = getPath().getParent().resolve(norm);
+            } catch (InvalidPathException e) {
+                return null;
+            }
             Path relatedPom = locator.locateExistingPom(path);
             if (relatedPom != null) {
                 return new BuildPathSource(relatedPom);

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
@@ -142,4 +142,27 @@ class SourcesTest {
         assertThrows(NullPointerException.class, () -> Sources.buildSource(null));
         assertThrows(NullPointerException.class, () -> Sources.resolvedSource(null, "location"));
     }
+
+    /**
+     * Tests that BuildPathSource.resolve() gracefully handles invalid path strings
+     * (e.g. containing ':' which is illegal on Windows) by returning null instead
+     * of throwing InvalidPathException. This reproduces MNG-8129.
+     * <p>
+     * On Linux/macOS, ':' is valid in paths so Path.resolve() does not throw
+     * and the method returns null because no POM exists at that path.
+     * On Windows, the catch clause handles the InvalidPathException.
+     */
+    @Test
+    void testBuildPathSourceResolveWithInvalidPath() throws IOException {
+        Path pomFile = tempDir.resolve("pom.xml");
+        Files.writeString(pomFile, "<project/>");
+
+        Sources.BuildPathSource source = (Sources.BuildPathSource) Sources.buildSource(pomFile);
+        ModelSource.ModelLocator locator = mock(ModelSource.ModelLocator.class);
+        when(locator.locateExistingPom(any(Path.class))).thenReturn(null);
+
+        // Must not throw InvalidPathException on any platform (MNG-8129)
+        ModelSource result = source.resolve(locator, "org.apache:apache");
+        assertNull(result);
+    }
 }

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
@@ -21,6 +21,7 @@ package org.apache.maven.model.building;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 import org.apache.maven.building.FileSource;
@@ -61,7 +62,17 @@ public class FileModelSource extends FileSource implements ModelSource2 {
     public ModelSource2 getRelatedSource(String relPath) {
         relPath = relPath.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 
-        Path relatedPom = getPath().getParent().resolve(relPath);
+        Path relatedPom;
+        try {
+            relatedPom = getPath().getParent().resolve(relPath);
+        } catch (InvalidPathException e) {
+            // The relative path is not a valid filesystem path (e.g. contains ':' on Windows).
+            // Some POMs in the wild have <relativePath> set to a groupId:artifactId coordinate
+            // rather than a filesystem path (e.g. artemis-project-2.33.0.pom uses
+            // <relativePath>org.apache:apache</relativePath>).
+            // Return null to let the caller fall through to repository resolution.
+            return null;
+        }
 
         if (Files.isDirectory(relatedPom)) {
             // TODO figure out how to reuse ModelLocator.locatePom(File) here

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
@@ -63,6 +63,26 @@ class FileModelSourceTest {
         assertTrue(upperCaseFileSource.equals(lowerCaseFileSource));
     }
 
+    /**
+     * Tests that getRelatedSource() gracefully handles invalid path strings
+     * (e.g. containing ':' which is illegal on Windows) by returning null instead
+     * of throwing InvalidPathException. This reproduces MNG-8129.
+     * <p>
+     * On Linux/macOS, ':' is valid in paths so Path.resolve() does not throw
+     * and the method returns null because the file does not exist.
+     * On Windows, without this fix, Path.resolve() would throw InvalidPathException.
+     */
+    @Test
+    void testGetRelatedSourceWithInvalidRelativePath() throws Exception {
+        File tempFile = createTempFile("pomTest");
+        FileModelSource source = new FileModelSource(tempFile);
+
+        // Must not throw InvalidPathException on any platform (MNG-8129)
+        ModelSource2 result = source.getRelatedSource("org.apache:apache");
+        // The nonsense path cannot resolve to an existing file, so result should be null
+        org.junit.jupiter.api.Assertions.assertNull(result);
+    }
+
     private File createTempFile(String name) throws IOException {
         File tempFile = File.createTempFile(name, ".xml");
         tempFile.deleteOnExit();


### PR DESCRIPTION
## Summary

- Catch `InvalidPathException` in `FileModelSource.getRelatedSource()` (compat) and `BuildPathSource.resolve()` (new API) and return `null`, letting the caller fall through to repository-based parent resolution
- Adds tests for both code paths

## Problem

Some POMs on Maven Central have `<relativePath>` set to a GAV coordinate instead of a proper filesystem path. For example, [`artemis-project-2.33.0.pom`](https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-project/2.33.0/artemis-project-2.33.0.pom) contains:

```xml
<relativePath>org.apache:apache</relativePath>
```

On Windows, colons are reserved for drive letters, so `Path.resolve("org.apache:apache")` throws `InvalidPathException` before any file-existence check can run. On Linux/macOS the same call succeeds (`:` is valid in paths), and the subsequent `Files.isRegularFile()` check returns `false`, so the invalid path is harmlessly ignored.

Maven 3.x accidentally handled this because the `Path.resolve()` call in `FileModelSource.getRelatedSource()` would succeed on all CI platforms (Linux), and the file-existence check made it a no-op. Maven 4 introduced `PathSource.resolve()` / `BuildPathSource.resolve()` which has the same vulnerability but is now also exercised on Windows CI.

## Approach

Catch `InvalidPathException` in both resolve methods and return `null` — an invalid path obviously cannot point to an existing parent POM, so returning `null` is the correct semantic (no local parent found → fall through to repository resolution).

Closes #12738
Closes #10492

🤖 Generated with [Claude Code](https://claude.com/claude-code)