### PR TITLE
Fix #12832: guard missing project index before auto-unbox NPE

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -438,9 +438,24 @@ public class MojoExecutor {
                             .getData()
                             .computeIfAbsent(PROJECT_INDEX, () -> new ProjectIndex(session.getProjects()));
 
-                    int index = projectIndex.getIndices().get(projectId);
+                    Integer index = projectIndex.getIndices().get(projectId);
+                    if (index == null) {
+                        throw new LifecycleExecutionException(
+                                "Forked execution references project '" + projectId
+                                        + "' which is not in the reactor. "
+                                        + "This can happen with parallel builds (-T) or when extensions modify the session projects.",
+                                mojoExecution,
+                                session.getCurrentProject());
+                    }
 
                     MavenProject forkedProject = projectIndex.getProjects().get(projectId);
+                    if (forkedProject == null) {
+                        throw new LifecycleExecutionException(
+                                "Forked execution references project '" + projectId
+                                        + "' which could not be found in the project index.",
+                                mojoExecution,
+                                session.getCurrentProject());
+                    }
 
                     forkedProjects.add(forkedProject);
 


### PR DESCRIPTION
## Summary

- Guard `projectIndex.getIndices().get(projectId)` and `projectIndex.getProjects().get(projectId)` with null checks in `MojoExecutor.executeForkedExecutions()`
- Throw `LifecycleExecutionException` with a clear diagnostic message instead of an opaque auto-unbox `NullPointerException`
- The `projectId` can legitimately be missing from the cached `ProjectIndex` under parallel builds (`-T`), stale cached index (extensions modifying session projects), or embedded/daemon Maven usage

## Test plan

- [x] `mvn -pl impl/maven-core -am compile` — BUILD SUCCESS
- [x] `mvn -pl impl/maven-core test` — 612 tests pass, 0 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)