### PR TITLE
Upgrade to maven-resolver 2.0.22

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/RepositorySystemSupplier.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.impl.standalone;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.api.annotations.Nullable;
@@ -313,13 +312,13 @@ public class RepositorySystemSupplier {
 
     @Singleton
     @Provides
-    static List<ValidatorFactory> newValidatorFactories() {
-        return List.of(new MavenValidatorFactory());
+    static Map<String, ValidatorFactory> newValidatorFactories() {
+        return Map.of("mavenValidatorFactory", new MavenValidatorFactory());
     }
 
     @Singleton
     @Provides
-    static RepositorySystemValidator newRepositorySystemValidator(List<ValidatorFactory> validatorFactories) {
+    static RepositorySystemValidator newRepositorySystemValidator(Map<String, ValidatorFactory> validatorFactories) {
         return new DefaultRepositorySystemValidator(validatorFactories);
     }
 

--- a/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/RepositorySystemSupplier.java
+++ b/impl/maven-testing/src/main/java/org/apache/maven/testing/plugin/stubs/RepositorySystemSupplier.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.testing.plugin.stubs;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -1195,9 +1194,9 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return new DefaultRepositorySystemValidator(getValidatorFactories());
     }
 
-    private List<ValidatorFactory> validatorFactories;
+    private Map<String, ValidatorFactory> validatorFactories;
 
-    public final List<ValidatorFactory> getValidatorFactories() {
+    public final Map<String, ValidatorFactory> getValidatorFactories() {
         checkClosed();
         if (validatorFactories == null) {
             validatorFactories = createValidatorFactories();
@@ -1205,9 +1204,9 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return validatorFactories;
     }
 
-    protected List<ValidatorFactory> createValidatorFactories() {
-        List<ValidatorFactory> result = new ArrayList<>();
-        result.add(new MavenValidatorFactory());
+    protected Map<String, ValidatorFactory> createValidatorFactories() {
+        Map<String, ValidatorFactory> result = new HashMap<>();
+        result.put("mavenValidatorFactory", new MavenValidatorFactory());
         return result;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ under the License.
     <plexusInterpolationVersion>1.30.0</plexusInterpolationVersion>
     <plexusTestingVersion>2.1.0</plexusTestingVersion>
     <plexusXmlVersion>4.2.0</plexusXmlVersion>
-    <resolverVersion>2.0.21</resolverVersion>
+    <resolverVersion>2.0.22</resolverVersion>
     <securityDispatcherVersion>4.2.0</securityDispatcherVersion>
     <sisuVersion>1.1.0</sisuVersion>
     <slf4jVersion>2.0.18</slf4jVersion>


### PR DESCRIPTION
Upgrade to maven-resolver 2.0.22 and adapt to the changes of type of validation factories. The name "mavenValidatorFactory" is chosen because a class annotated with `@Named` with no explicit name is automatically registered using its de-capitalized simple class name as its bean name. But this PR allows maintainers to edit stuff, so If I got the thing wrong, any good string, even actually "maven" could do.