### PR TITLE
Fix #12602: preserve Properties defaults chain in ROProperties

### DIFF
--- a/api/maven-api-xml/pom.xml
+++ b/api/maven-api-xml/pom.xml
@@ -35,6 +35,11 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
@@ -367,9 +367,13 @@ class ImmutableCollections {
         private ROProperties(Properties props) {
             super();
             if (props != null) {
-                // Do not use super.putAll, as it may delegate to put which throws an UnsupportedOperationException
-                for (Map.Entry<Object, Object> e : props.entrySet()) {
-                    super.put(e.getKey(), e.getValue());
+                // Use stringPropertyNames() to include entries from the defaults chain,
+                // then getProperty() to resolve each value through the chain.
+                // Do not use super.putAll or entrySet(), as the former may delegate to
+                // put (which throws UnsupportedOperationException) and the latter does
+                // not include entries inherited from defaults.
+                for (String name : props.stringPropertyNames()) {
+                    super.put(name, props.getProperty(name));
                 }
             }
         }

--- a/api/maven-api-xml/src/test/java/org/apache/maven/api/xml/ImmutableCollectionsTest.java
+++ b/api/maven-api-xml/src/test/java/org/apache/maven/api/xml/ImmutableCollectionsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api.xml;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ImmutableCollectionsTest {
+
+    @Test
+    void propertiesCopyPreservesDefaults() {
+        // Create a Properties chain: defaults -> child
+        Properties defaults = new Properties();
+        defaults.setProperty("inherited", "default-value");
+        defaults.setProperty("shadowed", "default-value");
+
+        Properties child = new Properties(defaults);
+        child.setProperty("direct", "direct-value");
+        child.setProperty("shadowed", "child-value"); // shadows default
+
+        // Copy via ImmutableCollections.copy()
+        Properties copy = ImmutableCollections.copy(child);
+
+        // Direct entries must be present
+        assertEquals("direct-value", copy.getProperty("direct"));
+        // Shadowed entry should use child's value
+        assertEquals("child-value", copy.getProperty("shadowed"));
+        // Inherited entry from defaults must be visible via getProperty
+        assertEquals("default-value", copy.getProperty("inherited"));
+
+        // Verify immutability of defaults: changing the original shouldn't affect the copy
+        defaults.setProperty("inherited", "changed");
+        assertEquals("default-value", copy.getProperty("inherited"));
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `ROProperties` constructor to flatten the entire `Properties` defaults chain into the immutable copy
- Replace `entrySet()` iteration (which misses defaults) with `stringPropertyNames()` + `getProperty()` (which resolves through the defaults chain)

## Problem
When a `Properties` object has a defaults chain (e.g. `new Properties(someDefaults)`), wrapping it with `ImmutableCollections.copy()` lost all entries from the defaults. This is because:
1. The `ROProperties` constructor called `super()`, discarding the defaults reference
2. `props.entrySet()` only returns entries from the `Properties` object itself, not from its defaults chain

## Fix
Use `props.stringPropertyNames()` which includes keys from the entire defaults chain, and `props.getProperty(name)` which resolves values through the chain. Since `ROProperties` is immutable, flattening is the correct approach -- the defaults cannot change after construction.

## Test plan
- [x] `cd api/maven-api-xml && mvn test -B` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)