### PR TITLE
Fix #11504: add replacement guidance to deprecated model and settings APIs

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -435,6 +435,7 @@
      *
      * @return The base directory for the corresponding project or {@code null} if this model does not belong to a local
      *         project (e.g. describes the metadata of some artifact from the repository).
+     * @deprecated Use {@link #getProjectDirectoryPath()} instead, which returns a {@link java.nio.file.Path}.
      */
     @Deprecated
     public java.io.File getProjectDirectory() {
@@ -641,7 +642,7 @@
           <name>reports</name>
           <version>4.0.0</version>
           <description>
-            @deprecated Now ignored by Maven.
+            @deprecated Now ignored by Maven. Use the {@code reporting} element to configure report plugins instead.
           </description>
           <type>DOM</type>
           <annotations>
@@ -1078,7 +1079,7 @@
           <version>4.0.0+</version>
           <type>String</type>
           <description>
-            @deprecated Where to send the notification to - eg email address.
+            @deprecated Use the {@code configuration} properties map to specify the notification address instead.
           </description>
           <annotations>
             <annotation>@Deprecated(since = "4.0.0")</annotation>
@@ -2597,10 +2598,16 @@
           <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
+    /**
+     * @deprecated This method is a no-op and has no replacement.
+     */
     @Deprecated
     public void unsetInheritanceApplied() {
     }
 
+    /**
+     * @deprecated Use {@link #setInherited(String)} instead.
+     */
     @Deprecated
     public void setInherited(boolean value) {
       setInherited(Boolean.toString(value));
@@ -2663,7 +2670,7 @@
           <name>goals</name>
           <version>4.0.0</version>
           <description>
-            @deprecated Unused by Maven.
+            @deprecated Unused by Maven. Use {@code executions} to configure plugin goals instead.
           </description>
           <type>DOM</type>
           <annotations>
@@ -2702,6 +2709,8 @@
 
     /**
      * Reset the {@code executionMap} field to {@code null}
+     *
+     * @deprecated This method is a no-op and has no replacement.
      */
      @Deprecated
     public void flushExecutionMap() {
@@ -2934,6 +2943,8 @@
 
     /**
      * Reset the <code>reportPluginMap</code> field to <code>null</code>
+     *
+     * @deprecated This method is a no-op and has no replacement.
      */
     @Deprecated
     public void flushReportPluginMap() {

--- a/api/maven-api-settings/src/main/mdo/settings.mdo
+++ b/api/maven-api-settings/src/main/mdo/settings.mdo
@@ -293,6 +293,10 @@
         return match;
     }
 
+    /**
+     * @deprecated This simplistic lookup does not support advanced mirror matching syntax.
+     * There is no direct replacement; use the Maven mirror matching infrastructure instead.
+     */
     @Deprecated
     public Mirror getMirrorOf(String repositoryId) {
         Mirror match = null;


### PR DESCRIPTION
Closes #11504

## Summary

- Add `@deprecated` Javadoc tags with replacement guidance to 9 deprecated elements across `maven.mdo` and `settings.mdo` that were missing "what to use instead" information
- Covers both the API model (`org.apache.maven.api.model`) and the compat model (`org.apache.maven.model`) as well as `org.apache.maven.settings`

### Changes

| Element | Guidance Added |
|---|---|
| `Notifier.address` | Use the `configuration` properties map |
| `Model.getProjectDirectory()` | Use `getProjectDirectoryPath()` (returns `Path`) |
| `ModelBase.reports` | Use the `reporting` element |
| `ConfigurationContainer.unsetInheritanceApplied()` | No-op, no replacement |
| `ConfigurationContainer.setInherited(boolean)` | Use `setInherited(String)` |
| `Plugin.goals` | Use `executions` |
| `Plugin.flushExecutionMap()` | No-op, no replacement |
| `Reporting.flushReportPluginMap()` | No-op, no replacement |
| `Settings.getMirrorOf(String)` | Use the Maven mirror matching infrastructure |

Elements that already had proper guidance (e.g., `modules` → `subprojects`, `sourceDirectory` → `<Source>` elements, `Resource` → `<Source>` with `resources` language) were left unchanged.

## Test plan

- [x] `mvn test -pl api/maven-api-model,compat/maven-model,api/maven-api-settings,compat/maven-settings` passes
- [x] Verified generated Java sources contain the updated `@deprecated` tags
- [x] Documentation-only changes — no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)