### PR TITLE
Remove maven-3.8.x from protected branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,7 +38,6 @@ github:
     maven-4.0.x: {}
     maven-3.10.x: {}
     maven-3.9.x: {}
-    maven-3.8.x: {}
     maven-3.0.x: {}
     maven-2.2.x: {}
     pre-reset-master: {}


### PR DESCRIPTION
The 3.8.x release stream is EOL (see dev@ thread: https://lists.apache.org/thread/2t99pftq06j25rq7j3h1l0z5xsn57z6b). The `maven-3.8.x` branch's final state is preserved at tag `archive/maven-3.8.x`; this removes it from `protected_branches` in `.asf.yaml` so the branch itself can be deleted.