### PR TITLE
Fix #12912: use a dumb fallback terminal for all build-thread reentrant calls

### DIFF
--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
@@ -18,10 +18,10 @@
  */
 package org.apache.maven.jline;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.util.concurrent.Callable;
@@ -37,6 +37,7 @@ import org.jline.terminal.MouseEvent;
 import org.jline.terminal.Size;
 import org.jline.terminal.Sized;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalExt;
 import org.jline.terminal.spi.TerminalProvider;
@@ -56,21 +57,37 @@ public class FastTerminal implements TerminalExt {
     private final Thread buildThread;
 
     /**
-     * Writer handed to {@link #buildThread} while the real terminal is still being built. Created on
-     * demand, and only ever by {@link #buildThread}.
+     * A dumb terminal constructed <em>before</em> the build thread starts, used as a stand-in for
+     * every delegate method when the build thread would otherwise wait on its own future. Guarding
+     * only individual methods was sufficient for JLine 4.3.x, but JLine 4.4.0's FFM provider
+     * initialization ({@code CLibrary.<clinit>}) reaches back through arbitrary terminal methods, so
+     * the fallback must cover all of them. Its output stream is wrapped so that closing the fallback
+     * terminal does not close the captured {@code System.err}. See
+     * <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
      */
-    private PrintWriter fallbackWriter;
-
-    /**
-     * Captured before {@link #buildThread} starts, hence before the consumer swaps the system streams
-     * for logging-backed ones. Writing to the live {@code System.err} instead would feed the fallback
-     * output back into the logger it came from.
-     */
-    private final OutputStream fallbackOutput;
+    private final TerminalExt fallbackTerminal;
 
     public FastTerminal(Callable<Terminal> builder, Consumer<Terminal> consumer) {
         this.terminal = new CompletableFuture<>();
-        this.fallbackOutput = System.err;
+        // Capture System.err before the build thread starts — the consumer swaps the system streams
+        // for logging-backed ones, and writing to the live System.err would feed the fallback output
+        // back into the logger it came from.
+        OutputStream fallbackOutput = System.err;
+        TerminalExt dumbFallback;
+        try {
+            // Construct a DumbTerminal directly instead of going through TerminalBuilder, which
+            // probes for grapheme-cluster support and can block on a null input stream in JLine 4.4.0.
+            // Wrap the output so closing the fallback does not close the underlying System.err.
+            dumbFallback = new DumbTerminal(InputStream.nullInputStream(), new FilterOutputStream(fallbackOutput) {
+                @Override
+                public void close() throws IOException {
+                    flush();
+                }
+            });
+        } catch (IOException e) {
+            dumbFallback = null;
+        }
+        this.fallbackTerminal = dumbFallback;
         this.buildThread = new Thread(
                 () -> {
                     try {
@@ -88,6 +105,12 @@ public class FastTerminal implements TerminalExt {
     }
 
     public TerminalExt getTerminal() {
+        if (isBuildThreadWaitingOnItself()) {
+            if (fallbackTerminal != null) {
+                return fallbackTerminal;
+            }
+            throw new IllegalStateException("Terminal not yet available (build in progress on this thread)");
+        }
         try {
             return (TerminalExt) terminal.get();
         } catch (Exception e) {
@@ -109,14 +132,6 @@ public class FastTerminal implements TerminalExt {
      */
     boolean isBuilt() {
         return terminal.isDone();
-    }
-
-    private PrintWriter fallbackWriter() {
-        // only buildThread reaches this, so no synchronization is needed
-        if (fallbackWriter == null) {
-            fallbackWriter = new PrintWriter(new OutputStreamWriter(fallbackOutput, Charset.defaultCharset()), true);
-        }
-        return fallbackWriter;
     }
 
     @Override
@@ -141,8 +156,7 @@ public class FastTerminal implements TerminalExt {
 
     @Override
     public PrintWriter writer() {
-        // the log sink writes here, and must not wait for the terminal this thread is building
-        return isBuildThreadWaitingOnItself() ? fallbackWriter() : getTerminal().writer();
+        return getTerminal().writer();
     }
 
     @Override
@@ -247,11 +261,7 @@ public class FastTerminal implements TerminalExt {
 
     @Override
     public String getType() {
-        // AttributedCharSequence.toAnsi asks for the type first and renders plain for a dumb one,
-        // so answering here keeps message rendering off the terminal this thread is building
-        return isBuildThreadWaitingOnItself()
-                ? Terminal.TYPE_DUMB
-                : getTerminal().getType();
+        return getTerminal().getType();
     }
 
     @Override

--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -32,15 +32,22 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link MessageUtils#systemInstall} publishes the terminal before the background thread has built
  * it, so anything that thread logs is rendered through a terminal that same thread is still
- * producing. See <a href="https://github.com/apache/maven/issues/12761">#12761</a>.
+ * producing. See <a href="https://github.com/apache/maven/issues/12761">#12761</a> and
+ * <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
  * <p>
  * A single log statement asks the terminal for two things, its type while rendering the message and
  * its writer while emitting the line, so both are exercised from both halves of the window: the
  * builder callable, and the consumer that runs before the terminal is published.
+ * <p>
+ * JLine 4.4.0's FFM provider initialization ({@code CLibrary.<clinit>}) can reach back through
+ * arbitrary terminal methods (e.g. {@code getName()}, {@code getSize()}, {@code encoding()}) on the
+ * build thread, so the fallback must cover all delegate methods, not just {@code writer()} and
+ * {@code getType()}.
  * <p>
  * The timeouts are preemptive on purpose: a regression parks the build thread forever, and only an
  * abandoning timeout turns that into a red test rather than a hung fork.
@@ -74,6 +81,44 @@ class FastTerminalReentrancyTest {
             CompletableFuture<String[]> probed = new CompletableFuture<>();
             installAndAwait(builder -> {}, terminal -> probed.complete(probe()));
             assertProbe(probed.get());
+        });
+    }
+
+    /**
+     * Exercises terminal methods beyond {@code writer()} and {@code getType()} that JLine's FFM
+     * provider initialization can reach on the build thread. Before the fallback terminal was added,
+     * these would deadlock. See <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
+     */
+    @Test
+    void arbitraryTerminalMethodsFromTheBuilderDoNotDeadlock() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<int[]> probed = new CompletableFuture<>();
+            installAndAwait(
+                    builder -> {
+                        Terminal t = MessageUtils.getTerminal();
+                        probed.complete(
+                                new int[] {t.getSize().getColumns(), t.getSize().getRows()});
+                    },
+                    terminal -> {});
+            int[] dims = probed.get();
+            assertTrue(dims[0] >= 0, "width should be non-negative");
+            assertTrue(dims[1] >= 0, "height should be non-negative");
+        });
+    }
+
+    /**
+     * Exercises terminal methods beyond {@code writer()} and {@code getType()} from the consumer
+     * callback. See <a href="https://github.com/apache/maven/issues/12912">#12912</a>.
+     */
+    @Test
+    void arbitraryTerminalMethodsFromTheConsumerDoNotDeadlock() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<String> probed = new CompletableFuture<>();
+            installAndAwait(builder -> {}, terminal -> {
+                Terminal t = MessageUtils.getTerminal();
+                probed.complete(t.getName());
+            });
+            assertNotNull(probed.get());
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes Maven 4.0.0-rc-6 hanging on startup with JDK 25 in Linux container environments, and fixes a flaky `FastTerminalReentrancyTest.usingTheTerminalFromTheConsumerDoesNotDeadlock` deadlock observed across JDK 17/21/25 on ubuntu CI runners ([example](https://github.com/apache/maven/actions/runs/33240711857/job/99092450601?pr=12913), [example](https://github.com/apache/maven/actions/runs/33258097527), [example](https://github.com/apache/maven/actions/runs/33255877185)).

**Root cause:** `FastTerminal` only guarded `writer()` and `getType()` against build-thread reentrancy. JLine 4.4.0's FFM provider initialization (`CLibrary.<clinit>`) and `AnsiConsole.systemInstall()` can reach back through other terminal methods (`getSize`, `getName`, `encoding`, etc.) on the build thread, causing a deadlock where the build thread waits on the `CompletableFuture` it is itself computing.

**Fix:** Move the `isBuildThreadWaitingOnItself()` guard into `getTerminal()` — the single choke point all delegate methods pass through — backed by a pre-built `DumbTerminal`. This covers all methods at once, including any new ones JLine may add.

**Improvements over #12921:**
- The `DumbTerminal`'s output stream is wrapped with `FilterOutputStream` so that `close()` flushes instead of closing the captured `System.err` — `DumbTerminal.doClose()` cascades to its writer's underlying stream, and closing `System.err` would silently break stderr for the process
- Removed the now-redundant per-method guards on `writer()` and `getType()`, along with the unused `fallbackWriter` field and `fallbackWriter()` method — the single guard in `getTerminal()` makes them dead code

## Test plan

- [x] Existing tests for `writer()` and `getType()` still pass (4 tests, 10/10 stress runs)
- [x] New test `arbitraryTerminalMethodsFromTheBuilderDoNotDeadlock` verifies `getSize()` from the builder callback
- [x] New test `arbitraryTerminalMethodsFromTheConsumerDoNotDeadlock` verifies `getName()` from the consumer callback
- [ ] CI passes on all platforms

Supersedes #12921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)