### PR TITLE
[MNG-8174] Fix NPE when a property references itself in a plugin configuration

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
@@ -716,14 +716,14 @@ public class StringVisitorModelInterpolator extends AbstractStringBasedModelInte
                 // Content
                 org = dom.getValue();
                 val = interpolate(org);
-                if (org != val) {
+                if (org != val && val != null) {
                     dom.setValue(val);
                 }
                 // Attributes
                 for (String attr : dom.getAttributeNames()) {
                     org = dom.getAttribute(attr);
                     val = interpolate(org);
-                    if (org != val) {
+                    if (org != val && val != null) {
                         dom.setAttribute(attr, val);
                     }
                 }

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
@@ -439,5 +439,43 @@ public abstract class AbstractModelInterpolatorTest {
                 collector.getErrors().get(0));
     }
 
+    @Test
+    public void testRecursiveExpressionCycleInPluginConfiguration() throws Exception {
+        // MNG-8174: a self-referencing property used in a plugin configuration attribute must not
+        // cause an NPE while interpolating the plugin configuration
+        Map<String, String> props = new HashMap<>();
+        props.put("prop", "${prop}");
+
+        org.apache.maven.api.xml.XmlNode filter = org.apache.maven.api.xml.XmlNode.newBuilder()
+                .name("filter")
+                .attributes(Map.of("token", "key", "value", "${prop}"))
+                .build();
+        org.apache.maven.api.xml.XmlNode configuration = org.apache.maven.api.xml.XmlNode.newBuilder()
+                .name("configuration")
+                .children(List.of(filter))
+                .build();
+
+        DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
+
+        Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
+                .properties(props)
+                .build(org.apache.maven.api.model.Build.newBuilder()
+                        .plugins(List.of(org.apache.maven.api.model.Plugin.newBuilder()
+                                .artifactId("maven-antrun-plugin")
+                                .configuration(configuration)
+                                .build()))
+                        .build())
+                .build());
+
+        SimpleProblemCollector collector = new SimpleProblemCollector();
+        ModelInterpolator interpolator = createInterpolator();
+        Model out = interpolator.interpolateModel(model, null, request, collector);
+
+        assertNotNull(out);
+        assertCollectorState(0, 1, 0, collector);
+        org.apache.maven.api.model.Plugin p = out.getBuild().getPlugins().get(0).getDelegate();
+        assertEquals("${prop}", p.getConfiguration().child("filter").attribute("value"));
+    }
+
     protected abstract ModelInterpolator createInterpolator() throws Exception;
 }


### PR DESCRIPTION
Fixes #10598 (MNG-8174)

### Problem
When a POM property references itself (e.g. `<prop>${prop}</prop>`) and that
property is also used inside a plugin configuration attribute such as
`<filter token="key" value="${prop}"/>`, invoking the model interpolation
throws

```
java.lang.NullPointerException: Attribute value can not be null
    at org.codehaus.plexus.util.xml.Xpp3Dom.setAttribute(Xpp3Dom.java:179)
    at ...StringVisitorModelInterpolator$ModelVisitor.visit(StringVisitorModelInterpolator.java:727)
```

A recursive expression cycle is detected by the interpolator, which then
returns `null` for the unresolved expression. `visit(Xpp3Dom)` in
`StringVisitorModelInterpolator` unconditionally called
`dom.setAttribute(attr, val)` (and `dom.setValue(val)`) even when the
interpolated value was `null`, causing the NPE. The `visit(Properties)`
method already guarded against `null` in the identical situation.

### Fix
When interpolation of an Xpp3Dom content value or attribute returns `null`
(which happens on a recursive expression cycle), leave the original value
untouched instead of writing `null` into the DOM. This mirrors the existing
guard in `visit(Properties)`.

### Test
Added `testRecursiveExpressionCycleInPluginConfiguration` to
`AbstractModelInterpolatorTest`, which builds a model with a
self-referencing property and a plugin configuration attribute referencing
it. Before the fix the test fails with the NPE above; after the fix the
interpolation completes, reports the recursive-expression-cycle error and
the attribute keeps its original value.