### PR TITLE
Support Maven version ranges in profile activation

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/PropertyProfileActivator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/PropertyProfileActivator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.impl.model.profile;
 
+import org.apache.maven.api.Constants;
+import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Singleton;
 import org.apache.maven.api.model.Activation;
@@ -26,6 +28,8 @@ import org.apache.maven.api.model.Profile;
 import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.api.services.ModelProblem;
 import org.apache.maven.api.services.ModelProblemCollector;
+import org.apache.maven.api.services.VersionParserException;
+import org.apache.maven.api.services.model.ModelVersionParser;
 import org.apache.maven.api.services.model.ProfileActivationContext;
 import org.apache.maven.api.services.model.ProfileActivator;
 
@@ -37,6 +41,13 @@ import org.apache.maven.api.services.model.ProfileActivator;
 @Named("property")
 @Singleton
 public class PropertyProfileActivator implements ProfileActivator {
+
+    private final ModelVersionParser versionParser;
+
+    @Inject
+    public PropertyProfileActivator(ModelVersionParser versionParser) {
+        this.versionParser = versionParser;
+    }
 
     @Override
     public boolean isActive(Profile profile, ProfileActivationContext context, ModelProblemCollector problems) {
@@ -85,11 +96,38 @@ public class PropertyProfileActivator implements ProfileActivator {
                 propValue = propValue.substring(1);
             }
 
-            // we have a value, so it has to match the system value...
-            return reverseValue != propValue.equals(sysValue);
+            boolean result;
+            if (Constants.MAVEN_VERSION.equals(name) && isVersionRange(propValue)) {
+                if (sysValue == null || sysValue.isEmpty()) {
+                    result = false;
+                } else {
+                    try {
+                        result = versionParser
+                                .parseVersionRange(propValue)
+                                .contains(versionParser.parseVersion(sysValue));
+                    } catch (VersionParserException e) {
+                        problems.add(
+                                BuilderProblem.Severity.WARNING,
+                                ModelProblem.Version.BASE,
+                                "Failed to determine Maven version activation for profile " + profile.getId()
+                                        + " due to invalid version range: '" + propValue + "'",
+                                property.getLocation("value"),
+                                e);
+                        return false;
+                    }
+                }
+            } else {
+                // we have a value, so it has to match the system value...
+                result = propValue.equals(sysValue);
+            }
+            return reverseValue != result;
         } else {
             return reverseName != (sysValue != null && !sysValue.isEmpty());
         }
+    }
+
+    private static boolean isVersionRange(String value) {
+        return value.startsWith("[") || value.startsWith("(");
     }
 
     @Override

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.maven.api.Constants;
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
 import org.apache.maven.api.model.Dependency;
@@ -182,6 +183,20 @@ class DefaultModelBuilderTest {
 
         assertEquals(source, state.getSource("org.apache.maven.test", "duplicate-artifact"));
         assertEquals(source, state.getSource(null, "duplicate-artifact"));
+    }
+
+    @Test
+    void testMavenVersionRangeProfileActivation() {
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(getPom("maven-version-range-profile")))
+                .systemProperties(Map.of(Constants.MAVEN_VERSION, "4.1.0"))
+                .build();
+
+        ModelBuilderResult result = builder.newSession().build(request);
+
+        assertEquals("true", result.getEffectiveModel().getProperties().get("maven.range.profile.active"));
     }
 
     @Test

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/PropertyProfileActivatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/PropertyProfileActivatorTest.java
@@ -20,11 +20,18 @@ package org.apache.maven.impl.model.profile;
 
 import java.util.Map;
 
+import org.apache.maven.api.Constants;
 import org.apache.maven.api.model.Activation;
 import org.apache.maven.api.model.ActivationProperty;
 import org.apache.maven.api.model.Profile;
