### PR TITLE
Fix #12660: inherit version from imported BOM when local dep mgmt entry has no version

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
@@ -83,6 +83,17 @@ public class DefaultDependencyManagementImporter implements DependencyManagement
                                         + toString(present) + ". Add the conflicting managed dependency directly "
                                         + "to the dependencyManagement section of the POM.");
                     }
+                    if (present != null
+                            && directDependencies.contains(key)
+                            && present.getVersion() == null
+                            && dependency.getVersion() != null) {
+                        dependencies.put(
+                                key,
+                                Dependency.newBuilder(present)
+                                        .version(dependency.getVersion())
+                                        .location("version", dependency.getLocation("version"))
+                                        .build());
+                    }
                     if (present == null && request.isLocationTracking()) {
                         Dependency updatedDependency = updateWithImportedFrom(dependency, source);
                         dependencies.put(key, updatedDependency);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
@@ -18,13 +18,19 @@
  */
 package org.apache.maven.impl.model;
 
+import java.util.List;
+
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputSource;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.services.ModelBuilderRequest;
+import org.apache.maven.api.services.ModelProblemCollector;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class DefaultDependencyManagementImporterTest {
     @Test
@@ -120,5 +126,45 @@ class DefaultDependencyManagementImporterTest {
         // Assert
         assertThat(result.getImportedFrom().toString())
                 .isEqualTo(differentSource.getLocation("").toString());
+    }
+
+    @Test
+    void testImportManagementInheritsVersionFromImportedBomWhenLocalEntryHasNoVersion() {
+        // A locally-declared dep mgmt entry with scope=provided but no version
+        Dependency localDep = Dependency.newBuilder()
+                .groupId("org.junit.jupiter")
+                .artifactId("junit-jupiter-api")
+                .scope("provided")
+                .build();
+
+        Model target = Model.newBuilder()
+                .dependencyManagement(DependencyManagement.newBuilder()
+                        .dependencies(List.of(localDep))
+                        .build())
+                .build();
+
+        // An imported BOM providing the same dependency with a version
+        Dependency importedDep = Dependency.newBuilder()
+                .groupId("org.junit.jupiter")
+                .artifactId("junit-jupiter-api")
+                .version("5.10.0")
+                .build();
+
+        DependencyManagement importedBom = DependencyManagement.newBuilder()
+                .dependencies(List.of(importedDep))
+                .build();
+
+        DefaultDependencyManagementImporter importer = new DefaultDependencyManagementImporter();
+        Model result = importer.importManagement(
+                target, List.of(importedBom), mock(ModelBuilderRequest.class), mock(ModelProblemCollector.class));
+
+        List<Dependency> resultDeps = result.getDependencyManagement().getDependencies();
+        assertThat(resultDeps).hasSize(1);
+
+        Dependency merged = resultDeps.get(0);
+        assertThat(merged.getGroupId()).isEqualTo("org.junit.jupiter");
+        assertThat(merged.getArtifactId()).isEqualTo("junit-jupiter-api");
+        assertThat(merged.getVersion()).isEqualTo("5.10.0");
+        assertThat(merged.getScope()).isEqualTo("provided");
     }
 }


### PR DESCRIPTION
## Summary
- When a BOM project declares a managed dependency without a version (e.g., `junit-jupiter-api` with `scope=provided`), and the version is expected to come from an imported BOM in the parent POM's dependency management, the consumer POM was generated with the dependency entry missing its version.
- The root cause was in `DefaultDependencyManagementImporter.importManagement()` where `putIfAbsent` skips the imported entry (including its version) when a locally-declared entry already exists.
- After the `putIfAbsent` call, we now check if the existing entry has a null version while the imported entry provides one, and merge the version from the import into the existing entry.

Fixes #12660

## Test plan
- [x] Added unit test `testImportManagementInheritsVersionFromImportedBomWhenLocalEntryHasNoVersion` that verifies a local dep mgmt entry with `scope=provided` but no version gets the version merged from an imported BOM while preserving its scope.
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)