### PR TITLE
[12811] Keep plexus-cipher at 2.0 on Maven 3.x: dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,8 @@ updates:
     ignore:
       - dependency-name: "ch.qos.logback:*"
         versions: [ "[1.3.0,)" ]
+      - dependency-name: "org.codehaus.plexus:plexus-cipher"
+        versions: [ ">=2.1.0" ]
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -56,6 +58,8 @@ updates:
         versions: [ "[4.0.0,)" ]
       - dependency-name: "ch.qos.logback:*"
         versions: [ "[1.3.0,)" ]
+      - dependency-name: "org.codehaus.plexus:plexus-cipher"
+        versions: [ ">=2.1.0" ]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Keep plexus-cipher at 2.0 on the Maven 3.x maintenance branches, per the decision in #12811.

This PR adds `org.codehaus.plexus:plexus-cipher >=2.1.0` to the `ignore` lists of the `maven-3.9.x` and `maven-3.10.x` blocks in `.github/dependabot.yml`. The file lives only on `master`: Dependabot reads its config from the default branch.

The matching POM comments are in #12878 and #12879. No ignore is needed for the default branch or `maven-4.0.x`: neither depends on `org.codehaus.plexus:plexus-cipher`.