### PR TITLE
Re-include macOS JLine native libraries in distribution

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -177,9 +177,6 @@ under the License.
             <configuration>
               <includeArtifactIds>jline-native</includeArtifactIds>
               <includes>org/jline/nativ/**</includes>
-              <!-- exclude Mac OS binaries to prevent them from being marked with quarantine flag (https://github.com/apache/maven/issues/10747) and therefore being protected via Gatekeeper
-                    see also https://www.cisa.gov/eviction-strategies-tool/info-attack/T1144 -->
-              <excludes>org/jline/nativ/Mac/**</excludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Summary

- Re-include macOS JLine native libraries in the Maven distribution by removing the `<excludes>org/jline/nativ/Mac/**</excludes>` added in #10747

JLine 4.4.0 now ships macOS native binaries **signed** with an Apple Developer ID certificate and hardened runtime ([jline/jline3#2173](https://github.com/jline/jline3/pull/2173)), so Gatekeeper will accept them even when the quarantine flag is set.

The exclusion was added to work around unsigned-binary Gatekeeper warnings, but it caused a regression (#12759): JLine's JAR-fallback extraction creates a fresh temp file on every invocation, making it impossible for users to permanently clear the quarantine flag — particularly when Maven is launched from GUI apps like Sourcetree.

**Note:** this PR should be merged after the JLine 4.4.0 version bump (expected via Dependabot).

Fixes #12759

## Test plan

- [ ] Verify the Maven distribution includes `lib/jline-native/Mac/` again after build
- [ ] On macOS, confirm no Gatekeeper warnings when running Maven from terminal
- [ ] On macOS, confirm no Gatekeeper warnings when running Maven from a GUI app (e.g., Sourcetree pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)