### PR TITLE
Fix: make ProjectIndex thread-safe for parallel builds (backport #12832)

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/MojoExecutor.java
@@ -431,9 +431,27 @@ public class MojoExecutor {
                 for (Map.Entry<String, List<MojoExecution>> fork : forkedExecutions.entrySet()) {
                     String projectId = fork.getKey();
 
-                    int index = projectIndex.getIndices().get(projectId);
+                    Integer idx = projectIndex.getIndices().get(projectId);
+                    if (idx == null) {
+                        throw new LifecycleExecutionException(
+                                "Forked execution references project '" + projectId
+                                        + "' which is not in the reactor. This can happen with parallel builds"
+                                        + " (-T) or when extensions modify the session projects.",
+                                mojoExecution,
+                                project);
+                    }
+                    int index = idx;
 
                     MavenProject forkedProject = projectIndex.getProjects().get(projectId);
+                    if (forkedProject == null) {
+                        throw new LifecycleExecutionException(
+                                "Forked execution references project '" + projectId
+                                        + "' which is not in the reactor (no project instance). This can happen"
+                                        + " with parallel builds (-T) or when extensions modify the session"
+                                        + " projects.",
+                                mojoExecution,
+                                project);
+                    }
 
                     forkedProjects.add(forkedProject);
 

--- a/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectIndex.java
+++ b/maven-core/src/main/java/org/apache/maven/lifecycle/internal/ProjectIndex.java
@@ -18,9 +18,9 @@
  */
 package org.apache.maven.lifecycle.internal;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.lifecycle.internal.builder.BuilderCommon;
 import org.apache.maven.project.MavenProject;
@@ -43,8 +43,8 @@ public final class ProjectIndex {
     private final Map<String, Integer> indices;
 
     public ProjectIndex(List<MavenProject> projects) {
-        this.projects = new HashMap<>(projects.size() * 2);
-        this.indices = new HashMap<>(projects.size() * 2);
+        this.projects = new ConcurrentHashMap<>(projects.size() * 2);
+        this.indices = new ConcurrentHashMap<>(projects.size() * 2);
 
         for (int i = 0; i < projects.size(); i++) {
             MavenProject project = projects.get(i);


### PR DESCRIPTION
## Summary

Backport of #12832 to `maven-3.10.x`.

- Switch `ProjectIndex` backing maps from `HashMap` to `ConcurrentHashMap` to fix root cause of index corruption under parallel builds (`-T`)
- Add null guards for both `indices` and `projects` lookups with enriched error messages mentioning parallel builds and extensions as possible causes

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)