+import org.apache.maven.api.services.model.ProfileActivationContext;
+import org.apache.maven.impl.DefaultModelVersionParser;
+import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Tests {@link PropertyProfileActivator}.
@@ -35,7 +42,7 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
     @BeforeEach
     @Override
     void setUp() throws Exception {
-        activator = new PropertyProfileActivator();
+        activator = new PropertyProfileActivator(new DefaultModelVersionParser(new GenericVersionScheme()));
     }
 
     private Profile newProfile(String key, String value) {
@@ -162,5 +169,101 @@ class PropertyProfileActivatorTest extends AbstractProfileActivatorTest<Property
         assertActivation(true, profile, newContext(props1, props2));
 
         assertActivation(false, profile, newContext(props2, props1));
+    }
+
+    @Test
+    void testMavenVersionRange() {
+        Profile profile = newProfile(Constants.MAVEN_VERSION, "[4.0.0-rc-5,4.0.0)");
+
+        assertActivation(true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0-rc-5")));
+        assertActivation(
+                true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0-rc-6-SNAPSHOT")));
+        assertActivation(false, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0")));
+        assertActivation(false, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "3.9.11")));
+        assertActivation(false, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "")));
+        assertActivation(false, profile, newContext(null, Map.of()));
+    }
+
+    @Test
+    void testMavenVersionLowerBoundedRange() {
+        Profile profile = newProfile(Constants.MAVEN_VERSION, "[4.0.0,)");
+
+        assertActivation(false, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0-rc-5")));
+        assertActivation(true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0")));
+        assertActivation(true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.1.0")));
+    }
+
+    @Test
+    void testMavenVersionUpperBoundedRange() {
+        Profile profile = newProfile(Constants.MAVEN_VERSION, "(,4.0.0)");
+
+        assertActivation(true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "3.9.11")));
+        assertActivation(true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0-rc-5")));
+        assertActivation(false, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0")));
+    }
+
+    @Test
+    void testMavenVersionRangeBoundaries() {
+        Profile inclusive = newProfile(Constants.MAVEN_VERSION, "[4.0.0,5.0.0]");
+        Profile exclusive = newProfile(Constants.MAVEN_VERSION, "(4.0.0,5.0.0)");
+
+        assertActivation(true, inclusive, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0")));
+        assertActivation(true, inclusive, newContext(null, newProperties(Constants.MAVEN_VERSION, "5.0.0")));
+        assertActivation(false, exclusive, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0")));
+        assertActivation(true, exclusive, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.1.0")));
+        assertActivation(false, exclusive, newContext(null, newProperties(Constants.MAVEN_VERSION, "5.0.0")));
+    }
+
+    @Test
+    void testNegatedMavenVersionRange() {
+        Profile profile = newProfile(Constants.MAVEN_VERSION, "![4.0.0,5.0.0)");
+
+        assertActivation(false, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.1.0")));
+        assertActivation(true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "5.0.0")));
+        assertActivation(true, profile, newContext(null, Map.of()));
+    }
+
+    @Test
+    void testMavenVersionExactMatchIsPreserved() {
+        Profile profile = newProfile(Constants.MAVEN_VERSION, "4.0.0-rc-5");
+
+        assertActivation(true, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0-rc-5")));
+        assertActivation(false, profile, newContext(null, newProperties(Constants.MAVEN_VERSION, "4.0.0-rc-6")));
+    }
+
+    @Test
+    void testRangeSyntaxRemainsAnExactMatchForOtherProperties() {
+        Profile profile = newProfile("prop", "[1,2)");
+
+        assertActivation(true, profile, newContext(null, newProperties("prop", "[1,2)")));
+        assertActivation(false, profile, newContext(null, newProperties("prop", "1.5")));
+    }
+
+    @Test
+    void testMalformedMavenVersionRangeDoesNotActivate() {
+        Profile profile = newProfile(Constants.MAVEN_VERSION, "[4.0.0,");
+        ProfileActivationContext context = newContext(null, newProperties(Constants.MAVEN_VERSION, "4.1.0"));
+        SimpleProblemCollector problems = new SimpleProblemCollector();
+
+        assertFalse(activator.isActive(profile, context, problems));
+        assertEquals(0, problems.getErrors().size());
+        assertEquals(1, problems.getWarnings().size());
+        assertEquals(
+                "Failed to determine Maven version activation for profile default due to invalid version range: '[4.0.0,'",
+                problems.getWarnings().get(0));
+    }
+
+    @Test
+    void testMalformedNegatedMavenVersionRangeDoesNotActivate() {
+        Profile profile = newProfile(Constants.MAVEN_VERSION, "![4.0.0,");
+        ProfileActivationContext context = newContext(null, newProperties(Constants.MAVEN_VERSION, "4.1.0"));
+        SimpleProblemCollector problems = new SimpleProblemCollector();
+
+        assertFalse(activator.isActive(profile, context, problems));
+        assertEquals(0, problems.getErrors().size());
+        assertEquals(1, problems.getWarnings().size());
+        assertEquals(
+                "Failed to determine Maven version activation for profile default due to invalid version range: '[4.0.0,'",
+                problems.getWarnings().get(0));
     }
 }

--- a/impl/maven-impl/src/test/resources/poms/factory/maven-version-range-profile.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/maven-version-range-profile.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+    <groupId>org.apache.maven.tests</groupId>
+    <artifactId>maven-version-range-profile</artifactId>
+    <version>1.0</version>
+
+    <profiles>
+        <profile>
+            <id>maven-version-range</id>
+            <activation>
+                <property>
+                    <name>maven.version</name>
+                    <value>[4.0.0,)</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.range.profile.active>true</maven.range.profile.active>
+            </properties>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
Fixes #11694.

Support Maven version ranges through the existing `maven.version` profile
activation property on `master`, without adding a POM model element.

The implementation recognizes range syntax only for `maven.version` and
evaluates it with the existing `ModelVersionParser`. Exact matching remains
unchanged for ordinary values and all other properties. Bounded, open-ended,
and negated ranges are supported; malformed ranges fail closed with a model
warning.

Tests cover the suggested `[4.0.0,)` form, prerelease and boundary behavior,
negation, malformed input, unchanged literal matching, and activation through
the model builder.

This implements the `master` path. Please consider a backport to
`maven-4.0.x`. Maven 3 requires a separate `maven-3.10.x` implementation using
its legacy model builder and version APIs.

Tests:
- `mvn -pl impl/maven-impl verify` (560 tests passed, 4 skipped)
- Full reactor and all 1,051 Core ITs executed
- Targeted Java 21 rerun of the affected IT classes (4 tests passed)

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [ ] You have run the Core IT successfully. See the test details above.
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004.
- [ ] In any other case, please file an Apache Individual Contributor License Agreement.