### PR TITLE
Fix version comparison and parsing inconsistencies in maven-artifact

### DIFF
--- a/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
+++ b/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
@@ -68,6 +68,16 @@ public class ComparableVersion implements Comparable<ComparableVersion> {
 
     private static final int MAX_LONGITEM_LENGTH = 18;
 
+    /**
+     * Maximum accepted length of a version string. Version strings routinely come from external
+     * repository metadata; without a bound, every {@code -} separator nests another list whose
+     * comparison, equality, hash code and canonicalization recurse one frame per level, and digit
+     * runs longer than {@value #MAX_LONGITEM_LENGTH} characters are parsed into {@link BigInteger}
+     * at quadratic cost. 256 characters is far beyond any real-world version identifier while
+     * keeping the nesting depth (at most about half the length) and numeric items small.
+     */
+    private static final int MAX_VERSION_LENGTH = 256;
+
     private String value;
 
     private String canonical;
@@ -640,8 +650,18 @@ public class ComparableVersion implements Comparable<ComparableVersion> {
         parseVersion(version);
     }
 
+    /**
+     * @throws IllegalArgumentException if the version string is longer than {@value #MAX_VERSION_LENGTH}
+     *         characters, to bound the parsing, comparison and canonicalization cost of arbitrarily large input
+     */
     @SuppressWarnings("checkstyle:innerassignment")
     public final void parseVersion(String version) {
+        if (version.length() > MAX_VERSION_LENGTH) {
+            throw new IllegalArgumentException("Version string is too long (" + version.length() + " > "
+                    + MAX_VERSION_LENGTH + " characters): "
+                    + version.substring(0, 32) + "...");
+        }
+
         this.value = version;
 
         items = new ListItem();

--- a/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
+++ b/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
@@ -70,8 +70,8 @@ public class ComparableVersion implements Comparable<ComparableVersion> {
 
     /**
      * Maximum accepted length of a version string. Version strings routinely come from external
-     * repository metadata; without a bound, every {@code -} separator nests another list whose
-     * comparison, equality, hash code and canonicalization recurse one frame per level, and digit
+     * repository metadata. Without a bound, every {@code -} separator nests another list whose
+     * comparison, equality, hash code, and canonicalization recurse one frame per level, and digit
      * runs longer than {@value #MAX_LONGITEM_LENGTH} characters are parsed into {@link BigInteger}
      * at quadratic cost. 256 characters is far beyond any real-world version identifier while
      * keeping the nesting depth (at most about half the length) and numeric items small.

--- a/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
+++ b/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
@@ -828,6 +828,53 @@ public class ComparableVersion implements Comparable<ComparableVersion> {
         return items.hashCode();
     }
 
+    /**
+     * Returns a hash code consistent with the ordering defined by {@link #compareTo(ComparableVersion)}:
+     * two versions that compare as equal get the same value even when their parsed representations
+     * differ, e.g. {@code 1-ga} ({@code [1, [ga]]}) and {@code 1} ({@code [1]}).
+     * <p>
+     * {@link #hashCode()} cannot provide this: it is structural, matching the structural
+     * {@link #equals(Object)} of this class. This method exists for classes such as
+     * {@link DefaultArtifactVersion} whose {@code equals} is defined as {@code compareTo == 0} and
+     * whose {@code hashCode} must therefore follow ordering equality (two equal objects must have
+     * equal hash codes).
+     *
+     * @return a hash code such that {@code a.compareTo(b) == 0} implies {@code a.orderingHashCode() == b.orderingHashCode()}
+     */
+    int orderingHashCode() {
+        return orderingHash(items);
+    }
+
+    private static int orderingHash(Item item) {
+        return switch (item.getType()) {
+            case Item.LIST_ITEM -> {
+                ListItem list = (ListItem) item;
+                int end = list.size();
+                // trailing items that compare as equal to null do not affect ordering: 1-ga == 1
+                while (end > 0 && list.get(end - 1).compareTo(null) == 0) {
+                    end--;
+                }
+                int hash = 1;
+                for (int i = 0; i < end; i++) {
+                    hash = 31 * hash + orderingHash(list.get(i));
+                }
+                yield hash;
+            }
+            // qualifiers that compare as equal ("ga", "final", "release" and the empty qualifier) must hash alike
+            case Item.STRING_ITEM ->
+                StringItem.comparableQualifier(((StringItem) item).value).hashCode();
+            case Item.COMBINATION_ITEM -> {
+                CombinationItem combination = (CombinationItem) item;
+                yield 31
+                                * StringItem.comparableQualifier(combination.stringPart.value)
+                                        .hashCode()
+                        + orderingHash(combination.digitPart);
+            }
+            // numeric items only compare as equal to items of the same type with the same value
+            default -> item.hashCode();
+        };
+    }
+
     // CHECKSTYLE_OFF: LineLength
 
     /**

--- a/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
+++ b/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
@@ -460,7 +460,14 @@ public class ComparableVersion implements Comparable<ComparableVersion> {
         public int compareTo(Item item) {
             if (item == null) {
                 // 1-rc1 < 1, 1-ga1 > 1
-                return stringPart.compareTo(item);
+                int result = stringPart.compareTo(item);
+                if (result == 0) {
+                    // the string part is equivalent to the release qualifier ("ga", "final", "release"),
+                    // so the digit part decides: 1-ga1 > 1. Returning 0 here would break compareTo
+                    // transitivity, since 1-ga1 < 1-ga2 while both would compare equal to 1.
+                    return digitPart.compareTo(null);
+                }
+                return result;
             }
             int result = 0;
             switch (item.getType()) {

--- a/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/DefaultArtifactVersion.java
+++ b/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/DefaultArtifactVersion.java
@@ -41,7 +41,10 @@ public class DefaultArtifactVersion implements ArtifactVersion {
 
     @Override
     public int hashCode() {
-        return 11 + comparable.hashCode();
+        // equals is defined as compareTo == 0, so the hash must follow ordering equality:
+        // "1-ga" and "1" are equal here and must hash alike, which the structural
+        // ComparableVersion.hashCode() does not guarantee
+        return 11 + comparable.orderingHashCode();
     }
 
     @Override

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -193,7 +193,7 @@ class ComparableVersionTest {
         // a release qualifier followed by a digit sorts above the bare version ("1-rc1 < 1, 1-ga1 > 1")
         // and must not compare equal to it: otherwise 1-ga1 == 1 == 1-ga2 while 1-ga1 < 1-ga2,
         // breaking compareTo transitivity, and an exact pin [1] would admit 1-gaN
-        checkVersionsOrder(new String[] {"1-rc1", "1", "1-ga1", "1-final2", "1-ga3", "1-release9", "1-sp"});
+        checkVersionsOrder(new String[] {"1-rc1", "1", "1-ga1", "1-final2", "1-ga3", "1-release9", "1-ga11", "1-sp"});
 
         // a release qualifier without a digit (or with a zero digit) still sorts as the bare version
         checkVersionsHaveSameOrder("1-ga", "1");

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -446,6 +447,23 @@ class ComparableVersionTest {
         } finally {
             Locale.setDefault(orig);
         }
+    }
+
+    @Test
+    void testVersionLengthIsBounded() {
+        // versions up to the cap parse and compare normally, including deeply nested ones
+        String deep = "1" + "-1".repeat(127); // 255 characters, ~127 nested lists
+        ComparableVersion c1 = new ComparableVersion(deep);
+        ComparableVersion c2 = new ComparableVersion(deep);
+        assertEquals(0, c1.compareTo(c2), "expected a deeply nested version to compare equal to itself");
+        assertTrue(c1.compareTo(new ComparableVersion("1")) > 0, "expected 1-1-... > 1");
+
+        // beyond the cap the parser refuses instead of doing unbounded work
+        // (comparison recurses one frame per '-' level; long digit runs cost quadratic BigInteger parsing)
+        String deepTooLong = "1" + "-1".repeat(150);
+        assertThrows(IllegalArgumentException.class, () -> new ComparableVersion(deepTooLong));
+        String digitsTooLong = "1".repeat(257);
+        assertThrows(IllegalArgumentException.class, () -> new ComparableVersion(digitsTooLong));
     }
 
     @Test

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java
@@ -189,6 +189,18 @@ class ComparableVersionTest {
     }
 
     @Test
+    void testReleaseQualifierWithDigitOrdering() {
+        // a release qualifier followed by a digit sorts above the bare version ("1-rc1 < 1, 1-ga1 > 1")
+        // and must not compare equal to it: otherwise 1-ga1 == 1 == 1-ga2 while 1-ga1 < 1-ga2,
+        // breaking compareTo transitivity, and an exact pin [1] would admit 1-gaN
+        checkVersionsOrder(new String[] {"1-rc1", "1", "1-ga1", "1-final2", "1-ga3", "1-release9", "1-sp"});
+
+        // a release qualifier without a digit (or with a zero digit) still sorts as the bare version
+        checkVersionsHaveSameOrder("1-ga", "1");
+        checkVersionsHaveSameOrder("1-ga0", "1");
+    }
+
+    @Test
     void testVersionComparing() {
         checkVersionsOrder("1", "2");
         checkVersionsOrder("1.5", "2");

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/DefaultArtifactVersionTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/DefaultArtifactVersionTest.java
@@ -181,6 +181,19 @@ class DefaultArtifactVersionTest {
     }
 
     @Test
+    void testHashCodeConsistentWithEquals() {
+        // equals is defined as compareTo == 0, so every compareTo-equal spelling
+        // must produce the same hash code (Object contract)
+        assertEqualsAndHash("1", "1-ga");
+        assertEqualsAndHash("1", "1-final");
+        assertEqualsAndHash("1", "1-release");
+        assertEqualsAndHash("1", "1.0-ga");
+        assertEqualsAndHash("1", "1-0");
+        assertEqualsAndHash("1", "1.0.0");
+        assertEqualsAndHash("1-SNAPSHOT", "1.0-SNAPSHOT");
+    }
+
+    @Test
     void testEqualsNullSafe() {
         assertFalse(newArtifactVersion("1").equals(null));
     }
@@ -188,6 +201,13 @@ class DefaultArtifactVersionTest {
     @Test
     void testEqualsTypeSafe() {
         assertFalse(newArtifactVersion("1").equals("non-an-artifact-version-instance"));
+    }
+
+    private void assertEqualsAndHash(String left, String right) {
+        ArtifactVersion v1 = newArtifactVersion(left);
+        ArtifactVersion v2 = newArtifactVersion(right);
+        assertTrue(v1.equals(v2), left + " and " + right + " should be equal");
+        assertEquals(v1.hashCode(), v2.hashCode(), left + " and " + right + " should have the same hash code");
     }
 
     private void assertVersionOlder(String left, String right) {

--- a/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
+++ b/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java
@@ -156,6 +156,16 @@ class VersionRangeTest {
     }
 
     @Test
+    void testExactRangeMatchesOnlyTheExactVersion() throws InvalidVersionSpecificationException {
+        // an exact-version pin must only match the pinned version, not a differently spelled
+        // one that happens to compare equal to it (see ComparableVersionTest#testReleaseQualifierWithDigitOrdering)
+        VersionRange range = VersionRange.createFromVersionSpec("[1.2.3]");
+        assertTrue(range.containsVersion(new DefaultArtifactVersion("1.2.3")));
+        assertFalse(range.containsVersion(new DefaultArtifactVersion("1.2.3-ga2")));
+        assertFalse(range.containsVersion(new DefaultArtifactVersion("1.2.3-final1")));
+    }
+
+    @Test
     void testSameUpperAndLowerBoundRoundtrip() throws InvalidVersionSpecificationException {
         VersionRange range = VersionRange.createFromVersionSpec("[1.0]");
         VersionRange range2 = VersionRange.createFromVersionSpec(range.toString());


### PR DESCRIPTION
Three independent fixes in `maven-artifact`'s version handling.

- **Release-qualifier ordering.** `1-ga1` compared equal to `1`, while `1-ga1 < 1-ga2`. That breaks the transitivity contract `Comparable` requires, and contradicts the intent stated in the code's own comment (`1-rc1 < 1`, `1-ga1 > 1`). `CombinationItem.compareTo(null)` consulted only the string part and never the digit. Includes a `VersionRange`-level regression test: an exact range `[1.2.3]` no longer matches `1.2.3-ga2`.
- **`hashCode`/`equals` consistency.** `DefaultArtifactVersion.equals` is defined via `compareTo`, but `hashCode` was structural, so two order-equal versions could hash differently. `HashSet` and `TreeSet` built from the same pair disagreed on size. `equals` and `compareTo` are unchanged, so no resolution outcome moves.
- **Parsing bound.** `ComparableVersion` now rejects version strings longer than 256 characters. Nested `-` separators recurse per level and long digit runs cost quadratic time in `BigInteger`; on a reduced worker-thread stack the cold overflow floor is a few hundred levels. Nothing in this repository has a version string over 40 characters. Measurements are in the commit body.

Each fix is a separate commit and independently revertible.
