### PR TITLE
Fix #12769: merge duplicate mirror repos to preserve snapshot policies

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -116,6 +116,7 @@ import org.apache.maven.api.services.xml.XmlReaderException;
 import org.apache.maven.api.services.xml.XmlReaderRequest;
 import org.apache.maven.api.spi.ModelParserException;
 import org.apache.maven.api.spi.ModelTransformer;
+import org.apache.maven.impl.DefaultRemoteRepository;
 import org.apache.maven.impl.InternalSession;
 import org.apache.maven.impl.RequestTraceHelper;
 import org.apache.maven.impl.cache.Cache;
@@ -303,10 +304,66 @@ public class DefaultModelBuilder implements ModelBuilder {
         }
 
         static List<RemoteRepository> repos(ModelBuilderRequest request) {
-            return List.copyOf(
-                    request.getRepositories() != null
-                            ? request.getRepositories()
-                            : request.getSession().getRemoteRepositories());
+            List<RemoteRepository> repos = request.getRepositories() != null
+                    ? request.getRepositories()
+                    : request.getSession().getRemoteRepositories();
+            return mergeRepositoriesById(repos);
+        }
+
+        /**
+         * Merges repositories that share the same ID by combining their policies.
+         * This handles the case where mirror injection produces multiple repository
+         * entries with the same mirror ID but different snapshot/release policies
+         * (e.g., when both "central" and a profile-defined repo are mirrored to the
+         * same mirror, producing two entries with the mirror's ID but different policies).
+         * Without this merge, policy deduplication in the resolver can drop the snapshot
+         * policy, causing SNAPSHOT parent resolution to fail (MNG-12769).
+         */
+        private static List<RemoteRepository> mergeRepositoriesById(List<RemoteRepository> repos) {
+            if (repos.size() <= 1) {
+                return List.copyOf(repos);
+            }
+            LinkedHashMap<String, RemoteRepository> byId = new LinkedHashMap<>();
+            boolean hasDuplicates = false;
+            for (RemoteRepository repo : repos) {
+                RemoteRepository existing = byId.putIfAbsent(repo.getId(), repo);
+                if (existing != null) {
+                    hasDuplicates = true;
+                    byId.put(repo.getId(), mergeRepositoryPolicies(existing, repo));
+                }
+            }
+            return hasDuplicates ? List.copyOf(byId.values()) : List.copyOf(repos);
+        }
+
+        /**
+         * Merges two repositories with the same ID by combining their policies.
+         * For each policy type (release/snapshot), the result is enabled if either
+         * input has it enabled. URL, proxy, authentication, and other properties
+         * are preserved from the dominant (first) repository.
+         */
+        private static RemoteRepository mergeRepositoryPolicies(RemoteRepository dominant, RemoteRepository recessive) {
+            if (dominant instanceof DefaultRemoteRepository d && recessive instanceof DefaultRemoteRepository r) {
+                org.eclipse.aether.repository.RemoteRepository dr = d.getRepository();
+                org.eclipse.aether.repository.RemoteRepository rr = r.getRepository();
+
+                boolean mergeSnapshots =
+                        rr.getPolicy(true).isEnabled() && !dr.getPolicy(true).isEnabled();
+                boolean mergeReleases =
+                        rr.getPolicy(false).isEnabled() && !dr.getPolicy(false).isEnabled();
+
+                if (mergeSnapshots || mergeReleases) {
+                    org.eclipse.aether.repository.RemoteRepository.Builder builder =
+                            new org.eclipse.aether.repository.RemoteRepository.Builder(dr);
+                    if (mergeSnapshots) {
+                        builder.setSnapshotPolicy(rr.getPolicy(true));
+                    }
+                    if (mergeReleases) {
+                        builder.setReleasePolicy(rr.getPolicy(false));
+                    }
+                    return new DefaultRemoteRepository(builder.build());
+                }
+            }
+            return dominant;
         }
 
         @SuppressWarnings("checkstyle:ParameterNumber")

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -46,7 +46,9 @@ import org.apache.maven.api.services.ModelBuilderRequest;
 import org.apache.maven.api.services.ModelBuilderResult;
 import org.apache.maven.api.services.ModelSource;
 import org.apache.maven.api.services.Sources;
