### PR TITLE
[backport maven-4.0.x] Fix parent profile cache matching across activation contexts

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileActivationContext.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultProfileActivationContext.java
@@ -237,10 +237,7 @@ public class DefaultProfileActivationContext implements ProfileActivationContext
     }
 
     Record stop() {
-        // only keep keys for which the value is `true`
         Objects.requireNonNull(record, "start() must be called before stop()");
-        record.usedActiveProfiles.values().removeIf(value -> !value);
-        record.usedInactiveProfiles.values().removeIf(value -> !value);
         return new Record(record); // Return immutable copy for thread-safe caching
     }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,6 +60,34 @@ class DefaultModelBuilderTest {
         session = ApiRunner.createSession();
         builder = session.getService(ModelBuilder.class);
         assertNotNull(builder);
+    }
+
+    @Test
+    public void testParentProfileCacheDistinguishesActiveProfileContexts() {
+        DefaultProfileActivationContext.Record withoutRelease = recordActiveProfile(List.of(), "release");
+        DefaultProfileActivationContext.Record withRelease = recordActiveProfile(List.of("release"), "release");
+
+        assertFalse(
+                withoutRelease.matches(newProfileActivationContext(List.of("release"), List.of())),
+                "a parent assembled without -Prelease must not be reused for a module built with -Prelease");
+        assertFalse(
+                withRelease.matches(newProfileActivationContext(List.of(), List.of())),
+                "a parent assembled with -Prelease must not be reused for a module built without it");
+        assertTrue(withoutRelease.matches(newProfileActivationContext(List.of(), List.of())));
+        assertTrue(withRelease.matches(newProfileActivationContext(List.of("release"), List.of())));
+    }
+
+    @Test
+    public void testParentProfileCacheDistinguishesInactiveProfileContexts() {
+        DefaultProfileActivationContext recording =
+                newProfileActivationContext(List.of(), List.of()).start();
+        recording.isProfileInactive("release");
+        DefaultProfileActivationContext.Record withoutSuppression = recording.stop();
+
+        assertFalse(
+                withoutSuppression.matches(newProfileActivationContext(List.of(), List.of("release"))),
+                "a parent assembled without -!release must not be reused for a module built with -!release");
+        assertTrue(withoutSuppression.matches(newProfileActivationContext(List.of(), List.of())));
     }
 
     @Test
@@ -516,6 +545,20 @@ class DefaultModelBuilderTest {
         assertNotNull(managedDep, "Managed dependency for the sibling module should be kept");
         assertEquals(
                 "1.0-SNAPSHOT", managedDep.getVersion(), "Version should be inferred from the reactor sibling module");
+    }
+
+    private static DefaultProfileActivationContext.Record recordActiveProfile(
+            List<String> activeIds, String profileId) {
+        DefaultProfileActivationContext recording =
+                newProfileActivationContext(activeIds, List.of()).start();
+        recording.isProfileActive(profileId);
+        return recording.stop();
+    }
+
+    private static DefaultProfileActivationContext newProfileActivationContext(
+            List<String> activeIds, List<String> inactiveIds) {
+        return new DefaultProfileActivationContext(
+                null, null, null, activeIds, inactiveIds, Map.of(), Map.of(), Model.newInstance());
     }
 
     private Path getPom(String name) {


### PR DESCRIPTION
## Backport of #12762

Cherry-pick of #12762 onto `maven-4.0.x`.

**Original PR:** #12762 - Fix parent profile cache matching across activation contexts
**Original author:** @ulofiai
**Target branch:** `maven-4.0.x`

### Original description

Fixes #12724.

Keep every explicitly consulted profile state in `DefaultProfileActivationContext.Record`, including values that evaluate to `false`. This prevents an assembled parent model from being reused when a later module has a different `-Pprofile` or `-!profile` context.

Add focused regression tests for both active-profile and inactive-profile cache matching.