### PR TITLE
[maven-3.9.x] Stop packaging a duplicate lib/jansi-native directory entry

### DIFF
--- a/apache-maven/src/main/assembly/component.xml
+++ b/apache-maven/src/main/assembly/component.xml
@@ -66,7 +66,9 @@ under the License.
       <directory>target/dependency/org/fusesource/jansi/internal/native</directory>
       <outputDirectory>lib/jansi-native</outputDirectory>
       <includes>
-        <include>**</include>
+        <include>**/*.so</include>
+        <include>**/*.jnilib</include>
+        <include>**/*.dll</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
Fixes #12778.

Adopts the include list 3.10.x already carries — the JLine migration (70d934d) replaced `**` with explicit file patterns there, which is why 3.10.0-rc-1 has no duplicate entry and 3.9.16 does.

Lossless: every native jansi 2.4.3 ships under `internal/native` is a `.so` (9), `.jnilib` (3) or `.dll` (3).

Verified: `tar tzf apache-maven-3.9.16-bin.tar.gz | sort | uniq -d` → `lib/jansi-native/`; the same command on 3.10.0-rc-1 and 4.0.0-rc-6 → empty. I have not yet run it against a distribution built from this branch.

*This change was created with AI assistance.*