### PR TITLE
[4.0.x] Fix #12602: Preserve Properties defaults in immutable copies

### DIFF
--- a/api/maven-api-xml/pom.xml
+++ b/api/maven-api-xml/pom.xml
@@ -35,6 +35,11 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
@@ -365,13 +365,30 @@ class ImmutableCollections {
 
     private static class ROProperties extends Properties {
         private ROProperties(Properties props) {
-            super();
+            super(copyDefaults(props));
             if (props != null) {
                 // Do not use super.putAll, as it may delegate to put which throws an UnsupportedOperationException
                 for (Map.Entry<Object, Object> e : props.entrySet()) {
                     super.put(e.getKey(), e.getValue());
                 }
             }
+        }
+
+        private static Properties copyDefaults(Properties props) {
+            if (props == null) {
+                return null;
+            }
+            Properties defaults = null;
+            for (String name : props.stringPropertyNames()) {
+                // A direct String shadows its default, while a non-String value does not for getProperty.
+                if (!(props.get(name) instanceof String)) {
+                    if (defaults == null) {
+                        defaults = new Properties();
+                    }
+                    defaults.setProperty(name, props.getProperty(name));
+                }
+            }
+            return defaults;
         }
 
         @Override

--- a/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
+++ b/api/maven-api-xml/src/main/java/org/apache/maven/api/xml/ImmutableCollections.java
@@ -378,13 +378,10 @@ class ImmutableCollections {
             if (props == null) {
                 return null;
             }
-            Properties defaults = null;
+            Properties defaults = new Properties();
             for (String name : props.stringPropertyNames()) {
                 // A direct String shadows its default, while a non-String value does not for getProperty.
                 if (!(props.get(name) instanceof String)) {
-                    if (defaults == null) {
-                        defaults = new Properties();
-                    }
                     defaults.setProperty(name, props.getProperty(name));
                 }
             }

--- a/api/maven-api-xml/src/test/java/org/apache/maven/api/xml/ImmutableCollectionsTest.java
+++ b/api/maven-api-xml/src/test/java/org/apache/maven/api/xml/ImmutableCollectionsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api.xml;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ImmutableCollectionsTest {
+
+    @Test
+    void propertiesCopyPreservesDefaults() {
+        Properties rootDefaults = new Properties();
+        rootDefaults.setProperty("root", "root-value");
+        rootDefaults.setProperty("shadowed", "default-value");
+        rootDefaults.setProperty("non-string-shadow", "fallback-value");
+        Properties defaults = new Properties(rootDefaults);
+        defaults.setProperty("inherited", "default-value");
+        Properties properties = new Properties(defaults);
+        properties.setProperty("direct", "direct-value");
+        properties.setProperty("shadowed", "direct-value");
+        properties.put("non-string-shadow", 42);
+
+        Properties copy = ImmutableCollections.copy(properties);
+
+        assertEquals("default-value", copy.getProperty("inherited"));
+        assertEquals("root-value", copy.getProperty("root"));
+        assertFalse(copy.containsKey("inherited"));
+        assertFalse(copy.containsKey("root"));
+        assertEquals(3, copy.size());
+        assertEquals("direct-value", copy.getProperty("direct"));
+        assertEquals("direct-value", copy.getProperty("shadowed"));
+        assertEquals(42, copy.get("non-string-shadow"));
+        assertEquals("fallback-value", copy.getProperty("non-string-shadow"));
+
+        defaults.setProperty("inherited", "changed");
+        rootDefaults.setProperty("root", "changed");
+        assertEquals("default-value", copy.getProperty("inherited"));
+        assertEquals("root-value", copy.getProperty("root"));
+    }
+}

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/ImmutableCollections.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/ImmutableCollections.java
@@ -365,13 +365,30 @@ class ImmutableCollections {
 
     private static class ROProperties extends Properties {
         private ROProperties(Properties props) {
-            super();
+            super(copyDefaults(props));
             if (props != null) {
                 // Do not use super.putAll, as it may delegate to put which throws an UnsupportedOperationException
                 for (Map.Entry<Object, Object> e : props.entrySet()) {
                     super.put(e.getKey(), e.getValue());
                 }
             }
+        }
+
+        private static Properties copyDefaults(Properties props) {
+            if (props == null) {
+                return null;
+            }
+            Properties defaults = null;
+            for (String name : props.stringPropertyNames()) {
+                // A direct String shadows its default, while a non-String value does not for getProperty.
+                if (!(props.get(name) instanceof String)) {
+                    if (defaults == null) {
+                        defaults = new Properties();
+                    }
+                    defaults.setProperty(name, props.getProperty(name));
+                }
+            }
+            return defaults;
         }
 
         @Override

--- a/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/ImmutableCollections.java
+++ b/impl/maven-xml/src/main/java/org/apache/maven/internal/xml/ImmutableCollections.java
@@ -378,13 +378,10 @@ class ImmutableCollections {
             if (props == null) {
                 return null;
             }
-            Properties defaults = null;
+            Properties defaults = new Properties();
             for (String name : props.stringPropertyNames()) {
                 // A direct String shadows its default, while a non-String value does not for getProperty.
                 if (!(props.get(name) instanceof String)) {
-                    if (defaults == null) {
-                        defaults = new Properties();
-                    }
                     defaults.setProperty(name, props.getProperty(name));
                 }
             }

--- a/src/mdo/java/ImmutableCollections.java
+++ b/src/mdo/java/ImmutableCollections.java
@@ -368,13 +368,30 @@ class ImmutableCollections {
 
     private static class ROProperties extends Properties {
         private ROProperties(Properties props) {
-            super();
+            super(copyDefaults(props));
             if (props != null) {
                 // Do not use super.putAll, as it may delegate to put which throws an UnsupportedOperationException
                 for (Map.Entry<Object, Object> e : props.entrySet()) {
                     super.put(e.getKey(), e.getValue());
                 }
             }
+        }
+
+        private static Properties copyDefaults(Properties props) {
+            if (props == null) {
+                return null;
+            }
+            Properties defaults = null;
+            for (String name : props.stringPropertyNames()) {
+                // A direct String shadows its default, while a non-String value does not for getProperty.
+                if (!(props.get(name) instanceof String)) {
+                    if (defaults == null) {
+                        defaults = new Properties();
+                    }
+                    defaults.setProperty(name, props.getProperty(name));
+                }
+            }
+            return defaults;
         }
 
         @Override

--- a/src/mdo/java/ImmutableCollections.java
+++ b/src/mdo/java/ImmutableCollections.java
@@ -381,13 +381,10 @@ class ImmutableCollections {
             if (props == null) {
                 return null;
             }
-            Properties defaults = null;
+            Properties defaults = new Properties();
             for (String name : props.stringPropertyNames()) {
                 // A direct String shadows its default, while a non-String value does not for getProperty.
                 if (!(props.get(name) instanceof String)) {
-                    if (defaults == null) {
-                        defaults = new Properties();
-                    }
                     defaults.setProperty(name, props.getProperty(name));
                 }
             }


### PR DESCRIPTION
Fixes #12602

## Summary

`ROProperties` copied only the direct entries from the source `Properties` instance. Any values inherited through its defaults chain were therefore lost, causing `getProperty` to return `null` for inherited properties.

This change snapshots the effective inherited string properties into a private defaults object before copying the direct entries. This preserves standard `Properties` behavior while:

- keeping inherited properties outside the direct map
- preserving recursive defaults
- preserving fallback through direct non-string values
- avoiding a mutable reference to the source defaults chain
- avoiding an additional allocation when no inherited defaults exist

The API implementation, internal XML implementation, and MDO generation template use the same behavior.

## Tests

Added regression coverage for:

- direct and inherited properties
- recursive defaults
- direct string overrides
- direct non-string values with string defaults
- direct-map size and membership semantics
- isolation from later source-default mutations

Verification:

- `mvn clean verify`
- `mvn -pl api/maven-api-xml -am -Dtest=ImmutableCollectionsTest -Dsurefire.failIfNoSpecifiedTests=false test`

`mvn -Prun-its clean install` was also attempted. The Core IT suite did not complete locally because its extracted Maven distribution directory disappeared during execution, resulting in cascading unrelated missing-file failures. Tests executed before that point passed after the matching `4.0.x` IT support artifacts were installed.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/