### PR TITLE
Fix #12605: remove synchronized bottleneck in createProjectRealm()

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultExtensionRealmCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultExtensionRealmCache.java
@@ -118,15 +118,11 @@ public class DefaultExtensionRealmCache implements ExtensionRealmCache, Disposab
             Key key, ClassRealm extensionRealm, ExtensionDescriptor extensionDescriptor, List<Artifact> artifacts) {
         Objects.requireNonNull(extensionRealm, "extensionRealm cannot be null");
 
-        if (cache.containsKey(key)) {
-            throw new IllegalStateException("Duplicate extension realm for extension " + key);
-        }
-
         CacheRecord record = new CacheRecord(extensionRealm, extensionDescriptor, artifacts);
 
-        cache.put(key, record);
+        CacheRecord existing = cache.putIfAbsent(key, record);
 
-        return record;
+        return existing != null ? existing : record;
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginArtifactsCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginArtifactsCache.java
@@ -140,15 +140,17 @@ public class DefaultPluginArtifactsCache implements PluginArtifactsCache {
     public CacheRecord put(Key key, List<Artifact> pluginArtifacts) {
         Objects.requireNonNull(pluginArtifacts, "pluginArtifacts cannot be null");
 
-        assertUniqueKey(key);
-
         CacheRecord record = new CacheRecord(Collections.unmodifiableList(new ArrayList<>(pluginArtifacts)));
 
-        cache.put(key, record);
+        CacheRecord existing = cache.putIfAbsent(key, record);
 
-        return record;
+        return existing != null ? existing : record;
     }
 
+    /**
+     * @deprecated No longer used. The put methods now use {@link ConcurrentHashMap#putIfAbsent} directly.
+     */
+    @Deprecated
     protected void assertUniqueKey(Key key) {
         if (cache.containsKey(key)) {
             throw new IllegalStateException("Duplicate artifact resolution result for plugin " + key);
@@ -159,13 +161,11 @@ public class DefaultPluginArtifactsCache implements PluginArtifactsCache {
     public CacheRecord put(Key key, PluginResolutionException exception) {
         Objects.requireNonNull(exception, "exception cannot be null");
 
-        assertUniqueKey(key);
-
         CacheRecord record = new CacheRecord(exception);
 
-        cache.put(key, record);
+        CacheRecord existing = cache.putIfAbsent(key, record);
 
-        return record;
+        return existing != null ? existing : record;
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultMavenPluginManager.java
@@ -106,6 +106,7 @@ import org.apache.maven.session.scope.internal.SessionScopeModule;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.composition.CycleDetectedInComponentGraphException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurator;
@@ -1025,6 +1026,15 @@ public class DefaultMavenPluginManager implements MavenPluginManager {
                 }
             }
             extensionRecord = extensionRealmCache.put(extensionKey, extensionRealm, extensionDescriptor, artifacts);
+
+            // If another thread already cached a record for this key, dispose the redundant realm
+            if (extensionRecord.getRealm() != extensionRealm) {
+                try {
+                    extensionRealm.getWorld().disposeRealm(extensionRealm.getId());
+                } catch (NoSuchRealmException e) {
+                    // ignore — realm was already disposed
+                }
+            }
         }
         extensionRealmCache.register(project, extensionKey, extensionRecord);
         pluginRealms.put(pluginKey, extensionRecord);

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuildingHelper.java
@@ -50,6 +50,7 @@ import org.apache.maven.plugin.PluginManagerException;
 import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.util.filter.ExclusionsDependencyFilter;
@@ -143,7 +144,7 @@ public class DefaultProjectBuildingHelper implements ProjectBuildingHelper {
     }
 
     @Override
-    public synchronized ProjectRealmCache.CacheRecord createProjectRealm(
+    public ProjectRealmCache.CacheRecord createProjectRealm(
             MavenProject project, Model model, ProjectBuildingRequest request)
             throws PluginResolutionException, PluginVersionResolutionException, PluginManagerException {
         ClassRealm projectRealm;
@@ -256,11 +257,24 @@ public class DefaultProjectBuildingHelper implements ProjectBuildingHelper {
             }
 
             record = projectRealmCache.put(projectRealmKey, projectRealm, extensionArtifactFilter);
+
+            // If another thread already cached a record for this key, dispose the redundant realm
+            if (record.getRealm() != projectRealm) {
+                disposeRealm(projectRealm);
+            }
         }
 
         projectRealmCache.register(project, projectRealmKey, record);
 
         return record;
+    }
+
+    private void disposeRealm(ClassRealm realm) {
+        try {
+            realm.getWorld().disposeRealm(realm.getId());
+        } catch (NoSuchRealmException e) {
+            // ignore — realm was already disposed
+        }
     }
 
     @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectRealmCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/DefaultProjectRealmCache.java
@@ -94,15 +94,11 @@ public class DefaultProjectRealmCache implements ProjectRealmCache, Disposable {
     public CacheRecord put(Key key, ClassRealm projectRealm, DependencyFilter extensionArtifactFilter) {
         Objects.requireNonNull(projectRealm, "projectRealm cannot be null");
 
-        if (cache.containsKey(key)) {
-            throw new IllegalStateException("Duplicate project realm for extensions " + key);
-        }
-
         CacheRecord record = new CacheRecord(projectRealm, extensionArtifactFilter);
 
-        cache.put(key, record);
+        CacheRecord existing = cache.putIfAbsent(key, record);
 
-        return record;
+        return existing != null ? existing : record;
     }
 
     @Override

--- a/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectRealmCacheTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/DefaultProjectRealmCacheTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.project;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link DefaultProjectRealmCache}.
+ */
+class DefaultProjectRealmCacheTest {
+
+    @Test
+    void testPutReturnsSameRecordForDuplicateKey() throws Exception {
+        DefaultProjectRealmCache cache = new DefaultProjectRealmCache();
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm1 = world.newRealm("test-realm-1");
+        ClassRealm realm2 = world.newRealm("test-realm-2");
+        DependencyFilter filter = mock(DependencyFilter.class);
+
+        ProjectRealmCache.Key key = cache.createKey(Collections.singletonList(realm1));
+
+        // First put should succeed and return a record with our realm
+        ProjectRealmCache.CacheRecord record1 = cache.put(key, realm1, filter);
+        assertNotNull(record1);
+        assertSame(realm1, record1.getRealm());
+
+        // Second put with the same key should return the existing record
+        ProjectRealmCache.Key sameKey = cache.createKey(Collections.singletonList(realm1));
+        ProjectRealmCache.CacheRecord record2 = cache.put(sameKey, realm2, filter);
+        assertNotNull(record2);
+        assertSame(record1, record2, "Duplicate put should return the existing cached record");
+        assertSame(realm1, record2.getRealm(), "Duplicate put should return the first realm, not the second");
+    }
+
+    @Test
+    void testConcurrentPutWithSameKeyDoesNotThrow() throws Exception {
+        DefaultProjectRealmCache cache = new DefaultProjectRealmCache();
+        ClassWorld world = new ClassWorld();
+
+        // Create a shared extension realm for the cache key
+        ClassRealm sharedExtensionRealm = world.newRealm("shared-extension");
+        DependencyFilter filter = mock(DependencyFilter.class);
+
+        int threadCount = 8;
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        try {
+            List<Future<ProjectRealmCache.CacheRecord>> futures = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+                futures.add(executor.submit(() -> {
+                    ClassRealm projectRealm = world.newRealm("project-realm-" + index);
+                    ProjectRealmCache.Key key = cache.createKey(Collections.singletonList(sharedExtensionRealm));
+                    barrier.await(); // synchronize all threads to maximize contention
+                    return cache.put(key, projectRealm, filter);
+                }));
+            }
+
+            // All threads should complete without throwing IllegalStateException
+            ProjectRealmCache.CacheRecord firstRecord = null;
+            for (Future<ProjectRealmCache.CacheRecord> future : futures) {
+                ProjectRealmCache.CacheRecord record = future.get();
+                assertNotNull(record);
+                if (firstRecord == null) {
+                    firstRecord = record;
+                }
+                // All threads should get back the same cached record
+                assertSame(firstRecord, record, "All concurrent puts should return the same cached record");
+            }
+
+            // Cache should contain exactly one entry
+            assertEquals(1, cache.cache.size(), "Cache should contain exactly one entry");
+        } finally {
+            executor.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Removed `synchronized`** from `DefaultProjectBuildingHelper.createProjectRealm()` which was serializing all extension realm setup across projects in parallel builds
- **Fixed TOCTOU race conditions** in three cache classes (`DefaultProjectRealmCache`, `DefaultExtensionRealmCache`, `DefaultPluginArtifactsCache`) by replacing the non-atomic `containsKey()` + `put()` with `ConcurrentHashMap.putIfAbsent()`
- **Added redundant realm disposal** in both `createProjectRealm()` and `setupExtensionsRealm()` to clean up ClassRealms when another thread wins the cache race

## Context

This is an alternative to #12630 which correctly identified the bottleneck but introduced a TOCTOU race condition at the caller level (as noted in the review). This PR addresses the review feedback by:

1. Using `putIfAbsent()` in the caches so the put operation is atomic — no `IllegalStateException` under contention
2. Having callers detect when `putIfAbsent` returns an existing record (via identity check `record.getRealm() != projectRealm`) and dispose the redundant realm
3. Also fixing `DefaultExtensionRealmCache` and `DefaultPluginArtifactsCache` which have the same check-then-act race and are exposed to concurrent access once the `synchronized` is removed

## Test plan

- [x] Added `DefaultProjectRealmCacheTest` with concurrent `putIfAbsent` test (8 threads, CyclicBarrier for maximum contention)
- [x] All 614 maven-core module tests pass
- [x] Full reactor build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)