### PR TITLE
[backport maven-4.0.x] Support the logical not operator in profile activation conditions

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/profile/ConditionParser.java
@@ -288,11 +288,21 @@ public class ConditionParser {
     }
 
     /**
-     * Parses unary operations (negation).
+     * Parses unary operations: logical not ({@code !}) and arithmetic negation ({@code -}).
+     * <p>
+     * {@code !} is equivalent to the {@code not()} function and uses the same {@link #toBoolean}
+     * coercion. Being handled here gives both operators a higher precedence than multiplication,
+     * addition, comparison and the logical operators, so {@code !a && b} parses as
+     * {@code (!a) && b}.
      *
      * @return the result of parsing unary operations
      */
     private Object parseUnary() {
+        if (current < tokens.size() && tokens.get(current).equals("!")) {
+            current++;
+            Object value = parseUnary();
+            return !toBoolean(value);
+        }
         if (current < tokens.size() && tokens.get(current).equals("-")) {
             current++;
             Object value = parseUnary();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/profile/ConditionParserTest.java
@@ -159,6 +159,71 @@ class ConditionParserTest {
         assertEquals("SUCCESS!", parser.parse(expression));
     }
 
+    /**
+     * The tokenizer emits a bare {@code !} token, so the parser has to be able to consume it.
+     * The {@code contains(..)} cases also cover a {@code !} inside a string literal, which the
+     * tokenizer must leave alone.
+     */
+    @Test
+    void testLogicalNotOperator() {
+        assertFalse((Boolean) parser.parse("!true"));
+        assertTrue((Boolean) parser.parse("!false"));
+        assertTrue((Boolean) parser.parse("!!true"));
+        assertFalse((Boolean) parser.parse("!!!true"));
+        assertTrue((Boolean) parser.parse("!contains('Hello, World!', 'OpenAI')"));
+        assertFalse((Boolean) parser.parse("!contains('Hello, World!', 'World')"));
+    }
+
+    /**
+     * {@code !x} is sugar for the {@code not(x)} function and must agree with it.
+     */
+    @Test
+    void testLogicalNotOperatorMatchesNotFunction() {
+        assertEquals(
+                parser.parse("not(contains('Hello, World!', 'OpenAI'))"),
+                parser.parse("!contains('Hello, World!', 'OpenAI')"));
+        assertEquals(
+                parser.parse("not(contains('Hello, World!', 'World'))"),
+                parser.parse("!contains('Hello, World!', 'World')"));
+        assertEquals(parser.parse("not(true)"), parser.parse("!true"));
+    }
+
+    /**
+     * {@code !} binds tighter than comparison and the logical operators, as it does in Java.
+     */
+    @Test
+    void testLogicalNotOperatorPrecedence() {
+        assertTrue((Boolean) parser.parse("!false && true"));
+        assertFalse((Boolean) parser.parse("!true && false"));
+        assertTrue((Boolean) parser.parse("!true || true"));
+        assertTrue((Boolean) parser.parse("!(true && false)"));
+        assertTrue((Boolean) parser.parse("!(1 > 2)"));
+        assertFalse((Boolean) parser.parse("!('a' != 'b')"));
+    }
+
+    /**
+     * Coercion of non-boolean operands must match what the {@code not()} function does.
+     */
+    @Test
+    void testLogicalNotOperatorCoercion() {
+        assertFalse((Boolean) parser.parse("!'abc'"));
+        assertTrue((Boolean) parser.parse("!''"));
+        assertFalse((Boolean) parser.parse("!length('ab')"));
+        assertTrue((Boolean) parser.parse("!0"));
+        assertFalse((Boolean) parser.parse("!1"));
+    }
+
+    /**
+     * A bare {@code !} must not disturb the {@code !=} operator, which the tokenizer emits as a
+     * single token.
+     */
+    @Test
+    void testNotEqualsStillParsesAsOneOperator() {
+        assertTrue((Boolean) parser.parse("1 != 2"));
+        assertFalse((Boolean) parser.parse("'abc' != 'abc'"));
+        assertTrue((Boolean) parser.parse("'abc' != 'cdf'"));
+    }
+
     @Test
     void testStringComparison() {
         assertTrue((Boolean) parser.parse("'abc' != 'cdf'"));


### PR DESCRIPTION
## Backport of #12737

Cherry-pick of #12737 onto `maven-4.0.x`.

**Original PR:** #12737 - Support the logical not operator in profile activation conditions
**Original author:** @SEPURI-SAI-KRISHNA
**Target branch:** `maven-4.0.x`

### Original description

Adds handling for the `!` operator to `ConditionParser.parseUnary()`.

The tokenizer already treats `!` as an operator and emits a bare `!` token, but no parser rule
consumed it. Writing the natural form of a negated condition (`!exists('some/path')`) failed
with `Unknown variable: !`.

`!` is defined as sugar for the `not()` function that already exists, using the same
`toBoolean()` coercion. It is handled in `parseUnary()`, giving it the same precedence as
in Java: tighter than arithmetic, comparison, `&&` and `||`.

`!=` is unaffected -- the tokenizer emits it as a single token before a bare `!` can be produced.

Fixes #12736