### PR TITLE
[backport 4.0.x] [MNG-8693] Avoid resolving unused plugins for direct goals

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator.java
@@ -121,7 +121,9 @@ public class DefaultLifecycleExecutionPlanCalculator implements LifecycleExecuti
             throws PluginNotFoundException, PluginResolutionException, LifecyclePhaseNotFoundException,
                     PluginDescriptorParsingException, MojoNotFoundException, InvalidPluginDescriptorException,
                     NoPluginFoundForPrefixException, LifecycleNotFoundException, PluginVersionResolutionException {
-        lifecyclePluginResolver.resolveMissingPluginVersions(project, session);
+        if (tasks.stream().anyMatch(LifecycleTask.class::isInstance)) {
+            lifecyclePluginResolver.resolveMissingPluginVersions(project, session);
+        }
 
         final List<MojoExecution> executions = calculateMojoExecutions(session, project, tasks);
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java
@@ -60,13 +60,9 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
 
     private final MojoDescriptorCreator mojoDescriptorCreator;
 
-    private final LifecyclePluginResolver lifecyclePluginResolver;
-
     @Inject
-    public DefaultLifecycleTaskSegmentCalculator(
-            MojoDescriptorCreator mojoDescriptorCreator, LifecyclePluginResolver lifecyclePluginResolver) {
+    public DefaultLifecycleTaskSegmentCalculator(MojoDescriptorCreator mojoDescriptorCreator) {
         this.mojoDescriptorCreator = mojoDescriptorCreator;
-        this.lifecyclePluginResolver = lifecyclePluginResolver;
     }
 
     @Override
@@ -107,8 +103,6 @@ public class DefaultLifecycleTaskSegmentCalculator implements LifecycleTaskSegme
             }
             if (isGoalSpecification(task)) {
                 // "pluginPrefix[:version]:goal" or "groupId:artifactId[:version]:goal"
-
-                lifecyclePluginResolver.resolveMissingPluginVersions(session.getTopLevelProject(), session);
 
                 MojoDescriptor mojoDescriptor =
                         mojoDescriptorCreator.getMojoDescriptor(task, session, session.getTopLevelProject());

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoDescriptorCreator.java
@@ -67,18 +67,15 @@ public class MojoDescriptorCreator {
     private final PluginVersionResolver pluginVersionResolver;
     private final BuildPluginManager pluginManager;
     private final PluginPrefixResolver pluginPrefixResolver;
-    private final LifecyclePluginResolver lifecyclePluginResolver;
 
     @Inject
     public MojoDescriptorCreator(
             PluginVersionResolver pluginVersionResolver,
             BuildPluginManager pluginManager,
-            PluginPrefixResolver pluginPrefixResolver,
-            LifecyclePluginResolver lifecyclePluginResolver) {
+            PluginPrefixResolver pluginPrefixResolver) {
         this.pluginVersionResolver = pluginVersionResolver;
         this.pluginManager = pluginManager;
         this.pluginPrefixResolver = pluginPrefixResolver;
-        this.lifecyclePluginResolver = lifecyclePluginResolver;
     }
 
     private Plugin findPlugin(String groupId, String artifactId, Collection<Plugin> plugins) {
@@ -236,15 +233,6 @@ public class MojoDescriptorCreator {
 
     public Plugin findPluginForPrefix(String prefix, MavenSession session) throws NoPluginFoundForPrefixException {
         // [prefix]:[goal]
-
-        if (session.getCurrentProject() != null) {
-            try {
-                lifecyclePluginResolver.resolveMissingPluginVersions(session.getCurrentProject(), session);
-            } catch (PluginVersionResolutionException e) {
-                // not critical here
-                logger.debug(e.getMessage(), e);
-            }
-        }
 
         PluginPrefixRequest prefixRequest = new DefaultPluginPrefixRequest(prefix, session);
         PluginPrefixResult prefixResult = pluginPrefixResolver.resolve(prefixRequest);

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/ConcurrentLifecycleStarter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/concurrent/ConcurrentLifecycleStarter.java
@@ -35,7 +35,6 @@ import org.apache.maven.lifecycle.MissingProjectException;
 import org.apache.maven.lifecycle.NoGoalSpecifiedException;
 import org.apache.maven.lifecycle.internal.ExecutionEventCatapult;
 import org.apache.maven.lifecycle.internal.GoalTask;
-import org.apache.maven.lifecycle.internal.LifecyclePluginResolver;
 import org.apache.maven.lifecycle.internal.LifecycleStarter;
 import org.apache.maven.lifecycle.internal.LifecycleTask;
 import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
@@ -61,7 +60,6 @@ public class ConcurrentLifecycleStarter implements LifecycleStarter {
     private final ExecutionEventCatapult eventCatapult;
     private final DefaultLifecycles defaultLifeCycles;
     private final BuildPlanExecutor executor;
-    private final LifecyclePluginResolver lifecyclePluginResolver;
     private final MojoDescriptorCreator mojoDescriptorCreator;
 
     @Inject
@@ -69,12 +67,10 @@ public class ConcurrentLifecycleStarter implements LifecycleStarter {
             ExecutionEventCatapult eventCatapult,
             DefaultLifecycles defaultLifeCycles,
             BuildPlanExecutor executor,
-            LifecyclePluginResolver lifecyclePluginResolver,
             MojoDescriptorCreator mojoDescriptorCreator) {
         this.eventCatapult = eventCatapult;
         this.defaultLifeCycles = defaultLifeCycles;
         this.executor = executor;
-        this.lifecyclePluginResolver = lifecyclePluginResolver;
         this.mojoDescriptorCreator = mojoDescriptorCreator;
     }
 
@@ -148,8 +144,6 @@ public class ConcurrentLifecycleStarter implements LifecycleStarter {
             }
             if (isGoalSpecification(task)) {
                 // "pluginPrefix[:version]:goal" or "groupId:artifactId[:version]:goal"
-
-                lifecyclePluginResolver.resolveMissingPluginVersions(session.getTopLevelProject(), session);
 
                 MojoDescriptor mojoDescriptor =
                         mojoDescriptorCreator.getMojoDescriptor(task, session, session.getTopLevelProject());

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver.java
@@ -47,6 +47,8 @@ import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
 import org.apache.maven.plugin.prefix.PluginPrefixRequest;
 import org.apache.maven.plugin.prefix.PluginPrefixResolver;
 import org.apache.maven.plugin.prefix.PluginPrefixResult;
+import org.apache.maven.plugin.version.DefaultPluginVersionRequest;
+import org.apache.maven.plugin.version.PluginVersionResolver;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
@@ -77,13 +79,18 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
     private final BuildPluginManager pluginManager;
     private final RepositorySystem repositorySystem;
     private final MetadataReader metadataReader;
+    private final PluginVersionResolver pluginVersionResolver;
 
     @Inject
     public DefaultPluginPrefixResolver(
-            BuildPluginManager pluginManager, RepositorySystem repositorySystem, MetadataReader metadataReader) {
+            BuildPluginManager pluginManager,
+            RepositorySystem repositorySystem,
+            MetadataReader metadataReader,
+            PluginVersionResolver pluginVersionResolver) {
         this.pluginManager = pluginManager;
         this.repositorySystem = repositorySystem;
         this.metadataReader = metadataReader;
+        this.pluginVersionResolver = pluginVersionResolver;
     }
 
     @Override
@@ -167,6 +174,13 @@ public class DefaultPluginPrefixResolver implements PluginPrefixResolver {
     private PluginPrefixResult doResolveFromProject(PluginPrefixRequest request, Collection<Plugin> plugins) {
         for (Plugin plugin : plugins) {
             try {
+                if (plugin.getVersion() == null) {
+                    DefaultPluginVersionRequest versionRequest = new DefaultPluginVersionRequest(
+                                    plugin, request.getRepositorySession(), request.getRepositories())
+                            .setPom(request.getPom());
+                    plugin.setVersion(
+                            pluginVersionResolver.resolve(versionRequest).getVersion());
+                }
                 PluginDescriptor pluginDescriptor =
                         pluginManager.loadPlugin(plugin, request.getRepositories(), request.getRepositorySession());
 

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculatorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.lifecycle.internal;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.Lifecycle;
+import org.apache.maven.lifecycle.LifecycleMappingDelegate;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultLifecycleExecutionPlanCalculatorTest {
+    @Test
+    void doesNotResolveProjectPluginsForDirectGoal() throws Exception {
+        MojoDescriptorCreator mojoDescriptorCreator = mock(MojoDescriptorCreator.class);
+        LifecyclePluginResolver lifecyclePluginResolver = mock(LifecyclePluginResolver.class);
+        MavenSession session = mock(MavenSession.class);
+        MavenProject project = new MavenProject();
+
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.setGroupId("org.apache.maven.plugins");
+        pluginDescriptor.setArtifactId("maven-help-plugin");
+        pluginDescriptor.setVersion("1.0");
+        MojoDescriptor mojoDescriptor = new MojoDescriptor();
+        mojoDescriptor.setPluginDescriptor(pluginDescriptor);
+        mojoDescriptor.setGoal("help");
+        when(mojoDescriptorCreator.getMojoDescriptor("help:help", session, project))
+                .thenReturn(mojoDescriptor);
+
+        DefaultLifecycleExecutionPlanCalculator calculator = new DefaultLifecycleExecutionPlanCalculator(
+                mock(BuildPluginManager.class),
+                mock(DefaultLifecycles.class),
+                mojoDescriptorCreator,
+                lifecyclePluginResolver);
+
+        calculator.calculateExecutionPlan(session, project, List.of(new GoalTask("help:help")), false);
+
+        verify(lifecyclePluginResolver, never()).resolveMissingPluginVersions(project, session);
+    }
+
+    @Test
+    void resolvesProjectPluginsForLifecycleTask() throws Exception {
+        LifecyclePluginResolver lifecyclePluginResolver = mock(LifecyclePluginResolver.class);
+        MavenSession session = mock(MavenSession.class);
+        MavenProject project = new MavenProject();
+        DefaultLifecycles defaultLifecycles = mock(DefaultLifecycles.class);
+        Lifecycle lifecycle = new Lifecycle("default", List.of("validate"), Map.of());
+        LifecycleMappingDelegate lifecycleMappingDelegate = mock(LifecycleMappingDelegate.class);
+
+        when(defaultLifecycles.get("validate")).thenReturn(lifecycle);
+        when(lifecycleMappingDelegate.calculateLifecycleMappings(session, project, lifecycle, "validate"))
+                .thenReturn(Map.of());
+
+        DefaultLifecycleExecutionPlanCalculator calculator = new DefaultLifecycleExecutionPlanCalculator(
+                mock(BuildPluginManager.class),
+                defaultLifecycles,
+                mock(MojoDescriptorCreator.class),
+                lifecyclePluginResolver,
+                lifecycleMappingDelegate,
+                Map.of(),
+                Map.of());
+
+        calculator.calculateExecutionPlan(session, project, List.of(new LifecycleTask("validate")), false);
+
+        verify(lifecyclePluginResolver).resolveMissingPluginVersions(project, session);
+    }
+}

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculatorTest.java
@@ -71,10 +71,7 @@ class LifecycleExecutionPlanCalculatorTest extends AbstractCoreMavenComponentTes
 
     public static MojoDescriptorCreator createMojoDescriptorCreator() {
         return new MojoDescriptorCreator(
-                new PluginVersionResolverStub(),
-                new BuildPluginManagerStub(),
-                new PluginPrefixResolverStub(),
-                new LifecyclePluginResolver(new PluginVersionResolverStub()));
+                new PluginVersionResolverStub(), new BuildPluginManagerStub(), new PluginPrefixResolverStub());
     }
 
     @Override

--- a/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecycleTaskSegmentCalculatorStub.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecycleTaskSegmentCalculatorStub.java
@@ -44,7 +44,7 @@ public class LifecycleTaskSegmentCalculatorStub extends DefaultLifecycleTaskSegm
     public static final String INSTALL = "install";
 
     public LifecycleTaskSegmentCalculatorStub() {
-        super(null, null);
+        super(null);
     }
 
     @Override

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolverTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolverTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.prefix.internal;
+
+import java.util.List;
+
+import org.apache.maven.artifact.repository.metadata.io.MetadataReader;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.prefix.DefaultPluginPrefixRequest;
+import org.apache.maven.plugin.prefix.PluginPrefixResult;
+import org.apache.maven.plugin.version.PluginVersionResolver;
+import org.apache.maven.plugin.version.PluginVersionResult;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultPluginPrefixResolverTest {
+    @Mock
+    private BuildPluginManager pluginManager;
+
+    @Mock
+    private RepositorySystem repositorySystem;
+
+    @Mock
+    private MetadataReader metadataReader;
+
+    @Mock
+    private PluginVersionResolver pluginVersionResolver;
+
+    @Mock
+    private RepositorySystemSession repositorySession;
+
+    @Mock
+    private PluginVersionResult pluginVersionResult;
+
+    @Test
+    void resolvesVersionOnlyForMatchingProjectPlugin() throws Exception {
+        Plugin matchingPlugin = plugin("com.example", "custom-maven-plugin");
+        Plugin unrelatedPlugin = plugin("org.apache.maven.plugins", "maven-release-plugin");
+
+        Build build = new Build();
+        build.setPlugins(List.of(unrelatedPlugin, matchingPlugin));
+        Model model = new Model();
+        model.setBuild(build);
+
+        when(pluginVersionResult.getVersion()).thenReturn("1.0");
+        when(pluginVersionResolver.resolve(any())).thenReturn(pluginVersionResult);
+
+        PluginDescriptor descriptor = new PluginDescriptor();
+        descriptor.setGroupId(matchingPlugin.getGroupId());
+        descriptor.setArtifactId(matchingPlugin.getArtifactId());
+        descriptor.setVersion("1.0");
+        descriptor.setGoalPrefix("custom");
+        when(pluginManager.loadPlugin(
+                        argThat(plugin -> matchingPlugin.getArtifactId().equals(plugin.getArtifactId())
+                                && "1.0".equals(plugin.getVersion())),
+                        eq(List.of()),
+                        eq(repositorySession)))
+                .thenReturn(descriptor);
+
+        DefaultPluginPrefixResolver resolver =
+                new DefaultPluginPrefixResolver(pluginManager, repositorySystem, metadataReader, pluginVersionResolver);
+        PluginPrefixResult result = resolver.resolve(new DefaultPluginPrefixRequest()
+                .setPrefix("custom")
+                .setPom(model)
+                .setRepositorySession(repositorySession));
+
+        assertEquals(matchingPlugin.getGroupId(), result.getGroupId());
+        assertEquals(matchingPlugin.getArtifactId(), result.getArtifactId());
+
+        verify(pluginVersionResolver)
+                .resolve(argThat(request ->
+                        matchingPlugin.getArtifactId().equals(request.getArtifactId()) && request.getPom() == model));
+        verify(pluginVersionResolver, never())
+                .resolve(argThat(request -> unrelatedPlugin.getArtifactId().equals(request.getArtifactId())));
+        verify(pluginManager, never())
+                .loadPlugin(
+                        argThat(plugin -> unrelatedPlugin.getArtifactId().equals(plugin.getArtifactId())),
+                        any(),
+                        eq(repositorySession));
+        verifyNoInteractions(repositorySystem);
+    }
+
+    private Plugin plugin(String groupId, String artifactId) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(groupId);
+        plugin.setArtifactId(artifactId);
+        return plugin;
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #12721 to `maven-4.0.x` for the rc-7 release.

Fixes #10128.

Direct CLI goals (`prefix:goal`) currently trigger missing-version resolution for every plugin in the project before Maven resolves the requested goal. This causes unnecessary downloads of plugins declared in `pluginManagement` or inactive profiles even when the goal does not use them.

This change:
- Skips project-wide plugin version resolution while calculating direct goal task segments
- Limits project-wide resolution during execution planning to plans that contain lifecycle phases
- Resolves a missing version lazily when a project-declared plugin is actually considered during prefix resolution

Cherry-picked from 1b0a19e3ee (master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)