### PR TITLE
Fix ArtifactCoordinates.getId() double colon when classifier is empty

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
@@ -84,9 +84,8 @@ public interface ArtifactCoordinates {
                 + getArtifactId()
                 + ':'
                 + getExtension()
+                + (c.isEmpty() ? "" : ":" + c)
                 + ':'
-                + c
-                + (c.isEmpty() ? "" : ":")
                 + getVersionConstraint();
     }
 }

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/ArtifactCoordinatesTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/ArtifactCoordinatesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArtifactCoordinatesTest {
+
+    @Test
+    void getIdOmitsEmptyClassifier() {
+        ArtifactCoordinates coords = stub("org.example", "demo", "jar", "", "1.0");
+        assertEquals("org.example:demo:jar:1.0", coords.getId());
+    }
+
+    @Test
+    void getIdIncludesNonEmptyClassifier() {
+        ArtifactCoordinates coords = stub("org.example", "demo", "jar", "sources", "1.0");
+        assertEquals("org.example:demo:jar:sources:1.0", coords.getId());
+    }
+
+    private static ArtifactCoordinates stub(
+            String groupId, String artifactId, String extension, String classifier, String version) {
+        return new ArtifactCoordinates() {
+            @Override
+            public String getGroupId() {
+                return groupId;
+            }
+
+            @Override
+            public String getArtifactId() {
+                return artifactId;
+            }
+
+            @Override
+            public String getClassifier() {
+                return classifier;
+            }
+
+            @Override
+            public VersionConstraint getVersionConstraint() {
+                return new VersionConstraint() {
+                    @Override
+                    public VersionRange getVersionRange() {
+                        return null;
+                    }
+
+                    @Override
+                    public Version getRecommendedVersion() {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean contains(Version v) {
+                        return false;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return version;
+                    }
+                };
+            }
+
+            @Override
+            public String getExtension() {
+                return extension;
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!--
Please open pull requests against one of the following branches:

- master — default target for all changes (new features + bug fixes).
  If the change should also go to maven-4.0.x, request a backport in the PR.

- maven-3.10.x — target for 3.x changes (new features + bug fixes).
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.

Backports are typically handled by maintainers;
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/

Fixes #12596.

`ArtifactCoordinates.getId()` always inserted the classifier field, so an empty classifier produced `g:a:ext::version`. `Artifact.key()` already omits that extra colon. Align `getId()` with `key()`:

- empty classifier → `g:a:ext:version`
- non-empty classifier → `g:a:ext:classifier:version`

Please consider backporting to maven-4.0.x; the same default method is broken there.