### PR TITLE
[maven-3.8.x] Stop packaging a duplicate lib/jansi-native directory entry

### DIFF
--- a/apache-maven/src/main/assembly/component.xml
+++ b/apache-maven/src/main/assembly/component.xml
@@ -66,7 +66,9 @@ under the License.
       <directory>target/dependency/org/fusesource/jansi/internal/native</directory>
       <outputDirectory>lib/jansi-native</outputDirectory>
       <includes>
-        <include>**</include>
+        <include>**/*.so</include>
+        <include>**/*.jnilib</include>
+        <include>**/*.dll</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
<!--
Please open pull requests against one of the following branches:

- master — default target for all changes (new features + bug fixes).  
  If the change should also go to maven-4.0.x, request a backport in the PR.

- maven-3.10.x — target for 3.x changes (new features + bug fixes).  
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.

Backports are typically handled by maintainers; 
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/

---

Fixes #12778 .

The 3.8.x branch has the same duplicate `lib/jansi-native/` directory entry described in #12778.

This applies the same file-only include patterns used by the 3.9.x fix in #12779.