### PR TITLE
[backport 4.0.x] Fix #12592: use string-based ID for forked execution cycle detection

### DIFF
--- a/compat/maven-plugin-api/src/test/java/org/apache/maven/plugin/descriptor/MojoDescriptorTest.java
+++ b/compat/maven-plugin-api/src/test/java/org/apache/maven/plugin/descriptor/MojoDescriptorTest.java
@@ -18,11 +18,52 @@
  */
 package org.apache.maven.plugin.descriptor;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MojoDescriptorTest {
+
+    @Test
+    void idBasedCycleDetectionWithClonedDescriptors() {
+        // Simulate two independently-loaded PluginDescriptor instances for the same plugin,
+        // as happens when DefaultPluginDescriptorCache clones on every cache retrieval.
+        PluginDescriptor pd1 = new PluginDescriptor();
+        pd1.setGroupId("org.example");
+        pd1.setArtifactId("example-plugin");
+        pd1.setVersion("1.0.0");
+
+        PluginDescriptor pd2 = new PluginDescriptor();
+        pd2.setGroupId("org.example");
+        pd2.setArtifactId("example-plugin");
+        pd2.setVersion("1.0.0");
+
+        assertNotSame(pd1, pd2, "must be different object instances");
+
+        MojoDescriptor md1 = new MojoDescriptor();
+        md1.setGoal("compile");
+        md1.setPluginDescriptor(pd1);
+
+        MojoDescriptor md2 = new MojoDescriptor();
+        md2.setGoal("compile");
+        md2.setPluginDescriptor(pd2);
+
+        assertNotSame(md1, md2, "must be different object instances");
+
+        // getId() must produce the same key for both independently-loaded descriptors
+        assertEquals(md1.getId(), md2.getId(), "IDs must match for same groupId:artifactId:version:goal");
+
+        // String-based cycle detection set must detect the duplicate
+        Set<String> alreadyPlanned = new HashSet<>();
+        alreadyPlanned.add(md1.getId());
+        assertTrue(alreadyPlanned.contains(md2.getId()), "cycle detection must find the cloned descriptor by ID");
+    }
+
     @Test
     void getParameterMap() throws DuplicateParameterException {
         MojoDescriptor mojoDescriptor = new MojoDescriptor();

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -25,7 +25,6 @@ import javax.xml.stream.XMLStreamException;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -147,22 +146,22 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,
                     MojoNotFoundException, InvalidPluginDescriptorException, NoPluginFoundForPrefixException,
                     LifecyclePhaseNotFoundException, LifecycleNotFoundException, PluginVersionResolutionException {
-        Set<MojoDescriptor> alreadyPlannedExecutions = fillMojoDescriptors(session, project, mojoExecutions);
+        Set<String> alreadyPlannedExecutions = fillMojoDescriptors(session, project, mojoExecutions);
 
         for (MojoExecution mojoExecution : mojoExecutions) {
             setupMojoExecution(session, project, mojoExecution, alreadyPlannedExecutions);
         }
     }
 
-    private Set<MojoDescriptor> fillMojoDescriptors(
+    private Set<String> fillMojoDescriptors(
             MavenSession session, MavenProject project, List<MojoExecution> mojoExecutions)
             throws InvalidPluginDescriptorException, MojoNotFoundException, PluginResolutionException,
                     PluginDescriptorParsingException, PluginNotFoundException {
-        Set<MojoDescriptor> descriptors = new HashSet<>(mojoExecutions.size());
+        Set<String> descriptors = new HashSet<>(mojoExecutions.size());
 
         for (MojoExecution execution : mojoExecutions) {
             MojoDescriptor mojoDescriptor = fillMojoDescriptor(session, project, execution);
-            descriptors.add(mojoDescriptor);
+            descriptors.add(mojoDescriptor.getId());
         }
 
         return descriptors;
@@ -191,7 +190,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             MavenSession session,
             MavenProject project,
             MojoExecution mojoExecution,
-            Set<MojoDescriptor> alreadyPlannedExecutions)
+            Set<String> alreadyPlannedExecutions)
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,
                     MojoNotFoundException, InvalidPluginDescriptorException, NoPluginFoundForPrefixException,
                     LifecyclePhaseNotFoundException, LifecycleNotFoundException, PluginVersionResolutionException {
@@ -354,7 +353,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             MojoExecution mojoExecution,
             MavenSession session,
             MavenProject project,
-            Collection<MojoDescriptor> alreadyPlannedExecutions)
+            Set<String> alreadyPlannedExecutions)
             throws MojoNotFoundException, PluginNotFoundException, PluginResolutionException,
                     PluginDescriptorParsingException, NoPluginFoundForPrefixException, InvalidPluginDescriptorException,
                     LifecyclePhaseNotFoundException, LifecycleNotFoundException, PluginVersionResolutionException {
@@ -364,7 +363,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             return;
         }
 
-        alreadyPlannedExecutions.add(mojoDescriptor);
+        alreadyPlannedExecutions.add(mojoDescriptor.getId());
 
         List<MavenProject> forkedProjects =
                 LifecycleDependencyResolver.getProjects(project, session, mojoDescriptor.isAggregator());
@@ -395,7 +394,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             MojoExecution mojoExecution,
             MavenSession session,
             MavenProject project,
-            Collection<MojoDescriptor> alreadyPlannedExecutions)
+            Set<String> alreadyPlannedExecutions)
             throws MojoNotFoundException, PluginNotFoundException, PluginResolutionException,
                     PluginDescriptorParsingException, NoPluginFoundForPrefixException, InvalidPluginDescriptorException,
                     LifecyclePhaseNotFoundException, LifecycleNotFoundException, PluginVersionResolutionException {
@@ -427,7 +426,8 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
 
         for (List<MojoExecution> forkedExecutions : lifecycleMappings.values()) {
             for (MojoExecution forkedExecution : forkedExecutions) {
-                if (!alreadyPlannedExecutions.contains(forkedExecution.getMojoDescriptor())) {
+                if (!alreadyPlannedExecutions.contains(
+                        forkedExecution.getMojoDescriptor().getId())) {
                     finalizeMojoConfiguration(forkedExecution);
 
                     calculateForkedExecutions(forkedExecution, session, project, alreadyPlannedExecutions);
@@ -535,7 +535,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             MojoExecution mojoExecution,
             MavenSession session,
             MavenProject project,
-            Collection<MojoDescriptor> alreadyPlannedExecutions)
+            Set<String> alreadyPlannedExecutions)
             throws MojoNotFoundException, PluginNotFoundException, PluginResolutionException,
                     PluginDescriptorParsingException, NoPluginFoundForPrefixException, InvalidPluginDescriptorException,
                     LifecyclePhaseNotFoundException, LifecycleNotFoundException, PluginVersionResolutionException {
@@ -550,7 +550,7 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             throw new MojoNotFoundException(forkedGoal, pluginDescriptor);
         }
 
-        if (alreadyPlannedExecutions.contains(forkedMojoDescriptor)) {
+        if (alreadyPlannedExecutions.contains(forkedMojoDescriptor.getId())) {
             return Collections.emptyList();
         }
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculator.java
@@ -31,7 +31,6 @@ import org.apache.maven.plugin.MojoNotFoundException;
 import org.apache.maven.plugin.PluginDescriptorParsingException;
 import org.apache.maven.plugin.PluginNotFoundException;
 import org.apache.maven.plugin.PluginResolutionException;
-import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
 import org.apache.maven.project.MavenProject;
@@ -60,7 +59,7 @@ public interface LifecycleExecutionPlanCalculator {
             MavenSession session,
             MavenProject project,
             MojoExecution mojoExecution,
-            Set<MojoDescriptor> alreadyPlannedExecutions)
+            Set<String> alreadyPlannedExecutions)
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,
                     MojoNotFoundException, InvalidPluginDescriptorException, NoPluginFoundForPrefixException,
                     LifecyclePhaseNotFoundException, LifecycleNotFoundException, PluginVersionResolutionException;

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecycleExecutionPlanCalculatorStub.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecycleExecutionPlanCalculatorStub.java
@@ -159,7 +159,7 @@ public class LifecycleExecutionPlanCalculatorStub implements LifecycleExecutionP
             MavenSession session,
             MavenProject project,
             MojoExecution mojoExecution,
-            Set<MojoDescriptor> alreadyForkedExecutions)
+            Set<String> alreadyForkedExecutions)
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,
                     MojoNotFoundException, InvalidPluginDescriptorException, NoPluginFoundForPrefixException,
                     LifecyclePhaseNotFoundException, LifecycleNotFoundException, PluginVersionResolutionException {}


### PR DESCRIPTION
Backport of #12867 to maven-4.0.x.

Original PR: https://github.com/apache/maven/pull/12867