### PR TITLE
Fix #12761: do not wait for the terminal on the thread building it

### DIFF
--- a/impl/maven-jline/pom.xml
+++ b/impl/maven-jline/pom.xml
@@ -80,5 +80,10 @@ under the License.
       <groupId>org.jline</groupId>
       <artifactId>jansi-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -36,6 +37,7 @@ import org.jline.terminal.MouseEvent;
 import org.jline.terminal.Size;
 import org.jline.terminal.Sized;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalExt;
 import org.jline.terminal.spi.TerminalProvider;
@@ -47,28 +49,88 @@ public class FastTerminal implements TerminalExt {
 
     private final CompletableFuture<Terminal> terminal;
 
+    /**
+     * The thread running the builder and the consumer. Every method of this class delegates through
+     * {@link #getTerminal()}, so code running on this thread before the terminal is published would
+     * wait on the very future it is itself computing.
+     */
+    private final Thread buildThread;
+
+    /**
+     * Stand-in handed to {@link #buildThread} while the real terminal is still being built, so that
+     * logging from the builder or the consumer degrades to unstyled output instead of deadlocking.
+     * Created on demand, and only ever by {@link #buildThread}.
+     */
+    private Terminal reentrantFallback;
+
+    /**
+     * Captured before {@link #buildThread} starts, hence before the consumer swaps the system streams
+     * for logging-backed ones. Writing to the live {@code System.err} instead would feed the fallback
+     * output back into the logger it came from.
+     */
+    private final OutputStream fallbackOutput;
+
     public FastTerminal(Callable<Terminal> builder, Consumer<Terminal> consumer) {
         this.terminal = new CompletableFuture<>();
-        new Thread(
-                        () -> {
-                            try {
-                                Terminal term = builder.call();
-                                consumer.accept(term);
-                                terminal.complete(term);
-                            } catch (Exception e) {
-                                terminal.completeExceptionally(new MavenException(e));
-                            }
-                        },
-                        "fast-terminal-thread")
-                .start();
+        this.fallbackOutput = System.err;
+        this.buildThread = new Thread(
+                () -> {
+                    try {
+                        Terminal term = builder.call();
+                        consumer.accept(term);
+                        terminal.complete(term);
+                    } catch (Exception e) {
+                        terminal.completeExceptionally(new MavenException(e));
+                    }
+                },
+                "fast-terminal-thread");
+        // a wedged builder must not keep the JVM alive; everything waits on the future, not the thread
+        this.buildThread.setDaemon(true);
+        this.buildThread.start();
     }
 
     public TerminalExt getTerminal() {
+        if (isBuildThreadWaitingOnItself()) {
+            return (TerminalExt) reentrantFallback();
+        }
         try {
             return (TerminalExt) terminal.get();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * True when the caller is the thread building the terminal and the terminal is not published yet.
+     * Waiting for the future here would never return, since this thread is the one that completes it.
+     */
+    private boolean isBuildThreadWaitingOnItself() {
+        return Thread.currentThread() == buildThread && !isBuilt();
+    }
+
+    /**
+     * Whether the terminal has been published. {@link MessageUtils#systemUninstall()} waits for the
+     * build to finish, so a caller that must not block has to check this first.
+     */
+    boolean isBuilt() {
+        return terminal.isDone();
+    }
+
+    private Terminal reentrantFallback() {
+        // only buildThread reaches this, so no synchronization is needed
+        if (reentrantFallback == null) {
+            try {
+                reentrantFallback = new DumbTerminal(
+                        "fast-terminal-fallback",
+                        Terminal.TYPE_DUMB,
+                        InputStream.nullInputStream(),
+                        fallbackOutput,
+                        StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new MavenException(e);
+            }
+        }
+        return reentrantFallback;
     }
 
     @Override

--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
@@ -21,9 +21,9 @@ package org.apache.maven.jline;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -37,7 +37,6 @@ import org.jline.terminal.MouseEvent;
 import org.jline.terminal.Size;
 import org.jline.terminal.Sized;
 import org.jline.terminal.Terminal;
-import org.jline.terminal.impl.DumbTerminal;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalExt;
 import org.jline.terminal.spi.TerminalProvider;
@@ -57,11 +56,10 @@ public class FastTerminal implements TerminalExt {
     private final Thread buildThread;
 
     /**
-     * Stand-in handed to {@link #buildThread} while the real terminal is still being built, so that
-     * logging from the builder or the consumer degrades to unstyled output instead of deadlocking.
-     * Created on demand, and only ever by {@link #buildThread}.
+     * Writer handed to {@link #buildThread} while the real terminal is still being built. Created on
+     * demand, and only ever by {@link #buildThread}.
      */
-    private Terminal reentrantFallback;
+    private PrintWriter fallbackWriter;
 
     /**
      * Captured before {@link #buildThread} starts, hence before the consumer swaps the system streams
@@ -90,9 +88,6 @@ public class FastTerminal implements TerminalExt {
     }
 
     public TerminalExt getTerminal() {
-        if (isBuildThreadWaitingOnItself()) {
-            return (TerminalExt) reentrantFallback();
-        }
         try {
             return (TerminalExt) terminal.get();
         } catch (Exception e) {
@@ -116,21 +111,12 @@ public class FastTerminal implements TerminalExt {
         return terminal.isDone();
     }
 
-    private Terminal reentrantFallback() {
+    private PrintWriter fallbackWriter() {
         // only buildThread reaches this, so no synchronization is needed
-        if (reentrantFallback == null) {
-            try {
-                reentrantFallback = new DumbTerminal(
-                        "fast-terminal-fallback",
-                        Terminal.TYPE_DUMB,
-                        InputStream.nullInputStream(),
-                        fallbackOutput,
-                        StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                throw new MavenException(e);
-            }
+        if (fallbackWriter == null) {
+            fallbackWriter = new PrintWriter(new OutputStreamWriter(fallbackOutput, Charset.defaultCharset()), true);
         }
-        return reentrantFallback;
+        return fallbackWriter;
     }
 
     @Override
@@ -155,7 +141,8 @@ public class FastTerminal implements TerminalExt {
 
     @Override
     public PrintWriter writer() {
-        return getTerminal().writer();
+        // the log sink writes here, and must not wait for the terminal this thread is building
+        return isBuildThreadWaitingOnItself() ? fallbackWriter() : getTerminal().writer();
     }
 
     @Override
@@ -260,7 +247,11 @@ public class FastTerminal implements TerminalExt {
 
     @Override
     public String getType() {
-        return getTerminal().getType();
+        // AttributedCharSequence.toAnsi asks for the type first and renders plain for a dumb one,
+        // so answering here keeps message rendering off the terminal this thread is building
+        return isBuildThreadWaitingOnItself()
+                ? Terminal.TYPE_DUMB
+                : getTerminal().getType();
     }
 
     @Override

--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -22,8 +22,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
  * {@link MessageUtils#systemInstall} publishes the terminal before the background thread has built
  * it, so anything that thread logs is rendered through a terminal that same thread is still
  * producing. See <a href="https://github.com/apache/maven/issues/12761">#12761</a>.
+ * <p>
+ * A single log statement asks the terminal for two things, its type while rendering the message and
+ * its writer while emitting the line, so both are exercised from both halves of the window: the
+ * builder callable, and the consumer that runs before the terminal is published.
  * <p>
  * The timeouts are preemptive on purpose: a regression parks the build thread forever, and only an
  * abandoning timeout turns that into a red test rather than a hung fork.
@@ -54,46 +60,39 @@ class FastTerminalReentrancyTest {
     }
 
     @Test
-    void renderingAMessageFromTheBuilderDoesNotDeadlock() {
+    void usingTheTerminalFromTheBuilderDoesNotDeadlock() {
         assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
-            CompletableFuture<String> rendered = new CompletableFuture<>();
-            installAndAwait(builder ->
-                    rendered.complete(MessageUtils.builder().warning("WARNING").build()));
-            // the stand-in reports itself as dumb, so the style is dropped rather than emitted blind
-            assertEquals("WARNING", rendered.get());
+            CompletableFuture<String[]> probed = new CompletableFuture<>();
+            installAndAwait(builder -> probed.complete(probe()), terminal -> {});
+            assertProbe(probed.get());
         });
     }
 
     @Test
-    void takingTheWriterFromTheBuilderDoesNotDeadlock() {
+    void usingTheTerminalFromTheConsumerDoesNotDeadlock() {
         assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
-            CompletableFuture<Object> writer = new CompletableFuture<>();
-            installAndAwait(
-                    builder -> writer.complete(MessageUtils.getTerminal().writer()));
-            assertNotNull(writer.get());
+            CompletableFuture<String[]> probed = new CompletableFuture<>();
+            installAndAwait(builder -> {}, terminal -> probed.complete(probe()));
+            assertProbe(probed.get());
         });
     }
 
-    @Test
-    void renderingAMessageFromTheConsumerDoesNotDeadlock() {
-        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
-            CompletableFuture<String> rendered = new CompletableFuture<>();
-            // the consumer runs on the same thread, before the future is completed
-            installAndAwait(
-                    builder -> {},
-                    terminal -> rendered.complete(
-                            MessageUtils.builder().warning("WARNING").build()));
-            assertEquals("WARNING", rendered.get());
-        });
+    /**
+     * Both terminal calls a single log statement makes, run on the terminal building thread.
+     */
+    private static String[] probe() {
+        String rendered = MessageUtils.builder().warning("WARNING").build();
+        assertNotNull(MessageUtils.getTerminal().writer());
+        return new String[] {rendered, MessageUtils.getTerminal().getType()};
     }
 
-    private void installAndAwait(java.util.function.Consumer<org.jline.terminal.TerminalBuilder> onBuilder) {
-        installAndAwait(onBuilder, terminal -> {});
+    private static void assertProbe(String[] probed) {
+        // the stand-in reports itself dumb, so the style is dropped rather than emitted blind
+        assertEquals(Terminal.TYPE_DUMB, probed[1]);
+        assertEquals("WARNING", probed[0]);
     }
 
-    private void installAndAwait(
-            java.util.function.Consumer<org.jline.terminal.TerminalBuilder> onBuilder,
-            java.util.function.Consumer<Terminal> onTerminal) {
+    private void installAndAwait(Consumer<TerminalBuilder> onBuilder, Consumer<Terminal> onTerminal) {
         MessageUtils.systemInstall(
                 builder -> {
                     onBuilder.accept(builder);

--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.jline;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import org.jline.terminal.Terminal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * {@link MessageUtils#systemInstall} publishes the terminal before the background thread has built
+ * it, so anything that thread logs is rendered through a terminal that same thread is still
+ * producing. See <a href="https://github.com/apache/maven/issues/12761">#12761</a>.
+ * <p>
+ * The timeouts are preemptive on purpose: a regression parks the build thread forever, and only an
+ * abandoning timeout turns that into a red test rather than a hung fork.
+ */
+class FastTerminalReentrancyTest {
+
+    @AfterEach
+    void tearDown() {
+        // MessageUtils.terminal is process-global; leaving it set breaks every later test.
+        // On a regression the build thread never finishes and systemUninstall waits for it (see
+        // #11048), on the test thread and outside any timeout, so the fork would hang instead of
+        // reporting the failure. Leave the state dirty in that case; the run is lost either way.
+        if (MessageUtils.getTerminal() instanceof FastTerminal ft && !ft.isBuilt()) {
+            return;
+        }
+        MessageUtils.systemUninstall();
+    }
+
+    @Test
+    void renderingAMessageFromTheBuilderDoesNotDeadlock() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<String> rendered = new CompletableFuture<>();
+            installAndAwait(builder ->
+                    rendered.complete(MessageUtils.builder().warning("WARNING").build()));
+            // the stand-in reports itself as dumb, so the style is dropped rather than emitted blind
+            assertEquals("WARNING", rendered.get());
+        });
+    }
+
+    @Test
+    void takingTheWriterFromTheBuilderDoesNotDeadlock() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<Object> writer = new CompletableFuture<>();
+            installAndAwait(
+                    builder -> writer.complete(MessageUtils.getTerminal().writer()));
+            assertNotNull(writer.get());
+        });
+    }
+
+    @Test
+    void renderingAMessageFromTheConsumerDoesNotDeadlock() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<String> rendered = new CompletableFuture<>();
+            // the consumer runs on the same thread, before the future is completed
+            installAndAwait(
+                    builder -> {},
+                    terminal -> rendered.complete(
+                            MessageUtils.builder().warning("WARNING").build()));
+            assertEquals("WARNING", rendered.get());
+        });
+    }
+
+    private void installAndAwait(java.util.function.Consumer<org.jline.terminal.TerminalBuilder> onBuilder) {
+        installAndAwait(onBuilder, terminal -> {});
+    }
+
+    private void installAndAwait(
+            java.util.function.Consumer<org.jline.terminal.TerminalBuilder> onBuilder,
+            java.util.function.Consumer<Terminal> onTerminal) {
+        MessageUtils.systemInstall(
+                builder -> {
+                    onBuilder.accept(builder);
+                    builder.dumb(true)
+                            .system(false)
+                            .streams(InputStream.nullInputStream(), OutputStream.nullOutputStream());
+                },
+                onTerminal);
+        // let the build finish, so a failure here is the build failing rather than a leaked thread
+        ((FastTerminal) MessageUtils.getTerminal()).getTerminal();
+    }
+}


### PR DESCRIPTION
Fixes #12761. A `mvn` start can hang before printing anything, with no Java-level deadlock reported.

`MessageUtils.systemInstall` publishes the `FastTerminal` immediately and builds the real terminal on `fast-terminal-thread`. Every `FastTerminal` method delegates through `getTerminal()`, which waits on the future that thread completes, so a single log statement from that thread parks it on its own result. `main` then parks behind it in `activateLogging`.

The trigger arrived with the rc-6 JLine 3.30.6 → 4.3.1 bump: JLine 4.x initialises its native loader during provider probing and logs a JUL warning when a library candidate fails `System.load`, by which time `activateLogging` has bridged JUL to SLF4J. The load failure itself is harmless — JLine recovers by extracting the bundled library.

Two details shaped the fix. The hazard window covers the consumer as well, since `consumer.accept(term)` runs before `terminal.complete(term)`. And one log statement reaches the terminal twice, through `MavenSimpleLogger.renderLevel` → `toAnsi` → `getType()` and again through `write` → the log sink installed in `createTerminal` → `terminal.writer()`, so guarding the message builder alone moves the hang rather than removing it.

Those two calls are the whole surface. `AttributedCharSequence.toAnsi` asks for the type first and renders plain for a dumb terminal, so it never reaches another method. `getType()` and `writer()` therefore answer the building thread directly, with `TYPE_DUMB` and a writer over the stream captured before the consumer swaps the system streams. Rendering degrades to unstyled text while the build is in flight, which is what a dumb terminal would produce anyway.

Two alternatives were tried and rejected. Handing back a stand-in `DumbTerminal` covers every delegating method at once, but it constructs a terminal inside terminal construction on that same thread, and wedged on ubuntu/jdk-17 (see the second commit). Throwing on re-entry escapes through the JUL handler and aborts JLine's fallback chain, turning a recoverable warning into a failed startup.

Verified: two tests in `maven-jline`, each exercising both calls from one half of the window. With the guards removed both fail at 30 s; with them they pass in 0.4 s.

`maven-4.0.x` carries the same code and the same JLine version. The CI symptom is apache/maven-executor#38.

*This change was created with AI assistance.*
