### PR TITLE
[3.10.x] Use try-with-resources

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
@@ -533,13 +533,14 @@ public class LegacyRepositorySystem implements RepositorySystem {
                     repo = new RemoteRepository.Builder(repo)
                             .setAuthentication(auth)
                             .build();
-                    AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo);
-                    Authentication result = new Authentication(
-                            authCtx.get(AuthenticationContext.USERNAME), authCtx.get(AuthenticationContext.PASSWORD));
-                    result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
-                    result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
-                    authCtx.close();
-                    return result;
+                    try (AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo)) {
+                        Authentication result = new Authentication(
+                                authCtx.get(AuthenticationContext.USERNAME),
+                                authCtx.get(AuthenticationContext.PASSWORD));
+                        result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
+                        result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
+                        return result;
+                    }
                 }
             }
         }
@@ -627,12 +628,12 @@ public class LegacyRepositorySystem implements RepositorySystem {
                         repo = new RemoteRepository.Builder(repo)
                                 .setProxy(proxy)
                                 .build();
-                        AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo);
-                        p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
-                        p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
-                        p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
-                        p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
-                        authCtx.close();
+                        try (AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo)) {
+                            p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
+                            p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
+                            p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
+                            p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
+                        }
                     }
                     return p;
                 }

--- a/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
+++ b/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
@@ -235,13 +235,14 @@ public class MavenRepositorySystem {
                     repo = new RemoteRepository.Builder(repo)
                             .setAuthentication(auth)
                             .build();
-                    AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo);
-                    Authentication result = new Authentication(
-                            authCtx.get(AuthenticationContext.USERNAME), authCtx.get(AuthenticationContext.PASSWORD));
-                    result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
-                    result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
-                    authCtx.close();
-                    return result;
+                    try (AuthenticationContext authCtx = AuthenticationContext.forRepository(session, repo)) {
+                        Authentication result = new Authentication(
+                                authCtx.get(AuthenticationContext.USERNAME),
+                                authCtx.get(AuthenticationContext.PASSWORD));
+                        result.setPrivateKey(authCtx.get(AuthenticationContext.PRIVATE_KEY_PATH));
+                        result.setPassphrase(authCtx.get(AuthenticationContext.PRIVATE_KEY_PASSPHRASE));
+                        return result;
+                    }
                 }
             }
         }
@@ -271,12 +272,12 @@ public class MavenRepositorySystem {
                         repo = new RemoteRepository.Builder(repo)
                                 .setProxy(proxy)
                                 .build();
-                        AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo);
-                        p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
-                        p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
-                        p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
-                        p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
-                        authCtx.close();
+                        try (AuthenticationContext authCtx = AuthenticationContext.forProxy(session, repo)) {
+                            p.setUserName(authCtx.get(AuthenticationContext.USERNAME));
+                            p.setPassword(authCtx.get(AuthenticationContext.PASSWORD));
+                            p.setNtlmDomain(authCtx.get(AuthenticationContext.NTLM_DOMAIN));
+                            p.setNtlmHost(authCtx.get(AuthenticationContext.NTLM_WORKSTATION));
+                        }
                     }
                     return p;
                 }

--- a/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -216,9 +216,9 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                     ZipEntry pluginDescriptorEntry = pluginJar.getEntry(getPluginDescriptorLocation());
 
                     if (pluginDescriptorEntry != null) {
-                        InputStream is = pluginJar.getInputStream(pluginDescriptorEntry);
-
-                        pluginDescriptor = parsePluginDescriptor(is, plugin, pluginFile.getAbsolutePath());
+                        try (InputStream is = pluginJar.getInputStream(pluginDescriptorEntry)) {
+                            pluginDescriptor = parsePluginDescriptor(is, plugin, pluginFile.getAbsolutePath());
+                        }
                     }
                 }
             } else {
@@ -258,9 +258,7 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
 
     private PluginDescriptor parsePluginDescriptor(InputStream is, Plugin plugin, String descriptorLocation)
             throws PluginDescriptorParsingException {
-        try {
-            Reader reader = ReaderFactory.newXmlReader(is);
-
+        try (Reader reader = ReaderFactory.newXmlReader(is)) {
             PluginDescriptor pluginDescriptor = builder.build(reader, descriptorLocation);
 
             return pluginDescriptor;

--- a/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectBuildingException.java
@@ -106,10 +106,8 @@ public class ProjectBuildingException extends Exception {
 
     private static String createMessage(List<ProjectBuildingResult> results) {
         StringWriter buffer = new StringWriter(1024);
-        PrintWriter writer = new PrintWriter(buffer);
-        writer.println("Some problems were encountered while processing the POMs:");
-        try {
-
+        try (PrintWriter writer = new PrintWriter(buffer)) {
+            writer.println("Some problems were encountered while processing the POMs:");
             for (ProjectBuildingResult result : results) {
                 for (ModelProblem problem : result.getProblems()) {
                     writer.print("[");
@@ -120,8 +118,6 @@ public class ProjectBuildingException extends Exception {
                     writer.println(ModelProblemUtils.formatLocation(problem, result.getProjectId()));
                 }
             }
-        } finally {
-            writer.close();
         }
         return buffer.toString();
     }


### PR DESCRIPTION
Make sure resources (`AuthenticationContext`, `InputStream`, `Reader`, `PrintWriter`) are properly closed even when exceptions are thrown by using try-with-resources.

Rebase / adaptation of #669 for `maven-3.10.x`:
- `LegacyRepositorySystem`: `AuthenticationContext` try-with-resources for `getAuthentication` and `getProxy`
- `MavenRepositorySystem`: `AuthenticationContext` try-with-resources for `getAuthentication` and `getProxy`
- `ProjectBuildingException`: `PrintWriter` try-with-resources in `createMessage`
- `DefaultMavenPluginManager`: `InputStream` and `Reader` try-with-resources in `extractPluginDescriptor` and `parsePluginDescriptor`

Related: #669, #12843

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)