### PR TITLE
Fix #12660: inherit version from imported BOM when local dep mgmt entry has no version

### DIFF
--- a/impl/maven-impl/pom.xml
+++ b/impl/maven-impl/pom.xml
@@ -136,6 +136,11 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
@@ -83,6 +83,17 @@ public class DefaultDependencyManagementImporter implements DependencyManagement
                                         + toString(present) + ". Add the conflicting managed dependency directly "
                                         + "to the dependencyManagement section of the POM.");
                     }
+                    if (present != null
+                            && directDependencies.contains(key)
+                            && present.getVersion() == null
+                            && dependency.getVersion() != null) {
+                        dependencies.put(
+                                key,
+                                Dependency.newBuilder(present)
+                                        .version(dependency.getVersion())
+                                        .location("version", dependency.getLocation("version"))
+                                        .build());
+                    }
                     if (present == null && request.isLocationTracking()) {
                         Dependency updatedDependency = updateWithImportedFrom(dependency, source);
                         dependencies.put(key, updatedDependency);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
@@ -18,14 +18,20 @@
  */
 package org.apache.maven.impl.model;
 
+import java.util.List;
+
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputSource;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.services.ModelBuilderRequest;
+import org.apache.maven.api.services.ModelProblemCollector;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 class DefaultDependencyManagementImporterTest {
     @Test
@@ -137,5 +143,45 @@ class DefaultDependencyManagementImporterTest {
                 expectedImportedFrom,
                 actualImportedFrom,
                 "Expected importedFrom to be " + expectedImportedFrom + " but was " + actualImportedFrom);
+    }
+
+    @Test
+    void testImportManagementInheritsVersionFromImportedBomWhenLocalEntryHasNoVersion() {
+        // A locally-declared dep mgmt entry with scope=provided but no version
+        Dependency localDep = Dependency.newBuilder()
+                .groupId("org.junit.jupiter")
+                .artifactId("junit-jupiter-api")
+                .scope("provided")
+                .build();
+
+        Model target = Model.newBuilder()
+                .dependencyManagement(DependencyManagement.newBuilder()
+                        .dependencies(List.of(localDep))
+                        .build())
+                .build();
+
+        // An imported BOM providing the same dependency with a version
+        Dependency importedDep = Dependency.newBuilder()
+                .groupId("org.junit.jupiter")
+                .artifactId("junit-jupiter-api")
+                .version("5.10.0")
+                .build();
+
+        DependencyManagement importedBom = DependencyManagement.newBuilder()
+                .dependencies(List.of(importedDep))
+                .build();
+
+        DefaultDependencyManagementImporter importer = new DefaultDependencyManagementImporter();
+        Model result = importer.importManagement(
+                target, List.of(importedBom), mock(ModelBuilderRequest.class), mock(ModelProblemCollector.class));
+
+        List<Dependency> resultDeps = result.getDependencyManagement().getDependencies();
+        assertEquals(1, resultDeps.size());
+
+        Dependency merged = resultDeps.get(0);
+        assertEquals("org.junit.jupiter", merged.getGroupId());
+        assertEquals("junit-jupiter-api", merged.getArtifactId());
+        assertEquals("5.10.0", merged.getVersion());
+        assertEquals("provided", merged.getScope());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@ under the License.
     <maven.site.path>ref/4-LATEST</maven.site.path>
     <project.build.outputTimestamp>2025-06-24T20:18:00Z</project.build.outputTimestamp>
     <!-- various versions -->
+    <assertjVersion>3.27.7</assertjVersion>
     <asmVersion>9.10.1</asmVersion>
     <byteBuddyVersion>1.18.12</byteBuddyVersion>
     <classWorldsVersion>2.12.1</classWorldsVersion>
@@ -638,6 +639,11 @@ under the License.
         </exclusions>
       </dependency>
 
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertjVersion}</version>
+      </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-testing</artifactId>


### PR DESCRIPTION
## Summary
Forward port of #12915 from `maven-4.0.x` to `master`.

- When a BOM project declares a managed dependency without a version (e.g., `junit-jupiter-api` with `scope=provided`), and the version is expected to come from an imported BOM in the parent POM's dependency management, the consumer POM was generated with the dependency entry missing its version.
- The root cause was in `DefaultDependencyManagementImporter.importManagement()` where `putIfAbsent` skips the imported entry (including its version) when a locally-declared entry already exists.
- After the `putIfAbsent` call, we now check if the existing entry has a null version while the imported entry provides one, and merge the version from the import into the existing entry.

Fixes #12660

## Test plan
- [x] Unit test `testImportManagementInheritsVersionFromImportedBomWhenLocalEntryHasNoVersion` included
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)