### PR TITLE
fix: interpolate properties in module/subproject path before filesystem resolution (backport #12734)

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -992,6 +992,18 @@ public class DefaultModelBuilder implements ModelBuilder {
                         continue;
                     }
 
+                    // #12729: interpolate properties in the subproject/module path (e.g.
+                    // <module>./../module/pom${version-discriminator}.xml</module>) before
+                    // resolving it against the filesystem. Model-wide interpolation happens
+                    // later in the build, but module paths must be resolved here, so we
+                    // interpolate just the path against the user, model and system properties.
+                    subproject = interpolator.interpolate(
+                            subproject,
+                            Interpolator.chain(
+                                    request.getUserProperties()::get,
+                                    activated.getProperties()::get,
+                                    request.getSystemProperties()::get));
+
                     subproject = subproject.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 
                     Path rawSubprojectFile = modelProcessor.locateExistingPom(pomDirectory.resolve(subproject));

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12729ModulePathPropertyInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12729ModulePathPropertyInterpolationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
+import java.io.File;
 
 import org.junit.jupiter.api.Test;
 
@@ -34,14 +34,18 @@ import org.junit.jupiter.api.Test;
  */
 class MavenITgh12729ModulePathPropertyInterpolationTest extends AbstractMavenIntegrationTestCase {
 
+    MavenITgh12729ModulePathPropertyInterpolationTest() {
+        super("[4.0.0-rc-1,)");
+    }
+
     /**
      * Verify that a POM-defined property in a {@code <module>} path is interpolated correctly.
      */
     @Test
     void testModulePathWithPomProperty() throws Exception {
-        Path basedir = extractResources("/gh-12729-module-path-property-interpolation");
+        File testDir = extractResources("/gh-12729-module-path-property-interpolation");
 
-        Verifier verifier = newVerifier(basedir);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -53,9 +57,9 @@ class MavenITgh12729ModulePathPropertyInterpolationTest extends AbstractMavenInt
      */
     @Test
     void testModulePathWithUserPropertyOverride() throws Exception {
-        Path basedir = extractResources("/gh-12729-module-path-property-interpolation");
+        File testDir = extractResources("/gh-12729-module-path-property-interpolation");
 
-        Verifier verifier = newVerifier(basedir);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         // The POM defines child-dir=child; this override should also resolve to "child"
         verifier.addCliArgument("-Dchild-dir=child");
         verifier.addCliArgument("validate");

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12729ModulePathPropertyInterpolationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12729ModulePathPropertyInterpolationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for <a href="https://github.com/apache/maven/issues/12729">#12729</a>.
+ * Verifies that properties in {@code <module>} (or {@code <subproject>}) paths of aggregator
+ * POMs are interpolated before filesystem resolution.
+ *
+ * <p>Maven 3 interpolated {@code ${property}} references in module paths, but Maven 4 lost
+ * this behaviour because the module path is resolved against the filesystem before model-wide
+ * interpolation runs. The fix performs a targeted early interpolation of the path string
+ * against user, model and system properties.
+ */
+class MavenITgh12729ModulePathPropertyInterpolationTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that a POM-defined property in a {@code <module>} path is interpolated correctly.
+     */
+    @Test
+    void testModulePathWithPomProperty() throws Exception {
+        Path basedir = extractResources("/gh-12729-module-path-property-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+
+    /**
+     * Verify that a user property ({@code -D}) overrides a POM property in a module path,
+     * following Maven's user → model → system property precedence.
+     */
+    @Test
+    void testModulePathWithUserPropertyOverride() throws Exception {
+        Path basedir = extractResources("/gh-12729-module-path-property-interpolation");
+
+        Verifier verifier = newVerifier(basedir);
+        // The POM defines child-dir=child; this override should also resolve to "child"
+        verifier.addCliArgument("-Dchild-dir=child");
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/child/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12729</groupId>
+    <artifactId>module-path-interpolation-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>module-path-interpolation-child</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12729-module-path-property-interpolation/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12729</groupId>
+  <artifactId>module-path-interpolation-parent</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <child-dir>child</child-dir>
+  </properties>
+
+  <modules>
+    <module>${child-dir}</module>
+  </modules>
+</project>


### PR DESCRIPTION
## Summary

Backport of #12734 to `maven-4.0.x`.

- Interpolate `${property}` references in `<module>`/`<subproject>` paths before filesystem resolution, restoring Maven 3 behaviour
- Use `Interpolator.chain()` with correct user → model → system property precedence
- Add regression integration test for gh-12729

Fixes #12729