### PR TITLE
Fix #12584: use identity comparison in SoftIdentityMap

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/SoftIdentityMap.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/cache/SoftIdentityMap.java
@@ -46,7 +46,7 @@ public class SoftIdentityMap<K, V> implements Map<K, V> {
 
         SoftIdentityReference(T referent, ReferenceQueue<T> queue) {
             super(referent, queue);
-            this.hash = referent.hashCode();
+            this.hash = System.identityHashCode(referent);
         }
 
         @Override
@@ -59,7 +59,7 @@ public class SoftIdentityMap<K, V> implements Map<K, V> {
             }
             T thisRef = this.get();
             Object otherRef = other.get();
-            return thisRef != null && thisRef.equals(otherRef);
+            return thisRef != null && thisRef == otherRef;
         }
 
         @Override

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/cache/SoftIdentityMapTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/cache/SoftIdentityMapTest.java
@@ -159,7 +159,7 @@ class SoftIdentityMapTest {
             return "value2";
         });
 
-        assertEquals(1, computeCount.get(), "Should compute once for equal but distinct keys");
+        assertEquals(2, computeCount.get(), "Should compute separately for equal but distinct keys");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixed `SoftIdentityReference.equals()` to use `==` instead of `.equals()` for identity comparison
- Fixed `SoftIdentityReference.hashCode()` to use `System.identityHashCode()` instead of `.hashCode()`
- Updated test assertion to expect correct identity semantics (distinct objects with equal values are treated as different keys)

## Test plan
- [x] `SoftIdentityMapTest.shouldUseIdentityComparison` updated to expect 2 computations for equal-but-distinct keys
- [x] All 493 tests in `maven-impl` pass (0 failures, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)