### PR TITLE
Output, transport and consumer POM robustness fixes

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/Constants.java
@@ -550,6 +550,23 @@ public final class Constants {
             "maven.consumer.pom.removeUnusedManagedDependencies";
 
     /**
+     * User property for controlling whether the repositories published in a consumer POM are restricted
+     * to the repositories declared in the project's own POM file.
+     * <ul>
+     *     <li>When set to <code>true</code> (default), repositories that are present in the effective model
+     * only because they were inherited from a (possibly remote) parent POM or injected by an active
+     * {@code settings.xml} profile are removed from the consumer POM before it is published. A warning is
+     * logged for every removed repository, and for every retained repository together with its URL.</li>
+     *     <li>When set to <code>false</code>, every non-central repository of the effective model is
+     * published in the consumer POM, restoring the previous behavior.</li>
+     * </ul>
+     *
+     * @since 4.1.0
+     */
+    @Config(type = "java.lang.Boolean", defaultValue = "true")
+    public static final String MAVEN_CONSUMER_POM_SANITIZE_REPOSITORIES = "maven.consumer.pom.sanitizeRepositories";
+
+    /**
      * User property for controlling "maven personality". If activated Maven will behave
      * as previous major version, Maven 3.
      *

--- a/api/maven-api-core/src/main/java/org/apache/maven/api/feature/Features.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/feature/Features.java
@@ -62,6 +62,15 @@ public final class Features {
     }
 
     /**
+     * Check if consumer POM repository sanitization is enabled: when active, only repositories
+     * declared in the project's own POM file are published in the consumer POM, while repositories
+     * inherited from parent POMs or injected by active settings.xml profiles are removed.
+     */
+    public static boolean consumerPomSanitizeRepositories(@Nullable Map<String, ?> userProperties) {
+        return doGet(userProperties, Constants.MAVEN_CONSUMER_POM_SANITIZE_REPOSITORIES, true);
+    }
+
+    /**
      * Check if automatic subproject discovery is enabled for POM-packaged projects.
      */
     public static boolean discoverSubprojects(@Nullable Map<String, ?> userProperties) {

--- a/compat/maven-compat/src/main/java/org/apache/maven/repository/DefaultMirrorSelector.java
+++ b/compat/maven-compat/src/main/java/org/apache/maven/repository/DefaultMirrorSelector.java
@@ -21,9 +21,9 @@ package org.apache.maven.repository;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -122,19 +122,31 @@ public class DefaultMirrorSelector implements MirrorSelector {
     }
 
     /**
-     * Checks the URL to see if this repository refers to an external repository
+     * Pattern matching the protocol (scheme) and host of a repository URL textually, the way the
+     * resolver's {@code RemoteRepository} does. {@code java.net.URL} must not be used here: it
+     * rejects any scheme without a registered JDK stream handler (e.g. {@code dav}, {@code
+     * dav:http}, {@code dav+http}), which would make such repositories silently bypass {@code
+     * external:*} and {@code external:http:*} mirror matching below.
+     */
+    private static final Pattern URL_PROTOCOL_AND_HOST =
+            Pattern.compile("([^:/]+(:[^:/]{2,}+(?=://))?):(//([^@/]*@)?([^/:]+))?.*");
+
+    /**
+     * Checks the URL to see if this repository refers to an external repository. A URL that
+     * cannot be parsed is treated as external, so that {@code external:*} mirror rules apply to
+     * it rather than silently skipping it.
      *
      * @param originalRepository
      * @return true if external.
      */
     static boolean isExternalRepo(ArtifactRepository originalRepository) {
-        try {
-            URL url = new URL(originalRepository.getUrl());
-            return !(isLocal(url.getHost()) || url.getProtocol().equals("file"));
-        } catch (MalformedURLException e) {
-            // bad url just skip it here. It should have been validated already, but the wagon lookup will deal with it
-            return false;
+        String url = originalRepository.getUrl();
+        Matcher m = url != null ? URL_PROTOCOL_AND_HOST.matcher(url) : null;
+        if (m == null || !m.matches()) {
+            // an unparseable url is not exempt from external:* mirror rules; treat it as external
+            return true;
         }
+        return !(isLocal(m.group(5)) || "file".equalsIgnoreCase(m.group(1)));
     }
 
     private static boolean isLocal(String host) {
@@ -143,22 +155,25 @@ public class DefaultMirrorSelector implements MirrorSelector {
 
     /**
      * Checks the URL to see if this repository refers to a non-localhost repository using HTTP.
+     * A URL that cannot be parsed is treated as external, so that the shipped {@code
+     * external:http:*} mirror rule applies to it rather than silently skipping it.
      *
      * @param originalRepository
      * @return true if external.
      */
     static boolean isExternalHttpRepo(ArtifactRepository originalRepository) {
-        try {
-            URL url = new URL(originalRepository.getUrl());
-            return ("http".equalsIgnoreCase(url.getProtocol())
-                            || "dav".equalsIgnoreCase(url.getProtocol())
-                            || "dav:http".equalsIgnoreCase(url.getProtocol())
-                            || "dav+http".equalsIgnoreCase(url.getProtocol()))
-                    && !isLocal(url.getHost());
-        } catch (MalformedURLException e) {
-            // bad url just skip it here. It should have been validated already, but the wagon lookup will deal with it
-            return false;
+        String url = originalRepository.getUrl();
+        Matcher m = url != null ? URL_PROTOCOL_AND_HOST.matcher(url) : null;
+        if (m == null || !m.matches()) {
+            // an unparseable url is not exempt from the external:http:* mirror rule; treat it as external
+            return true;
         }
+        String protocol = m.group(1);
+        return ("http".equalsIgnoreCase(protocol)
+                        || "dav".equalsIgnoreCase(protocol)
+                        || "dav:http".equalsIgnoreCase(protocol)
+                        || "dav+http".equalsIgnoreCase(protocol))
+                && !isLocal(m.group(5));
     }
 
     static boolean matchesLayout(ArtifactRepository repository, Mirror mirror) {

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/DefaultMirrorSelectorTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/DefaultMirrorSelectorTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.artifact.repository.DefaultArtifactRepository;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Deprecated
 class DefaultMirrorSelectorTest {
@@ -31,5 +32,40 @@ class DefaultMirrorSelectorTest {
         ArtifactRepository repository = new DefaultArtifactRepository("snapshots.repo", "http://whatever", null);
         String pattern = "external:*, !snapshots.repo";
         assertFalse(DefaultMirrorSelector.matchPattern(repository, pattern));
+    }
+
+    @Test
+    void testExternalHttpRepoMatchesDavProtocols() {
+        assertTrue(DefaultMirrorSelector.isExternalHttpRepo(repo("http://repo.example.com/m2/")));
+        assertTrue(DefaultMirrorSelector.isExternalHttpRepo(repo("dav:http://repo.example.com/m2/")));
+        assertTrue(DefaultMirrorSelector.isExternalHttpRepo(repo("dav+http://repo.example.com/m2/")));
+        assertTrue(DefaultMirrorSelector.isExternalHttpRepo(repo("dav://repo.example.com/m2/")));
+    }
+
+    @Test
+    void testExternalHttpRepoClassificationForNonHttpUrls() {
+        assertFalse(DefaultMirrorSelector.isExternalHttpRepo(repo("https://repo.example.com/m2/")));
+        assertFalse(DefaultMirrorSelector.isExternalHttpRepo(repo("http://localhost:8080/m2/")));
+        assertFalse(DefaultMirrorSelector.isExternalHttpRepo(repo("http://127.0.0.1/m2/")));
+        assertFalse(DefaultMirrorSelector.isExternalHttpRepo(repo("file:///tmp/repo")));
+    }
+
+    @Test
+    void testUnparseableUrlClassification() {
+        assertTrue(DefaultMirrorSelector.isExternalRepo(repo("not a url")));
+        assertTrue(DefaultMirrorSelector.isExternalHttpRepo(repo("not a url")));
+    }
+
+    @Test
+    void testExternalRepoClassification() {
+        assertTrue(DefaultMirrorSelector.isExternalRepo(repo("https://repo.example.com/m2/")));
+        assertTrue(DefaultMirrorSelector.isExternalRepo(repo("dav:http://repo.example.com/m2/")));
+        assertFalse(DefaultMirrorSelector.isExternalRepo(repo("file:///tmp/repo")));
+        assertFalse(DefaultMirrorSelector.isExternalRepo(repo("http://localhost/m2/")));
+        assertFalse(DefaultMirrorSelector.isExternalRepo(repo("http://127.0.0.1/m2/")));
+    }
+
+    private static ArtifactRepository repo(String url) {
+        return new DefaultArtifactRepository("test", url, null);
     }
 }

--- a/compat/maven-compat/src/test/java/org/apache/maven/repository/MirrorProcessorTest.java
+++ b/compat/maven-compat/src/test/java/org/apache/maven/repository/MirrorProcessorTest.java
@@ -61,9 +61,9 @@ class MirrorProcessorTest {
         assertFalse(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "file:///somepath")));
         assertFalse(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "file://D:/somepath")));
 
-        // not a proper url so returns false;
-        assertFalse(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "192.168.101.1")));
-        assertFalse(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "")));
+        // not a proper url, so it is treated as external and stays subject to external:* mirror rules
+        assertTrue(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "192.168.101.1")));
+        assertTrue(DefaultMirrorSelector.isExternalRepo(getRepo("foo", "")));
     }
 
     @Test

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/transfer/AbstractMavenTransferListener.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/transfer/AbstractMavenTransferListener.java
@@ -190,6 +190,34 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
         this.out = out;
     }
 
+    /**
+     * Escapes control characters so that transfer messages render literally on a terminal.
+     * Tab and newline are preserved; every other C0 control, DEL and the C1 controls are escaped.
+     *
+     * @param str the string to escape, may be {@code null}
+     * @return the escaped string, or {@code null} if the input was {@code null}
+     */
+    static String sanitize(String str) {
+        if (str == null) {
+            return null;
+        }
+        StringBuilder sb = null;
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            boolean escape = (c < 0x20 && c != '\t' && c != '\n') || (c >= 0x7F && c <= 0x9F);
+            if (escape) {
+                if (sb == null) {
+                    sb = new StringBuilder(str.length() + 8);
+                    sb.append(str, 0, i);
+                }
+                sb.append(String.format("\\u%04x", (int) c));
+            } else if (sb != null) {
+                sb.append(c);
+            }
+        }
+        return sb != null ? sb.toString() : str;
+    }
+
     @Override
     public void transferInitiated(TransferEvent event) {
         String darkOn = MessageUtils.isColorEnabled() ? ANSI_DARK_SET : "";
@@ -201,9 +229,9 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
         TransferResource resource = event.getResource();
         StringBuilder message = new StringBuilder();
         message.append(darkOn).append(action).append(' ').append(direction).append(' ');
-        message.append(darkOff).append(resource.getRepositoryId());
-        message.append(darkOn).append(": ").append(resource.getRepositoryUrl());
-        message.append(darkOff).append(resource.getResourceName());
+        message.append(darkOff).append(sanitize(resource.getRepositoryId()));
+        message.append(darkOn).append(": ").append(sanitize(resource.getRepositoryUrl()));
+        message.append(darkOff).append(sanitize(resource.getResourceName()));
 
         out.println(message);
     }