+import org.apache.maven.impl.DefaultRemoteRepository;
 import org.apache.maven.impl.standalone.ApiRunner;
+import org.eclipse.aether.repository.RepositoryPolicy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -254,6 +256,128 @@ class DefaultModelBuilderTest {
         assertEquals("third", repositories.get(1).getId());
         assertEquals("https://third.repo", repositories.get(1).getUrl()); // interpolated (own model properties)
         assertEquals("central", repositories.get(2).getId()); // default
+    }
+
+    /**
+     * Verifies that when multiple repositories share the same ID (e.g., after mirror injection
+     * maps both "central" and a profile-defined repo to the same mirror ID), their policies are
+     * merged so that SNAPSHOT resolution is not broken.
+     * <p>
+     * This is a regression test for <a href="https://github.com/apache/maven/issues/12769">MNG-12769</a>:
+     * when two mirror-injected repos with the same mirror ID but different snapshot policies
+     * were passed to the resolver, the deduplication logic would drop the snapshot-enabled policy,
+     * making SNAPSHOT parent POM resolution fail.
+     */
+    @Test
+    public void testDuplicateMirrorReposMergedForSnapshotResolution() throws Exception {
+        // Simulate two repos with the same mirror ID but different snapshot policies,
+        // as produced by mirror injection when multiple repos map to the same mirror.
+        org.eclipse.aether.repository.RemoteRepository releasesOnly =
+                new org.eclipse.aether.repository.RemoteRepository.Builder(
+                                "my-mirror", "default", "https://mirror.example.com/maven")
+                        .setReleasePolicy(new RepositoryPolicy(
+                                true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .setSnapshotPolicy(new RepositoryPolicy(
+                                false, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .build();
+        org.eclipse.aether.repository.RemoteRepository releasesAndSnapshots =
+                new org.eclipse.aether.repository.RemoteRepository.Builder(
+                                "my-mirror", "default", "https://mirror.example.com/maven")
+                        .setReleasePolicy(new RepositoryPolicy(
+                                true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .setSnapshotPolicy(new RepositoryPolicy(
+                                true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .build();
+
+        RemoteRepository repo1 = new DefaultRemoteRepository(releasesOnly);
+        RemoteRepository repo2 = new DefaultRemoteRepository(releasesAndSnapshots);
+
+        // Build a request with duplicate mirror repos
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(getPom("simple-standalone")))
+                .repositories(List.of(repo1, repo2))
+                .build();
+        ModelBuilder.ModelBuilderSession mbs = builder.newSession();
+        mbs.build(request);
+
+        // Access the internal state to verify repository deduplication
+        DefaultModelBuilder.ModelBuilderSessionState mainState =
+                ((DefaultModelBuilder.ModelBuilderSessionImpl) mbs).mainSession;
+        Field repositoriesField = DefaultModelBuilder.ModelBuilderSessionState.class.getDeclaredField("repositories");
+        repositoriesField.setAccessible(true);
+        List<RemoteRepository> repositories = (List<RemoteRepository>) repositoriesField.get(mainState);
+
+        // Should be deduplicated to a single entry
+        long mirrorCount =
+                repositories.stream().filter(r -> "my-mirror".equals(r.getId())).count();
+        assertEquals(1, mirrorCount, "Duplicate mirror repos should be merged into one");
+
+        // The merged repo should have snapshots enabled (most permissive policy wins)
+        RemoteRepository merged = repositories.stream()
+                .filter(r -> "my-mirror".equals(r.getId()))
+                .findFirst()
+                .orElseThrow();
+        DefaultRemoteRepository mergedImpl = (DefaultRemoteRepository) merged;
+        assertTrue(mergedImpl.getRepository().getPolicy(true).isEnabled(), "Merged repo should have snapshots enabled");
+        assertTrue(mergedImpl.getRepository().getPolicy(false).isEnabled(), "Merged repo should have releases enabled");
+    }
+
+    /**
+     * Verifies that repo deduplication also handles the reverse case: dominant has snapshots,
+     * recessive has releases-only. The merge should enable both.
+     */
+    @Test
+    public void testDuplicateMirrorReposMergedReversePolicyOrder() throws Exception {
+        // First repo: snapshots only
+        org.eclipse.aether.repository.RemoteRepository snapshotsOnly =
+                new org.eclipse.aether.repository.RemoteRepository.Builder(
+                                "my-mirror", "default", "https://mirror.example.com/maven")
+                        .setReleasePolicy(new RepositoryPolicy(
+                                false, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .setSnapshotPolicy(new RepositoryPolicy(
+                                true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .build();
+        // Second repo: releases only
+        org.eclipse.aether.repository.RemoteRepository releasesOnly =
+                new org.eclipse.aether.repository.RemoteRepository.Builder(
+                                "my-mirror", "default", "https://mirror.example.com/maven")
+                        .setReleasePolicy(new RepositoryPolicy(
+                                true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .setSnapshotPolicy(new RepositoryPolicy(
+                                false, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                        .build();
+
+        RemoteRepository repo1 = new DefaultRemoteRepository(snapshotsOnly);
+        RemoteRepository repo2 = new DefaultRemoteRepository(releasesOnly);
+
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(getPom("simple-standalone")))
+                .repositories(List.of(repo1, repo2))
+                .build();
+        ModelBuilder.ModelBuilderSession mbs = builder.newSession();
+        mbs.build(request);
+
+        DefaultModelBuilder.ModelBuilderSessionState mainState =
+                ((DefaultModelBuilder.ModelBuilderSessionImpl) mbs).mainSession;
+        Field repositoriesField = DefaultModelBuilder.ModelBuilderSessionState.class.getDeclaredField("repositories");
+        repositoriesField.setAccessible(true);
+        List<RemoteRepository> repositories = (List<RemoteRepository>) repositoriesField.get(mainState);
+
+        RemoteRepository merged = repositories.stream()
+                .filter(r -> "my-mirror".equals(r.getId()))
+                .findFirst()
+                .orElseThrow();
+        DefaultRemoteRepository mergedImpl = (DefaultRemoteRepository) merged;
+        assertTrue(
+                mergedImpl.getRepository().getPolicy(true).isEnabled(),
+                "Merged repo should have snapshots enabled (from dominant)");
+        assertTrue(
+                mergedImpl.getRepository().getPolicy(false).isEnabled(),
+                "Merged repo should have releases enabled (from recessive)");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fixes SNAPSHOT parent POM resolution failure when mirror injection produces multiple repository entries with the same mirror ID but different snapshot/release policies (regression in 4.0.0-rc-6)
- Adds pre-deduplication of repositories by ID in `ModelBuilderSessionState.repos()`, merging policies so that enabled wins over disabled for each policy type
- Prevents the Aether resolver's `aggregateRepositories()`/`mergeMirrors()` from dropping the snapshot-enabled policy during dedup

## Root Cause

When `<mirrorOf>*</mirrorOf>` maps both `central` (releases-only) and a profile-defined repo (releases+snapshots) to the same mirror ID, `MavenExecutionRequest.getRemoteRepositories()` returns two entries like:
- `my-mirror (releases)`
- `my-mirror (releases+snapshots)`

In `DefaultModelBuilder`, these are stored as-is in `ModelBuilderSessionState.repositories`. When the resolver deduplicates them in `toResolvingRepositories()` → `aggregateRepositories()` → `mergeMirrors()`, the recessive's snapshot-enabled mirrored repo has the same key as the dominant's releases-only mirrored repo, so it's skipped. The result is a single repo with snapshots **disabled**, causing SNAPSHOT parent resolution to fail with "artifact not found".

## Fix

`ModelBuilderSessionState.repos()` now calls `mergeRepositoriesById()` which:
1. Groups repositories by ID (preserving insertion order)
2. For duplicate IDs, merges policies: `enabled` wins for both release and snapshot policies
3. Preserves URL, proxy, authentication from the dominant (first) entry

This ensures a single repository entry with the most permissive policy combination reaches the resolver.

## Test plan

- [x] Added `testDuplicateMirrorReposMergedForSnapshotResolution()` — verifies that repos with the same mirror ID but different snapshot policies are merged into one with snapshots enabled
- [x] Added `testDuplicateMirrorReposMergedReversePolicyOrder()` — verifies reverse-order merging (dominant has snapshots-only, recessive has releases-only)
- [x] All 576 tests in `maven-impl` pass
- [ ] CI build

Closes #12769 

🤖 Generated with [Claude Code](https://claude.com/claude-code)