### PR TITLE
[12811] Keep plexus-cipher at 2.0: POM note

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@ under the License.
     <guavafailureaccessVersion>1.0.3</guavafailureaccessVersion>
     <wagonVersion>3.5.3</wagonVersion>
     <securityDispatcherVersion>2.0</securityDispatcherVersion>
+    <!-- plexus-cipher 2.1.0 uses an incompatible KDF; ciphertext encrypted with 2.0 will no longer decrypt — see #12811. Do not bump on this branch. -->
     <cipherVersion>2.0</cipherVersion>
     <jxpathVersion>1.4.0</jxpathVersion>
     <resolverVersion>2.0.21</resolverVersion>


### PR DESCRIPTION
Keep plexus-cipher at 2.0 on this branch, per the decision in #12811.

plexus-cipher 2.1.0 uses an incompatible key derivation function, so ciphertext encrypted with 2.0 no longer decrypts. That kind of break doesn't belong on a patch release.

This PR adds a short comment above the `<cipherVersion>` property in the root POM asking maintainers and Dependabot not to bump it. The matching Dependabot ignore is in #12880.