### PR TITLE
chore: simplify integration-tests CI job

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -291,36 +291,13 @@ jobs:
             master-${{ runner.os }}-
             master-
 
-      - name: Download Maven distribution
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-distributions
-          path: maven-dist
-
-      - name: List downloaded files
+      - name: Set up Maven
         shell: bash
-        run: ls -la maven-dist
-
-      - name: Extract Maven distribution
-        shell: bash
-        run: |
-          mkdir -p maven-local
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            unzip maven-dist/apache-maven-*-bin.zip -d maven-local
-            # Get the name of the extracted directory
-            MAVEN_DIR=$(ls maven-local)
-            # Move contents up one level
-            mv "maven-local/$MAVEN_DIR"/* maven-local/
-            rm -r "maven-local/$MAVEN_DIR"
-          else
-            tar xzf maven-dist/apache-maven-*-bin.tar.gz -C maven-local --strip-components 1
-          fi
-          echo "MAVEN_HOME=$PWD/maven-local" >> $GITHUB_ENV
-          echo "$PWD/maven-local/bin" >> $GITHUB_PATH
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=4.0.0-rc-6"
 
       - name: Build Maven and ITs and run them
         shell: bash
-        run: mvn install -e -B -V -Prun-its,mimir
+        run: ./mvnw install -e -B -V -Prun-its,mimir
 
       - name: Upload Mimir caches
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

- Remove the redundant download/extract/PATH steps from the `integration-tests` CI job
- Use the Maven wrapper instead, since the `run-its` profile now handles distribution extraction self-contained (since #2476 and #12828)

The `run-its` profile's `maven-dependency-plugin` + `maven-antrun-plugin` downloads and extracts the built distribution from the local Maven repository, so the workflow no longer needs to download the GHA artifact and manually extract it onto `$PATH`.

The `full-build` job is unchanged — it still needs the built distribution on PATH because its purpose is to verify the built Maven can self-host (build the project + site).

## Test plan

- [ ] CI passes: the `integration-tests` matrix (3 OS × 3 JDK) should all pass with the wrapper-based approach
- [ ] Verify ITs test the correct distribution (the one built by `./mvnw install`, not the wrapper's Maven 4.0.0-rc-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)