### PR TITLE
[MNG-8129] Handle InvalidPathException for broken relativePath on Windows

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/Sources.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/Sources.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Objects;
 
@@ -228,7 +229,12 @@ public final class Sources {
         @Nullable
         public ModelSource resolve(@Nonnull ModelLocator locator, @Nonnull String relative) {
             String norm = relative.replace('\\', File.separatorChar).replace('/', File.separatorChar);
-            Path path = getPath().getParent().resolve(norm);
+            Path path;
+            try {
+                path = getPath().getParent().resolve(norm);
+            } catch (InvalidPathException e) {
+                return null;
+            }
             Path relatedPom = locator.locateExistingPom(path);
             if (relatedPom != null) {
                 return new BuildPathSource(relatedPom);

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/services/SourcesTest.java
@@ -136,6 +136,26 @@ class SourcesTest {
         }
     }
 
+    /**
+     * Tests that BuildPathSource.resolve() gracefully handles relative paths
+     * that are not valid filesystem paths (e.g. containing ':' which is illegal
+     * on Windows) by returning null instead of throwing InvalidPathException.
+     * This reproduces MNG-8129.
+     */
+    @Test
+    void testBuildPathSourceResolveWithInvalidPath() throws IOException {
+        Path pomFile = tempDir.resolve("pom.xml");
+        Files.writeString(pomFile, "<project/>");
+
+        Sources.BuildPathSource source = (Sources.BuildPathSource) Sources.buildSource(pomFile);
+        ModelSource.ModelLocator locator = mock(ModelSource.ModelLocator.class);
+        when(locator.locateExistingPom(any(Path.class))).thenReturn(null);
+
+        // Must not throw InvalidPathException on any platform (MNG-8129)
+        ModelSource result = source.resolve(locator, "org.apache:apache");
+        assertNull(result);
+    }
+
     @Test
     void testNullHandling() {
         assertThrows(NullPointerException.class, () -> Sources.fromPath(null));

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/FileModelSource.java
@@ -21,6 +21,7 @@ package org.apache.maven.model.building;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 import org.apache.maven.building.FileSource;
@@ -61,7 +62,12 @@ public class FileModelSource extends FileSource implements ModelSource2 {
     public ModelSource2 getRelatedSource(String relPath) {
         relPath = relPath.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 
-        Path relatedPom = getPath().getParent().resolve(relPath);
+        Path relatedPom;
+        try {
+            relatedPom = getPath().getParent().resolve(relPath);
+        } catch (InvalidPathException e) {
+            return null;
+        }
 
         if (Files.isDirectory(relatedPom)) {
             // TODO figure out how to reuse ModelLocator.locatePom(File) here

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -84,6 +84,8 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
+    private static final String ILLEGAL_RELATIVE_PATH_CHARS = ":\"<>|?*";
+
     private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
 
     private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_FS_CHARS;
@@ -156,6 +158,23 @@ public class DefaultModelValidator implements ModelValidator {
             }
         } else if (request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
             Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+            Severity errOn31 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1);
+
+            // [MNG-8129] Validate that relativePath does not contain characters that are illegal in filesystem paths
+            if (parent != null
+                    && parent.getRelativePath() != null
+                    && !parent.getRelativePath().isEmpty()) {
+                validateBannedCharacters(
+                        "parent.",
+                        "relativePath",
+                        problems,
+                        errOn31,
+                        Version.V20,
+                        parent.getRelativePath(),
+                        null,
+                        parent,
+                        ILLEGAL_RELATIVE_PATH_CHARS);
+            }
 
             // [MNG-6074] Maven should produce an error if no model version has been set in a POM file used to build an
             // effective model.

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/FileModelSourceTest.java
@@ -63,6 +63,22 @@ class FileModelSourceTest {
         assertTrue(upperCaseFileSource.equals(lowerCaseFileSource));
     }
 
+    /**
+     * Tests that getRelatedSource() gracefully handles relative paths that are
+     * not valid filesystem paths (e.g. containing ':' which is illegal on Windows)
+     * by returning null instead of throwing InvalidPathException.
+     * This reproduces MNG-8129.
+     */
+    @Test
+    void testGetRelatedSourceWithInvalidRelativePath() throws Exception {
+        File tempFile = createTempFile("pomTest");
+        FileModelSource source = new FileModelSource(tempFile);
+
+        // Must not throw InvalidPathException on any platform (MNG-8129)
+        ModelSource2 result = source.getRelatedSource("org.apache:apache");
+        org.junit.jupiter.api.Assertions.assertNull(result);
+    }
+
     private File createTempFile(String name) throws IOException {
         File tempFile = File.createTempFile(name, ".xml");
         tempFile.deleteOnExit();

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -470,6 +470,16 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testBadParentRelativePath() throws Exception {
+        SimpleProblemCollector result = validateRaw("bad-parent-relativePath.xml");
+
+        assertViolations(result, 0, 0, 1);
+
+        assertContains(result.getWarnings().get(0), "parent.relativePath");
+        assertContains(result.getWarnings().get(0), "must not contain any of these characters");
+    }
+
+    @Test
     void testIncompleteParent() throws Exception {
         SimpleProblemCollector result = validateRaw("incomplete-parent.xml");
 

--- a/compat/maven-model-builder/src/test/resources/poms/validation/bad-parent-relativePath.xml
+++ b/compat/maven-model-builder/src/test/resources/poms/validation/bad-parent-relativePath.xml
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>1</version>
+    <relativePath>org.apache:apache</relativePath>
+  </parent>
+
+  <artifactId>aid</artifactId>
+  <groupId>gid</groupId>
+  <version>0.1</version>
+</project>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -93,6 +93,8 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
+    private static final String ILLEGAL_RELATIVE_PATH_CHARS = ":\"<>|?*";
+
     private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
 
     private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_FS_CHARS;
@@ -439,6 +441,23 @@ public class DefaultModelValidator implements ModelValidator {
             }
 
             Severity errOn30 = getSeverity(validationLevel, ModelValidator.VALIDATION_LEVEL_MAVEN_3_0);
+            Severity errOn31 = getSeverity(validationLevel, ModelValidator.VALIDATION_LEVEL_MAVEN_3_1);
+
+            // [MNG-8129] Validate that relativePath does not contain characters that are illegal in filesystem paths
+            if (parent != null
+                    && parent.getRelativePath() != null
+                    && !parent.getRelativePath().isEmpty()) {
+                validateBannedCharacters(
+                        "parent.",
+                        "relativePath",
+                        problems,
+                        errOn31,
+                        Version.V20,
+                        parent.getRelativePath(),
+                        null,
+                        parent,
+                        ILLEGAL_RELATIVE_PATH_CHARS);
+            }
 
             boolean isModelVersion41OrMore = !Objects.equals(ModelBuilder.MODEL_VERSION_4_0_0, m.getModelVersion());
             if (isModelVersion41OrMore) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelValidatorTest.java
@@ -540,6 +540,16 @@ class DefaultModelValidatorTest {
     }
 
     @Test
+    void testBadParentRelativePath() throws Exception {
+        SimpleProblemCollector result = validateFile("bad-parent-relativePath.xml");
+
+        assertViolations(result, 0, 1, 0);
+
+        assertContains(result.getErrors().get(0), "parent.relativePath");
+        assertContains(result.getErrors().get(0), "must not contain any of these characters");
+    }
+
+    @Test
     void testIncompleteParent() throws Exception {
         SimpleProblemCollector result = validateRaw("incomplete-parent.xml");
 

--- a/impl/maven-impl/src/test/resources/poms/validation/bad-parent-relativePath.xml
+++ b/impl/maven-impl/src/test/resources/poms/validation/bad-parent-relativePath.xml
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>1</version>
+    <relativePath>org.apache:apache</relativePath>
+  </parent>
+
+  <artifactId>aid</artifactId>
+  <groupId>gid</groupId>
+  <version>0.1</version>
+</project>


### PR DESCRIPTION
## Summary

Backport of #12740 to `maven-4.0.x` for RC-7.

- Catch `InvalidPathException` in `BuildPathSource.resolve()` and `FileModelSource.getRelatedSource()` when the `<relativePath>` value contains characters illegal on certain platforms (e.g. `:` on Windows)
- Return `null` instead of throwing, matching the behavior on platforms where `Path.resolve()` succeeds but the path doesn't exist
- Some POMs on Maven Central have nonsensical `<relativePath>` values like `org.apache:apache` (e.g. `artemis-project-2.33.0.pom`) which trigger this on Windows

Fixes https://issues.apache.org/jira/browse/MNG-8129
Related: #12738

🤖 Generated with [Claude Code](https://claude.com/claude-code)