### PR TITLE
feat: add relativePath validation

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -80,6 +80,7 @@ public class DefaultModelValidator implements ModelValidator {
     private static final Pattern CI_FRIENDLY_EXPRESSION = Pattern.compile("\\$\\{(.+?)}");
     private static final Pattern EXPRESSION_PROJECT_NAME_PATTERN = Pattern.compile("\\$\\{(project.+?)}");
 
+    // see below; multiple fields depend on this field
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
     private static final String ILLEGAL_RELATIVE_PATH_FS_CHARS =
@@ -156,7 +157,9 @@ public class DefaultModelValidator implements ModelValidator {
         } else if (request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
             Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
-            if (parent != null && parent.getRelativePath() != null) {
+            if (parent != null
+                    && parent.getRelativePath() != null
+                    && !parent.getRelativePath().isEmpty()) {
                 validateBannedCharacters(
                         "parent.",
                         "relativePath",

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -83,7 +83,7 @@ public class DefaultModelValidator implements ModelValidator {
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
     private static final String ILLEGAL_RELATIVE_PATH_FS_CHARS =
-            ":\"<>|?*"; // same as above but FS sep removed (unix+win)
+            ILLEGAL_FS_CHARS.replace("\\", "").replace("/", "");
 
     private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
 

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -82,7 +82,8 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
-    private static final String ILLEGAL_RELATIVE_PATH_FS_CHARS = ":\"<>|?*"; // same as above but FS sep removed (unix+win)
+    private static final String ILLEGAL_RELATIVE_PATH_FS_CHARS =
+            ":\"<>|?*"; // same as above but FS sep removed (unix+win)
 
     private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
 

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -82,7 +82,7 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
-    private static final String ILLEGAL_RELATIVE_PATH_FS_CHARS = "\\:\"<>|?*"; // same as above but allow / (slash)
+    private static final String ILLEGAL_RELATIVE_PATH_FS_CHARS = ":\"<>|?*"; // same as above but FS sep removed (unix+win)
 
     private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
 
@@ -160,7 +160,7 @@ public class DefaultModelValidator implements ModelValidator {
                         "parent.",
                         "relativePath",
                         problems,
-                        Severity.ERROR,
+                        errOn30,
                         Version.BASE,
                         parent.getRelativePath(),
                         null,

--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -82,6 +82,8 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
+    private static final String ILLEGAL_RELATIVE_PATH_FS_CHARS = "\\:\"<>|?*"; // same as above but allow / (slash)
+
     private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
 
     private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_FS_CHARS;
@@ -152,6 +154,19 @@ public class DefaultModelValidator implements ModelValidator {
             }
         } else if (request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
             Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+
+            if (parent != null && parent.getRelativePath() != null) {
+                validateBannedCharacters(
+                        "parent.",
+                        "relativePath",
+                        problems,
+                        Severity.ERROR,
+                        Version.BASE,
+                        parent.getRelativePath(),
+                        null,
+                        parent,
+                        ILLEGAL_RELATIVE_PATH_FS_CHARS);
+            }
 
             // [MNG-6074] Maven should produce an error if no model version has been set in a POM file used to build an
             // effective model.

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -893,8 +893,7 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testBadParentRelativePath1() throws Exception {
-        SimpleProblemCollector result =
-                validateRaw("raw-model/bad-parent-relativePath1.xml");
+        SimpleProblemCollector result = validateRaw("raw-model/bad-parent-relativePath1.xml");
         assertViolations(result, 0, 1, 0);
 
         assertEquals(
@@ -904,8 +903,7 @@ public class DefaultModelValidatorTest {
 
     @Test
     public void testOkParentRelativePath1() throws Exception {
-        SimpleProblemCollector result =
-                validateRaw("raw-model/ok-parent-relativePath1.xml");
+        SimpleProblemCollector result = validateRaw("raw-model/ok-parent-relativePath1.xml");
         assertViolations(result, 0, 0, 0);
     }
 }

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -890,4 +890,22 @@ public class DefaultModelValidatorTest {
         SimpleProblemCollector result = validateRaw("raw-model/minimal-without-parent.xml");
         assertViolations(result, 0, 0, 0);
     }
+
+    @Test
+    public void testBadParentRelativePath1() throws Exception {
+        SimpleProblemCollector result =
+                validateRaw("raw-model/bad-parent-relativePath1.xml");
+        assertViolations(result, 0, 1, 0);
+
+        assertEquals(
+                "'parent.relativePath' must not contain any of these characters :\"<>|?* but found :",
+                result.getErrors().get(0));
+    }
+
+    @Test
+    public void testOkParentRelativePath1() throws Exception {
+        SimpleProblemCollector result =
+                validateRaw("raw-model/ok-parent-relativePath1.xml");
+        assertViolations(result, 0, 0, 0);
+    }
 }

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/bad-parent-relativePath1.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/bad-parent-relativePath1.xml
@@ -1,0 +1,37 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.example.group</groupId>
+		<artifactId>com-parent</artifactId>
+		<version>1.0</version>
+		<relativePath>g:a:v</relativePath>
+	</parent>
+	<groupId>com.example.group</groupId>
+	<artifactId>valid-version-wrong</artifactId>
+	<version>1.0</version>
+
+	<description>
+        This will test if the validation for the parent version
+        is working correct in case of usage of RELEASE
+	</description>
+</project>

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/bad-parent-relativePath1.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/bad-parent-relativePath1.xml
@@ -27,7 +27,7 @@ under the License.
 		<relativePath>g:a:v</relativePath>
 	</parent>
 	<groupId>com.example.group</groupId>
-	<artifactId>valid-version-wrong</artifactId>
+	<artifactId>invalid-relative-path</artifactId>
 	<version>1.0</version>
 
 	<description>

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/bad-parent-relativePath1.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/bad-parent-relativePath1.xml
@@ -31,7 +31,7 @@ under the License.
 	<version>1.0</version>
 
 	<description>
-        This will test if the validation for the parent version
-        is working correct in case of usage of RELEASE
+		This will test if the validation for the parent relativePath
+		is working correct in case of illegal characters
 	</description>
 </project>

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/ok-parent-relativePath1.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/ok-parent-relativePath1.xml
@@ -27,7 +27,7 @@ under the License.
 		<relativePath>a\b</relativePath>
 	</parent>
 	<groupId>com.example.group</groupId>
-	<artifactId>valid-version-wrong</artifactId>
+	<artifactId>valid-relative-path</artifactId>
 	<version>1.0</version>
 
 	<description>

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/ok-parent-relativePath1.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/ok-parent-relativePath1.xml
@@ -31,7 +31,7 @@ under the License.
 	<version>1.0</version>
 
 	<description>
-        This will test if the validation for the parent version
-        is working correct in case of usage of RELEASE
+		This will test if the validation for the parent relativePath
+		is working correct in case of file separators
 	</description>
 </project>

--- a/maven-model-builder/src/test/resources/poms/validation/raw-model/ok-parent-relativePath1.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/raw-model/ok-parent-relativePath1.xml
@@ -1,0 +1,37 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.example.group</groupId>
+		<artifactId>com-parent</artifactId>
+		<version>1.0</version>
+		<relativePath>a\b</relativePath>
+	</parent>
+	<groupId>com.example.group</groupId>
+	<artifactId>valid-version-wrong</artifactId>
+	<version>1.0</version>
+
+	<description>
+        This will test if the validation for the parent version
+        is working correct in case of usage of RELEASE
+	</description>
+</project>


### PR DESCRIPTION
As it seems no Maven 3.x version did validate it. Validation fails if project being built (uses strict validation), while dependencies are not failing (uses minimal validation).
