### PR TITLE
[4.0.x] Re-include macOS JLine native libraries in distribution

### DIFF
--- a/apache-maven/pom.xml
+++ b/apache-maven/pom.xml
@@ -169,9 +169,6 @@ under the License.
             <configuration>
               <includeArtifactIds>jline-native</includeArtifactIds>
               <includes>org/jline/nativ/**</includes>
-              <!-- exclude Mac OS binaries to prevent them from being marked with quarantine flag (https://github.com/apache/maven/issues/10747) and therefore being protected via Gatekeeper
-                    see also https://www.cisa.gov/eviction-strategies-tool/info-attack/T1144 -->
-              <excludes>org/jline/nativ/Mac/**</excludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Summary

Backport of #12873 to `maven-4.0.x`.

- Re-include macOS JLine native libraries in the Maven distribution now that JLine 4.4.0 ships signed binaries (Apple Developer ID + hardened runtime)

Fixes #12759

🤖 Generated with [Claude Code](https://claude.com/claude-code)