### PR TITLE
Add integration test for #12660: BOM version from imported BOM

### DIFF
--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12660BomVersionFromImportedBomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12660BomVersionFromImportedBomTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a BOM's consumer POM inherits the version from an imported BOM
+ * when the local dependency management entry declares only a scope but no version.
+ * <p>
+ * Reproducer for <a href="https://github.com/apache/maven/issues/12660">#12660</a>:
+ * when a BOM module declares a managed dependency with {@code scope=provided} but
+ * no version, and the version is expected to come from an imported BOM, the consumer
+ * POM was generated without the version. The fix in
+ * {@code DefaultDependencyManagementImporter.importManagement()} now merges the
+ * version from the imported entry into the local entry when the local version is null.
+ *
+ * @since 4.0.0
+ */
+class MavenITgh12660BomVersionFromImportedBomTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh12660BomVersionFromImportedBomTest() {
+        super("[4.0.0-rc-1,)");
+    }
+
+    /**
+     * Verify that the BOM consumer POM contains the version inherited from the
+     * imported BOM for a locally-declared dependency with no version.
+     * <p>
+     * The BOM module imports {@code ext-bom} (which declares {@code ext-lib} version
+     * {@code 3.0.0}) and locally declares {@code ext-lib} with {@code scope=provided}
+     * but no version. The consumer POM must contain {@code ext-lib} with version
+     * {@code 3.0.0} and scope {@code provided}.
+     */
+    @Test
+    void testBomConsumerPomInheritsVersionFromImportedBom() throws Exception {
+        File basedir = extractResources("/gh-12660-bom-version-from-imported-bom");
+
+        Verifier verifier = newVerifier(basedir.getAbsolutePath());
+        verifier.deleteArtifacts("org.apache.maven.its.gh12660");
+        verifier.addCliArguments("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Read the consumer POM that was installed to the local repo
+        Path consumerPomPath =
+                Path.of(verifier.getArtifactPath("org.apache.maven.its.gh12660", "bom", "1.0.0-SNAPSHOT", "pom"));
+
+        assertTrue(Files.exists(consumerPomPath), "Consumer POM not found at " + consumerPomPath);
+
+        String content = Files.readString(consumerPomPath);
+
+        // 1. Packaging must be "pom" (not "bom")
+        assertTrue(content.contains("<packaging>pom</packaging>"), "Consumer POM packaging should be 'pom'");
+
+        // 2. Must contain the declared entries: mod-1, mod-2, and ext-lib
+        assertTrue(
+                content.contains("<artifactId>mod-1</artifactId>"),
+                "Consumer POM must contain mod-1.\nActual:\n" + content);
+        assertTrue(
+                content.contains("<artifactId>mod-2</artifactId>"),
+                "Consumer POM must contain mod-2.\nActual:\n" + content);
+        assertTrue(
+                content.contains("<artifactId>ext-lib</artifactId>"),
+                "Consumer POM must contain ext-lib.\nActual:\n" + content);
+
+        // 3. ext-lib must have version 3.0.0 (inherited from the imported ext-bom)
+        // This is the core assertion for the #12660 fix
+        assertTrue(
+                content.contains("<version>3.0.0</version>"),
+                "Consumer POM must contain ext-lib with version 3.0.0 from imported BOM.\nActual:\n" + content);
+
+        // 4. ext-lib must preserve scope=provided
+        assertTrue(
+                content.contains("<scope>provided</scope>"),
+                "Consumer POM must preserve ext-lib scope=provided.\nActual:\n" + content);
+
+        // 5. Must not contain unresolved property references
+        assertFalse(
+                content.contains("${"),
+                "Consumer POM must not contain unresolved property references.\nActual:\n" + content);
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -104,6 +104,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * a fail fast technique as well.
          */
         suite.addTestSuite(MavenITmdep0590ClassifiedPomArtifactFromReactorTest.class);
+        suite.addTestSuite(MavenITgh12660BomVersionFromImportedBomTest.class);
         suite.addTestSuite(MavenITgh11346DependencyManagementOverrideTest.class);
         suite.addTestSuite(MavenITgh11314PluginInjectionTest.class);
         suite.addTestSuite(MavenITgh2576ItrNotHonoredTest.class);

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/bom/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bom</artifactId>
+  <packaging>bom</packaging>
+
+  <name>GH-12660 :: BOM</name>
+
+  <!--
+    Reproducer for GH-12660: a BOM project that imports ext-bom and declares
+    ext-lib with scope=provided but NO version. The version should be
+    inherited from the imported ext-bom. Before the fix, the consumer POM
+    was generated without a version for ext-lib.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>ext-bom</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>mod-1</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>mod-2</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>ext-lib</artifactId>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/ext-bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/ext-bom/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>ext-bom</artifactId>
+  <packaging>pom</packaging>
+
+  <name>GH-12660 :: External BOM</name>
+
+  <!--
+    This POM acts as an external BOM that provides version management for
+    ext-lib. The child BOM module imports this BOM and declares ext-lib
+    with scope=provided but no version; the version should be inherited
+    from this import.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>ext-lib</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-1/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-1/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-1</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Module 1</name>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-2/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-2/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-2</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Module 2</name>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12660</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>GH-12660: BOM version from imported BOM test</name>
+
+  <modules>
+    <module>ext-bom</module>
+    <module>mod-1</module>
+    <module>mod-2</module>
+    <module>bom</module>
+  </modules>
+</project>


### PR DESCRIPTION
## Summary
- Adds an end-to-end integration test for the fix merged in #12915 (for issue #12660)
- The test exercises the scenario where a BOM module declares a managed dependency with `scope=provided` but **no version**, and the version should be inherited from an imported BOM
- Verifies the consumer POM contains the resolved version (`3.0.0`) and preserves the scope (`provided`)
- Registers the test in `TestSuiteOrdering`

## Context
PR #12915 fixed the version inheritance in `DefaultDependencyManagementImporter.importManagement()` but only included a unit test. This IT provides end-to-end regression coverage by:
1. Building a multi-module project with an `ext-bom` (providing `ext-lib` version `3.0.0`)
2. A `bom` module that imports `ext-bom` and declares `ext-lib` with `scope=provided` but no version
3. Asserting the installed consumer POM contains `ext-lib` with version `3.0.0` and scope `provided`

## Test plan
- [x] IT passes locally against the built Maven 4.0.0-SNAPSHOT distribution
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)