### PR TITLE
[backport 4.0.x] Fix #12749: suppress false ERROR in mvnsh for successful commands

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnsh/builtin/BuiltinShellCommandRegistryFactory.java
@@ -202,7 +202,9 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvn command exited with exit code " + e.getExitCode());
+                if (e.getExitCode() != 0) {
+                    shellContext.logger.error("mvn command exited with exit code " + e.getExitCode());
+                }
             } catch (Exception e) {
                 saveException(e);
             }
@@ -240,7 +242,9 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvnenc command exited with exit code " + e.getExitCode());
+                if (e.getExitCode() != 0) {
+                    shellContext.logger.error("mvnenc command exited with exit code " + e.getExitCode());
+                }
             } catch (Exception e) {
                 saveException(e);
             }
@@ -258,7 +262,9 @@ public class BuiltinShellCommandRegistryFactory implements ShellCommandRegistryF
                                 .cwd(shellContext.cwd.get())
                                 .build()));
             } catch (InvokerException.ExitException e) {
-                shellContext.logger.error("mvnup command exited with exit code " + e.getExitCode());
+                if (e.getExitCode() != 0) {
+                    shellContext.logger.error("mvnup command exited with exit code " + e.getExitCode());
+                }
             } catch (Exception e) {
                 saveException(e);
             }


### PR DESCRIPTION
Backport of #12864 to maven-4.0.x.

Original PR: https://github.com/apache/maven/pull/12864