### PR TITLE
[MNG-8129] Validate relativePath for illegal filesystem characters

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -82,6 +82,8 @@ public class DefaultModelValidator implements ModelValidator {
 
     private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
 
+    private static final String ILLEGAL_RELATIVE_PATH_CHARS = ":\"<>|?*";
+
     private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
 
     private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_FS_CHARS;
@@ -152,6 +154,24 @@ public class DefaultModelValidator implements ModelValidator {
             }
         } else if (request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
             Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
+
+            Severity errOn31 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1);
+
+            // [MNG-8129] Validate that relativePath does not contain characters that are illegal in filesystem paths
+            if (parent != null
+                    && parent.getRelativePath() != null
+                    && !parent.getRelativePath().isEmpty()) {
+                validateBannedCharacters(
+                        "parent.",
+                        "relativePath",
+                        problems,
+                        errOn31,
+                        Version.V20,
+                        parent.getRelativePath(),
+                        null,
+                        parent,
+                        ILLEGAL_RELATIVE_PATH_CHARS);
+            }
 
             // [MNG-6074] Maven should produce an error if no model version has been set in a POM file used to build an
             // effective model.

--- a/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/validation/DefaultModelValidatorTest.java
@@ -416,6 +416,16 @@ public class DefaultModelValidatorTest {
     }
 
     @Test
+    public void testBadParentRelativePath() throws Exception {
+        SimpleProblemCollector result = validateRaw("bad-parent-relativePath.xml");
+
+        assertViolations(result, 0, 0, 1);
+
+        assertContains(result.getWarnings().get(0), "parent.relativePath");
+        assertContains(result.getWarnings().get(0), "must not contain any of these characters");
+    }
+
+    @Test
     public void testIncompleteParent() throws Exception {
         SimpleProblemCollector result = validateRaw("incomplete-parent.xml");
 

--- a/maven-model-builder/src/test/resources/poms/validation/bad-parent-relativePath.xml
+++ b/maven-model-builder/src/test/resources/poms/validation/bad-parent-relativePath.xml
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>1</version>
+    <relativePath>org.apache:apache</relativePath>
+  </parent>
+
+  <artifactId>aid</artifactId>
+  <groupId>gid</groupId>
+  <version>0.1</version>
+</project>


### PR DESCRIPTION
## Summary

- Add validation in `DefaultModelValidator` to reject `<relativePath>` values containing characters illegal in filesystem paths (`: " < > | ? *`)
- Uses `errOn31` severity (WARNING at default strict level) to avoid breaking existing builds
- Path separators (`/` and `\`) are intentionally excluded from the banned list since the resolver handles them
- Catches nonsensical values like `org.apache:apache` early with a clear error message

Note: Maven 3.10.x uses `java.io.File` for path resolution (not `java.nio.file.Path`), so there is no `InvalidPathException` crash — `new File()` silently accepts any string. The validator check is sufficient for this branch.

Companion to #12740 (master) and #12741 (maven-4.0.x) which also fix the `InvalidPathException` crash in the `Path.resolve()` code paths.

Fixes https://issues.apache.org/jira/browse/MNG-8129

🤖 Generated with [Claude Code](https://claude.com/claude-code)