### PR TITLE
[MNG-8174] Fix NPE when a property references itself in a plugin configuration (backport #12932)

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
@@ -716,14 +716,14 @@ public class StringVisitorModelInterpolator extends AbstractStringBasedModelInte
                 // Content
                 org = dom.getValue();
                 val = interpolate(org);
-                if (org != val) {
+                if (org != val && val != null) {
                     dom.setValue(val);
                 }
                 // Attributes
                 for (String attr : dom.getAttributeNames()) {
                     org = dom.getAttribute(attr);
                     val = interpolate(org);
-                    if (org != val) {
+                    if (org != val && val != null) {
                         dom.setAttribute(attr, val);
                     }
                 }

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
@@ -439,5 +439,43 @@ public abstract class AbstractModelInterpolatorTest {
                 collector.getErrors().get(0));
     }
 
+    @Test
+    public void testRecursiveExpressionCycleInPluginConfiguration() throws Exception {
+        // MNG-8174: a self-referencing property used in a plugin configuration attribute must not
+        // cause an NPE while interpolating the plugin configuration
+        Map<String, String> props = new HashMap<>();
+        props.put("prop", "${prop}");
+
+        org.apache.maven.api.xml.XmlNode filter = org.apache.maven.api.xml.XmlNode.newBuilder()
+                .name("filter")
+                .attributes(Map.of("token", "key", "value", "${prop}"))
+                .build();
+        org.apache.maven.api.xml.XmlNode configuration = org.apache.maven.api.xml.XmlNode.newBuilder()
+                .name("configuration")
+                .children(List.of(filter))
+                .build();
+
+        DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
+
+        Model model = new Model(org.apache.maven.api.model.Model.newBuilder()
+                .properties(props)
+                .build(org.apache.maven.api.model.Build.newBuilder()
+                        .plugins(List.of(org.apache.maven.api.model.Plugin.newBuilder()
+                                .artifactId("maven-antrun-plugin")
+                                .configuration(configuration)
+                                .build()))
+                        .build())
+                .build());
+
+        SimpleProblemCollector collector = new SimpleProblemCollector();
+        ModelInterpolator interpolator = createInterpolator();
+        Model out = interpolator.interpolateModel(model, null, request, collector);
+
+        assertNotNull(out);
+        assertCollectorState(0, 1, 0, collector);
+        org.apache.maven.api.model.Plugin p = out.getBuild().getPlugins().get(0).getDelegate();
+        assertEquals("${prop}", p.getConfiguration().child("filter").attribute("value"));
+    }
+
     protected abstract ModelInterpolator createInterpolator() throws Exception;
 }


### PR DESCRIPTION
Backport of #12932 (merge commit `8638f335`) to `maven-4.0.x`, fixing MNG-8174.

A self-referencing property used in a plugin configuration attribute caused an NPE during interpolation because `interpolate()` could return `null` while recursing, and the guard `if (org != val)` would still call `setValue`/`setAttribute` with `null`.

This backport:
- Adds `&& val != null` to both `visit(Xpp3Dom)` setters in `StringVisitorModelInterpolator`.
- Adds regression test `testRecursiveExpressionCycleInPluginConfiguration` asserting 1 model error and that the config attribute retains `${prop}`.

Tested: full `StringVisitorModelInterpolatorTest` (19 tests) + `StringSearchModelInterpolatorTest` pass.

Closes https://issues.apache.org/jira/browse/MNG-8174