### PR TITLE
Fix #12774: skip consumer POM re-attachment on repeated task segments

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
@@ -79,19 +79,20 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
             return;
         }
         if (Features.consumerPom(session.getConfigProperties())) {
-            Path buildDir =
-                    project.getBuild() != null ? Paths.get(project.getBuild().getDirectory()) : null;
-            if (buildDir != null) {
-                Files.createDirectories(buildDir);
-            }
-            Path consumer = buildDir != null
-                    ? Files.createTempFile(buildDir, CONSUMER_POM_CLASSIFIER + "-", ".pom")
-                    : Files.createTempFile(CONSUMER_POM_CLASSIFIER + "-", ".pom");
-            deferDeleteFile(consumer);
-
             boolean alreadyAttached = project.getAttachedArtifacts().stream()
                     .anyMatch(a -> CONSUMER_POM_CLASSIFIER.equals(a.getClassifier()) && "pom".equals(a.getType()));
             if (!alreadyAttached) {
+                Path buildDir = project.getBuild() != null
+                        ? Paths.get(project.getBuild().getDirectory())
+                        : null;
+                if (buildDir != null) {
+                    Files.createDirectories(buildDir);
+                }
+                Path consumer = buildDir != null
+                        ? Files.createTempFile(buildDir, CONSUMER_POM_CLASSIFIER + "-", ".pom")
+                        : Files.createTempFile(CONSUMER_POM_CLASSIFIER + "-", ".pom");
+                deferDeleteFile(consumer);
+
                 project.addAttachedArtifact(createConsumerPomArtifact(project, consumer, session));
             }
         } else if (project.getModel().getDelegate().isRoot()) {

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformer.java
@@ -89,7 +89,11 @@ class ConsumerPomArtifactTransformer extends TransformerSupport {
                     : Files.createTempFile(CONSUMER_POM_CLASSIFIER + "-", ".pom");
             deferDeleteFile(consumer);
 
-            project.addAttachedArtifact(createConsumerPomArtifact(project, consumer, session));
+            boolean alreadyAttached = project.getAttachedArtifacts().stream()
+                    .anyMatch(a -> CONSUMER_POM_CLASSIFIER.equals(a.getClassifier()) && "pom".equals(a.getType()));
+            if (!alreadyAttached) {
+                project.addAttachedArtifact(createConsumerPomArtifact(project, consumer, session));
+            }
         } else if (project.getModel().getDelegate().isRoot()) {
             throw new IllegalStateException(
                     "The use of the root attribute on the model requires the buildconsumer feature to be active");

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformerTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomArtifactTransformerTest.java
@@ -23,14 +23,17 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import org.apache.maven.api.services.Sources;
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.v4.MavenStaxReader;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.SessionData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.xmlunit.assertj.XmlAssert;
 
@@ -105,5 +108,46 @@ class ConsumerPomArtifactTransformerTest {
                 .injectTransformedArtifacts(systemSessionMock, emptyProject);
 
         assertThat(emptyProject.getAttachedArtifacts()).isEmpty();
+    }
+
+    @Test
+    void injectTransformedArtifactsTwiceShouldNotDuplicate(@TempDir Path tempDir) throws IOException {
+        // Set up a minimal POM file
+        Path pomFile = tempDir.resolve("pom.xml");
+        Files.writeString(
+                pomFile,
+                "<project><modelVersion>4.0.0</modelVersion>"
+                        + "<groupId>test</groupId><artifactId>test</artifactId>"
+                        + "<version>1.0</version></project>");
+
+        // Create project with the POM file and a build directory
+        Model model = new Model();
+        model.setGroupId("test");
+        model.setArtifactId("test");
+        model.setVersion("1.0");
+        Build build = new Build();
+        build.setDirectory(tempDir.resolve("target").toString());
+        model.setBuild(build);
+        MavenProject project = new MavenProject(model);
+        project.setFile(pomFile.toFile());
+
+        // Mock session with consumer POM feature enabled (default for Maven 4)
+        RepositorySystemSession session = Mockito.mock(RepositorySystemSession.class);
+        SessionData sessionData = Mockito.mock(SessionData.class);
+        when(session.getData()).thenReturn(sessionData);
+        when(session.getConfigProperties()).thenReturn(Collections.emptyMap());
+
+        ConsumerPomArtifactTransformer transformer =
+                new ConsumerPomArtifactTransformer((s, p, src) -> p.getModel().getDelegate());
+
+        // First invocation should attach the consumer POM
+        transformer.injectTransformedArtifacts(session, project);
+        assertThat(project.getAttachedArtifacts()).hasSize(1);
+        assertThat(project.getAttachedArtifacts().get(0).getClassifier()).isEqualTo("consumer");
+        assertThat(project.getAttachedArtifacts().get(0).getType()).isEqualTo("pom");
+
+        // Second invocation should be a no-op (not duplicate the artifact)
+        transformer.injectTransformedArtifacts(session, project);
+        assertThat(project.getAttachedArtifacts()).hasSize(1);
     }
 }


### PR DESCRIPTION
## Summary

- Make `ConsumerPomArtifactTransformer.injectTransformedArtifacts()` idempotent by checking if a consumer POM artifact (classifier=`consumer`, type=`pom`) is already attached before calling `addAttachedArtifact()`
- Prevents the duplicate "Building ..." header and `artifact '...:pom:consumer:...' already attached, replacing previous instance` warning when running multiple task segments (e.g. `mvn package compiler:help`)
- Add unit test verifying that a second invocation does not duplicate the attached artifact

Fixes #12774

## Test plan

- [x] New unit test `injectTransformedArtifactsTwiceShouldNotDuplicate` verifies idempotency
- [ ] Manual verification: `mvn package compiler:help` no longer produces the warning


🤖 Generated with [Claude Code](https://claude.com/claude-code)