### PR TITLE
[MNG-8174] Fix NPE when a property references itself in a plugin configuration (backport #12932)

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolator.java
@@ -714,14 +714,14 @@ public class StringVisitorModelInterpolator extends AbstractStringBasedModelInte
                 // Content
                 org = dom.getValue();
                 val = interpolate(org);
-                if (org != val) {
+                if (org != val && val != null) {
                     dom.setValue(val);
                 }
                 // Attributes
                 for (String attr : dom.getAttributeNames()) {
                     org = dom.getAttribute(attr);
                     val = interpolate(org);
-                    if (org != val) {
+                    if (org != val && val != null) {
                         dom.setAttribute(attr, val);
                     }
                 }

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/AbstractModelInterpolatorTest.java
@@ -31,6 +31,7 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Organization;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.Resource;
 import org.apache.maven.model.Scm;
@@ -38,6 +39,7 @@ import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.SimpleProblemCollector;
 import org.apache.maven.model.path.PathTranslator;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -455,6 +457,37 @@ public abstract class AbstractModelInterpolatorTest {
         assertEquals(
                 new File(basedir, "artifact.jar").getAbsolutePath(),
                 new File(rDeps.get(0).getSystemPath()).getAbsolutePath());
+    }
+
+    @Test
+    public void testRecursiveExpressionCycleInPluginConfiguration() throws Exception {
+        // MNG-8174: a self-referencing property used in a plugin configuration attribute must not
+        // cause an NPE while interpolating the plugin configuration
+        Model model = new Model();
+        model.addProperty("prop", "${prop}");
+
+        Xpp3Dom configuration = new Xpp3Dom("configuration");
+        Xpp3Dom filter = new Xpp3Dom("filter");
+        filter.setAttribute("token", "key");
+        filter.setAttribute("value", "${prop}");
+        configuration.addChild(filter);
+
+        Plugin plugin = new Plugin();
+        plugin.setArtifactId("maven-antrun-plugin");
+        plugin.setConfiguration(configuration);
+
+        Build build = new Build();
+        build.addPlugin(plugin);
+        model.setBuild(build);
+
+        SimpleProblemCollector collector = new SimpleProblemCollector();
+        ModelInterpolator interpolator = createInterpolator();
+        Model out = interpolator.interpolateModel(model, null, createModelBuildingRequest(context), collector);
+
+        assertNotNull(out);
+        assertCollectorState(0, 2, 0, collector);
+        Xpp3Dom outConfig = (Xpp3Dom) out.getBuild().getPlugins().get(0).getConfiguration();
+        assertEquals("${prop}", outConfig.getChild("filter").getAttribute("value"));
     }
 
     protected abstract ModelInterpolator createInterpolator(PathTranslator translator) throws Exception;

--- a/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/interpolation/StringVisitorModelInterpolatorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.interpolation;
+
+import org.apache.maven.model.path.PathTranslator;
+
+public class StringVisitorModelInterpolatorTest extends AbstractModelInterpolatorTest {
+    @Override
+    protected ModelInterpolator createInterpolator(PathTranslator translator) throws Exception {
+        return new StringVisitorModelInterpolator().setVersionPropertiesProcessor(new DefaultModelVersionProcessor());
+    }
+
+    @Override
+    protected ModelInterpolator createInterpolator() throws Exception {
+        return new StringVisitorModelInterpolator().setVersionPropertiesProcessor(new DefaultModelVersionProcessor());
+    }
+}


### PR DESCRIPTION
Backport of #12932 (merge commit `8638f335`) to `maven-3.9.x`, fixing MNG-8174.

A self-referencing property used in a plugin configuration attribute caused an NPE during interpolation because `interpolate()` could return `null` while recursing, and the guard `if (org != val)` would still call `setValue`/`setAttribute` with `null`.

This backport:
- Adds `&& val != null` to both `visit(Xpp3Dom)` setters in `StringVisitorModelInterpolator`.
- Adds regression test `testRecursiveExpressionCycleInPluginConfiguration` (asserts 2 model errors on 3.x, since the cycle is reported twice by the older plexus-interpolation) plus a new `StringVisitorModelInterpolatorTest` so the fix is actually exercised on 3.x.

Tested: focused new test + full `StringSearchModelInterpolatorTest` (33 tests) pass. Note: `StringVisitorModelInterpolatorTest` has 2 pre-existing, unrelated failures (`testBasedir`/`testBaseUri`) when `projectDir` is null, present even without this change.

Closes https://issues.apache.org/jira/browse/MNG-8174