### PR TITLE
Fix concurrent updates to mapped model sources

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -466,7 +466,7 @@ public class DefaultModelBuilder implements ModelBuilder {
 
         public void putSource(String groupId, String artifactId, ModelSource source) {
             mappedSources
-                    .computeIfAbsent(new GAKey(groupId, artifactId), k -> new HashSet<>())
+                    .computeIfAbsent(new GAKey(groupId, artifactId), k -> ConcurrentHashMap.newKeySet())
                     .add(source);
             // Also  register the source under the null groupId
             if (groupId != null) {

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -21,9 +21,17 @@ package org.apache.maven.impl.model;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
@@ -35,6 +43,7 @@ import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.services.ModelBuilder;
 import org.apache.maven.api.services.ModelBuilderRequest;
 import org.apache.maven.api.services.ModelBuilderResult;
+import org.apache.maven.api.services.ModelSource;
 import org.apache.maven.api.services.Sources;
 import org.apache.maven.impl.standalone.ApiRunner;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -71,6 +81,78 @@ class DefaultModelBuilderTest {
         ModelBuilderResult result = builder.newSession().build(request);
         assertNotNull(result);
         assertEquals("21", result.getEffectiveModel().getProperties().get("maven.compiler.release"));
+    }
+
+    @Test
+    void testMappedSourcesSupportsConcurrentUpdates() throws Exception {
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(getPom("simple-standalone")))
+                .build();
+        DefaultModelBuilder.ModelBuilderSessionState state =
+                ((DefaultModelBuilder) builder).new ModelBuilderSessionState(request);
+
+        int threadCount = 16;
+        int sourcesPerThread = 500;
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Future<?>> futures = new ArrayList<>(threadCount);
+        try {
+            for (int thread = 0; thread < threadCount; thread++) {
+                int threadId = thread;
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(10, TimeUnit.SECONDS));
+                    for (int source = 0; source < sourcesPerThread; source++) {
+                        state.putSource(
+                                "org.apache.maven.test",
+                                "shared-artifact",
+                                Sources.buildSource(Path.of("target", "source-" + threadId + '-' + source, "pom.xml")));
+                    }
+                    return null;
+                }));
+            }
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        int expectedSources = threadCount * sourcesPerThread;
+        Set<ModelSource> sources =
+                state.mappedSources.get(new DefaultModelBuilder.GAKey("org.apache.maven.test", "shared-artifact"));
+        assertTrue(sources.spliterator().hasCharacteristics(Spliterator.CONCURRENT));
+        assertEquals(expectedSources, sources.size());
+        assertEquals(
+                expectedSources,
+                state.mappedSources
+                        .get(new DefaultModelBuilder.GAKey(null, "shared-artifact"))
+                        .size());
+        assertThrows(IllegalStateException.class, () -> state.getSource("org.apache.maven.test", "shared-artifact"));
+        assertThrows(IllegalStateException.class, () -> state.getSource(null, "shared-artifact"));
+    }
+
+    @Test
+    void testMappedSourcesSuppressesDuplicateSources() {
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(getPom("simple-standalone")))
+                .build();
+        DefaultModelBuilder.ModelBuilderSessionState state =
+                ((DefaultModelBuilder) builder).new ModelBuilderSessionState(request);
+        ModelSource source = Sources.buildSource(Path.of("target", "duplicate-source", "pom.xml"));
+
+        state.putSource("org.apache.maven.test", "duplicate-artifact", source);
+        state.putSource("org.apache.maven.test", "duplicate-artifact", source);
+
+        assertEquals(source, state.getSource("org.apache.maven.test", "duplicate-artifact"));
+        assertEquals(source, state.getSource(null, "duplicate-artifact"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #12597.

`mappedSources` uses a `ConcurrentHashMap`, but its values were ordinary
`HashSet` instances. Parallel model discovery could therefore lose sources
when multiple tasks updated the same group/artifact index.

Use `ConcurrentHashMap.newKeySet()` for each mapped source set. This preserves
duplicate suppression while making concurrent updates and iteration safe.

Regression coverage exercises concurrent writes to both the direct
group/artifact key and the secondary null-group key, verifies concurrent
collection semantics and multi-source lookup behavior, and preserves duplicate
suppression.

A backport to `maven-4.0.x` may be appropriate.

Tests:
- `mvn -pl impl/maven-impl verify` (552 tests passed, 4 skipped)
- `mvn -Prun-its verify` under Java 21 (all 1,051 Core ITs executed)
- Targeted Java 21 rerun of the two previously toolchain-sensitive IT classes
  (4 tests passed)

The full Core IT run reported two stale generated-file errors in toolchain
tests and one existing MNG-8181 log-format assertion. None exercises the
changed model-source code.

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [ ] You have run the Core IT successfully. See the test details above.
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004.
- [ ] In any other case, please file an Apache Individual Contributor License Agreement.