### PR TITLE
Use the just built maven to run integration tests

### DIFF
--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -516,7 +516,7 @@ under the License.
             <configuration>
               <target>
                 <delete dir="${mavenHome}" />
-                <unzip dest="${mavenHome}" src="${sessionRootDirectory}/apache-maven/target/apache-maven-${project.version}-bin.zip">
+                <unzip dest="${mavenHome}" src="${maven.multiModuleProjectDirectory}/apache-maven/target/apache-maven-${project.version}-bin.zip">
                   <regexpmapper from="^([^/]+)/(.*)$" handledirsep="true" to="\2" />
                 </unzip>
                 <chmod dir="${mavenHome}/bin" includes="mvn,mvnDebug,mvnenc" perm="ugo+rx" />
@@ -662,6 +662,11 @@ under the License.
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
+              <!-- Disable the default distribution extraction -->
+              <execution>
+                <id>unpack-built-maven-distro</id>
+                <phase>none</phase>
+              </execution>
               <execution>
                 <id>unpack-maven-distro</id>
                 <goals>

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -584,6 +584,9 @@ under the License.
     </profile>
     <profile>
       <id>run-its</id>
+      <properties>
+        <mavenHome>${project.build.directory}/apache-maven</mavenHome>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.maven</groupId>
@@ -628,6 +631,54 @@ under the License.
               <skipTests>false</skipTests>
               <redirectTestOutputToFile>false</redirectTestOutputToFile>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>download-maven-distro</id>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <phase>process-test-resources</phase>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.maven</groupId>
+                      <artifactId>apache-maven</artifactId>
+                      <version>${maven-version}</version>
+                      <classifier>bin</classifier>
+                      <type>zip</type>
+                      <destFileName>maven-bin.zip</destFileName>
+                    </artifactItem>
+                  </artifactItems>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-maven-distro</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>process-test-resources</phase>
+                <configuration>
+                  <target>
+                    <delete dir="${mavenHome}" />
+                    <unzip dest="${mavenHome}" src="${project.build.directory}/maven-bin.zip">
+                      <globmapper from="apache-maven-${maven-version}/*" handledirsep="true" to="*" />
+                    </unzip>
+                    <chmod dir="${mavenHome}/bin" includes="mvn,mvnDebug,mvnenc" perm="ugo+rx" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
When building maven 4.0.x using maven 3, I realized that the integration tests were failing and went down the rabbit hole to see why. The reason was that not the recently built maven was used for the integration tests, but the maven that built it. This somehow defeats the purpose of integration tests. This simple change makes maven use its own build result to run integration tests.