### PR TITLE
Fix #12730: quiet mode implies raw streams to avoid stdout decoration (backport to 4.0.x)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/LookupInvoker.java
@@ -370,7 +370,11 @@ public abstract class LookupInvoker<C extends LookupContext> implements Invoker 
                 context.coloredOutput != null ? context.coloredOutput : !Terminal.TYPE_DUMB.equals(terminal.getType()));
 
         // handle rawStreams: some would like to act on true, some on false
-        if (context.options().rawStreams().orElse(false)) {
+        // quiet mode implies raw streams — plugins that write to System.out (e.g. help:evaluate
+        // -DforceStdout) must not be decorated with "[INFO] [stdout]" prefix, otherwise scripting
+        // use cases like $(mvn -q help:evaluate ...) break (see GH-12730)
+        if (context.options().rawStreams().orElse(false)
+                || context.options().quiet().orElse(false)) {
             doConfigureWithTerminalWithRawStreamsEnabled(context);
         } else {
             doConfigureWithTerminalWithRawStreamsDisabled(context);


### PR DESCRIPTION
## Summary

Backport of #12810 (merged to master) to `maven-4.0.x`.

When `-q`/`--quiet` is used, plugin stdout (e.g. `help:evaluate -DforceStdout`) was still wrapped by `LoggingOutputStream` which adds the `[INFO] [stdout]` prefix. This broke scripting use cases like `$(mvn -q help:evaluate ...)` — a regression from Maven 3.

The fix treats `-q` the same as `--raw-streams`: when quiet mode is active, `System.out`/`System.err` are set to the original raw streams, bypassing the `LoggingOutputStream` wrapper entirely.

Cherry-pick applied cleanly, no conflicts.