### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: 17
           distribution: 'temurin'
@@ -150,7 +150,7 @@ jobs:
         java: ['17', '21', '25']
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -263,7 +263,7 @@ jobs:
         java: ['17', '21', '25']
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Upgrade all `actions/setup-java` references in the active Maven workflow from v5.7.0 to v6.0.0, retaining SHA pinning.

## Testing

- Verified the v6.0.0 tag resolves to `dd06d9cba3e5552c54d9f8ea23572deb30010f7c`.
- Ran `git diff --check`.
- Verified no pre-v6 `actions/setup-java` references remain in active workflows.
