### PR TITLE
[backport maven-4.0.x] fix(api-core): properly implement Clock.withZone() in MonotonicClock

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/MonotonicClock.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/MonotonicClock.java
@@ -32,9 +32,10 @@ import java.time.ZoneOffset;
  * is computed from the monotonic duration since system start to ensure consistency
  * between time measurements.
  * <p>
- * This implementation is singleton-based and always uses UTC timezone. The clock
- * cannot be adjusted to different timezones to maintain consistent monotonic behavior.
- * Users needing local time representation should convert the result of {@link #instant()}
+ * This implementation uses UTC timezone for the singleton instance.
+ * Timezone variants can be created via {@link #withZone(ZoneId)} while maintaining
+ * the same monotonic timing base. Users needing local time representation can either
+ * use {@link #withZone(ZoneId)} or convert the result of {@link #instant()}
  * to their desired timezone:
  * <pre>{@code
  * Instant now = MonotonicClock.now();
@@ -49,6 +50,7 @@ public class MonotonicClock extends Clock {
 
     private final long startNanos;
     private final Instant startInstant;
+    private final ZoneId zone;
 
     /**
      * Private constructor to enforce singleton pattern.
@@ -57,6 +59,7 @@ public class MonotonicClock extends Clock {
     private MonotonicClock() {
         this.startNanos = System.nanoTime();
         this.startInstant = Clock.systemUTC().instant();
+        this.zone = ZoneOffset.UTC;
     }
 
     /**
@@ -146,27 +149,51 @@ public class MonotonicClock extends Clock {
     }
 
     /**
-     * Returns the zone ID of this clock, which is always UTC.
+     * Returns the zone ID of this clock.
+     * <p>
+     * The singleton instance always returns UTC. Clock instances created
+     * via {@link #withZone(ZoneId)} return their configured timezone.
      *
-     * @return the UTC zone ID
+     * @return the zone ID
      */
     @Override
     public ZoneId getZone() {
-        return ZoneOffset.UTC;
+        return zone;
     }
 
     /**
-     * Returns this clock since timezone adjustments are not supported.
+     * Returns a copy of this clock with the specified timezone.
      * <p>
-     * This implementation maintains UTC time to ensure monotonic behavior.
-     * The provided zone parameter is ignored.
+     * Since {@link Instant} instances are timezone-agnostic and the monotonic
+     * property derives from {@link System#nanoTime()}, the returned clock
+     * maintains identical monotonic timing but reports the requested timezone.
      *
-     * @param zone the target timezone (ignored)
-     * @return this clock instance
+     * @param zone the target timezone, not null
+     * @return a new clock with the specified timezone
+     * @throws NullPointerException if zone is {@code null}
      */
     @Override
     public Clock withZone(ZoneId zone) {
-        // Monotonic clock is always UTC-based
-        return this;
+        java.util.Objects.requireNonNull(zone, "zone");
+        if (zone.equals(this.zone)) {
+            return this;
+        }
+        return new MonotonicClock(startNanos, startInstant, zone);
+    }
+
+    /**
+     * Creates a new MonotonicClock with the specified timezone.
+     * <p>
+     * This constructor allows creating timezone variants of the clock while
+     * maintaining the same monotonic timing base.
+     *
+     * @param startNanos the monotonic start time in nanoseconds
+     * @param startInstant the wall-clock start time
+     * @param zone the timezone for this clock variant
+     */
+    private MonotonicClock(long startNanos, Instant startInstant, ZoneId zone) {
+        this.startNanos = startNanos;
+        this.startInstant = startInstant;
+        this.zone = zone;
     }
 }

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/MonotonicClockTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/MonotonicClockTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,10 +51,51 @@ class MonotonicClockTest {
         MonotonicClock clock = MonotonicClock.get();
 
         assertEquals(ZoneOffset.UTC, clock.getZone(), "Clock should use UTC timezone");
+    }
 
-        // Verify that attempting to change timezone returns the same instance
+    @Test
+    @DisplayName("withZone() should return a new clock with the specified timezone")
+    void testWithZoneReturnsNewClock() {
+        MonotonicClock clock = MonotonicClock.get();
+
+        // withZone should return a new instance with the requested timezone
         Clock newClock = clock.withZone(ZoneId.systemDefault());
-        assertSame(clock, newClock, "withZone() should return the same clock instance");
+        assertNotNull(newClock, "withZone() should return a non-null clock");
+        assertEquals(ZoneId.systemDefault(), newClock.getZone(), "New clock should have the requested zone");
+        assertNotSame(clock, newClock, "withZone() should return a new instance, not the same clock");
+
+        // Both clocks should report instants that are very close (within 1ms)
+        Instant originalInstant = clock.instant();
+        Instant newClockInstant = newClock.instant();
+        assertEquals(
+                originalInstant.getEpochSecond(),
+                newClockInstant.getEpochSecond(),
+                "Clocks should report the same instant (monotonic time is preserved)");
+        long nanoDiff = Math.abs(originalInstant.getNano() - newClockInstant.getNano());
+        assertTrue(
+                nanoDiff < 1_000_000,
+                "Clocks should report instants within 1ms of each other (diff: " + nanoDiff + "ns)");
+    }
+
+    @Test
+    @DisplayName("withZone() with the same zone should return the same instance")
+    void testWithZoneSameZoneReturnsThis() {
+        MonotonicClock clock = MonotonicClock.get();
+
+        // Requesting UTC from a UTC clock should return the same instance
+        assertSame(
+                clock, clock.withZone(ZoneOffset.UTC), "withZone(UTC) should return this when the zone is already UTC");
+    }
+
+    @Test
+    @DisplayName("withZone() should throw NullPointerException on null zone")
+    void testWithZoneNullThrows() {
+        MonotonicClock clock = MonotonicClock.get();
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+                NullPointerException.class,
+                () -> clock.withZone(null),
+                "withZone(null) should throw NullPointerException");
     }
 
     @Test


### PR DESCRIPTION
## Backport of #12753

Cherry-pick of #12753 onto `maven-4.0.x`.

**Original PR:** #12753 - fix(api-core): properly implement Clock.withZone() in MonotonicClock
**Original author:** @poliglots
**Target branch:** `maven-4.0.x`

### Original description

Fix issue #12608: MonotonicClock.withZone() was ignoring the zone parameter and returning 'this', violating the java.time.Clock contract.

Changes:
- Add a 'zone' field to track timezone per instance
- Implement withZone() to create a new clock variant with the requested timezone, preserving monotonic timing
- Update getZone() to return the instance's actual zone
- Throw NullPointerException on null zone (per JDK Clock convention)
- Add tests verifying withZone() returns a new instance with correct zone and that monotonic timing is preserved

The singleton instance continues to use UTC. Creating timezone variants does not compromise monotonicity since Instant is timezone-agnostic and monotonicity derives from System.nanoTime().

🤖 Generated with [Claude Code](https://claude.com/claude-code)