### PR TITLE
[backport 4.0.x] Fix #12607: prevent session scope leak on MavenChainedWorkspaceReader constructor exception

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -209,9 +209,9 @@ public class DefaultMaven implements Maven {
         // AbstractLifecycleParticipant lookups
         // so that @SessionScoped components can be @Injected into AbstractLifecycleParticipants.
         //
-        sessionScope.enter();
         MavenChainedWorkspaceReader chainedWorkspaceReader =
                 new MavenChainedWorkspaceReader(request.getWorkspaceReader(), ideWorkspaceReader);
+        sessionScope.enter();
         try (CloseableSession closeableSession = newCloseableSession(request, chainedWorkspaceReader)) {
             MavenSession session = new MavenSession(closeableSession, request, result);
             session.setSession(defaultSessionFactory.newSession(session));


### PR DESCRIPTION
Backport of #12863 to maven-4.0.x.

Original PR: https://github.com/apache/maven/pull/12863