### PR TITLE
[backport 4.0.x] Fix #12868: Restore --define as long option for -D

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -152,6 +152,7 @@ public class CLIManager {
                 .desc("Force the use of an alternate POM file (or directory with pom.xml)")
                 .build());
         options.addOption(Option.builder(Character.toString(SET_USER_PROPERTY))
+                .longOpt("define")
                 .numberOfArgs(2)
                 .valueSeparator('=')
                 .desc("Define a user property")

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
@@ -350,6 +350,7 @@ public class CommonsCliOptions implements Options {
                     .desc("Display help information")
                     .get());
             options.addOption(Option.builder(USER_PROPERTY)
+                    .longOpt("define")
                     .numberOfArgs(2)
                     .valueSeparator('=')
                     .desc("Define a user property")

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/CommonsCliOptionsTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/CommonsCliOptionsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker;
+
+import java.util.Map;
+
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CommonsCliOptionsTest {
+
+    @Test
+    void shortPropertyOption() throws ParseException {
+        CommonsCliOptions options = CommonsCliOptions.parse("test", new String[] {"-Dfoo=bar"});
+        assertTrue(options.userProperties().isPresent());
+        Map<String, String> props = options.userProperties().get();
+        assertEquals("bar", props.get("foo"));
+    }
+
+    @Test
+    void longDefineOption() throws ParseException {
+        CommonsCliOptions options = CommonsCliOptions.parse("test", new String[] {"--define", "foo=bar"});
+        assertTrue(options.userProperties().isPresent());
+        Map<String, String> props = options.userProperties().get();
+        assertEquals("bar", props.get("foo"));
+    }
+
+    @Test
+    void longDefineOptionMultiple() throws ParseException {
+        CommonsCliOptions options =
+                CommonsCliOptions.parse("test", new String[] {"--define", "foo=bar", "--define", "baz=qux"});
+        assertTrue(options.userProperties().isPresent());
+        Map<String, String> props = options.userProperties().get();
+        assertEquals("bar", props.get("foo"));
+        assertEquals("qux", props.get("baz"));
+    }
+}


### PR DESCRIPTION
Backport of #12869 to maven-4.0.x.

Original PR: https://github.com/apache/maven/pull/12869