### PR TITLE
[4.0.x] Fix ArtifactCoordinates.getId() double colon when classifier is empty

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/ArtifactCoordinates.java
@@ -84,9 +84,8 @@ public interface ArtifactCoordinates {
                 + getArtifactId()
                 + ':'
                 + getExtension()
+                + (c.isEmpty() ? "" : ":" + c)
                 + ':'
-                + c
-                + (c.isEmpty() ? "" : ":")
                 + getVersionConstraint();
     }
 }

--- a/api/maven-api-core/src/test/java/org/apache/maven/api/ArtifactCoordinatesTest.java
+++ b/api/maven-api-core/src/test/java/org/apache/maven/api/ArtifactCoordinatesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArtifactCoordinatesTest {
+
+    @Test
+    void getIdOmitsEmptyClassifier() {
+        ArtifactCoordinates coords = stub("org.example", "demo", "jar", "", "1.0");
+        assertEquals("org.example:demo:jar:1.0", coords.getId());
+    }
+
+    @Test
+    void getIdIncludesNonEmptyClassifier() {
+        ArtifactCoordinates coords = stub("org.example", "demo", "jar", "sources", "1.0");
+        assertEquals("org.example:demo:jar:sources:1.0", coords.getId());
+    }
+
+    private static ArtifactCoordinates stub(
+            String groupId, String artifactId, String extension, String classifier, String version) {
+        return new ArtifactCoordinates() {
+            @Override
+            public String getGroupId() {
+                return groupId;
+            }
+
+            @Override
+            public String getArtifactId() {
+                return artifactId;
+            }
+
+            @Override
+            public String getClassifier() {
+                return classifier;
+            }
+
+            @Override
+            public VersionConstraint getVersionConstraint() {
+                return new VersionConstraint() {
+                    @Override
+                    public VersionRange getVersionRange() {
+                        return null;
+                    }
+
+                    @Override
+                    public Version getRecommendedVersion() {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean contains(Version v) {
+                        return false;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return version;
+                    }
+                };
+            }
+
+            @Override
+            public String getExtension() {
+                return extension;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Backport of #12813 to `maven-4.0.x`.

`ArtifactCoordinates.getId()` always inserted the classifier field, so an empty classifier produced `g:a:ext::version`. This aligns `getId()` with `Artifact.key()`:

- empty classifier → `g:a:ext:version`
- non-empty classifier → `g:a:ext:classifier:version`

Fixes #12596.