### PR TITLE
[Backport 4.0.x] Fix operator precedence skipping type=bom dependency imports

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2097,8 +2097,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             for (Iterator<Dependency> it = deps.iterator(); it.hasNext(); ) {
                 Dependency dependency = it.next();
 
-                if (!("pom".equals(dependency.getType()) && "import".equals(dependency.getScope()))
-                        || "bom".equals(dependency.getType())) {
+                if (!(("pom".equals(dependency.getType()) && "import".equals(dependency.getScope()))
+                        || "bom".equals(dependency.getType()))) {
                     continue;
                 }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -32,6 +32,8 @@ import java.util.Set;
 
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.Model;
@@ -44,6 +46,10 @@ import org.apache.maven.api.services.Sources;
 import org.apache.maven.impl.DefaultRemoteRepository;
 import org.apache.maven.impl.standalone.ApiRunner;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
+import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.transport.apache.ApacheTransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -829,6 +835,42 @@ class DefaultModelBuilderTest {
                         + "which indicates the path normalization fix (GH-12598) is not working.");
     }
 
+    /**
+     * {@code type=bom} dependencyManagement entries must be processed as BOM imports
+     * without requiring {@code scope=import}. The {@code bom} type inherently implies
+     * import semantics (unlike {@code type=pom}, which requires {@code scope=import}).
+     * Operator precedence previously skipped {@code type=bom} always (GH-12589).
+     */
+    @Test
+    public void testBomTypeImpliesImportWithoutScope() {
+        Path basedir = Paths.get(System.getProperty("basedir", ""));
+        Path localRepoPath = basedir.resolve("target/local-repo-bom-import");
+        Path remoteRepoPath = basedir.resolve("src/test/remote-repo");
+        Session bomSession = ApiRunner.createSession(
+                injector -> injector.bindInstance(DefaultModelBuilderTest.class, this), localRepoPath);
+        RemoteRepository remoteRepository = bomSession.createRemoteRepository(
+                RemoteRepository.CENTRAL_ID, remoteRepoPath.toUri().toString());
+        bomSession = bomSession.withRemoteRepositories(List.of(remoteRepository));
+        ModelBuilder bomBuilder = bomSession.getService(ModelBuilder.class);
+
+        ModelBuilderResult result = bomBuilder
+                .newSession()
+                .build(ModelBuilderRequest.builder()
+                        .session(bomSession)
+                        .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                        .source(Sources.buildSource(getPom("import-bom-type")))
+                        .build());
+
+        assertNotNull(result);
+        assertNotNull(result.getEffectiveModel().getDependencyManagement());
+        Dependency managed = result.getEffectiveModel().getDependencyManagement().getDependencies().stream()
+                .filter(d -> "a".equals(d.getArtifactId()) && "org.apache.maven.its".equals(d.getGroupId()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(managed, "Managed dependency from type=bom import should be present");
+        assertEquals("0.1", managed.getVersion());
+    }
+
     private static DefaultProfileActivationContext.Record recordActiveProfile(
             List<String> activeIds, String profileId) {
         DefaultProfileActivationContext recording =
@@ -841,6 +883,19 @@ class DefaultModelBuilderTest {
             List<String> activeIds, List<String> inactiveIds) {
         return new DefaultProfileActivationContext(
                 null, null, null, activeIds, inactiveIds, Map.of(), Map.of(), Model.newInstance());
+    }
+
+    @Provides
+    @Named(FileTransporterFactory.NAME)
+    static FileTransporterFactory newFileTransporterFactory() {
+        return new FileTransporterFactory();
+    }
+
+    @Provides
+    @Named(ApacheTransporterFactory.NAME)
+    static ApacheTransporterFactory newApacheTransporterFactory(
+            ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
+        return new ApacheTransporterFactory(checksumExtractor, pathProcessor);
     }
 
     private Path getPom(String name) {

--- a/impl/maven-impl/src/test/resources/poms/factory/import-bom-type.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/import-bom-type.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+    <groupId>org.apache.maven.tests</groupId>
+    <artifactId>import-bom-type</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- type=bom without scope=import: the bom type inherently implies import -->
+            <dependency>
+                <groupId>org.apache.maven.its</groupId>
+                <artifactId>bom</artifactId>
+                <version>0.1</version>
+                <type>bom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>


### PR DESCRIPTION
## Summary

Backport of #12722 to `maven-4.0.x`.

`importDependencyManagement` skipped every dependency with `type=bom` because of operator precedence:

```java
if (!(pom && import) || bom) {
    continue;
}
```

For `type=bom` the `|| bom` term is always true, so BOM-typed entries never loaded managed dependencies. This fix treats `(pom && import) || bom` as an import BOM/POM entry.

Fixes #12589