### PR TITLE
Fix: make ProjectIndex thread-safe for parallel builds (backport #12832)

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -438,15 +438,27 @@ public class MojoExecutor {
                             .getData()
                             .computeIfAbsent(PROJECT_INDEX, () -> new ProjectIndex(session.getProjects()));
 
-                    Integer index = projectIndex.getIndices().get(projectId);
-                    if (index == null) {
+                    Integer idx = projectIndex.getIndices().get(projectId);
+                    if (idx == null) {
                         throw new LifecycleExecutionException(
-                                "Forked execution references project '" + projectId + "' which is not in the reactor",
+                                "Forked execution references project '" + projectId
+                                        + "' which is not in the reactor. This can happen with parallel builds"
+                                        + " (-T) or when extensions modify the session projects.",
                                 mojoExecution,
                                 project);
                     }
+                    int index = idx;
 
                     MavenProject forkedProject = projectIndex.getProjects().get(projectId);
+                    if (forkedProject == null) {
+                        throw new LifecycleExecutionException(
+                                "Forked execution references project '" + projectId
+                                        + "' which is not in the reactor (no project instance). This can happen"
+                                        + " with parallel builds (-T) or when extensions modify the session"
+                                        + " projects.",
+                                mojoExecution,
+                                project);
+                    }
 
                     forkedProjects.add(forkedProject);
 

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectIndex.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectIndex.java
@@ -18,9 +18,9 @@
  */
 package org.apache.maven.lifecycle.internal;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.lifecycle.internal.builder.BuilderCommon;
 import org.apache.maven.project.MavenProject;
@@ -41,8 +41,8 @@ public final class ProjectIndex {
     private final Map<String, Integer> indices;
 
     public ProjectIndex(List<MavenProject> projects) {
-        this.projects = new HashMap<>(projects.size() * 2);
-        this.indices = new HashMap<>(projects.size() * 2);
+        this.projects = new ConcurrentHashMap<>(projects.size() * 2);
+        this.indices = new ConcurrentHashMap<>(projects.size() * 2);
 
         for (int i = 0; i < projects.size(); i++) {
             MavenProject project = projects.get(i);


### PR DESCRIPTION
## Summary

Backport of #12832 to `maven-4.0.x`.

- Switch `ProjectIndex` backing maps from `HashMap` to `ConcurrentHashMap` to fix root cause of index corruption under parallel builds (`-T`)
- Add `forkedProject` null guard (the `indices` null guard was already backported via #12911)
- Enrich error messages with diagnostic hints about parallel builds and extensions

## Test plan

- [x] Existing `MojoExecutorForkedExecutionTest` covers the null-guard behavior
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)