### PR TITLE
[4.0.x] Use try-with-resources for AuthenticationContext

### DIFF
--- a/compat/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
@@ -526,13 +526,14 @@ public class LegacyRepositorySystem implements RepositorySystem {
                     repo = new RemoteRepository.Builder(repo)
                             .setAuthentication(auth)
                             .build();
-                    AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo);
-                    Authentication result = new Authentication(
-                            authCtx.get(AuthenticationContext.USERNAME), authCtx.get(AuthenticationContext.PASSWORD));
-                    result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
-                    result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
-                    authCtx.close();
-                    return result;
+                    try (AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo)) {
+                        Authentication result = new Authentication(
+                                authCtx.get(AuthenticationContext.USERNAME),
+                                authCtx.get(AuthenticationContext.PASSWORD));
+                        result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
+                        result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
+                        return result;
+                    }
                 }
             }
         }
@@ -623,12 +624,12 @@ public class LegacyRepositorySystem implements RepositorySystem {
                         repo = new RemoteRepository.Builder(repo)
                                 .setProxy(proxy)
                                 .build();
-                        AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo);
-                        p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
-                        p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
-                        p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
-                        p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
-                        authCtx.close();
+                        try (AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo)) {
+                            p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
+                            p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
+                            p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
+                            p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
+                        }
                     }
                     return p;
                 }

--- a/impl/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
@@ -230,13 +230,14 @@ public class MavenRepositorySystem {
                     repo = new RemoteRepository.Builder(repo)
                             .setAuthentication(auth)
                             .build();
-                    AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo);
-                    Authentication result = new Authentication(
-                            authCtx.get(AuthenticationContext.USERNAME), authCtx.get(AuthenticationContext.PASSWORD));
-                    result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
-                    result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
-                    authCtx.close();
-                    return result;
+                    try (AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo)) {
+                        Authentication result = new Authentication(
+                                authCtx.get(AuthenticationContext.USERNAME),
+                                authCtx.get(AuthenticationContext.PASSWORD));
+                        result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
+                        result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
+                        return result;
+                    }
                 }
             }
         }
@@ -266,12 +267,12 @@ public class MavenRepositorySystem {
                         repo = new RemoteRepository.Builder(repo)
                                 .setProxy(proxy)
                                 .build();
-                        AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo);
-                        p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
-                        p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
-                        p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
-                        p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
-                        authCtx.close();
+                        try (AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo)) {
+                            p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
+                            p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
+                            p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
+                            p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
+                        }
                     }
                     return p;
                 }

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/aether/LegacyRepositorySystemSessionExtender.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/aether/LegacyRepositorySystemSessionExtender.java
@@ -110,12 +110,12 @@ public class LegacyRepositorySystemSessionExtender implements RepositorySystemSe
                 p.setPort(proxy.getPort());
                 if (proxy.getAuthentication() != null) {
                     repo = new RemoteRepository.Builder(repo).setProxy(proxy).build();
-                    AuthenticationContext authCtx = AuthenticationContext.forProxy(null, repo);
-                    p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
-                    p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
-                    p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
-                    p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
-                    authCtx.close();
+                    try (AuthenticationContext authCtx = AuthenticationContext.forProxy(null, repo)) {
+                        p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
+                        p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
+                        p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
+                        p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
+                    }
                 }
                 return p;
             }
@@ -139,13 +139,13 @@ public class LegacyRepositorySystemSessionExtender implements RepositorySystemSe
                 repo = new RemoteRepository.Builder(repo)
                         .setAuthentication(auth)
                         .build();
-                AuthenticationContext authCtx = AuthenticationContext.forRepository(null, repo);
-                Authentication result = new Authentication(
-                        authCtx.get(AuthenticationContext.USERNAME), authCtx.get(AuthenticationContext.PASSWORD));
-                result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
-                result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
-                authCtx.close();
-                return result;
+                try (AuthenticationContext authCtx = AuthenticationContext.forRepository(null, repo)) {
+                    Authentication result = new Authentication(
+                            authCtx.get(AuthenticationContext.USERNAME), authCtx.get(AuthenticationContext.PASSWORD));
+                    result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
+                    result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
+                    return result;
+                }
             }
         }
         return null;


### PR DESCRIPTION
Make sure `AuthenticationContext` instances are properly closed even when exceptions are thrown during property retrieval, using try-with-resources.

Backport / rebase of #12843 for `maven-4.0.x`:
- The `AuthenticationContext` try-with-resources conversions in `LegacyRepositorySystem` and `MavenRepositorySystem` are applied for current paths (`compat/maven-compat` and `impl/maven-core`).
- Added try-with-resources conversion for `LegacyRepositorySystemSessionExtender`.

Related: #669, #12843

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)