### PR TITLE
fix: synchronize ReflectionValueExtractor class-introspection caches (backport to 4.0.x)

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/reflection/ReflectionValueExtractor.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/reflection/ReflectionValueExtractor.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,7 +52,8 @@ public class ReflectionValueExtractor {
      * This approach prevents permgen space overflows due to retention of discarded
      * classloaders.
      */
-    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS = new WeakHashMap<>();
+    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     static final int EOF = -1;
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/reflection/ReflectionValueExtractor.java
@@ -23,6 +23,7 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,7 +49,8 @@ public class ReflectionValueExtractor {
      * This approach prevents permgen space overflows due to retention of discarded
      * classloaders.
      */
-    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS = new WeakHashMap<>();
+    private static final Map<Class<?>, WeakReference<ClassMap>> CLASS_MAPS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     static final int EOF = -1;
 


### PR DESCRIPTION
Backport of #12841 to `maven-4.0.x`.

Cherry-pick of 05657fde3c (squash-merge of #12841 on master).

Fixes #12731 on the 4.0.x line — synchronizes the static `WeakHashMap` class-introspection cache in both the impl and compat copies of `ReflectionValueExtractor` to prevent infinite-loop hangs under `-T` parallel builds.

Original fix by @waterWang (#12732), compat extension by @kec (#12841).