### PR TITLE
[MNG-4921] Add qualityManagement element to POM model 4.2.0

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -359,6 +359,19 @@
         </field>
 
         <!-- ====================================================================== -->
+        <!-- Quality Management                                                     -->
+        <!-- ====================================================================== -->
+
+        <field>
+          <name>qualityManagement</name>
+          <version>4.2.0+</version>
+          <description>The project's quality management information.</description>
+          <association>
+            <type>QualityManagement</type>
+          </association>
+        </field>
+
+        <!-- ====================================================================== -->
         <!-- Build                                                                  -->
         <!-- ====================================================================== -->
 
@@ -1479,6 +1492,50 @@
     public String toString()
     {
         return "IssueManagement {system=" + getSystem() + ", url=" + getUrl() + "}";
+    }
+            ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
+    </class>
+    <class>
+      <name>QualityManagement</name>
+      <description>
+        <![CDATA[
+        The {@code <qualityManagement>} element contains information required to the
+        quality management system of the project.
+        ]]>
+      </description>
+      <version>4.2.0+</version>
+      <fields>
+        <field>
+          <name>system</name>
+          <version>4.2.0+</version>
+          <description>
+            <![CDATA[
+            The name of the quality management system, e.g. {@code SonarQube}.
+            ]]>
+          </description>
+          <type>String</type>
+        </field>
+        <field>
+          <name>url</name>
+          <version>4.2.0+</version>
+          <description>URL for the quality management system used by the project if it has a web interface.</description>
+          <type>String</type>
+        </field>
+      </fields>
+      <codeSegments>
+        <codeSegment>
+          <version>4.2.0+</version>
+          <code>
+            <![CDATA[
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        return "QualityManagement {system=" + getSystem() + ", url=" + getUrl() + "}";
     }
             ]]>
           </code>

