### PR TITLE
3.10.x Build by JDK 25, limit JDK to min and max LTS in build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
 
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 11, 17, 21, 25]
+        java: [8, 25, 26]
 
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
What changed:
- Changed Java version from 21 to 25 build job.
- Updated Java matrix in ITs to include versions 8, 25, and 26, minimum and maximum LTS and latest release
