### PR TITLE
Fix #12749: suppress false ERROR in mvnsh for successful commands

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
@@ -202,7 +202,9 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvn command exited with exit code " + e.getExitCode());
+                if (e.getExitCode() != 0) {
+                    shellContext.logger.error("mvn command exited with exit code " + e.getExitCode());
+                }
             } catch (Exception e) {
                 saveException(e);
             }
@@ -240,7 +242,9 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvnenc command exited with exit code " + e.getExitCode());
+                if (e.getExitCode() != 0) {
+                    shellContext.logger.error("mvnenc command exited with exit code " + e.getExitCode());
+                }
             } catch (Exception e) {
                 saveException(e);
             }
@@ -258,7 +262,9 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvnup command exited with exit code " + e.getExitCode());
+                if (e.getExitCode() != 0) {
+                    shellContext.logger.error("mvnup command exited with exit code " + e.getExitCode());
+                }
             } catch (Exception e) {
                 saveException(e);
             }


### PR DESCRIPTION
## Summary

In `mvnsh`, the `mvn`, `mvnenc`, and `mvnup` commands unconditionally logged an `[ERROR]` message when catching `InvokerException.ExitException`, even when the exit code was 0 (success). This produced confusing output like:

```
maven-buch mvnsh> mvn --version
Apache Maven 4.0.0-rc-6 (...)
...
[ERROR] mvn command exited with exit code 0
```

The fix adds an `if (e.getExitCode() != 0)` guard before the error log in all three command methods, consistent with how the shell (`!`) command already handles exit codes at line 165 of the same file.

The `ExitException` Javadoc explicitly states: *"Exception for intentional exit: No message or anything will be displayed, just the carried exit code will be returned."* — logging an ERROR on exit code 0 violated this contract.

Fixes #12749

🤖 Generated with [Claude Code](https://claude.ai/code)