### PR TITLE
Fix #12912: use a dumb fallback terminal for all build-thread reentrant calls

### DIFF
--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
@@ -37,6 +37,7 @@ import org.jline.terminal.MouseEvent;
 import org.jline.terminal.Size;
 import org.jline.terminal.Sized;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalExt;
 import org.jline.terminal.spi.TerminalProvider;
@@ -68,9 +69,28 @@ public class FastTerminal implements TerminalExt {
      */
     private final OutputStream fallbackOutput;
 
+    /**
+     * A dumb terminal constructed <em>before</em> the build thread starts, used as a stand-in for
+     * every delegate method when the build thread would otherwise wait on its own future. Guarding
+     * only {@code writer()} and {@code getType()} was sufficient for JLine 4.3.x, but JLine 4.4.0's
+     * FFM provider initialization ({@code CLibrary.<clinit>}) reaches back through other terminal
+     * methods, so the fallback must cover all of them. See
+     * <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
+     */
+    private final TerminalExt fallbackTerminal;
+
     public FastTerminal(Callable<Terminal> builder, Consumer<Terminal> consumer) {
         this.terminal = new CompletableFuture<>();
         this.fallbackOutput = System.err;
+        TerminalExt dumbFallback;
+        try {
+            // Construct a DumbTerminal directly instead of going through TerminalBuilder, which
+            // probes for grapheme-cluster support and can block on a null input stream in JLine 4.4.0.
+            dumbFallback = new DumbTerminal(InputStream.nullInputStream(), fallbackOutput);
+        } catch (IOException e) {
+            dumbFallback = null;
+        }
+        this.fallbackTerminal = dumbFallback;
         this.buildThread = new Thread(
                 () -> {
                     try {
@@ -88,6 +108,12 @@ public class FastTerminal implements TerminalExt {
     }
 
     public TerminalExt getTerminal() {
+        if (isBuildThreadWaitingOnItself()) {
+            if (fallbackTerminal != null) {
+                return fallbackTerminal;
+            }
+            throw new IllegalStateException("Terminal not yet available (build in progress on this thread)");
+        }
         try {
             return (TerminalExt) terminal.get();
         } catch (Exception e) {

--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -32,15 +32,22 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link MessageUtils#systemInstall} publishes the terminal before the background thread has built
  * it, so anything that thread logs is rendered through a terminal that same thread is still
- * producing. See <a href="https://github.com/apache/maven/issues/12761">#12761</a>.
+ * producing. See <a href="https://github.com/apache/maven/issues/12761">#12761</a> and
+ * <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
  * <p>
  * A single log statement asks the terminal for two things, its type while rendering the message and
  * its writer while emitting the line, so both are exercised from both halves of the window: the
  * builder callable, and the consumer that runs before the terminal is published.
+ * <p>
+ * JLine 4.4.0's FFM provider initialization ({@code CLibrary.<clinit>}) can reach back through
+ * other terminal methods (e.g. {@code getName()}, {@code getWidth()}, {@code encoding()}) on the
+ * build thread, so the fallback must cover all delegate methods, not just {@code writer()} and
+ * {@code getType()}.
  * <p>
  * The timeouts are preemptive on purpose: a regression parks the build thread forever, and only an
  * abandoning timeout turns that into a red test rather than a hung fork.
@@ -74,6 +81,44 @@ class FastTerminalReentrancyTest {
             CompletableFuture<String[]> probed = new CompletableFuture<>();
             installAndAwait(builder -> {}, terminal -> probed.complete(probe()));
             assertProbe(probed.get());
+        });
+    }
+
+    /**
+     * Exercises terminal methods beyond {@code writer()} and {@code getType()} that JLine's FFM
+     * provider initialization can reach on the build thread. Before the fallback terminal was added,
+     * these would deadlock. See <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
+     */
+    @Test
+    void arbitraryTerminalMethodsFromTheBuilderDoNotDeadlock() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<int[]> probed = new CompletableFuture<>();
+            installAndAwait(
+                    builder -> {
+                        Terminal t = MessageUtils.getTerminal();
+                        probed.complete(
+                                new int[] {t.getSize().getColumns(), t.getSize().getRows()});
+                    },
+                    terminal -> {});
+            int[] dims = probed.get();
+            assertTrue(dims[0] >= 0, "width should be non-negative");
+            assertTrue(dims[1] >= 0, "height should be non-negative");
+        });
+    }
+
+    /**
+     * Exercises terminal methods beyond {@code writer()} and {@code getType()} from the consumer
+     * callback. See <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
+     */
+    @Test
+    void arbitraryTerminalMethodsFromTheConsumerDoNotDeadlock() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<String> probed = new CompletableFuture<>();
+            installAndAwait(builder -> {}, terminal -> {
+                Terminal t = MessageUtils.getTerminal();
+                probed.complete(t.getName());
+            });
+            assertNotNull(probed.get());
         });
     }
 


### PR DESCRIPTION
## Summary

- Fixes Maven 4.0.0-rc-6 hanging on startup with JDK 25 in Linux container environments
- The previous fix for #12761 guarded only `writer()` and `getType()` against reentrant calls from the build thread, but JLine 4.4.0's FFM provider initialization (`CLibrary.<clinit>`) reaches back through other terminal methods (`getSize`, `getName`, `encoding`, etc.), causing the same deadlock
- Constructs a `DumbTerminal` directly (bypassing `TerminalBuilder`'s grapheme-cluster probing) before the build thread starts, and returns it from `getTerminal()` whenever the build thread would otherwise wait on its own future — covering all delegate methods at once

Fixes #12912

## Test plan

- [x] Existing `FastTerminalReentrancyTest` tests for `writer()` and `getType()` still pass
- [x] New test `arbitraryTerminalMethodsFromTheBuilderDoNotDeadlock` verifies `getSize()` from the builder callback does not deadlock
- [x] New test `arbitraryTerminalMethodsFromTheConsumerDoNotDeadlock` verifies `getName()` from the consumer callback does not deadlock
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)