@@ -212,8 +240,9 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
     public void transferCorrupted(TransferEvent event) throws TransferCancelledException {
         TransferResource resource = event.getResource();
         // TODO This needs to be colorized
-        out.println("[WARNING] " + event.getException().getMessage() + " from " + resource.getRepositoryId() + " for "
-                + resource.getRepositoryUrl() + resource.getResourceName());
+        out.println("[WARNING] " + sanitize(event.getException().getMessage()) + " from "
+                + sanitize(resource.getRepositoryId()) + " for " + sanitize(resource.getRepositoryUrl())
+                + sanitize(resource.getResourceName()));
     }
 
     @Override
@@ -230,9 +259,9 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
 
         StringBuilder message = new StringBuilder();
         message.append(action).append(darkOn).append(' ').append(direction).append(' ');
-        message.append(darkOff).append(resource.getRepositoryId());
-        message.append(darkOn).append(": ").append(resource.getRepositoryUrl());
-        message.append(darkOff).append(resource.getResourceName());
+        message.append(darkOff).append(sanitize(resource.getRepositoryId()));
+        message.append(darkOn).append(": ").append(sanitize(resource.getRepositoryUrl()));
+        message.append(darkOff).append(sanitize(resource.getResourceName()));
         message.append(darkOn).append(" (").append(format.format(contentLength));
 
         long duration = System.currentTimeMillis() - resource.getTransferStartTime();

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/transfer/ConsoleMavenTransferListener.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/transfer/ConsoleMavenTransferListener.java
@@ -98,7 +98,7 @@ public class ConsoleMavenTransferListener extends AbstractMavenTransferListener 
         StringBuilder status = new StringBuilder();
 
         if (printResourceNames) {
-            status.append(resourceName(resourceName));
+            status.append(sanitize(resourceName(resourceName)));
             status.append(" (");
         }
 

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/transfer/Slf4jMavenTransferListener.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/transfer/Slf4jMavenTransferListener.java
@@ -49,9 +49,14 @@ public class Slf4jMavenTransferListener extends AbstractTransferListener {
 
         TransferResource resource = event.getResource();
         StringBuilder message = new StringBuilder();
-        message.append(action).append(' ').append(direction).append(' ').append(resource.getRepositoryId());
+        message.append(action)
+                .append(' ')
+                .append(direction)
+                .append(' ')
+                .append(AbstractMavenTransferListener.sanitize(resource.getRepositoryId()));
         message.append(": ");
-        message.append(resource.getRepositoryUrl()).append(resource.getResourceName());
+        message.append(AbstractMavenTransferListener.sanitize(resource.getRepositoryUrl()))
+                .append(AbstractMavenTransferListener.sanitize(resource.getResourceName()));
 
         out.info(message.toString());
     }
@@ -61,10 +66,10 @@ public class Slf4jMavenTransferListener extends AbstractTransferListener {
         TransferResource resource = event.getResource();
         out.warn(
                 "{} from {} for {}{}",
-                event.getException().getMessage(),
-                resource.getRepositoryId(),
-                resource.getRepositoryUrl(),
-                resource.getResourceName());
+                AbstractMavenTransferListener.sanitize(event.getException().getMessage()),
+                AbstractMavenTransferListener.sanitize(resource.getRepositoryId()),
+                AbstractMavenTransferListener.sanitize(resource.getRepositoryUrl()),
+                AbstractMavenTransferListener.sanitize(resource.getResourceName()));
     }
 
     @Override
