### PR TITLE
Fix #12589: fix operator precedence for BOM import dependency filtering

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2085,8 +2085,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             for (Iterator<Dependency> it = deps.iterator(); it.hasNext(); ) {
                 Dependency dependency = it.next();
 
-                if (!("pom".equals(dependency.getType()) && "import".equals(dependency.getScope()))
-                        || "bom".equals(dependency.getType())) {
+                if (!(("pom".equals(dependency.getType()) && "import".equals(dependency.getScope()))
+                        || "bom".equals(dependency.getType()))) {
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- Fix operator precedence bug in `DefaultModelBuilder.importDependencyManagement()` where BOM-type dependencies were always skipped
- The condition `!(pom AND import) OR bom` incorrectly evaluates so that `bom` type dependencies always hit `continue`
- Changed to `!((pom AND import) OR bom)` to correctly skip only non-import, non-BOM dependencies

## Test plan
- [x] `mvn test` passes in `impl/maven-impl` module (493 tests, 0 failures)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)