### PR TITLE
[4.0.x] Make run-its profile extract the built distribution

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -281,36 +281,13 @@ jobs:
             mvn40-${{ runner.os }}-
             mvn40-
 
-      - name: Download Maven distribution
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-distributions
-          path: maven-dist
-
-      - name: List downloaded files
+      - name: Set up Maven
         shell: bash
-        run: ls -la maven-dist
-
-      - name: Extract Maven distribution
-        shell: bash
-        run: |
-          mkdir -p maven-local
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            unzip maven-dist/apache-maven-*-bin.zip -d maven-local
-            # Get the name of the extracted directory
-            MAVEN_DIR=$(ls maven-local)
-            # Move contents up one level
-            mv "maven-local/$MAVEN_DIR"/* maven-local/
-            rm -r "maven-local/$MAVEN_DIR"
-          else
-            tar xzf maven-dist/apache-maven-*-bin.tar.gz -C maven-local --strip-components 1
-          fi
-          echo "MAVEN_HOME=$PWD/maven-local" >> $GITHUB_ENV
-          echo "$PWD/maven-local/bin" >> $GITHUB_PATH
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=4.0.0-rc-6"
 
       - name: Build Maven and ITs and run them
         shell: bash
-        run: mvn install -e -B -V -Prun-its,mimir
+        run: ./mvnw install -e -B -V -Prun-its,mimir
 
       - name: Upload Mimir caches
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/its/core-it-suite/pom.xml
+++ b/its/core-it-suite/pom.xml
@@ -606,6 +606,9 @@ under the License.
     </profile>
     <profile>
       <id>run-its</id>
+      <properties>
+        <mavenHome>${project.build.directory}/apache-maven</mavenHome>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.maven</groupId>
@@ -613,6 +616,13 @@ under the License.
           <version>${maven-version}</version>
           <classifier>bin</classifier>
           <type>zip</type>
+          <exclusions>
+            <!-- dependency only on Maven distribution -->
+            <exclusion>
+              <groupId>*</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <!-- not really used but will force download in the local repo used -->
         <dependency>
@@ -635,6 +645,54 @@ under the License.
             <configuration>
               <skip>false</skip>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>download-maven-distro</id>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <phase>process-test-resources</phase>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.maven</groupId>
+                      <artifactId>apache-maven</artifactId>
+                      <version>${maven-version}</version>
+                      <classifier>bin</classifier>
+                      <type>zip</type>
+                      <destFileName>maven-bin.zip</destFileName>
+                    </artifactItem>
+                  </artifactItems>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-maven-distro</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>process-test-resources</phase>
+                <configuration>
+                  <target>
+                    <delete dir="${mavenHome}" />
+                    <unzip dest="${mavenHome}" src="${project.build.directory}/maven-bin.zip">
+                      <globmapper from="apache-maven-${maven-version}/*" handledirsep="true" to="*" />
+                    </unzip>
+                    <chmod dir="${mavenHome}/bin" includes="mvn,mvnDebug,mvnenc" perm="ugo+rx" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## Summary

Backport of the self-contained IT distribution extraction from master (#2476 and #12828), adapted for the `maven-4.0.x` branch structure.

**Problem:** The `run-its` profile on `4.0.x` uses `<mavenHome>${maven.home}</mavenHome>`, which resolves to whichever Maven *runs* the build — not the Maven being tested. On CI this was masked because the workflow downloads/extracts the built distribution and puts it on `$PATH`, so `${maven.home}` happens to point at the right thing. Locally, `mvn test -Prun-its` silently tests the wrong Maven.

**Fix (pom.xml):**
- Override `mavenHome` to `${project.build.directory}/apache-maven` in the `run-its` profile
- Download the built distribution via `maven-dependency-plugin:copy`
- Extract it via `maven-antrun-plugin`
- This follows the same pattern already used by the `maven-from-repo` and `maven-distro` profiles

**Fix (workflow):**
- Remove the now-redundant download/extract/PATH steps from the `integration-tests` CI job
- Use the Maven wrapper instead, since the pom.xml now handles distribution extraction self-contained

## Test plan

- [ ] CI passes: the `integration-tests` matrix (3 OS × 3 JDK) should all pass
- [ ] `full-build` job is unchanged and still passes (it still needs the artifact for self-hosting verification)
- [ ] Locally, `mvn install -Prun-its` tests the built Maven distribution, not the building Maven

🤖 Generated with [Claude Code](https://claude.com/claude-code)