### PR TITLE
Fix #12730: quiet mode implies raw streams to avoid stdout decoration

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -370,7 +370,11 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
                 context.coloredOutput != null ? context.coloredOutput : !Terminal.TYPE_DUMB.equals(terminal.getType()));
 
         // handle rawStreams: some would like to act on true, some on false
-        if (context.options().rawStreams().orElse(false)) {
+        // quiet mode implies raw streams — plugins that write to System.out (e.g. help:evaluate
+        // -DforceStdout) must not be decorated with "[INFO] [stdout]" prefix, otherwise scripting
+        // use cases like $(mvn -q help:evaluate ...) break (see GH-12730)
+        if (context.options().rawStreams().orElse(false)
+                || context.options().quiet().orElse(false)) {
             doConfigureWithTerminalWithRawStreamsEnabled(context);
         } else {
             doConfigureWithTerminalWithRawStreamsDisabled(context);


### PR DESCRIPTION
## Summary

Fixes #12730 — `mvn -q help:evaluate -DforceStdout` prints `[INFO] [stdout] value` instead of just `value`.

**Root cause:** `doConfigureWithTerminalWithRawStreamsDisabled()` wraps `System.out` with a `LoggingOutputStream` that prefixes every line with `[INFO] [stdout]`. The stdout logger is hardcoded to `INFO_INT`, overriding the root logger's `ERROR` level set by `-q`. So the prefix leaks through even in quiet mode.

**Fix:** Treat `-q`/`--quiet` the same as `--raw-streams` — when quiet mode is active, use the raw `System.out`/`System.err` streams directly (via `doConfigureWithTerminalWithRawStreamsEnabled`), bypassing the `LoggingOutputStream` wrapper entirely. This restores Maven 3 behavior where `-q` produced clean stdout suitable for scripting.

This is a one-line condition change (adding `|| context.options().quiet().orElse(false)` to the existing `rawStreams` check). No new code paths, no behavioral change for non-quiet invocations.

**Supersedes #12733** — that PR attempted to fix this by changing the stdout logger's level to `ERROR` when `-q` is used. However, since the output is emitted via `stdout.info("[stdout] " + s)`, setting the logger to ERROR suppresses the message *entirely* (both the prefix AND the value), resulting in silent output rather than clean output.

## Test plan
- [ ] `mvn -q help:evaluate -Dexpression=project.name -DforceStdout` produces only the value (no `[INFO] [stdout]` prefix)
- [ ] `mvn help:evaluate -Dexpression=project.name -DforceStdout` still shows `[INFO] [stdout] value` (non-quiet behavior unchanged)
- [ ] `mvn --raw-streams help:evaluate -Dexpression=project.name -DforceStdout` still works (raw-streams behavior unchanged)
- [ ] Existing IT `MavenITmng4387QuietLoggingTest` passes