### PR TITLE
[4.0.x] Fix #11504: add replacement guidance to deprecated model and settings APIs

### DIFF
--- a/api/maven-api-model/src/main/mdo/maven.mdo
+++ b/api/maven-api-model/src/main/mdo/maven.mdo
@@ -416,6 +416,7 @@
      *
      * @return The base directory for the corresponding project or {@code null} if this model does not belong to a local
      *         project (e.g. describes the metadata of some artifact from the repository).
+     * @deprecated Use {@link #getProjectDirectoryPath()} instead, which returns a {@link java.nio.file.Path}.
      */
     @Deprecated
     public java.io.File getProjectDirectory() {
@@ -622,7 +623,7 @@
           <name>reports</name>
           <version>4.0.0</version>
           <description>
-            @deprecated Now ignored by Maven.
+            @deprecated Now ignored by Maven. Use the {@code reporting} element to configure report plugins instead.
           </description>
           <type>DOM</type>
           <annotations>
@@ -1057,7 +1058,7 @@
           <version>4.0.0+</version>
           <type>String</type>
           <description>
-            @deprecated Where to send the notification to - eg email address.
+            @deprecated Use the {@code configuration} properties map to specify the notification address instead.
           </description>
           <annotations>
             <annotation>@Deprecated(since = "4.0.0")</annotation>
@@ -2559,10 +2560,16 @@
           <version>4.0.0/4.0.99</version>
           <code>
             <![CDATA[
+    /**
+     * @deprecated This method is a no-op and has no replacement.
+     */
     @Deprecated
     public void unsetInheritanceApplied() {
     }
 
+    /**
+     * @deprecated Use {@link #setInherited(String)} instead.
+     */
     @Deprecated
     public void setInherited(boolean value) {
       setInherited(Boolean.toString(value));
@@ -2625,7 +2632,7 @@
           <name>goals</name>
           <version>4.0.0</version>
           <description>
-            @deprecated Unused by Maven.
+            @deprecated Unused by Maven. Use {@code executions} to configure plugin goals instead.
           </description>
           <type>DOM</type>
           <annotations>
@@ -2664,6 +2671,8 @@
 
     /**
      * Reset the {@code executionMap} field to {@code null}
+     *
+     * @deprecated This method is a no-op and has no replacement.
      */
      @Deprecated
     public void flushExecutionMap() {
@@ -2896,6 +2905,8 @@
 
     /**
      * Reset the <code>reportPluginMap</code> field to <code>null</code>
+     *
+     * @deprecated This method is a no-op and has no replacement.
      */
     @Deprecated
     public void flushReportPluginMap() {

--- a/api/maven-api-settings/src/main/mdo/settings.mdo
+++ b/api/maven-api-settings/src/main/mdo/settings.mdo
@@ -293,6 +293,10 @@
         return match;
     }
 
+    /**
+     * @deprecated This simplistic lookup does not support advanced mirror matching syntax.
+     * There is no direct replacement; use the Maven mirror matching infrastructure instead.
+     */
     @Deprecated
     public Mirror getMirrorOf(String repositoryId) {
         Mirror match = null;


### PR DESCRIPTION
Backport of #12872 to `maven-4.0.x`.

## Summary

- Add `@deprecated` Javadoc tags with replacement guidance to 9 deprecated elements across `maven.mdo` and `settings.mdo` that were missing "what to use instead" information
- Covers both the API model (`org.apache.maven.api.model`) and the compat model (`org.apache.maven.model`) as well as `org.apache.maven.settings`

## Test plan

- [ ] CI passes on `maven-4.0.x`