### PR TITLE
[backport 4.0.x] Enable PathConflictResolver by default

### DIFF
--- a/apache-maven/src/assembly/maven/conf/maven-user.properties
+++ b/apache-maven/src/assembly/maven/conf/maven-user.properties
@@ -31,4 +31,13 @@
 ${includes} = ?"${maven.user.conf}/maven-user.properties", \
               ?"${maven.user.conf}/maven.properties", \
               ?"${maven.project.conf}/maven-user.properties", \
-              ?"${maven.project.conf}/maven.properties",
+              ?"${maven.project.conf}/maven.properties"
+
+#
+# Conflict Resolver
+#
+# Selects the dependency conflict resolution algorithm.
+# Options: auto (classic), classic, path
+# The "path" resolver uses an O(N) algorithm based on a parallel path tree,
+# significantly faster than the O(N^2) classic resolver on large dependency graphs.
+aether.conflictResolver.impl = path


### PR DESCRIPTION
Backport of #12662 to maven-4.0.x.

Original PR: https://github.com/apache/maven/pull/12662