### PR TITLE
[backport maven-4.0.x] Fix BuildPlanExecutor thread pool leak on constructor failure

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/BuildPlanExecutor.java
@@ -211,10 +211,10 @@ public class BuildPlanExecutor {
                     session.getProjects().size());
             // Propagate the parallel flag to the root session
             session.setParallel(threads > 1);
-            this.executor = new PhasingExecutor(Executors.newFixedThreadPool(threads, new BuildThreadFactory()));
 
-            // build initial plan
+            // Build the initial plan before creating the executor so constructor failures cannot leak it.
             this.plan = buildInitialPlan(taskSegments);
+            this.executor = new PhasingExecutor(Executors.newFixedThreadPool(threads, new BuildThreadFactory()));
         }
 
         BuildContext() {


### PR DESCRIPTION
## Backport of #12748

Cherry-pick of #12748 onto `maven-4.0.x`.

**Original PR:** #12748 - Fix BuildPlanExecutor thread pool leak on constructor failure
**Original author:** @ulofiai
**Target branch:** `maven-4.0.x`

### Original description

Fixes #12599.

Build the initial plan before creating the `PhasingExecutor`. If plan construction throws, `BuildContext` now fails before allocating the executor, so cleanup cannot be skipped.

The change is limited to the initialization order in `BuildPlanExecutor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)