### PR TITLE
Bump jlineVersion from 4.3.1 to 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ under the License.
     <hamcrestVersion>3.0</hamcrestVersion>
     <jakartaInjectApiVersion>2.0.1</jakartaInjectApiVersion>
     <javaxAnnotationApiVersion>1.3.2</javaxAnnotationApiVersion>
-    <jlineVersion>4.3.1</jlineVersion>
+    <jlineVersion>4.4.0</jlineVersion>
     <jmhVersion>1.37</jmhVersion>
     <junitVersion>5.13.4</junitVersion>
     <jxpathVersion>1.4.0</jxpathVersion>


### PR DESCRIPTION
Bumps `jlineVersion` from 4.3.1 to 4.4.0.

Dependabot had this version on cooldown (recently released). Creating manually to bypass the wait.