### PR TITLE
Fix #12607: prevent session scope leak on MavenChainedWorkspaceReader constructor exception

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -209,9 +209,9 @@ public class DefaultMaven implements Maven {
         // AbstractLifecycleParticipant lookups
         // so that @SessionScoped components can be @Injected into AbstractLifecycleParticipants.
         //
-        sessionScope.enter();
         MavenChainedWorkspaceReader chainedWorkspaceReader =
                 new MavenChainedWorkspaceReader(request.getWorkspaceReader(), ideWorkspaceReader);
+        sessionScope.enter();
         try (CloseableSession closeableSession = newCloseableSession(request, chainedWorkspaceReader)) {
             MavenSession session = new MavenSession(closeableSession, request, result);
             session.setSession(defaultSessionFactory.newSession(session));


### PR DESCRIPTION
## Summary

- Move `MavenChainedWorkspaceReader` construction **before** `sessionScope.enter()` in `DefaultMaven.doExecute()` to prevent a session scope thread-local leak when the constructor throws

## Problem

`sessionScope.enter()` was called at line 212, followed by `new MavenChainedWorkspaceReader(...)` at lines 213-214, **before** the `try` block at line 215. If the constructor threw any exception, the `sessionScope.exit()` in the `finally` block would never execute, leaking the session scope's thread-local `ScopeState`.

## Fix

Reorder the two statements so the workspace reader is constructed first. Since `MavenChainedWorkspaceReader` has no dependency on the session scope, this is safe. If its constructor throws, the scope was never entered, so no cleanup is needed.

## Test plan

- [x] Verified the fix by code inspection — the workspace reader constructor has no session scope dependency
- [x] All 612 existing tests in `maven-core` pass (including `DefaultMavenTest` and `SessionScopeProxyTest`)
- [x] Minimal one-line reorder diff — no behavioral change to the normal path

🤖 Generated with [Claude Code](https://claude.com/claude-code)