### PR TITLE
[12811] Warn about obfuscation-grade password encryption in the CLI

### DIFF
--- a/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -946,6 +946,9 @@ public class MavenCli {
     // This should probably be a separate tool and not be baked into Maven.
     //
     private void encryption(CliRequest cliRequest) throws Exception {
+        System.out.println(
+                "Note: Maven 3.x password encryption is obfuscation-grade and does not protect against a determined "
+                        + "attacker; see https://maven.apache.org/guides/mini/guide-encryption.html");
         if (cliRequest.commandLine.hasOption(CLIManager.ENCRYPT_MASTER_PASSWORD)) {
             String passwd = cliRequest.commandLine.getOptionValue(CLIManager.ENCRYPT_MASTER_PASSWORD);
 


### PR DESCRIPTION
Implements the console warning from the decision in #12811.

`MavenCli.encryption()` handles `--encrypt-master-password` and `--encrypt-password`. It now prints this notice before the encrypted value:

```
Note: Maven 3.x password encryption is obfuscation-grade and does not protect against a determined attacker; see https://maven.apache.org/guides/mini/guide-encryption.html
```

The documentation counterpart is apache/maven-site#1659.