### PR TITLE
[backport maven-4.0.x] Preserve coordinates when merging InputLocation

### DIFF
--- a/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocation.java
+++ b/api/maven-api-model/src/main/java/org/apache/maven/api/model/InputLocation.java
@@ -297,7 +297,17 @@ public final class InputLocation implements Serializable, InputLocationTracker {
             locations.putAll(sourceDominant ? sourceLocations : targetLocations);
         }
 
-        return InputLocation.of(-1, -1, InputSource.merge(source.getSource(), target.getSource()), locations);
+        InputLocation dominant = sourceDominant ? source : target;
+        InputLocation recessive = sourceDominant ? target : source;
+        int lineNumber = dominant.getLineNumber();
+        int columnNumber = dominant.getColumnNumber();
+        if (lineNumber < 0 && columnNumber < 0) {
+            lineNumber = recessive.getLineNumber();
+            columnNumber = recessive.getColumnNumber();
+        }
+
+        return InputLocation.of(
+                lineNumber, columnNumber, InputSource.merge(source.getSource(), target.getSource()), locations);
     } // -- InputLocation merge( InputLocation, InputLocation, boolean )
 
     /**
@@ -336,7 +346,15 @@ public final class InputLocation implements Serializable, InputLocationTracker {
             }
         }
 
-        return InputLocation.of(-1, -1, InputSource.merge(source.getSource(), target.getSource()), locations);
+        int lineNumber = target.getLineNumber();
+        int columnNumber = target.getColumnNumber();
+        if (lineNumber < 0 && columnNumber < 0) {
+            lineNumber = source.getLineNumber();
+            columnNumber = source.getColumnNumber();
+        }
+
+        return InputLocation.of(
+                lineNumber, columnNumber, InputSource.merge(source.getSource(), target.getSource()), locations);
     } // -- InputLocation merge( InputLocation, InputLocation, java.util.Collection )
 
     /**

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
@@ -20,6 +20,8 @@ package org.apache.maven.impl.model;
 
 import java.util.Collections;
 
+import org.apache.maven.api.model.InputLocation;
+import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Prerequisites;
 import org.apache.maven.api.model.Profile;
@@ -30,6 +32,37 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class MavenModelMergerTest {
     private MavenModelMerger modelMerger = new MavenModelMerger();
+
+    @Test
+    void testMergeInputLocationCoordinates() {
+        InputLocation target = InputLocation.of(10, 20, InputSource.of("target", "target.xml"));
+        InputLocation source = InputLocation.of(30, 40, InputSource.of("source", "source.xml"));
+
+        assertCoordinates(30, 40, InputLocation.merge(target, source, true));
+        assertCoordinates(10, 20, InputLocation.merge(target, source, false));
+
+        InputLocation unknownTarget = InputLocation.of(-1, -1, target.getSource());
+        assertCoordinates(30, 40, InputLocation.merge(unknownTarget, source, false));
+
+        InputLocation unknownSource = InputLocation.of(-1, -1, source.getSource());
+        assertCoordinates(10, 20, InputLocation.merge(target, unknownSource, true));
+    }
+
+    @Test
+    void testMergeListInputLocationCoordinates() {
+        InputLocation target = InputLocation.of(10, 20, InputSource.of("target", "target.xml"));
+        InputLocation source = InputLocation.of(30, 40, InputSource.of("source", "source.xml"));
+
+        assertCoordinates(10, 20, InputLocation.merge(target, source, Collections.emptyList()));
+
+        InputLocation unknownTarget = InputLocation.of(-1, -1, target.getSource());
+        assertCoordinates(30, 40, InputLocation.merge(unknownTarget, source, Collections.emptyList()));
+    }
+
+    private static void assertCoordinates(int lineNumber, int columnNumber, InputLocation location) {
+        assertEquals(lineNumber, location.getLineNumber());
+        assertEquals(columnNumber, location.getColumnNumber());
+    }
 
     // modelVersion is neither inherited nor injected
     @Test

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
@@ -35,8 +35,8 @@ class MavenModelMergerTest {
 
     @Test
     void testMergeInputLocationCoordinates() {
-        InputLocation target = InputLocation.of(10, 20, InputSource.of("target", "target.xml"));
-        InputLocation source = InputLocation.of(30, 40, InputSource.of("source", "source.xml"));
+        InputLocation target = InputLocation.of(10, 20, new InputSource("target", "target.xml"));
+        InputLocation source = InputLocation.of(30, 40, new InputSource("source", "source.xml"));
 
         assertCoordinates(30, 40, InputLocation.merge(target, source, true));
         assertCoordinates(10, 20, InputLocation.merge(target, source, false));
@@ -50,8 +50,8 @@ class MavenModelMergerTest {
 
     @Test
     void testMergeListInputLocationCoordinates() {
-        InputLocation target = InputLocation.of(10, 20, InputSource.of("target", "target.xml"));
-        InputLocation source = InputLocation.of(30, 40, InputSource.of("source", "source.xml"));
+        InputLocation target = InputLocation.of(10, 20, new InputSource("target", "target.xml"));
+        InputLocation source = InputLocation.of(30, 40, new InputSource("source", "source.xml"));
 
         assertCoordinates(10, 20, InputLocation.merge(target, source, Collections.emptyList()));
 

--- a/src/mdo/java/InputLocation.java
+++ b/src/mdo/java/InputLocation.java
@@ -263,7 +263,12 @@ public final class InputLocation implements Serializable, InputLocationTracker {
             locations.putAll(sourceDominant ? sourceLocations : targetLocations);
         }
 
-        return InputLocation.of(target.getLineNumber(), target.getColumnNumber(), target.getSource(), locations);
+        InputLocation location = sourceDominant ? source : target;
+        if (location.getLineNumber() < 0 && location.getColumnNumber() < 0) {
+            location = sourceDominant ? target : source;
+        }
+
+        return InputLocation.of(location.getLineNumber(), location.getColumnNumber(), target.getSource(), locations);
     } // -- InputLocation merge( InputLocation, InputLocation, boolean )
 
     /**
@@ -302,7 +307,12 @@ public final class InputLocation implements Serializable, InputLocationTracker {
             }
         }
 
-        return InputLocation.of(target.getLineNumber(), target.getColumnNumber(), target.getSource(), locations);
+        InputLocation location = target;
+        if (location.getLineNumber() < 0 && location.getColumnNumber() < 0) {
+            location = source;
+        }
+
+        return InputLocation.of(location.getLineNumber(), location.getColumnNumber(), target.getSource(), locations);
     } // -- InputLocation merge( InputLocation, InputLocation, java.util.Collection )
 
     /**


### PR DESCRIPTION
## Backport of #12747

Cherry-pick of #12747 onto `maven-4.0.x`.

**Original PR:** #12747 - Preserve coordinates when merging InputLocation
**Original author:** @ulofiai
**Target branch:** `maven-4.0.x`

### Original description

Fixes #12610.

Update the InputLocation MDO template so generated Maven API merge results retain line and column information. The boolean overload uses the dominant input location and falls back to the other input when its coordinates are unknown; indexed list merges prefer the target and use the source as fallback.

Add regression coverage for both merge overloads.

### Backport notes

Resolved a merge conflict in `src/mdo/java/InputLocation.java`: the `maven-4.0.x` branch does not use Velocity `#if ( $isMavenModel )` conditionals, so the coordinate preservation logic was adapted to work directly with `InputLocation.of(...)` and `target.getSource()` (matching the existing code style on this branch).