--- a/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/MavenProject.java
@@ -249,6 +249,14 @@ public class MavenProject implements Cloneable {
     }
 
     /**
+     * {@return the project's {@code <qualityManagement>} information (POM model 4.2.0), or {@code null} if none}
+     * @since 4.2.0
+     */
+    public org.apache.maven.api.model.QualityManagement getQualityManagement() {
+        return getModel().getDelegate().getQualityManagement();
+    }
+
+    /**
      * Returns the project corresponding to a declared parent.
      *
      * @return the parent, or null if no parent is declared or there was an error building it
@@ -611,11 +619,9 @@ public class MavenProject implements Cloneable {
 
     public String getGroupId() {
         String groupId = getModel().getGroupId();
-
         if ((groupId == null) && (getModel().getParent() != null)) {
             groupId = getModel().getParent().getGroupId();
         }
-
         return groupId;
     }
 
@@ -632,11 +638,7 @@ public class MavenProject implements Cloneable {
     }
 
     public String getName() {
-        if (getModel().getName() != null) {
-            return getModel().getName();
-        } else {
-            return getArtifactId();
-        }
+        return getModel().getName() != null ? getModel().getName() : getArtifactId();
     }
 
     public void setVersion(String version) {
@@ -645,11 +647,9 @@ public class MavenProject implements Cloneable {
 
     public String getVersion() {
         String version = getModel().getVersion();
-
         if ((version == null) && (getModel().getParent() != null)) {
             version = getModel().getParent().getVersion();
         }
-
         return version;
     }
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/MavenModelMerger.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/MavenModelMerger.java
@@ -39,6 +39,7 @@ import org.apache.maven.api.model.ModelBase;
 import org.apache.maven.api.model.Organization;
 import org.apache.maven.api.model.Plugin;
 import org.apache.maven.api.model.PluginExecution;
+import org.apache.maven.api.model.QualityManagement;
 import org.apache.maven.api.model.ReportPlugin;
 import org.apache.maven.api.model.ReportSet;
 import org.apache.maven.api.model.Repository;
@@ -146,6 +147,19 @@ public class MavenModelMerger extends MavenMerger {
             if (tgt == null) {
                 builder.ciManagement(src);
                 builder.location("ciManagement", source.getLocation("ciManagement"));
+            }
+        }
+    }
+
+    @Override
+    protected void mergeModel_QualityManagement(
+            Model.Builder builder, Model target, Model source, boolean sourceDominant, Map<Object, Object> context) {
+        QualityManagement src = source.getQualityManagement();
+        if (src != null) {
+            QualityManagement tgt = target.getQualityManagement();
+            if (tgt == null) {
+                builder.qualityManagement(src);
+                builder.location("qualityManagement", source.getLocation("qualityManagement"));
             }
         }
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/MavenModelMergerTest.java
@@ -25,6 +25,7 @@ import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Prerequisites;
 import org.apache.maven.api.model.Profile;
+import org.apache.maven.api.model.QualityManagement;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -132,5 +133,28 @@ class MavenModelMergerTest {
         modelMerger.mergeModel_Profiles(builder, model, parent, false, null);
         assertEquals(1, builder.build().getProfiles().size());
         assertEquals("MODEL", builder.build().getProfiles().get(0).getId());
+    }
+
+    @Test
+    void testMergeModelQualityManagement() {
+        QualityManagement parentQualityManagement = QualityManagement.newBuilder()
+                .system("SonarQube")
+                .url("https://sonar.parent")
+                .build();
+        Model parent =
+                Model.newBuilder().qualityManagement(parentQualityManagement).build();
+        Model model = Model.newInstance();
+        Model.Builder builder = Model.newBuilder(model);
+        modelMerger.mergeModel_QualityManagement(builder, model, parent, false, null);
+        assertEquals(parentQualityManagement, builder.build().getQualityManagement());
+
+        QualityManagement childQualityManagement = QualityManagement.newBuilder()
+                .system("SonarQubeChild")
+                .url("https://sonar.child")
+                .build();
+        model = Model.newBuilder().qualityManagement(childQualityManagement).build();
+        builder = Model.newBuilder(model);
+        modelMerger.mergeModel_QualityManagement(builder, model, parent, false, null);
+        assertEquals(childQualityManagement, builder.build().getQualityManagement());
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4921QualityManagementTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4921QualityManagementTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-4921">MNG-4921</a>.
+ *
+ * Verifies that the {@code <qualityManagement>} element (POM model 4.2.0) is read from the POM,
+ * inherited from the parent and can be overridden by a child.
+ */
+class MavenITmng4921QualityManagementTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng4921QualityManagementTest() {}
+
+    /**
+     * Verify that the quality management information is read from the effective model, inherited from the parent POM
+     * unless overridden by the child.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void testitQualityManagement() throws Exception {
+        Path testDir = extractResources("mng-4921");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteDirectory("inherit/target");
+        verifier.deleteDirectory("override/target");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        Properties props = verifier.loadProperties("target/pom.properties");
+        assertEquals("SonarQube", props.getProperty("project.qualityManagement.system"));
+        assertEquals("https://sonar.parent.example.org", props.getProperty("project.qualityManagement.url"));
+
+        // child without own qualityManagement inherits it from the parent
+        props = verifier.loadProperties("inherit/target/pom.properties");
+        assertEquals("SonarQube", props.getProperty("project.qualityManagement.system"));
+        assertEquals("https://sonar.parent.example.org", props.getProperty("project.qualityManagement.url"));
+
+        // child declaring its own qualityManagement overrides the parent's
+        props = verifier.loadProperties("override/target/pom.properties");
+        assertEquals("Coverity", props.getProperty("project.qualityManagement.system"));
+        assertEquals("https://scan.child.example.org", props.getProperty("project.qualityManagement.url"));
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-4921/inherit/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-4921/inherit/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.2.0 http://maven.apache.org/xsd/maven-4.2.0.xsd">
+  <modelVersion>4.2.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng4921</groupId>
+    <artifactId>mng4921</artifactId>
+  </parent>
+
+  <artifactId>mng4921-inherit</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: MNG-4921 :: Inherit</name>
+  <description>Quality management inherited from parent.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputFile>target/pom.properties</outputFile>
+              <expressions>
+                <expression>project</expression>
+              </expressions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-4921/override/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-4921/override/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.2.0 http://maven.apache.org/xsd/maven-4.2.0.xsd">
+  <modelVersion>4.2.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.mng4921</groupId>
+    <artifactId>mng4921</artifactId>
+  </parent>
+
+  <artifactId>mng4921-override</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: MNG-4921 :: Override</name>
+  <description>Quality management overridden by child.</description>
+
+  <qualityManagement>
+    <system>Coverity</system>
+    <url>https://scan.child.example.org</url>
+  </qualityManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputFile>target/pom.properties</outputFile>
+              <expressions>
+                <expression>project</expression>
+              </expressions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-4921/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-4921/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" root="true" xsi:schemaLocation="http://maven.apache.org/POM/4.2.0 http://maven.apache.org/xsd/maven-4.2.0.xsd">
+  <modelVersion>4.2.0</modelVersion>
+  <groupId>org.apache.maven.its.mng4921</groupId>
+  <artifactId>mng4921</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: MNG-4921</name>
+  <description>Test the qualityManagement element.</description>
+
+  <qualityManagement>
+    <system>SonarQube</system>
+    <url>https://sonar.parent.example.org</url>
+  </qualityManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputFile>target/pom.properties</outputFile>
+              <expressions>
+                <expression>project</expression>
+              </expressions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <subprojects>
+    <subproject>inherit</subproject>
+    <subproject>override</subproject>
+  </subprojects>
+</project>


### PR DESCRIPTION
This PR reimplements and replaces #33 on top of current `master`, adding the `<qualityManagement>` element to the POM model for the **Maven 4 model line**, targeting model version **4.2.0** (`<version>4.2.0+</version>`) since the 4.1.0 schema is already frozen.

This also serves to validate how adding new POM elements works in the Maven 4.x model architecture:

- Scoped to model version **4.2.0+** so the legacy 4.0.0 (Maven 3.x) compatibility model remains untouched.
- Modello velocity templates generate the immutable V4 API model (`org.apache.maven.api.model.QualityManagement`), StAX readers/writers, transformer and the `maven-4.2.0.xsd` schema.
- Automatic model version detection (`MavenModelVersion`) correctly identifies `<qualityManagement>` as requiring model version `4.2.0`.
- Model inheritance and merging support in `MavenModelMerger` ensures quality management metadata is inherited from parent POMs unless overridden by the child.

Fixes / Closes #33
Jira: [MNG-4921](https://issues.apache.org/jira/browse/MNG-4921)

---

Integration test: `MavenITmng4921QualityManagementTest` verifies the element is read, inherited from the parent and overridable by a child.

---

- [x] Scoped exclusively to Maven 4.2.0+ model
- [x] Model merging support in `MavenModelMerger`
- [x] Unit test in `MavenModelMergerTest`
