### PR TITLE
Fix #12600: guard against NPE on missing project index in MojoExecutor

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -438,9 +438,17 @@ public class MojoExecutor {
                             .getData()
                             .computeIfAbsent(PROJECT_INDEX, () -> new ProjectIndex(session.getProjects()));
 
-                    int index = projectIndex.getIndices().get(projectId);
+                    Integer index = projectIndex.getIndices().get(projectId);
+                    if (index == null) {
+                        throw new LifecycleExecutionException("Project index not found for forked execution: project '"
+                                + projectId + "' is not in the reactor");
+                    }
 
                     MavenProject forkedProject = projectIndex.getProjects().get(projectId);
+                    if (forkedProject == null) {
+                        throw new LifecycleExecutionException("Project not found for forked execution: project '"
+                                + projectId + "' is not in the reactor");
+                    }
 
                     forkedProjects.add(forkedProject);
 


### PR DESCRIPTION
## Summary
- Guard against `NullPointerException` caused by auto-unboxing when a project ID is not found in the reactor's `ProjectIndex` during forked execution
- Changed `int index` to `Integer index` and added explicit null checks for both the index lookup and the project lookup
- Throws a descriptive `LifecycleExecutionException` instead of a cryptic NPE when the project is missing

## Test plan
- [x] Existing tests pass (`mvn test` in `impl/maven-core`: 568 tests, 0 failures)
- [ ] Verify with a multi-module project that triggers forked executions (e.g., `maven-javadoc-plugin:aggregate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)