@@ -77,10 +82,14 @@ public class Slf4jMavenTransferListener extends AbstractTransferListener {
         FileSizeFormat format = new FileSizeFormat();
 
         StringBuilder message = new StringBuilder();
-        message.append(action).append(' ').append(direction).append(' ').append(resource.getRepositoryId());
+        message.append(action)
+                .append(' ')
+                .append(direction)
+                .append(' ')
+                .append(AbstractMavenTransferListener.sanitize(resource.getRepositoryId()));
         message.append(": ");
-        message.append(resource.getRepositoryUrl())
-                .append(resource.getResourceName())
+        message.append(AbstractMavenTransferListener.sanitize(resource.getRepositoryUrl()))
+                .append(AbstractMavenTransferListener.sanitize(resource.getResourceName()))
                 .append(" (");
         format.format(message, contentLength);
 

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/AbstractUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/AbstractUpgradeStrategy.java
@@ -21,6 +21,7 @@ package org.apache.maven.cling.invoker.mvnup.goals;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,13 +38,12 @@ import org.apache.maven.api.Session;
 import org.apache.maven.api.cli.mvnup.UpgradeOptions;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Provides;
-import org.apache.maven.api.model.Repository;
-import org.apache.maven.api.model.RepositoryPolicy;
 import org.apache.maven.api.services.ModelBuilder;
 import org.apache.maven.api.services.ModelBuilderRequest;
 import org.apache.maven.api.services.ModelBuilderResult;
-import org.apache.maven.api.services.RepositoryFactory;
 import org.apache.maven.api.services.Sources;
+import org.apache.maven.api.settings.Proxy;
+import org.apache.maven.api.settings.Settings;
 import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
 import org.apache.maven.impl.standalone.ApiRunner;
 import org.codehaus.plexus.components.secdispatcher.Dispatcher;
@@ -211,31 +211,83 @@ public abstract class AbstractUpgradeStrategy implements UpgradeStrategy {
         return new HashSet<>(coordinatesByGAV.values());
     }
 
-    protected Session getSession() {
+    protected Session getSession(UpgradeContext context) {
         if (session == null) {
-            session = createMaven4Session();
+            session = createMaven4Session(context);
         }
         return session;
     }
 
-    private Session createMaven4Session() {
-        Session session = ApiRunner.createSession(injector -> {
-            injector.bindInstance(Dispatcher.class, new LegacyDispatcher());
-            injector.bindImplicit(TransporterFactoryConfig.class);
-        });
+    /**
+     * Returns the reason why remote resolution cannot honor the operator's configured
+     * repository posture, or {@code null} if remote resolution may proceed.
+     *
+     * <p>The standalone resolver session used by mvnup does not apply mirrors, proxies or
+     * offline mode from the effective settings. Rather than silently resolving remote POMs
+     * while ignoring that configuration, strategies must call this method and skip the
+     * remote-model-dependent work whenever a posture is configured that the standalone
+     * session cannot honor.</p>
+     *
+     * <p>Blocked mirrors (such as the default {@code external:http:*} blocker shipped in the
+     * Maven installation settings) do not redirect traffic and therefore do not disable
+     * remote resolution by themselves.</p>
+     *
+     * @param context the upgrade context
+     * @return a human-readable reason to skip remote resolution, or {@code null} if allowed
+     */
+    protected static String remoteResolutionUnsupportedReason(UpgradeContext context) {
+        Settings settings = context.effectiveSettings;
+        if (settings == null) {
+            // Settings were never loaded (embedded or test use): there is no operator
+            // repository posture declared that could be violated.
+            return null;
+        }
+        if (settings.isOffline()) {
+            return "offline mode is enabled in settings";
+        }
+        boolean hasRedirectingMirror = settings.getMirrors().stream().anyMatch(mirror -> !mirror.isBlocked());
+        if (hasRedirectingMirror) {
+            return "settings declare mirror(s) that the mvnup standalone resolver cannot honor";
+        }
+        boolean hasActiveProxy = settings.getProxies().stream().anyMatch(Proxy::isActive);
+        if (hasActiveProxy) {
+            return "settings declare an active proxy that the mvnup standalone resolver cannot honor";
+        }
+        return null;
+    }
 
-        // TODO: we should read settings
-        RemoteRepository central =
-                session.createRemoteRepository(RemoteRepository.CENTRAL_ID, "https://repo.maven.apache.org/maven2");
-        RemoteRepository snapshots = session.getService(RepositoryFactory.class)
-                .createRemote(Repository.newBuilder()
-                        .id("apache-snapshots")
-                        .url("https://repository.apache.org/content/repositories/snapshots/")
-                        .releases(RepositoryPolicy.newBuilder().enabled("false").build())
-                        .snapshots(RepositoryPolicy.newBuilder().enabled("true").build())
-                        .build());
+    private Session createMaven4Session(UpgradeContext context) {
+        // Reuse the operator's real user home (settings.xml) and local repository so remote
+        // resolution follows the configured repository posture instead of the standalone
+        // test defaults. When settings were never loaded (unit tests, embedding), keep the
+        // isolated test user home.
+        boolean settingsLoaded = context.effectiveSettings != null;
+        Session session = ApiRunner.createSession(
+                injector -> {
+                    injector.bindInstance(Dispatcher.class, new LegacyDispatcher());
+                    injector.bindImplicit(TransporterFactoryConfig.class);
+                },
+                context.localRepositoryPath,
+                !settingsLoaded);
 
-        return session.withRemoteRepositories(List.of(central, snapshots));
+        if (remoteResolutionUnsupportedReason(context) != null) {
+            // No remote repositories at all, rather than resolving from hardcoded public
+            // repositories while ignoring the operator's settings.
+            return session.withRemoteRepositories(List.of());
+        }
+
+        // Repositories declared in the effective settings are already part of the session
+        // (ApiRunner reads settings.xml from the real user home above); add central as the
+        // built-in fallback, exactly like a regular Maven build would. The apache-snapshots
+        // repository is intentionally not added: mvnup runs must not silently consume
+        // snapshot content that was never part of the operator's configuration.
+        List<RemoteRepository> repositories = new ArrayList<>(session.getRemoteRepositories());
+        boolean hasCentral = repositories.stream().anyMatch(r -> RemoteRepository.CENTRAL_ID.equals(r.getId()));
+        if (!hasCentral) {
+            repositories.add(session.createRemoteRepository(
+                    RemoteRepository.CENTRAL_ID, "https://repo.maven.apache.org/maven2"));
+        }
+        return session.withRemoteRepositories(repositories);
     }
 
     protected Path createTempProjectStructure(UpgradeContext context, Map<Path, Document> pomMap) throws Exception {
@@ -292,8 +344,8 @@ public abstract class AbstractUpgradeStrategy implements UpgradeStrategy {
         }
     }
 
-    protected org.apache.maven.api.model.Model buildEffectiveModel(Path pomPath) {
-        Session session = getSession();
+    protected org.apache.maven.api.model.Model buildEffectiveModel(UpgradeContext context, Path pomPath) {
+        Session session = getSession(context);
         ModelBuilder modelBuilder = session.getService(ModelBuilder.class);
 
         ModelBuilderRequest request = ModelBuilderRequest.builder()

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/CompatibilityFixStrategy.java
@@ -142,7 +142,17 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
         Set<Path> errorPoms = new HashSet<>();
 
         Set<String> allDefinedProperties = collectAllDefinedProperties(pomMap);
-        allDefinedProperties.addAll(collectEffectiveProperties(context, pomMap));
+        // Skip when the operator's settings declare a repository posture the standalone
+        // resolver cannot honor (mirrors, proxies, offline): properties defined only in
+        // remote parent POMs cannot be verified in that case, so the undefined-property
+        // fixes below are skipped instead of guessing and commenting out valid elements.
+        String unsupportedReason = remoteResolutionUnsupportedReason(context);
+        if (unsupportedReason == null) {
+            allDefinedProperties.addAll(collectEffectiveProperties(context, pomMap));
+        } else {
+            context.warning("Cannot resolve parent POMs remotely: " + unsupportedReason
+                    + ". Skipping undefined-property compatibility fixes.");
+        }
 
         for (Map.Entry<Path, Document> entry : pomMap.entrySet()) {
             Path pomPath = entry.getKey();
@@ -160,8 +170,11 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
                 hasIssues |= fixUnsupportedRepositoryExpressions(pomDocument, context);
                 hasIssues |= fixDeprecatedPropertyExpressions(pomDocument, context);
                 hasIssues |= fixIncorrectParentRelativePaths(pomDocument, pomPath, pomMap, context);
-                hasIssues |= fixUndefinedPropertyExpressions(pomDocument, allDefinedProperties, context);
-                hasIssues |= fixUndefinedPropertyExpressionsInRepositories(pomDocument, allDefinedProperties, context);
+                if (unsupportedReason == null) {
+                    hasIssues |= fixUndefinedPropertyExpressions(pomDocument, allDefinedProperties, context);
+                    hasIssues |=
+                            fixUndefinedPropertyExpressionsInRepositories(pomDocument, allDefinedProperties, context);
+                }
 
                 // Warning-only checks: emit warnings for issues that cannot be auto-fixed
                 // These do not modify the POM and do not affect hasIssues
@@ -321,7 +334,7 @@ public class CompatibilityFixStrategy extends AbstractUpgradeStrategy {
         Set<String> properties = new HashSet<>();
         for (Path pomPath : pomMap.keySet()) {
             try {
-                org.apache.maven.api.model.Model effectiveModel = buildEffectiveModel(pomPath);
+                org.apache.maven.api.model.Model effectiveModel = buildEffectiveModel(context, pomPath);
                 properties.addAll(effectiveModel.getProperties().keySet());
             } catch (Exception e) {
                 context.debug("Failed to build effective model for " + pomPath + ": " + e.getMessage());

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -199,8 +199,19 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             // Phase 1: Write all modifications to temp directory (keeping project structure)
             Path tempDir = createTempProjectStructure(context, pomMap);
 
-            // Phase 2: For each POM, build effective model using the session and analyze plugins
-            PluginAnalysisResults analysisResults = analyzePluginsUsingEffectiveModels(context, pomMap, tempDir);
+            // Phase 2: For each POM, build effective model using the session and analyze plugins.
+            // Skip when the operator's settings declare a repository posture the standalone
+            // resolver cannot honor (mirrors, proxies, offline): resolving outside that
+            // posture would bypass the operator's configuration, so the remote-model-dependent
+            // analysis is skipped instead.
+            PluginAnalysisResults analysisResults;
+            String unsupportedReason = remoteResolutionUnsupportedReason(context);
+            if (unsupportedReason == null) {
+                analysisResults = analyzePluginsUsingEffectiveModels(context, pomMap, tempDir);
+            } else {
+                context.warning("Skipping effective-model plugin analysis: " + unsupportedReason);
+                analysisResults = new PluginAnalysisResults(Map.of(), Map.of());
+            }
 
             // Collect locally declared plugin keys so we can add comments for remote-parent overrides
             Set<String> localPluginKeys = collectLocallyDeclaredPluginKeys(pomMap);
@@ -427,7 +438,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             // Check for Maven 4 pre-release versions (alpha/beta/rc) that should be
             // upgraded to the latest available pre-release rather than downgraded to 3.x.
             if (isMaven4PreRelease(currentVersion) && upgrade.latestPreRelease != null) {
-                if (isVersionBelow(currentVersion, upgrade.latestPreRelease)) {
+                if (isVersionBelow(context, currentVersion, upgrade.latestPreRelease)) {
                     Editor editor = new Editor(pomDocument);
                     editor.setTextContent(versionElement, upgrade.latestPreRelease);
                     context.detail("Upgraded " + upgrade.groupId + ":" + upgrade.artifactId + " from pre-release "
@@ -441,7 +452,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             }
 
             // Direct version comparison and upgrade (for 3.x versions)
-            if (isVersionBelow(currentVersion, upgrade.minVersion)) {
+            if (isVersionBelow(context, currentVersion, upgrade.minVersion)) {
                 Editor editor = new Editor(pomDocument);
                 editor.setTextContent(versionElement, upgrade.minVersion);
                 context.detail("Upgraded " + upgrade.groupId + ":" + upgrade.artifactId + " from " + currentVersion
@@ -476,7 +487,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 String currentVersion = propertyElement.textContentTrimmed();
                 // For 4.x pre-release versions, upgrade to latest pre-release (not 3.x)
                 if (isMaven4PreRelease(currentVersion) && upgrade.latestPreRelease != null) {
-                    if (isVersionBelow(currentVersion, upgrade.latestPreRelease)) {
+                    if (isVersionBelow(context, currentVersion, upgrade.latestPreRelease)) {
                         editor.setTextContent(propertyElement, upgrade.latestPreRelease);
                         context.detail("Upgraded property " + propertyName + " (for " + upgrade.groupId + ":"
                                 + upgrade.artifactId + ") from pre-release " + currentVersion + " to "
@@ -486,7 +497,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                         context.debug("Property " + propertyName + " version " + currentVersion + " is already >= "
                                 + upgrade.latestPreRelease);
                     }
-                } else if (isVersionBelow(currentVersion, upgrade.minVersion)) {
+                } else if (isVersionBelow(context, currentVersion, upgrade.minVersion)) {
                     editor.setTextContent(propertyElement, upgrade.minVersion);
                     context.detail(
                             "Upgraded property " + propertyName + " (for " + upgrade.groupId + ":" + upgrade.artifactId
@@ -624,11 +635,14 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
      * Simple version comparison to check if current version is below minimum version. This is a basic implementation
      * that works for most Maven plugin versions.
      */
-    private boolean isVersionBelow(String currentVersion, String minVersion) {
+    private boolean isVersionBelow(UpgradeContext context, String currentVersion, String minVersion) {
         if (currentVersion == null || minVersion == null) {
             return false;
         }
-        return getSession().parseVersion(currentVersion).compareTo(getSession().parseVersion(minVersion)) < 0;
+        return getSession(context)
+                        .parseVersion(currentVersion)
+                        .compareTo(getSession(context).parseVersion(minVersion))
+                < 0;
     }
 
     /**
@@ -709,7 +723,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
 
     private PluginAnalysis analyzeEffectiveModelForPlugins(
             UpgradeContext context, Path tempPomPath, Map<String, PluginUpgrade> pluginUpgrades) {
-        Model effectiveModel = buildEffectiveModel(tempPomPath);
+        Model effectiveModel = buildEffectiveModel(context, tempPomPath);
         return analyzePluginsFromEffectiveModel(context, effectiveModel, pluginUpgrades);
     }
 
@@ -741,7 +755,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 PluginUpgrade upgrade = pluginUpgrades.get(pluginKey);
                 if (upgrade != null) {
                     String effectiveVersion = plugin.getVersion();
-                    if (isVersionBelow(effectiveVersion, upgrade.minVersion())) {
+                    if (isVersionBelow(context, effectiveVersion, upgrade.minVersion())) {
                         needsManagement.add(pluginKey);
                         String managedVersion = managedVersions.get(pluginKey);
                         if (managedVersion == null || !managedVersion.equals(effectiveVersion)) {
@@ -767,7 +781,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     PluginUpgrade upgrade = pluginUpgrades.get(pluginKey);
                     if (upgrade != null && !needsManagement.contains(pluginKey)) {
                         String effectiveVersion = plugin.getVersion();
-                        if (isVersionBelow(effectiveVersion, upgrade.minVersion())) {
+                        if (isVersionBelow(context, effectiveVersion, upgrade.minVersion())) {
                             needsManagement.add(pluginKey);
                             context.debug("Managed plugin " + pluginKey + " version " + effectiveVersion
                                     + " needs upgrade to " + upgrade.minVersion());
@@ -803,7 +817,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     private Path findLastLocalParentForPluginManagement(
             UpgradeContext context, Path tempPomPath, Map<Path, Document> pomMap, Path tempDir, Path commonRoot) {
 
-        Model effectiveModel = buildEffectiveModel(tempPomPath);
+        Model effectiveModel = buildEffectiveModel(context, tempPomPath);
 
         // Convert the temp path back to the original path
         Path relativePath = tempDir.relativize(tempPomPath);
@@ -824,7 +838,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 lastLocalParent = parentPath;
 
                 Path parentTempPath = tempDir.resolve(commonRoot.relativize(parentPath));
-                currentModel = buildEffectiveModel(parentTempPath);
+                currentModel = buildEffectiveModel(context, parentTempPath);
             } else {
                 // Parent is external, stop here
                 break;
@@ -1217,7 +1231,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             return false;
         }
 
-        if (!isVersionBelow(currentVersion, upgrade.minVersion)) {
+        if (!isVersionBelow(context, currentVersion, upgrade.minVersion)) {
             context.debug("Quarkus plugin version (via shared property " + sharedPropertyName + ") " + currentVersion
                     + " is already >= " + upgrade.minVersion);
             return false;

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/transfer/AbstractMavenTransferListener.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/transfer/AbstractMavenTransferListener.java
@@ -44,6 +44,34 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
         this.out = out;
     }
 
+    /**
+     * Escapes control characters so that transfer messages render literally on a terminal.
+     * Tab and newline are preserved; every other C0 control, DEL and the C1 controls are escaped.
+     *
+     * @param str the string to escape, may be {@code null}
+     * @return the escaped string, or {@code null} if the input was {@code null}
+     */
+    static String sanitize(String str) {
+        if (str == null) {
+            return null;
+        }
+        StringBuilder sb = null;
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            boolean escape = (c < 0x20 && c != '\t' && c != '\n') || (c >= 0x7F && c <= 0x9F);
+            if (escape) {
+                if (sb == null) {
+                    sb = new StringBuilder(str.length() + 8);
+                    sb.append(str, 0, i);
+                }
+                sb.append(String.format("\\u%04x", (int) c));
+            } else if (sb != null) {
+                sb.append(c);
+            }
+        }
+        return sb != null ? sb.toString() : str;
+    }
+
     @Override
     public void transferInitiated(TransferEvent event) {
         String action = event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploading" : "Downloading";
@@ -52,9 +80,9 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
         TransferResource resource = event.getResource();
         MessageBuilder message = messageBuilderFactory.builder();
         message.style(STYLE).append(action).append(' ').append(direction).append(' ');
-        message.resetStyle().append(resource.getRepositoryId());
-        message.style(STYLE).append(": ").append(resource.getRepositoryUrl());
-        message.resetStyle().append(resource.getResourceName());
+        message.resetStyle().append(sanitize(resource.getRepositoryId()));
+        message.style(STYLE).append(": ").append(sanitize(resource.getRepositoryUrl()));
+        message.resetStyle().append(sanitize(resource.getResourceName()));
 
         out.println(message);
     }
@@ -63,8 +91,9 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
     public void transferCorrupted(TransferEvent event) throws TransferCancelledException {
         TransferResource resource = event.getResource();
         // TODO This needs to be colorized
-        out.println("[WARNING] " + event.getException().getMessage() + " from " + resource.getRepositoryId() + " for "
-                + resource.getRepositoryUrl() + resource.getResourceName());
+        out.println("[WARNING] " + sanitize(event.getException().getMessage()) + " from "
+                + sanitize(resource.getRepositoryId()) + " for " + sanitize(resource.getRepositoryUrl())
+                + sanitize(resource.getResourceName()));
     }
 
     @Override
@@ -78,9 +107,9 @@ public abstract class AbstractMavenTransferListener extends AbstractTransferList
 
         MessageBuilder message = messageBuilderFactory.builder();
         message.append(action).style(STYLE).append(' ').append(direction).append(' ');
-        message.resetStyle().append(resource.getRepositoryId());
-        message.style(STYLE).append(": ").append(resource.getRepositoryUrl());
-        message.resetStyle().append(resource.getResourceName());
+        message.resetStyle().append(sanitize(resource.getRepositoryId()));
+        message.style(STYLE).append(": ").append(sanitize(resource.getRepositoryUrl()));
+        message.resetStyle().append(sanitize(resource.getResourceName()));
         message.style(STYLE).append(" (").append(format.format(contentLength));
 
         Duration duration = Duration.between(resource.getStartTime(), MonotonicClock.now());

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/transfer/ConsoleMavenTransferListener.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/transfer/ConsoleMavenTransferListener.java
@@ -78,7 +78,7 @@ public class ConsoleMavenTransferListener extends AbstractMavenTransferListener 
             long complete = Math.max(0, entry.transferredBytes);
             long total = Math.max(complete, entry.resource.getContentLength());
 
-            String resourceName = entry.resource.getResourceName();
+            String resourceName = sanitize(entry.resource.getResourceName());
 
             if (printResourceNames) {
                 int idx = resourceName.lastIndexOf('/');

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/transfer/Slf4jMavenTransferListener.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/transfer/Slf4jMavenTransferListener.java
@@ -52,9 +52,14 @@ public class Slf4jMavenTransferListener extends AbstractTransferListener {
 
         TransferResource resource = event.getResource();
         StringBuilder message = new StringBuilder();
-        message.append(action).append(' ').append(direction).append(' ').append(resource.getRepositoryId());
+        message.append(action)
+                .append(' ')
+                .append(direction)
+                .append(' ')
+                .append(AbstractMavenTransferListener.sanitize(resource.getRepositoryId()));
         message.append(": ");
-        message.append(resource.getRepositoryUrl()).append(resource.getResourceName());
+        message.append(AbstractMavenTransferListener.sanitize(resource.getRepositoryUrl()))
+                .append(AbstractMavenTransferListener.sanitize(resource.getResourceName()));
 
         out.info(message.toString());
     }
@@ -64,10 +69,10 @@ public class Slf4jMavenTransferListener extends AbstractTransferListener {
         TransferResource resource = event.getResource();
         out.warn(
                 "{} from {} for {}{}",
-                event.getException().getMessage(),
-                resource.getRepositoryId(),
-                resource.getRepositoryUrl(),
-                resource.getResourceName());
+                AbstractMavenTransferListener.sanitize(event.getException().getMessage()),
+                AbstractMavenTransferListener.sanitize(resource.getRepositoryId()),
+                AbstractMavenTransferListener.sanitize(resource.getRepositoryUrl()),
+                AbstractMavenTransferListener.sanitize(resource.getResourceName()));
     }
 
     @Override
@@ -80,10 +85,14 @@ public class Slf4jMavenTransferListener extends AbstractTransferListener {
         FileSizeFormat format = new FileSizeFormat();
 
         StringBuilder message = new StringBuilder();
-        message.append(action).append(' ').append(direction).append(' ').append(resource.getRepositoryId());
+        message.append(action)
+                .append(' ')
+                .append(direction)
+                .append(' ')
+                .append(AbstractMavenTransferListener.sanitize(resource.getRepositoryId()));
         message.append(": ");
-        message.append(resource.getRepositoryUrl())
-                .append(resource.getResourceName())
+        message.append(AbstractMavenTransferListener.sanitize(resource.getRepositoryUrl()))
+                .append(AbstractMavenTransferListener.sanitize(resource.getResourceName()))
                 .append(" (");
         format.format(message, contentLength);
 

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/RemoteResolutionGateTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/RemoteResolutionGateTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnup.goals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import eu.maveniverse.domtrip.Document;
+import org.apache.maven.api.settings.Mirror;
+import org.apache.maven.api.settings.Proxy;
+import org.apache.maven.api.settings.Settings;
+import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the remote-resolution gate in {@link AbstractUpgradeStrategy}.
+ *
+ * <p>mvnup builds effective models with a standalone resolver session that cannot honor
+ * mirrors, proxies or offline mode from the operator's settings. The gate must skip
+ * remote-model-dependent work whenever such a posture is configured, instead of silently
+ * resolving from public repositories.</p>
+ */
+@DisplayName("Remote resolution gate")
+class RemoteResolutionGateTest {
+
+    private static Settings settingsWithRedirectingMirror() {
+        return Settings.newBuilder()
+                .mirrors(List.of(Mirror.newBuilder()
+                        .id("corp-mirror")
+                        .mirrorOf("*")
+                        .url("https://mirror.corp.example/maven2")
+                        .build()))
+                .build();
+    }
+
+    @Test
+    @DisplayName("no reason when settings were never loaded (test/embedded use)")
+    void reasonIsNullWhenSettingsWereNotLoaded() {
+        UpgradeContext context = TestUtils.createMockContext();
+        context.effectiveSettings = null;
+        assertNull(AbstractUpgradeStrategy.remoteResolutionUnsupportedReason(context));
+    }
+
+    @Test
+    @DisplayName("no reason for empty effective settings")
+    void reasonIsNullForEmptySettings() {
+        UpgradeContext context = TestUtils.createMockContext();
+        context.effectiveSettings = Settings.newInstance();
+        assertNull(AbstractUpgradeStrategy.remoteResolutionUnsupportedReason(context));
+    }
+
+    @Test
+    @DisplayName("no reason when only blocked mirrors are configured (default http blocker)")
+    void reasonIsNullWhenOnlyBlockedMirrorsAreConfigured() {
+        UpgradeContext context = TestUtils.createMockContext();
+        context.effectiveSettings = Settings.newBuilder()
+                .mirrors(List.of(Mirror.newBuilder()
+                        .id("maven-default-http-blocker")
+                        .mirrorOf("external:http:*")
+                        .url("http://0.0.0.0/")
+                        .blocked(true)
+                        .build()))
+                .build();
+        assertNull(AbstractUpgradeStrategy.remoteResolutionUnsupportedReason(context));
+    }
+
+    @Test
+    @DisplayName("redirecting mirror disables remote resolution")
+    void reasonIsNonNullForRedirectingMirror() {
+        UpgradeContext context = TestUtils.createMockContext();
+        context.effectiveSettings = settingsWithRedirectingMirror();
+        assertNotNull(AbstractUpgradeStrategy.remoteResolutionUnsupportedReason(context));
+    }
+
+    @Test
+    @DisplayName("active proxy disables remote resolution")
+    void reasonIsNonNullForActiveProxy() {
+        UpgradeContext context = TestUtils.createMockContext();
+        context.effectiveSettings = Settings.newBuilder()
+                .proxies(List.of(Proxy.newBuilder()
+                        .id("corp-proxy")
+                        .activeString("true")
+                        .host("proxy.corp.example")
+                        .build()))
+                .build();
+        assertNotNull(AbstractUpgradeStrategy.remoteResolutionUnsupportedReason(context));
+    }
+
+    @Test
+    @DisplayName("offline mode disables remote resolution")
+    void reasonIsNonNullForOfflineMode() {
+        UpgradeContext context = TestUtils.createMockContext();
+        context.effectiveSettings = Settings.newBuilder().offline(true).build();
+        assertNotNull(AbstractUpgradeStrategy.remoteResolutionUnsupportedReason(context));
+    }
+
+    @Test
+    @DisplayName("compatibility fixes must not comment out elements when the posture cannot be honored")
+    void compatibilityFixDoesNotCommentOutWhenPostureCannotBeHonored() {
+        String pomXml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>test</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0.0</version>
+                <dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>${guava-version}</version>
+                        </dependency>
+                    </dependencies>
+                </dependencyManagement>
+            </project>
+            """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = TestUtils.createMockContext();
+        // Operator routes all repository traffic through a mirror: the standalone resolver
+        // cannot honor it, so no effective model is available and the property cannot be
+        // proven undefined. The fix must be skipped rather than commenting out a possibly
+        // valid dependency.
+        context.effectiveSettings = settingsWithRedirectingMirror();
+
+        CompatibilityFixStrategy strategy = new CompatibilityFixStrategy();
+        UpgradeResult result = strategy.doApply(context, pomMap);
+
+        assertTrue(result.success(), "Strategy should succeed while skipping the unverifiable fix");
+        assertEquals(0, result.modifiedCount(), "No POM should be modified");
+
+        String xml = DomUtils.toXml(document);
+        assertFalse(xml.contains("mvnup: commented out"), "Nothing may be commented out");
+        assertTrue(xml.contains("${guava-version}"), "The dependency must be left untouched");
+    }
+}

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/transfer/TransferListenerOutputTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/transfer/TransferListenerOutputTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.transfer;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.apache.maven.jline.JLineMessageBuilderFactory;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.transfer.ChecksumFailureException;
+import org.eclipse.aether.transfer.TransferCancelledException;
+import org.eclipse.aether.transfer.TransferEvent;
+import org.eclipse.aether.transfer.TransferResource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that transfer listener output escapes control characters.
+ */
+class TransferListenerOutputTest {
+
+    private static final char ESC = '\u001b';
+    private static final String CURSOR_UP_AND_ERASE = ESC + "[1A" + ESC + "[2K";
+
+    @Test
+    void transferMessagesEscapeTerminalControlCharacters() throws TransferCancelledException {
+        StringWriter out = new StringWriter();
+        ConsoleMavenTransferListener listener =
+                new ConsoleMavenTransferListener(new JLineMessageBuilderFactory(), new PrintWriter(out), true);
+
+        TransferResource resource =
+                new TransferResource("central", "http://repo/", "test/test-resource", new File(""), null);
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> false); // no close handle
+        TransferEvent event = new TransferEvent.Builder(session, resource)
+                .setType(TransferEvent.EventType.CORRUPTED)
+                .setException(new ChecksumFailureException("Checksum validation failed, expected 'deadbeef"
+                        + CURSOR_UP_AND_ERASE + "' but is actually 'cafebabe'"))
+                .build();
+
+        listener.transferCorrupted(event);
+
+        String printed = out.toString();
+        assertTrue(printed.contains("Checksum validation failed"), "warning must still be printed");
+        assertFalse(printed.indexOf(ESC) >= 0, "raw ESC must not reach the terminal");
+        assertTrue(printed.contains("\\u001b"), "control characters must be escaped visibly");
+    }
+
+    @Test
+    void escapesC0DelAndC1ButKeepsTabAndNewline() {
+        assertEquals("plain-1.0.jar", AbstractMavenTransferListener.sanitize("plain-1.0.jar"));
+        assertEquals("a\tb\nc", AbstractMavenTransferListener.sanitize("a\tb\nc"));
+        assertEquals("a\\u001bb", AbstractMavenTransferListener.sanitize("a" + ESC + "b")); // ESC
+        assertEquals("a\\u000db", AbstractMavenTransferListener.sanitize("a\rb")); // CR
+        assertEquals("a\\u0007b", AbstractMavenTransferListener.sanitize("a\u0007b")); // BEL (OSC terminator)
+        assertEquals("a\\u007fb", AbstractMavenTransferListener.sanitize("a\u007fb")); // DEL
+        assertEquals("a\\u009bb", AbstractMavenTransferListener.sanitize("a\u009bb")); // CSI (C1)
+        assertNull(AbstractMavenTransferListener.sanitize(null));
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/bridge/MavenRepositorySystem.java
@@ -23,8 +23,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,6 +32,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
@@ -770,19 +770,31 @@ public class MavenRepositorySystem {
     }
 
     /**
-     * Checks the URL to see if this repository refers to an external repository
+     * Pattern matching the protocol (scheme) and host of a repository URL textually, the way the
+     * resolver's {@code RemoteRepository} does. {@code java.net.URL} must not be used here: it
+     * rejects any scheme without a registered JDK stream handler (e.g. {@code dav}, {@code
+     * dav:http}, {@code dav+http}), which would make such repositories silently bypass {@code
+     * external:*} and {@code external:http:*} mirror matching below.
+     */
+    private static final Pattern URL_PROTOCOL_AND_HOST =
+            Pattern.compile("([^:/]+(:[^:/]{2,}+(?=://))?):(//([^@/]*@)?([^/:]+))?.*");
+
+    /**
+     * Checks the URL to see if this repository refers to an external repository. A URL that
+     * cannot be parsed is treated as external, so that {@code external:*} mirror rules apply to
+     * it rather than silently skipping it.
      *
      * @param originalRepository
      * @return true if external.
      */
     static boolean isExternalRepo(ArtifactRepository originalRepository) {
-        try {
-            URL url = new URL(originalRepository.getUrl());
-            return !(isLocal(url.getHost()) || url.getProtocol().equals("file"));
-        } catch (MalformedURLException e) {
-            // bad url just skip it here. It should have been validated already, but the wagon lookup will deal with it
-            return false;
+        String url = originalRepository.getUrl();
+        Matcher m = url != null ? URL_PROTOCOL_AND_HOST.matcher(url) : null;
+        if (m == null || !m.matches()) {
+            // an unparseable url is not exempt from external:* mirror rules; treat it as external
+            return true;
         }
+        return !(isLocal(m.group(5)) || "file".equalsIgnoreCase(m.group(1)));
     }
 
     private static boolean isLocal(String host) {
@@ -791,22 +803,25 @@ public class MavenRepositorySystem {
 
     /**
      * Checks the URL to see if this repository refers to a non-localhost repository using HTTP.
+     * A URL that cannot be parsed is treated as external, so that the shipped {@code
+     * external:http:*} mirror rule applies to it rather than silently skipping it.
      *
      * @param originalRepository
      * @return true if external.
      */
     static boolean isExternalHttpRepo(ArtifactRepository originalRepository) {
-        try {
-            URL url = new URL(originalRepository.getUrl());
-            return ("http".equalsIgnoreCase(url.getProtocol())
-                            || "dav".equalsIgnoreCase(url.getProtocol())
-                            || "dav:http".equalsIgnoreCase(url.getProtocol())
-                            || "dav+http".equalsIgnoreCase(url.getProtocol()))
-                    && !isLocal(url.getHost());
-        } catch (MalformedURLException e) {
-            // bad url just skip it here. It should have been validated already, but the wagon lookup will deal with it
-            return false;
+        String url = originalRepository.getUrl();
+        Matcher m = url != null ? URL_PROTOCOL_AND_HOST.matcher(url) : null;
+        if (m == null || !m.matches()) {
+            // an unparseable url is not exempt from the external:http:* mirror rule; treat it as external
+            return true;
         }
+        String protocol = m.group(1);
+        return ("http".equalsIgnoreCase(protocol)
+                        || "dav".equalsIgnoreCase(protocol)
+                        || "dav:http".equalsIgnoreCase(protocol)
+                        || "dav+http".equalsIgnoreCase(protocol))
+                && !isLocal(m.group(5));
     }
 
     static boolean matchesLayout(ArtifactRepository repository, Mirror mirror) {

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -451,7 +451,7 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         return model;
     }
 
-    private static Model transformBom(Model model, MavenProject project, Set<String> declaredRepositoryIds) {
+    static Model transformBom(Model model, MavenProject project, Set<String> declaredRepositoryIds) {
         boolean preserveModelVersion = model.isPreserveModelVersion();
 
         Model.Builder builder = prune(

--- a/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/transformation/impl/DefaultConsumerPomBuilder.java
@@ -23,14 +23,17 @@ import javax.inject.Named;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.maven.api.ArtifactCoordinates;
+import org.apache.maven.api.Constants;
 import org.apache.maven.api.DependencyScope;
 import org.apache.maven.api.Node;
 import org.apache.maven.api.PathScope;
@@ -154,7 +157,7 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         // Filter the effective model's dependency management to only include entries
         // explicitly declared in this BOM, using the effective model for resolved values.
         Model model = filterToOwnDependencyManagement(rawModel, effectiveModel, project);
-        return transformBom(model, project);
+        return transformBom(model, project, declaredRepositoryIds(session, rawModel));
     }
 
     /**
@@ -241,14 +244,14 @@ class DefaultConsumerPomBuilder implements PomBuilder {
 
     protected Model buildNonPom(RepositorySystemSession session, MavenProject project, ModelSource src)
             throws ModelBuilderException {
-        Model model = buildEffectiveModel(session, project, src);
-        return transformNonPom(model, project);
+        ModelBuilderResult result = buildModel(session, project, src);
+        Model model = buildEffectiveModel(session, project, result);
+        return transformNonPom(model, project, declaredRepositoryIds(session, result.getRawModel()));
     }
 
-    private Model buildEffectiveModel(RepositorySystemSession session, MavenProject project, ModelSource src)
+    private Model buildEffectiveModel(RepositorySystemSession session, MavenProject project, ModelBuilderResult result)
             throws ModelBuilderException {
         InternalSession iSession = InternalSession.from(session);
-        ModelBuilderResult result = buildModel(session, project, src);
         Model model = result.getEffectiveModel();
         boolean removeUnusedManagedDeps =
                 Features.consumerPomRemoveUnusedManagedDependencies(session.getConfigProperties());
@@ -407,6 +410,10 @@ class DefaultConsumerPomBuilder implements PomBuilder {
     }
 
     static Model transformNonPom(Model model, MavenProject project) {
+        return transformNonPom(model, project, null);
+    }
+
+    static Model transformNonPom(Model model, MavenProject project, Set<String> declaredRepositoryIds) {
         boolean preserveModelVersion = model.isPreserveModelVersion();
         String packaging = model.getPackaging();
 
@@ -419,7 +426,9 @@ class DefaultConsumerPomBuilder implements PomBuilder {
                                 .root(false)
                                 .parent(null)
                                 .build(null),
-                        model)
+                        model,
+                        declaredRepositoryIds,
+                        project != null ? project.getId() : model.getId())
                 .mailingLists(null)
                 .issueManagement(null)
                 .scm(
@@ -442,7 +451,7 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         return model;
     }
 
-    static Model transformBom(Model model, MavenProject project) {
+    private static Model transformBom(Model model, MavenProject project, Set<String> declaredRepositoryIds) {
         boolean preserveModelVersion = model.isPreserveModelVersion();
 
         Model.Builder builder = prune(
@@ -451,7 +460,9 @@ class DefaultConsumerPomBuilder implements PomBuilder {
                         .root(false)
                         .parent(null)
                         .build(null),
-                model);
+                model,
+                declaredRepositoryIds,
+                project != null ? project.getId() : model.getId());
         builder.packaging(POM_PACKAGING);
         builder.profiles(prune(model.getProfiles()));
 
@@ -682,7 +693,12 @@ class DefaultConsumerPomBuilder implements PomBuilder {
         return profiles.stream()
                 .map(p -> {
                     Profile.Builder builder = Profile.newBuilder(p, true);
-                    prune((ModelBase.Builder) builder, p);
+                    // Profile-level repositories in the published POM only ever come from the
+                    // project's own raw profiles (settings.xml profiles are injected into the
+                    // effective model, not appended to the model's own profile list), so the
+                    // legacy central-only filtering remains correct here: pass null to skip
+                    // declared-id filtering.
+                    prune((ModelBase.Builder) builder, p, null, null);
                     builder.activation(stripExecutableCondition(p.getActivation()));
                     return builder.build(null).build();
                 })
@@ -705,7 +721,8 @@ class DefaultConsumerPomBuilder implements PomBuilder {
                 && profile.getReporting() == null;
     }
 
-    private static <T extends ModelBase.Builder> T prune(T builder, ModelBase model) {
+    private static <T extends ModelBase.Builder> T prune(
+            T builder, ModelBase model, Set<String> declaredRepositoryIds, String modelId) {
         builder.properties(null).reporting(null);
         if (model.getDistributionManagement() != null
                 && model.getDistributionManagement().getRelocation() != null) {
@@ -714,15 +731,66 @@ class DefaultConsumerPomBuilder implements PomBuilder {
                     .relocation(model.getDistributionManagement().getRelocation())
                     .build());
         }
-        // only keep repositories other than 'central'
-        builder.repositories(pruneRepositories(model.getRepositories()));
+        // only keep repositories other than 'central' that the project's own POM declares
+        builder.repositories(pruneRepositories(model.getRepositories(), declaredRepositoryIds, modelId));
         builder.pluginRepositories(null);
         return builder;
     }
 
-    private static List<Repository> pruneRepositories(List<Repository> repositories) {
-        return repositories.stream()
-                .filter(r -> !org.apache.maven.api.Repository.CENTRAL_ID.equals(r.getId()))
-                .collect(Collectors.toList());
+    /**
+     * Collects the identifiers of the repositories declared by the project's own POM file, either at the
+     * model level or inside one of its profiles. Repositories present in the effective model whose id is
+     * not in this set came from elsewhere in the effective model (a parent POM or an active
+     * {@code settings.xml} profile) and are not published.
+     * <p>
+     * Returns {@code null} when repository sanitization is disabled via
+     * {@link Constants#MAVEN_CONSUMER_POM_SANITIZE_REPOSITORIES}, which restores the legacy behavior of
+     * publishing every non-central repository of the effective model.
+     */
+    private static Set<String> declaredRepositoryIds(RepositorySystemSession session, Model rawModel) {
+        if (rawModel == null || !Features.consumerPomSanitizeRepositories(session.getConfigProperties())) {
+            return null;
+        }
+        Set<String> ids = new LinkedHashSet<>();
+        for (Repository repository : rawModel.getRepositories()) {
+            ids.add(repository.getId());
+        }
+        for (Profile profile : rawModel.getProfiles()) {
+            for (Repository repository : profile.getRepositories()) {
+                ids.add(repository.getId());
+            }
+        }
+        return ids;
+    }
+
+    private static List<Repository> pruneRepositories(
+            List<Repository> repositories, Set<String> declaredRepositoryIds, String modelId) {
+        List<Repository> result = new ArrayList<>();
+        for (Repository repository : repositories) {
+            if (org.apache.maven.api.Repository.CENTRAL_ID.equals(repository.getId())) {
+                continue;
+            }
+            if (declaredRepositoryIds != null && !declaredRepositoryIds.contains(repository.getId())) {
+                LOGGER.warn(
+                        "Consumer POM for {}: dropping repository '{}' ({}) because it is not declared in the"
+                                + " project's own POM file (it was inherited from a parent POM or injected by an"
+                                + " active settings.xml profile). Set the property '{}' to false to restore the"
+                                + " previous behavior of publishing it.",
+                        modelId,
+                        repository.getId(),
+                        repository.getUrl(),
+                        Constants.MAVEN_CONSUMER_POM_SANITIZE_REPOSITORIES);
+                continue;
+            }
+            if (declaredRepositoryIds != null) {
+                LOGGER.info(
+                        "Consumer POM for {}: publishing repository '{}' with URL '{}'.",
+                        modelId,
+                        repository.getId(),
+                        repository.getUrl());
+            }
+            result.add(repository);
+        }
+        return result;
     }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/bridge/MavenRepositorySystemTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/bridge/MavenRepositorySystemTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.bridge;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MavenRepositorySystemTest {
+
+    @Test
+    void testExternalHttpRepoMatchesDavProtocols() {
+        assertTrue(MavenRepositorySystem.isExternalHttpRepo(repo("http://repo.example.com/m2/")));
+        assertTrue(MavenRepositorySystem.isExternalHttpRepo(repo("dav:http://repo.example.com/m2/")));
+        assertTrue(MavenRepositorySystem.isExternalHttpRepo(repo("dav+http://repo.example.com/m2/")));
+        assertTrue(MavenRepositorySystem.isExternalHttpRepo(repo("dav://repo.example.com/m2/")));
+    }
+
+    @Test
+    void testExternalHttpRepoClassificationForNonHttpUrls() {
+        assertFalse(MavenRepositorySystem.isExternalHttpRepo(repo("https://repo.example.com/m2/")));
+        assertFalse(MavenRepositorySystem.isExternalHttpRepo(repo("http://localhost:8080/m2/")));
+        assertFalse(MavenRepositorySystem.isExternalHttpRepo(repo("http://127.0.0.1/m2/")));
+        assertFalse(MavenRepositorySystem.isExternalHttpRepo(repo("file:///tmp/repo")));
+    }
+
+    @Test
+    void testUnparseableUrlClassification() {
+        assertTrue(MavenRepositorySystem.isExternalRepo(repo("not a url")));
+        assertTrue(MavenRepositorySystem.isExternalHttpRepo(repo("not a url")));
+    }
+
+    @Test
+    void testExternalRepoClassification() {
+        assertTrue(MavenRepositorySystem.isExternalRepo(repo("https://repo.example.com/m2/")));
+        assertTrue(MavenRepositorySystem.isExternalRepo(repo("dav:http://repo.example.com/m2/")));
+        assertFalse(MavenRepositorySystem.isExternalRepo(repo("file:///tmp/repo")));
+        assertFalse(MavenRepositorySystem.isExternalRepo(repo("http://localhost/m2/")));
+        assertFalse(MavenRepositorySystem.isExternalRepo(repo("http://127.0.0.1/m2/")));
+    }
+
+    private static ArtifactRepository repo(String url) {
+        return new MavenArtifactRepository("test", url, null, null, null);
+    }
+}

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.maven.api.DependencyCoordinates;
 import org.apache.maven.api.Node;
@@ -360,6 +361,68 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
         assertNull(transformed.getScm().getChildScmConnectionInheritAppendPath());
         assertNull(transformed.getScm().getChildScmUrlInheritAppendPath());
         assertNull(transformed.getScm().getChildScmDeveloperConnectionInheritAppendPath());
+    }
+
+    /**
+     * Verifies that repositories not declared in the project's own POM file (e.g. inherited from a
+     * parent POM or injected by an active settings.xml profile into the effective model) are pruned
+     * from the consumer POM, while repositories the project itself declares are retained. The central
+     * repository is always removed.
+     */
+    @Test
+    void testConsumerPomKeepsOnlyDeclaredRepositories() {
+        Model model = Model.newBuilder()
+                .groupId("test")
+                .artifactId("test")
+                .version("1.0")
+                .repositories(List.of(
+                        Repository.newBuilder()
+                                .id("central")
+                                .url("https://repo.maven.apache.org/maven2")
+                                .build(),
+                        Repository.newBuilder()
+                                .id("own-repo")
+                                .url("https://repo.example.com/releases")
+                                .build(),
+                        Repository.newBuilder()
+                                .id("corp-nexus")
+                                .url("https://nexus.corp.internal/repo")
+                                .build()))
+                .build();
+
+        Model transformed = DefaultConsumerPomBuilder.transformNonPom(model, null, Set.of("own-repo"));
+
+        assertEquals(
+                List.of("own-repo"),
+                transformed.getRepositories().stream().map(Repository::getId).toList());
+    }
+
+    /**
+     * Verifies the legacy behavior when repository sanitization is disabled (a {@code null} set of
+     * declared repository ids): every repository except central is published in the consumer POM.
+     */
+    @Test
+    void testAllNonCentralRepositoriesKeptWhenSanitizationDisabled() {
+        Model model = Model.newBuilder()
+                .groupId("test")
+                .artifactId("test")
+                .version("1.0")
+                .repositories(List.of(
+                        Repository.newBuilder()
+                                .id("central")
+                                .url("https://repo.maven.apache.org/maven2")
+                                .build(),
+                        Repository.newBuilder()
+                                .id("corp-nexus")
+                                .url("https://nexus.corp.internal/repo")
+                                .build()))
+                .build();
+
+        Model transformed = DefaultConsumerPomBuilder.transformNonPom(model, null, null);
+
+        assertEquals(
+                List.of("corp-nexus"),
+                transformed.getRepositories().stream().map(Repository::getId).toList());
     }
 
     /**

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.internal.transformation.impl;
 
 import javax.inject.Inject;
 
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -58,6 +59,7 @@ import org.apache.maven.impl.cache.DefaultRequestCacheFactory;
 import org.apache.maven.impl.resolver.MavenVersionScheme;
 import org.apache.maven.internal.impl.InternalMavenSession;
 import org.apache.maven.internal.transformation.AbstractRepositoryTestCase;
+import org.apache.maven.model.v4.MavenStaxWriter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.junit.jupiter.api.Test;
@@ -297,6 +299,44 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
         assertTrue(model.getProfiles().isEmpty());
     }
 
+    /**
+     * End-to-end check that the repository restriction actually reaches the published consumer
+     * POM. Uses a bom-packaged child (whose parent declares repository 'corp-nexus' and which
+     * declares its own repository 'own-repo'): bom packaging always goes through the
+     * effective-model (buildBom) path regardless of maven.consumer.pom.flatten, whereas a
+     * non-bom, non-flattened project publishes the raw model via buildPom/transformPom and was
+     * never affected by this issue (the raw model has no parent-inherited repositories to begin
+     * with). Builds through the real public entry point used by the deploy/install path, then
+     * serializes the resulting model with the same {@link MavenStaxWriter} the production
+     * {@code ConsumerPomArtifactTransformer} uses, and asserts on the generated XML text itself
+     * rather than on an intermediate model object.
+     */
+    @Test
+    void testConsumerPomRepositoriesRestrictedToOwnPomEndToEnd() throws Exception {
+        setRootDirectory("bom-repo-scope");
+        Path file = Paths.get("src/test/resources/consumer/bom-repo-scope/child/pom.xml");
+
+        MavenProject project = getEffectiveModel(file);
+        Model model = builder.build(session, project, Sources.buildSource(file));
+
+        StringWriter sw = new StringWriter();
+        MavenStaxWriter staxWriter = new MavenStaxWriter();
+        staxWriter.setNamespace(String.format("http://maven.apache.org/POM/%s", model.getModelVersion()));
+        staxWriter.write(sw, model);
+        String xml = sw.toString();
+
+        assertTrue(xml.contains("own-repo"), "the project's own declared repository must be published:\n" + xml);
+        assertTrue(
+                xml.contains("repo.example.com"),
+                "the project's own declared repository URL must be published:\n" + xml);
+        assertFalse(
+                xml.contains("corp-nexus"),
+                "the parent-only repository id must not appear in the published consumer POM:\n" + xml);
+        assertFalse(
+                xml.contains("nexus.corp.internal"),
+                "the parent-only repository URL must not appear in the published consumer POM:\n" + xml);
+    }
+
     @Test
     void testMultiModuleConsumer() throws Exception {
         setRootDirectory("multi-module");
@@ -402,7 +442,7 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
      * declared repository ids): every repository except central is published in the consumer POM.
      */
     @Test
-    void testAllNonCentralRepositoriesKeptWhenSanitizationDisabled() {
+    void testAllNonCentralRepositoriesKeptWhenRestrictionDisabled() {
         Model model = Model.newBuilder()
                 .groupId("test")
                 .artifactId("test")

--- a/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/internal/transformation/impl/ConsumerPomBuilderTest.java
@@ -225,7 +225,7 @@ public class ConsumerPomBuilderTest extends AbstractRepositoryTestCase {
                 .build();
 
         MavenProject project = new MavenProject(model);
-        Model transformed = DefaultConsumerPomBuilder.transformBom(model, project);
+        Model transformed = DefaultConsumerPomBuilder.transformBom(model, project, Collections.emptySet());
 
         assertEquals(1, transformed.getProfiles().size());
         Profile profile = transformed.getProfiles().get(0);

--- a/impl/maven-core/src/test/resources/consumer/bom-repo-scope/child/pom.xml
+++ b/impl/maven-core/src/test/resources/consumer/bom-repo-scope/child/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.my.group</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+  <artifactId>child-bom</artifactId>
+  <packaging>bom</packaging>
+
+  <repositories>
+    <repository>
+      <id>own-repo</id>
+      <url>https://repo.example.com/releases</url>
+    </repository>
+  </repositories>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.9</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-core/src/test/resources/consumer/bom-repo-scope/pom.xml
+++ b/impl/maven-core/src/test/resources/consumer/bom-repo-scope/pom.xml
@@ -1,0 +1,17 @@
+<project root="true" xmlns="http://maven.apache.org/POM/4.1.0">
+  <groupId>org.my.group</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>child</subproject>
+  </subprojects>
+
+  <repositories>
+    <repository>
+      <id>corp-nexus</id>
+      <url>https://nexus.corp.internal/repo</url>
+    </repository>
+  </repositories>
+</project>

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsBuilder.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,6 +52,7 @@ import org.apache.maven.api.services.xml.XmlReaderRequest;
 import org.apache.maven.api.settings.Activation;
 import org.apache.maven.api.settings.IdentifiableBase;
 import org.apache.maven.api.settings.Profile;
+import org.apache.maven.api.settings.Proxy;
 import org.apache.maven.api.settings.Repository;
 import org.apache.maven.api.settings.RepositoryPolicy;
 import org.apache.maven.api.settings.Server;
@@ -279,43 +281,8 @@ public class DefaultSettingsBuilder implements SettingsBuilder {
         }
         SecDispatcher secDispatcher = new DefaultSecDispatcher(dispatchers, getSecuritySettings(request.getSession()));
         final AtomicInteger preMaven4Passwords = new AtomicInteger(0);
-        UnaryOperator<String> decryptFunction = str -> {
-            if (str != null && !str.isEmpty() && !str.contains("${") && secDispatcher.isAnyEncryptedString(str)) {
-                if (secDispatcher.isLegacyEncryptedString(str)) {
-                    // the call above return true for too broad types of strings, original idea with 2.x sec-dispatcher
-                    // was to make it possible to add "descriptions" to encrypted passwords. Maven 4 is
-                    // limiting itself to decryption of ONLY the simplest cases of legacy passwords, those having form
-                    // as documented on page: https://maven.apache.org/guides/mini/guide-encryption.html
-                    // Examples of decrypted legacy passwords:
-                    // <password>{COQLCE6DU6GtcS5P=}</password>
-                    // <password>Oleg reset this password on 2009-03-11 {COQLCE6DU6GtcS5P=}</password>
-
-                    // In short, secDispatcher#isLegacyEncryptedString(str) did return true, but we apply more scrutiny
-                    // and check does string start with "{" or contains " {" (whitespace before opening curly braces),
-                    // and that it ends with "}" strictly. Otherwise, we refuse it.
-                    if ((!str.startsWith("{") && !str.contains(" {")) || !str.endsWith("}")) {
-                        // this is not a legacy password we care for
-                        return str;
-                    }
-
-                    // add a problem
-                    preMaven4Passwords.incrementAndGet();
-                }
-                try {
-                    return secDispatcher.decrypt(str);
-                } catch (Exception e) {
-                    problems.reportProblem(new DefaultBuilderProblem(
-                            settingsSource.getLocation(),
-                            -1,
-                            -1,
-                            e,
-                            "Could not decrypt password (fix the corrupted password or remove it, if unused) " + str,
-                            BuilderProblem.Severity.FATAL));
-                }
-            }
-            return str;
-        };
-        Settings result = new SettingsTransformer(decryptFunction).visit(settings);
+        Settings result = new DecryptingSettingsTransformer(settingsSource, secDispatcher, preMaven4Passwords, problems)
+                .visit(settings);
         if (preMaven4Passwords.get() > 0) {
             problems.reportProblem(new DefaultBuilderProblem(
                     settingsSource.getLocation(),
@@ -327,6 +294,124 @@ public class DefaultSettingsBuilder implements SettingsBuilder {
                     BuilderProblem.Severity.WARNING));
         }
         return result;
+    }
+
+    /**
+     * Decrypts every encrypted-looking string value found in the settings, reporting a problem
+     * for any value that cannot be decrypted. Unlike a plain string transform, this keeps track
+     * of which server, proxy or profile property is currently being decrypted so a failure can be
+     * reported by that reference rather than by echoing the encrypted value itself.
+     */
+    private static class DecryptingSettingsTransformer extends SettingsTransformer {
+        private final Source settingsSource;
+        private final SecDispatcher secDispatcher;
+        private final AtomicInteger preMaven4Passwords;
+        private final ProblemCollector<BuilderProblem> problems;
+        private String currentReference;
+
+        DecryptingSettingsTransformer(
+                Source settingsSource,
+                SecDispatcher secDispatcher,
+                AtomicInteger preMaven4Passwords,
+                ProblemCollector<BuilderProblem> problems) {
+            super(UnaryOperator.identity());
+            this.settingsSource = settingsSource;
+            this.secDispatcher = secDispatcher;
+            this.preMaven4Passwords = preMaven4Passwords;
+            this.problems = problems;
+        }
+
+        @Override
+        protected String transform(String str) {
+            if (str == null || str.isEmpty() || str.contains("${") || !secDispatcher.isAnyEncryptedString(str)) {
+                return str;
+            }
+            if (secDispatcher.isLegacyEncryptedString(str)) {
+                // the call above return true for too broad types of strings, original idea with 2.x sec-dispatcher
+                // was to make it possible to add "descriptions" to encrypted passwords. Maven 4 is
+                // limiting itself to decryption of ONLY the simplest cases of legacy passwords, those having form
+                // as documented on page: https://maven.apache.org/guides/mini/guide-encryption.html
+                // Examples of decrypted legacy passwords:
+                // <password>{COQLCE6DU6GtcS5P=}</password>
+                // <password>Oleg reset this password on 2009-03-11 {COQLCE6DU6GtcS5P=}</password>
+
+                // In short, secDispatcher#isLegacyEncryptedString(str) did return true, but we apply more scrutiny
+                // and check does string start with "{" or contains " {" (whitespace before opening curly braces),
+                // and that it ends with "}" strictly. Otherwise, we refuse it.
+                if ((!str.startsWith("{") && !str.contains(" {")) || !str.endsWith("}")) {
+                    // this is not a legacy password we care for
+                    return str;
+                }
+
+                // add a problem
+                preMaven4Passwords.incrementAndGet();
+            }
+            try {
+                return secDispatcher.decrypt(str);
+            } catch (Exception e) {
+                problems.reportProblem(new DefaultBuilderProblem(
+                        settingsSource.getLocation(),
+                        -1,
+                        -1,
+                        e,
+                        "Could not decrypt password (fix the corrupted password or remove it, if unused)"
+                                + (currentReference != null ? " for " + currentReference : ""),
+                        BuilderProblem.Severity.FATAL));
+                return str;
+            }
+        }
+
+        @Override
+        protected Server.Builder transformServer_Password(
+                Supplier<? extends Server.Builder> creator, Server.Builder builder, Server target) {
+            return withReference(
+                    "server " + target.getId(), () -> super.transformServer_Password(creator, builder, target));
+        }
+
+        @Override
+        protected Server.Builder transformServer_Passphrase(
+                Supplier<? extends Server.Builder> creator, Server.Builder builder, Server target) {
+            return withReference(
+                    "server " + target.getId(), () -> super.transformServer_Passphrase(creator, builder, target));
+        }
+
+        @Override
+        protected Proxy.Builder transformProxy_Password(
+                Supplier<? extends Proxy.Builder> creator, Proxy.Builder builder, Proxy target) {
+            return withReference(
+                    "proxy " + target.getId(), () -> super.transformProxy_Password(creator, builder, target));
+        }
+
+        @Override
+        protected Profile.Builder transformProfile_Properties(
+                Supplier<? extends Profile.Builder> creator, Profile.Builder builder, Profile target) {
+            Map<String, String> props = target.getProperties();
+            Map<String, String> newProps = null;
+            for (Map.Entry<String, String> entry : props.entrySet()) {
+                String newVal = withReference(
+                        "property " + entry.getKey() + " in profile " + target.getId(),
+                        () -> transform(entry.getValue()));
+                if (newVal != null && newVal != entry.getValue()) {
+                    if (newProps == null) {
+                        newProps = new HashMap<>(props);
+                        builder = builder != null ? builder : creator.get();
+                        builder.properties(newProps);
+                    }
+                    newProps.put(entry.getKey(), newVal);
+                }
+            }
+            return builder;
+        }
+
+        private <T> T withReference(String reference, Supplier<T> action) {
+            String previous = currentReference;
+            currentReference = reference;
+            try {
+                return action.get();
+            } finally {
+                currentReference = previous;
+            }
+        }
     }
 
     private Path getSecuritySettings(ProtoSession session) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultTransport.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultTransport.java
@@ -34,25 +34,46 @@ import org.eclipse.aether.spi.connector.transport.Transporter;
 import static java.util.Objects.requireNonNull;
 
 public class DefaultTransport implements Transport {
+    /** The repository base URI, normalized to end with a slash. */
     private final URI baseURI;
+
     private final Transporter transporter;
 
     public DefaultTransport(URI baseURI, Transporter transporter) {
-        this.baseURI = requireNonNull(baseURI);
+        requireNonNull(baseURI, "baseURI is null");
+        // Normalize the base to end with '/' so that URI.resolve() keeps the base's last
+        // path segment and the containment check in resolveWithinBase() compares whole
+        // path segments instead of raw strings. Without this, a base of ".../repo" would
+        // resolve "foo" to ".../foo", and the previous plain-string prefix check would also
+        // accept a sibling tree that merely shares a string prefix, such as ".../repo-other/".
+        String base = baseURI.toASCIIString();
+        this.baseURI = base.endsWith("/") ? baseURI : URI.create(base + "/");
         this.transporter = requireNonNull(transporter);
+    }
+
+    /**
+     * Resolves the given relative URI against the repository base and checks that the
+     * result stays inside the repository root as a path hierarchy. Because the comparison
+     * is made against the slash-terminated base, the base can only be a whole-segment
+     * prefix of a passing result, so sibling trees that merely share a string prefix are
+     * rejected along with absolute and dot-dot-escaping references.
+     */
+    private URI resolveWithinBase(URI relative) {
+        if (relative.isAbsolute()) {
+            throw new IllegalArgumentException("Supplied URI is not relative");
+        }
+        URI resolved = baseURI.resolve(relative);
+        if (!resolved.toASCIIString().startsWith(baseURI.toASCIIString())) {
+            throw new IllegalArgumentException("Supplied relative URI escapes baseUrl");
+        }
+        return resolved;
     }
 
     @Override
     public boolean get(URI relativeSource, Path target) {
         requireNonNull(relativeSource, "relativeSource is null");
         requireNonNull(target, "target is null");
-        if (relativeSource.isAbsolute()) {
-            throw new IllegalArgumentException("Supplied URI is not relative");
-        }
-        URI source = baseURI.resolve(relativeSource);
-        if (!source.toASCIIString().startsWith(baseURI.toASCIIString())) {
-            throw new IllegalArgumentException("Supplied relative URI escapes baseUrl");
-        }
+        URI source = resolveWithinBase(relativeSource);
         GetTask getTask = new GetTask(source);
         getTask.setDataPath(target);
         try {
@@ -101,14 +122,7 @@ public class DefaultTransport implements Transport {
         if (!Files.isRegularFile(source)) {
             throw new IllegalArgumentException("source file does not exist or is not a file");
         }
-        if (relativeTarget.isAbsolute()) {
-            throw new IllegalArgumentException("Supplied URI is not relative");
-        }
-        URI target = baseURI.resolve(relativeTarget);
-        if (!target.toASCIIString().startsWith(baseURI.toASCIIString())) {
-            throw new IllegalArgumentException("Supplied relative URI escapes baseUrl");
-        }
-
+        URI target = resolveWithinBase(relativeTarget);
         PutTask putTask = new PutTask(target);
         putTask.setDataPath(source);
         try {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/ApiRunner.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/standalone/ApiRunner.java
@@ -126,11 +126,28 @@ public class ApiRunner {
      * @return a new {@link Session} instance
      */
     public static Session createSession(Consumer<Injector> injectorConsumer, Path localRepo) {
+        return createSession(injectorConsumer, localRepo, true);
+    }
+
+    /**
+     * Creates a new Maven session with custom injector configuration, local repository path
+     * and control over {@code user.home} isolation.
+     *
+     * @param injectorConsumer consumer function to customize the injector
+     * @param localRepo path to the local repository
+     * @param isolateUserHome when {@code true}, the session remaps {@code user.home} to the
+     *        {@code target} directory so the invoking user's {@code settings.xml} and local
+     *        repository cannot interfere with tests; callers that want the operator's real
+     *        configuration honored (such as the mvnup tool) must pass {@code false}
+     * @return a new {@link Session} instance
+     */
+    public static Session createSession(Consumer<Injector> injectorConsumer, Path localRepo, boolean isolateUserHome) {
         Injector injector = Injector.create();
         injector.bindInstance(Injector.class, injector);
         injector.bindImplicit(ApiRunner.class);
         injector.bindImplicit(RepositorySystemSupplier.class);
         injector.bindInstance(LocalRepoProvider.class, () -> localRepo);
+        injector.bindInstance(UserHomeIsolation.class, () -> isolateUserHome);
         injector.discover(ApiRunner.class.getClassLoader());
         if (injectorConsumer != null) {
             injectorConsumer.accept(injector);
@@ -141,6 +158,17 @@ public class ApiRunner {
         scope.seed(Session.class, session);
         injector.bindScope(SessionScoped.class, scope);
         return session;
+    }
+
+    /**
+     * Controls whether the standalone session isolates {@code user.home} from the invoking
+     * user's environment.
+     */
+    interface UserHomeIsolation {
+        /**
+         * @return {@code true} to remap {@code user.home} away from the real user home
+         */
+        boolean isolated();
     }
 
     /**
@@ -365,16 +393,23 @@ public class ApiRunner {
 
     @Provides
     @SuppressWarnings("unused")
-    static Session newSession(RepositorySystem system, Lookup lookup, @Nullable LocalRepoProvider localRepoProvider) {
+    static Session newSession(
+            RepositorySystem system,
+            Lookup lookup,
+            @Nullable LocalRepoProvider localRepoProvider,
+            @Nullable UserHomeIsolation userHomeIsolation) {
         Map<String, String> properties = new HashMap<>();
         // Env variables prefixed with "env."
         System.getenv().forEach((k, v) -> properties.put("env." + k, v));
         // Java System properties
         System.getProperties().forEach((k, v) -> properties.put(k.toString(), v.toString()));
 
-        // Do not allow user settings to interfere with our unit tests
-        // TODO: remove that when this go more public
-        properties.put("user.home", "target");
+        // Test isolation shim: do not let the invoking user's settings interfere with unit
+        // tests. Callers that want the operator's real settings.xml and local repository
+        // honored must create the session with isolateUserHome=false (see createSession).
+        if (userHomeIsolation == null || userHomeIsolation.isolated()) {
+            properties.put("user.home", "target");
+        }
 
         Path userHome = Paths.get(properties.get("user.home"));
         Path mavenUserHome = userHome.resolve(".m2");

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsBuilderDecryptTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultSettingsBuilderDecryptTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.apache.maven.api.Constants;
+import org.apache.maven.api.Session;
+import org.apache.maven.api.services.SettingsBuilder;
+import org.apache.maven.api.services.SettingsBuilderException;
+import org.apache.maven.api.services.SettingsBuilderRequest;
+import org.apache.maven.api.services.Sources;
+import org.apache.maven.api.services.xml.SettingsXmlFactory;
+import org.apache.maven.impl.model.DefaultInterpolator;
+import org.codehaus.plexus.components.secdispatcher.Dispatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that a settings decryption failure is reported without echoing the encrypted value that
+ * failed to decrypt, and that the credential is instead identified by its server/proxy/profile
+ * reference.
+ */
+@ExtendWith(MockitoExtension.class)
+class DefaultSettingsBuilderDecryptTest {
+
+    // corrupted on purpose: not a valid encrypted value for the master password below
+    private static final String CORRUPTED_ENCRYPTED_VALUE =
+            "{L6L/HbmrY+cH+sNkphn-this password is corrupted intentionally-q3fguYepTpM04WlIXb8nB1pk=}";
+
+    @Mock
+    Session session;
+
+    @Mock
+    Dispatcher dispatcher;
+
+    @BeforeEach
+    void setup() {
+        Mockito.lenient()
+                .when(session.getService(SettingsXmlFactory.class))
+                .thenReturn(new DefaultSettingsXmlFactory());
+        Mockito.lenient()
+                .when(session.getEffectiveProperties())
+                .thenReturn(Map.of(
+                        Constants.MAVEN_SETTINGS_SECURITY,
+                        securitySettingsPath().toString()));
+    }
+
+    @Test
+    void decryptFailureMessageExcludesEncryptedValueAndIdentifiesTheServer() {
+        SettingsBuilder builder = new DefaultSettingsBuilder(
+                new DefaultSettingsXmlFactory(), new DefaultInterpolator(), Map.of("test", dispatcher));
+
+        SettingsBuilderRequest request = SettingsBuilderRequest.builder()
+                .session(session)
+                .userSettingsSource(Sources.buildSource(getSettings("settings-servers-decrypt-fail")))
+                .build();
+
+        SettingsBuilderException exception = assertThrows(SettingsBuilderException.class, () -> builder.build(request));
+
+        String message = exception.getMessage();
+        assertFalse(
+                message.contains(CORRUPTED_ENCRYPTED_VALUE),
+                "decrypt-failure message must not contain the encrypted value: " + message);
+        assertTrue(
+                message.contains("for server corrupted-server"),
+                "decrypt-failure message should identify the credential by server id: " + message);
+    }
+
+    private Path getSettings(String name) {
+        return Paths.get("src/test/resources/settings/" + name + ".xml").toAbsolutePath();
+    }
+
+    private Path securitySettingsPath() {
+        return Paths.get("src/test/resources/settings/settings-security-decrypt.xml")
+                .toAbsolutePath();
+    }
+}

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultTransportTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/DefaultTransportTest.java
@@ -22,11 +22,14 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.eclipse.aether.spi.connector.transport.GetTask;
 import org.eclipse.aether.spi.connector.transport.PutTask;
 import org.eclipse.aether.spi.connector.transport.Transporter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -61,5 +64,36 @@ class DefaultTransportTest {
         URI dest = URI.create("dest.txt");
         transport.putBytes("test content".getBytes(), dest);
         verify(transporter).put(any(PutTask.class));
+    }
+
+    @Test
+    void testRelativeUriResolvesInsideBaseWithoutTrailingSlash(@TempDir Path tempDir) throws Exception {
+        Transporter transporter = mock(Transporter.class);
+        // base deliberately configured without a trailing slash
+        DefaultTransport transport = new DefaultTransport(URI.create("http://example.com/repo"), transporter);
+        transport.get(URI.create("repo-other/artifact.jar"), tempDir.resolve("out.jar"));
+
+        ArgumentCaptor<GetTask> task = ArgumentCaptor.forClass(GetTask.class);
+        verify(transporter).get(task.capture());
+        // must resolve under the repository root, not to the sibling ".../repo-other/" tree
+        assertEquals(
+                "http://example.com/repo/repo-other/artifact.jar",
+                task.getValue().getLocation().toString());
+    }
+
+    @Test
+    void testRelativeUriOutsideBaseIsRejected(@TempDir Path tempDir) throws Exception {
+        Transporter transporter = mock(Transporter.class);
+        DefaultTransport transport = new DefaultTransport(URI.create("http://example.com/repo/"), transporter);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> transport.get(URI.create("../other/artifact.jar"), tempDir.resolve("out.jar")));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> transport.get(URI.create("//other.example.com/artifact.jar"), tempDir.resolve("out.jar")));
+
+        Path source = tempDir.resolve("source.txt");
+        Files.writeString(source, "content");
+        assertThrows(IllegalArgumentException.class, () -> transport.put(source, URI.create("../other/artifact.jar")));
     }
 }

--- a/impl/maven-impl/src/test/resources/settings/settings-security-decrypt.xml
+++ b/impl/maven-impl/src/test/resources/settings/settings-security-decrypt.xml
@@ -1,0 +1,3 @@
+<settingsSecurity>
+  <master>{KDvsYOFLlXgH4LU8tvpzAGg5otiosZXvfdQq0yO86LU=}</master>
+</settingsSecurity>

--- a/impl/maven-impl/src/test/resources/settings/settings-servers-decrypt-fail.xml
+++ b/impl/maven-impl/src/test/resources/settings/settings-servers-decrypt-fail.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <servers>
+    <server>
+      <id>corrupted-server</id>
+      <username>someuser</username>
+      <password>{L6L/HbmrY+cH+sNkphn-this password is corrupted intentionally-q3fguYepTpM04WlIXb8nB1pk=}</password>
+    </server>
+  </servers>
+</settings>

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh10210SettingsXmlDecryptTest.java
@@ -71,10 +71,10 @@ class MavenITgh10210SettingsXmlDecryptTest extends AbstractMavenIntegrationTestC
         try {
             verifier.execute();
         } catch (VerificationException e) {
-            assertTrue(
-                    verifier.loadLogContent()
-                            .contains(
-                                    "Could not decrypt password (fix the corrupted password or remove it, if unused) {L6L/HbmrY+cH+sNkphn-this password is corrupted intentionally-q3fguYepTpM04WlIXb8nB1pk=}"));
+            String log = verifier.loadLogContent();
+            assertTrue(log.contains(
+                    "Could not decrypt password (fix the corrupted password or remove it, if unused) for property prop6 in profile just-some-random-profile"));
+            assertFalse(log.contains("L6L/HbmrY+cH+sNkphn-this password is corrupted intentionally-q3fguYepTpM04WlIXb8nB1pk="));
         }
     }
 }


### PR DESCRIPTION
Robustness fixes across the CLI, transport and consumer POM.

- **Transfer listener output.** Control characters in transfer messages are escaped so they render literally rather than being interpreted by the terminal. Tab and newline are preserved.
- **Transport base URI.** Relative locations resolve against a slash-terminated base, so a relative reference cannot resolve outside it.
- **Mirror matching.** `isExternalRepo`/`isExternalHttpRepo` parsed with `java.net.URL`, which throws on `dav:`, `dav:http:` and `dav+http:` — leaving those branches unreachable — and returned `false` on any parse failure, so an unparseable URL matched no `external:*` mirror. Parsing is now textual and an unparseable URL is treated as external.
- **Settings decryption messages.** Decryption failure messages identify the server or profile property concerned rather than including the encrypted value.
- **Consumer POM repositories.** The consumer POM now publishes only repositories the project's own POM declares; those present only via a parent POM or an active `settings.xml` profile are dropped, with a warning naming each. `maven.consumer.pom.sanitizeRepositories=false` restores the previous behaviour. **This changes a published artifact format** — see the note below.
- **mvnup resolution.** `mvnup` reused hardcoded repositories and forced `user.home`, so a real `settings.xml` was never read. It now uses the settings the CLI already loaded and the configured local repository. Where the standalone resolver cannot honour the configuration — offline mode, a redirecting mirror, an active proxy — it is given no remote repositories and the affected strategies skip their remote work with a warning.

**Release note for the consumer POM change:** a downstream consumer relying on inheriting a repository declaration that existed only in a parent POM or the publisher's settings will need to declare that repository itself.

Each change is a separate commit.


---

*Draft while related code paths are reviewed — the same guard may be needed in sibling implementations of these interfaces, and I would rather establish that before asking for review time.*
