### PR TITLE
fix: synchronize ReflectionValueExtractor class-introspection caches (impl and compat) for thread safety

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/reflection/ReflectionValueExtractor.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/reflection/ReflectionValueExtractor.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,7 +52,8 @@ public class ReflectionValueExtractor {
      * This approach prevents permgen space overflows due to retention of discarded
      * classloaders.
      */
-    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS = new WeakHashMap<>();
+    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     static final int EOF = -1;
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
@@ -23,6 +23,7 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,7 +49,8 @@ public class ReflectionValueExtractor {
      * This approach prevents permgen space overflows due to retention of discarded
      * classloaders.
      */
-    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS = new WeakHashMap<>();
+    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     static final int EOF = -1;
 


### PR DESCRIPTION
Both halves of the fix for #12731 as one merge-ready PR — an alternative vehicle to #12732, not a competing fix.

**Commits, in order:**

1. @waterWang's fix from #12732, cherry-picked verbatim with authorship preserved: wrap the impl copy's static `CLASS_MAPS` in `Collections.synchronizedMap()` (`impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java`).
2. The identical change to the deprecated compat copy (`compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/reflection/ReflectionValueExtractor.java`), which review on #12732 flagged as the remaining gap — the same unsynchronized `WeakHashMap`, still reachable via `ObjectBasedValueSource`.

**Why a second PR.** Review on #12732 asked for both copies in a single PR. I sent the compat half to @waterWang's branch on 14 Aug as waterWang/maven#1 so it would fold into #12732, but the fork has been quiet since 11 Aug, and #12731 is now milestoned for 4.0.0-rc-7. This PR carries the same two commits in already-integrated form so the fix is not gated on fork availability — and CI here exercises both changes together, which neither existing PR does.

**No preference on which vehicle merges:**

- If #12732 picks up the compat commit — @waterWang merging waterWang/maven#1, or a committer pushing it directly (maintainer edits are enabled there) — I will close this immediately.
- If this PR is the easier path, it supersedes #12732 with @waterWang's commit and credit intact.

**The defect, briefly.** `ReflectionValueExtractor` keeps a static `Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS = new WeakHashMap<>()`, read and written from every builder thread under `-T`. `WeakHashMap` re-links bucket chains entry-by-entry during `resize`; two threads resizing concurrently can leave a chain circular, and the next walk spins forever — the build hangs at 100% CPU with no output and no exception. Full analysis, thread-dump excerpt, and incident history in #12731. This targets `master` as #12732 does; #12731 is milestoned 4.0.0-rc-7, so a cherry-pick to `maven-4.0.x` follows whichever PR merges.

Fixes #12731
