### PR TITLE
Fix #12749: Do not report a zero exit code from mvnsh as an error

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
@@ -69,11 +69,11 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
     }
 
     /**
-     * Reports the exit code of a command invoked from the shell. Commands terminate by throwing
-     * {@link InvokerException.ExitException}, and they do so on success as well: {@code --help} and
-     * {@code --version} exit with code 0. Only a non-zero code is an error worth reporting.
+     * Logs an error when a shell command exits with a non-zero code.
+     * A zero exit code is silently ignored because commands such as {@code --help} and
+     * {@code --version} terminate normally via {@link InvokerException.ExitException} with code 0.
      */
-    static void reportExitCode(Logger logger, String commandName, int exitCode) {
+    static void reportNonZeroExitCode(Logger logger, String commandName, int exitCode) {
         if (exitCode != 0) {
             logger.error(commandName + " command exited with exit code " + exitCode);
         }
@@ -214,7 +214,7 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                reportExitCode(shellContext.logger, "mvn", e.getExitCode());
+                reportNonZeroExitCode(shellContext.logger, "mvn", e.getExitCode());
             } catch (Exception e) {
                 saveException(e);
             }
@@ -252,7 +252,7 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                reportExitCode(shellContext.logger, "mvnenc", e.getExitCode());
+                reportNonZeroExitCode(shellContext.logger, "mvnenc", e.getExitCode());
             } catch (Exception e) {
                 saveException(e);
             }
@@ -270,7 +270,7 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                reportExitCode(shellContext.logger, "mvnup", e.getExitCode());
+                reportNonZeroExitCode(shellContext.logger, "mvnup", e.getExitCode());
             } catch (Exception e) {
                 saveException(e);
             }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 
 import org.apache.maven.api.Lifecycle;
 import org.apache.maven.api.cli.InvokerException;
+import org.apache.maven.api.cli.Logger;
 import org.apache.maven.api.cli.ParserRequest;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Singleton;
@@ -65,6 +66,17 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
     @Override
     public CommandRegistry createShellCommandRegistry(LookupContext context) {
         return new BuiltinShellCommandRegistry(context);
+    }
+
+    /**
+     * Reports the exit code of a command invoked from the shell. Commands terminate by throwing
+     * {@link InvokerException.ExitException}, and they do so on success as well: {@code --help} and
+     * {@code --version} exit with code 0. Only a non-zero code is an error worth reporting.
+     */
+    static void reportExitCode(Logger logger, String commandName, int exitCode) {
+        if (exitCode != 0) {
+            logger.error(commandName + " command exited with exit code " + exitCode);
+        }
     }
 
     private static class BuiltinShellCommandRegistry extends JlineCommandRegistry implements AutoCloseable {
@@ -202,7 +214,7 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvn command exited with exit code " + e.getExitCode());
+                reportExitCode(shellContext.logger, "mvn", e.getExitCode());
             } catch (Exception e) {
                 saveException(e);
             }
@@ -240,7 +252,7 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvnenc command exited with exit code " + e.getExitCode());
+                reportExitCode(shellContext.logger, "mvnenc", e.getExitCode());
             } catch (Exception e) {
                 saveException(e);
             }
@@ -258,7 +270,7 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvnup command exited with exit code " + e.getExitCode());
+                reportExitCode(shellContext.logger, "mvnup", e.getExitCode());
             } catch (Exception e) {
                 saveException(e);
             }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactoryTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnsh.builtin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.api.cli.Logger;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuiltinShellCommandRegistryFactoryTest {
+
+    @Test
+    void zeroExitCodeIsNotReported() {
+        RecordingLogger logger = new RecordingLogger();
+
+        BuiltinShellCommandRegistryFactory.reportExitCode(logger, "mvn", 0);
+
+        assertTrue(logger.entries.isEmpty(), () -> "unexpected output: " + logger.entries);
+    }
+
+    @Test
+    void nonZeroExitCodeIsReportedAsError() {
+        RecordingLogger logger = new RecordingLogger();
+
+        BuiltinShellCommandRegistryFactory.reportExitCode(logger, "mvn", 1);
+
+        assertEquals(1, logger.entries.size());
+        assertEquals(Logger.Level.ERROR, logger.entries.get(0).level());
+        assertEquals(
+                "mvn command exited with exit code 1", logger.entries.get(0).message());
+    }
+
+    static class RecordingLogger implements Logger {
+        final List<Entry> entries = new ArrayList<>();
+
+        @Override
+        public void log(Level level, String message, Throwable error) {
+            entries.add(new Entry(level, message, error));
+        }
+    }
+}

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactoryTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactoryTest.java
@@ -33,7 +33,7 @@ class BuiltinShellCommandRegistryFactoryTest {
     void zeroExitCodeIsNotReported() {
         RecordingLogger logger = new RecordingLogger();
 
-        BuiltinShellCommandRegistryFactory.reportExitCode(logger, "mvn", 0);
+        BuiltinShellCommandRegistryFactory.reportNonZeroExitCode(logger, "mvn", 0);
 
         assertTrue(logger.entries.isEmpty(), () -> "unexpected output: " + logger.entries);
     }
@@ -42,7 +42,7 @@ class BuiltinShellCommandRegistryFactoryTest {
     void nonZeroExitCodeIsReportedAsError() {
         RecordingLogger logger = new RecordingLogger();
 
-        BuiltinShellCommandRegistryFactory.reportExitCode(logger, "mvn", 1);
+        BuiltinShellCommandRegistryFactory.reportNonZeroExitCode(logger, "mvn", 1);
 
         assertEquals(1, logger.entries.size());
         assertEquals(Logger.Level.ERROR, logger.entries.get(0).level());


### PR DESCRIPTION
`helpOrVersionAndMayExit()` throws `InvokerException.ExitException(0)` for `--help` and `--version`, so a successful command reaches the shell's catch block exactly like a failing one. The `mvn`, `mvnenc` and `mvnup` handlers logged an error without looking at the code:

```
mvnsh> mvn --version
Apache Maven 4.0.0-rc-6 ...
[ERROR] mvn command exited with exit code 0
```

The three handlers now share `reportExitCode()`, which logs only a non-zero code.

Two unit tests cover both branches. With the guard removed, `zeroExitCodeIsNotReported` fails on the exact message from the report; `impl/maven-cli` is green at 637 tests with checkstyle and spotless enabled.

Fixes #12749
