### PR TITLE
Validate coordinates and repository precedence during artifact resolution

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManager.java
@@ -273,6 +273,8 @@ public class DefaultRepositoryMetadataManager extends AbstractLogEnabled impleme
             ValidatingMetadataXpp3Reader mappingReader = new ValidatingMetadataXpp3Reader();
 
             result = mappingReader.read(reader, false);
+
+            validateVersioning(result);
         } catch (FileNotFoundException e) {
             throw new RepositoryMetadataReadException("Cannot read metadata from '" + mappingFile + "'", e);
         } catch (IOException | XmlPullParserException e) {
@@ -280,6 +282,51 @@ public class DefaultRepositoryMetadataManager extends AbstractLogEnabled impleme
                     "Cannot read metadata from '" + mappingFile + "': " + e.getMessage(), e);
         }
         return result;
+    }
+
+    /**
+     * Version tokens adopted from repository metadata must be valid coordinate components; metadata carrying
+     * anything else is treated as invalid.
+     */
+    private static void validateVersioning(Metadata metadata) throws RepositoryMetadataReadException {
+        if (metadata == null) {
+            return;
+        }
+        Versioning versioning = metadata.getVersioning();
+        if (versioning == null) {
+            return;
+        }
+        validateVersionToken(versioning.getLatest());
+        validateVersionToken(versioning.getRelease());
+        for (String version : versioning.getVersions()) {
+            validateVersionToken(version);
+        }
+        for (SnapshotVersion snapshotVersion : versioning.getSnapshotVersions()) {
+            validateVersionToken(snapshotVersion.getVersion());
+        }
+        Snapshot snapshot = versioning.getSnapshot();
+        if (snapshot != null) {
+            validateVersionToken(snapshot.getTimestamp());
+        }
+    }
+
+    private static void validateVersionToken(String value) throws RepositoryMetadataReadException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new RepositoryMetadataReadException("Metadata contains an invalid version token: '" + value + "'");
+        }
     }
 
     /**

--- a/maven-compat/src/test/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManagerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository.metadata;
+
+import java.io.File;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@link DefaultRepositoryMetadataManager} rejects repository metadata carrying version tokens that
+ * are not valid coordinate components, on the legacy read path used when metadata is loaded for merging.
+ */
+public class DefaultRepositoryMetadataManagerTest {
+
+    private final DefaultRepositoryMetadataManager manager = new DefaultRepositoryMetadataManager();
+
+    @Test
+    void testMetadataWithInvalidVersionTokenIsRejected() {
+        File metadataFile = testFile("metadata-invalid-token/maven-metadata.xml");
+
+        RepositoryMetadataReadException exception =
+                assertThrows(RepositoryMetadataReadException.class, () -> manager.readMetadata(metadataFile));
+
+        assertTrue(exception.getMessage().contains("invalid version token"), exception.getMessage());
+    }
+
+    @Test
+    void testMetadataWithInvalidSnapshotTimestampIsRejected() {
+        File metadataFile = testFile("metadata-invalid-timestamp/maven-metadata.xml");
+
+        RepositoryMetadataReadException exception =
+                assertThrows(RepositoryMetadataReadException.class, () -> manager.readMetadata(metadataFile));
+
+        assertTrue(exception.getMessage().contains("invalid version token"), exception.getMessage());
+    }
+
+    private static File testFile(String resource) {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(resource);
+        assertNotNull(url, "test resource not found: " + resource);
+        return new File(url.getFile());
+    }
+}

--- a/maven-compat/src/test/resources/metadata-invalid-timestamp/maven-metadata.xml
+++ b/maven-compat/src/test/resources/metadata-invalid-timestamp/maven-metadata.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata xmlns="http://maven.apache.org/METADATA/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/METADATA/1.1.0 http://maven.apache.org/xsd/metadata-1.1.0.xsd"
+  modelVersion="1.1.0">
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-timestamp</artifactId>
+  <version>1.0-SNAPSHOT</version><!-- metadata with an invalid snapshot timestamp token -->
+  <versioning>
+    <snapshot>
+      <timestamp>20120809.112920:1</timestamp>
+      <buildNumber>1</buildNumber>
+    </snapshot>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-compat/src/test/resources/metadata-invalid-token/maven-metadata.xml
+++ b/maven-compat/src/test/resources/metadata-invalid-token/maven-metadata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata xmlns="http://maven.apache.org/METADATA/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/METADATA/1.1.0 http://maven.apache.org/xsd/metadata-1.1.0.xsd"
+  modelVersion="1.1.0">
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-token</artifactId>
+  <version>1.0-SNAPSHOT</version><!-- metadata with an invalid release token -->
+  <versioning>
+    <release>1.0:2.0</release>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReader.java
+++ b/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReader.java
@@ -29,6 +29,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Plugin;
+import org.apache.maven.artifact.repository.metadata.Snapshot;
+import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
+import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.repository.internal.metadata.ValidatingMetadataXpp3Reader;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -54,7 +58,9 @@ public class DefaultMetadataReader implements MetadataReader {
         Objects.requireNonNull(input, "input cannot be null");
 
         try (Reader in = input) {
-            return new ValidatingMetadataXpp3Reader().read(in, isStrict(options));
+            Metadata metadata = new ValidatingMetadataXpp3Reader().read(in, isStrict(options));
+            validateMetadata(metadata);
+            return metadata;
         } catch (XmlPullParserException e) {
             throw new MetadataParseException(e.getMessage(), e.getLineNumber(), e.getColumnNumber(), e);
         }
@@ -64,7 +70,9 @@ public class DefaultMetadataReader implements MetadataReader {
         Objects.requireNonNull(input, "input cannot be null");
 
         try (InputStream in = input) {
-            return new ValidatingMetadataXpp3Reader().read(in, isStrict(options));
+            Metadata metadata = new ValidatingMetadataXpp3Reader().read(in, isStrict(options));
+            validateMetadata(metadata);
+            return metadata;
         } catch (XmlPullParserException e) {
             throw new MetadataParseException(e.getMessage(), e.getLineNumber(), e.getColumnNumber(), e);
         }
@@ -73,5 +81,58 @@ public class DefaultMetadataReader implements MetadataReader {
     private boolean isStrict(Map<String, ?> options) {
         Object value = (options != null) ? options.get(IS_STRICT) : null;
         return value == null || Boolean.parseBoolean(value.toString());
+    }
+
+    /**
+     * Coordinate-shaped tokens read from this metadata (versions, plugin artifactIds and prefixes) get carried
+     * forward by callers as if they were already-validated path and coordinate components. Reject anything that
+     * would not itself be a valid coordinate component here, before it leaves this reader.
+     */
+    private static void validateMetadata(Metadata metadata) throws IOException {
+        if (metadata == null) {
+            return;
+        }
+
+        Versioning versioning = metadata.getVersioning();
+        if (versioning != null) {
+            validateToken("version", versioning.getRelease());
+            validateToken("version", versioning.getLatest());
+            for (String version : versioning.getVersions()) {
+                validateToken("version", version);
+            }
+            for (SnapshotVersion snapshotVersion : versioning.getSnapshotVersions()) {
+                validateToken("version", snapshotVersion.getVersion());
+            }
+            Snapshot snapshot = versioning.getSnapshot();
+            if (snapshot != null) {
+                validateToken("snapshot timestamp", snapshot.getTimestamp());
+            }
+        }
+
+        if (metadata.getPlugins() != null) {
+            for (Plugin plugin : metadata.getPlugins()) {
+                validateToken("plugin artifactId", plugin.getArtifactId());
+                validateToken("plugin prefix", plugin.getPrefix());
+            }
+        }
+    }
+
+    private static void validateToken(String field, String value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new IOException("Metadata contains an invalid " + field + ": '" + value + "'");
+        }
     }
 }

--- a/maven-core/src/test/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReaderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReaderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository.metadata.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DefaultMetadataReaderTest {
+
+    private final DefaultMetadataReader reader = new DefaultMetadataReader();
+
+    private File resource(String name) throws URISyntaxException {
+        return new File(getClass().getResource(name).toURI());
+    }
+
+    @Test
+    public void testWellFormedMetadataParsesUnchanged() throws Exception {
+        Metadata metadata = reader.read(resource("well-formed-metadata.xml"), Collections.emptyMap());
+
+        assertEquals("org.apache.maven.its", metadata.getGroupId());
+        assertEquals("sample", metadata.getArtifactId());
+        assertEquals("1.1", metadata.getVersioning().getRelease());
+        assertEquals("1.1", metadata.getVersioning().getLatest());
+        assertEquals("maven-sample-plugin", metadata.getPlugins().get(0).getArtifactId());
+    }
+
+    @Test
+    public void testVersionContainingColonIsRejected() throws Exception {
+        File input = resource("invalid-version-token.xml");
+
+        IOException e = assertThrows(IOException.class, () -> reader.read(input, Collections.emptyMap()));
+        assertTrue(e.getMessage().contains("1.0:evil"));
+    }
+
+    @Test
+    public void testPluginArtifactIdContainingSlashIsRejected() throws Exception {
+        File input = resource("invalid-plugin-artifactid.xml");
+
+        IOException e = assertThrows(IOException.class, () -> reader.read(input, Collections.emptyMap()));
+        assertTrue(e.getMessage().contains("maven/sample-plugin"));
+    }
+}

--- a/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-plugin-artifactid.xml
+++ b/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-plugin-artifactid.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>sample</artifactId>
+  <plugins>
+    <plugin>
+      <name>Sample Plugin</name>
+      <prefix>sample</prefix>
+      <!-- not a valid coordinate component -->
+      <artifactId>maven/sample-plugin</artifactId>
+    </plugin>
+  </plugins>
+</metadata>

--- a/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-version-token.xml
+++ b/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-version-token.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>sample</artifactId>
+  <versioning>
+    <!-- not a valid coordinate component -->
+    <release>1.0:evil</release>
+    <lastUpdated>20150428055824</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/well-formed-metadata.xml
+++ b/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/well-formed-metadata.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>sample</artifactId>
+  <versioning>
+    <latest>1.1</latest>
+    <release>1.1</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.1</version>
+    </versions>
+    <lastUpdated>20150428055824</lastUpdated>
+  </versioning>
+  <plugins>
+    <plugin>
+      <name>Sample Plugin</name>
+      <prefix>sample</prefix>
+      <artifactId>maven-sample-plugin</artifactId>
+    </plugin>
+  </plugins>
+</metadata>

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -75,6 +75,8 @@ class DefaultModelResolver implements ModelResolver {
 
     private final Set<String> repositoryIds;
 
+    private final Set<String> externalRepositoryIds;
+
     DefaultModelResolver(
             RepositorySystemSession session,
             RequestTrace trace,
@@ -93,6 +95,11 @@ class DefaultModelResolver implements ModelResolver {
         this.externalRepositories = Collections.unmodifiableList(new ArrayList<>(repositories));
 
         this.repositoryIds = new HashSet<>();
+        Set<String> externalIds = new HashSet<>();
+        for (RemoteRepository externalRepository : this.externalRepositories) {
+            externalIds.add(externalRepository.getId());
+        }
+        this.externalRepositoryIds = Collections.unmodifiableSet(externalIds);
     }
 
     private DefaultModelResolver(DefaultModelResolver original) {
@@ -105,6 +112,7 @@ class DefaultModelResolver implements ModelResolver {
         this.repositories = new ArrayList<>(original.repositories);
         this.externalRepositories = original.externalRepositories;
         this.repositoryIds = new HashSet<>(original.repositoryIds);
+        this.externalRepositoryIds = original.externalRepositoryIds;
     }
 
     @Override
@@ -120,6 +128,13 @@ class DefaultModelResolver implements ModelResolver {
 
         if (!repositoryIds.add(repository.getId())) {
             if (!replace) {
+                return;
+            }
+
+            if (externalRepositoryIds.contains(repository.getId())) {
+                // Replacement is meant to refresh a repository this model declared earlier, e.g.
+                // once its URL has been interpolated. Repositories supplied by the request or the
+                // session are not model-declared, so they keep precedence and are left in place.
                 return;
             }
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -274,9 +275,13 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver, Servic
 
                     if (metadata.getFile() != null && metadata.getFile().exists()) {
                         try (InputStream in = new FileInputStream(metadata.getFile())) {
-                            versioning = new ValidatingMetadataXpp3Reader()
+                            Versioning parsed = new ValidatingMetadataXpp3Reader()
                                     .read(in, false)
                                     .getVersioning();
+
+                            validateVersioning(parsed);
+
+                            versioning = parsed;
                         }
                     }
                 }
@@ -287,6 +292,40 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver, Servic
         }
 
         return (versioning != null) ? versioning : new Versioning();
+    }
+
+    /**
+     * Version tokens adopted from repository metadata must be valid coordinate components; metadata carrying
+     * anything else is treated as invalid.
+     */
+    private static void validateVersioning(Versioning versioning) throws IOException {
+        if (versioning == null) {
+            return;
+        }
+        for (String version : versioning.getVersions()) {
+            validateVersionToken(version);
+        }
+        validateVersionToken(versioning.getLatest());
+        validateVersionToken(versioning.getRelease());
+    }
+
+    private static void validateVersionToken(String value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new IOException("Metadata contains an invalid version token: '" + value + "'");
+        }
     }
 
     private Versioning filterVersionsByRepositoryType(Versioning versioning, RemoteRepository remoteRepository) {

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionResolver.java
@@ -278,9 +278,13 @@ public class DefaultVersionResolver implements VersionResolver, Service {
 
                     if (metadata.getFile() != null && metadata.getFile().exists()) {
                         try (InputStream in = new FileInputStream(metadata.getFile())) {
-                            versioning = new ValidatingMetadataXpp3Reader()
+                            Versioning parsed = new ValidatingMetadataXpp3Reader()
                                     .read(in, false)
                                     .getVersioning();
+
+                            validateVersioning(parsed);
+
+                            versioning = parsed;
 
                             /*
                             NOTE: Users occasionally misuse the id "local" for remote repos which screws up the metadata
@@ -310,6 +314,44 @@ public class DefaultVersionResolver implements VersionResolver, Service {
         }
 
         return (versioning != null) ? versioning : new Versioning();
+    }
+
+    /**
+     * Version tokens adopted from repository metadata must be valid coordinate components; metadata carrying
+     * anything else is treated as invalid.
+     */
+    private static void validateVersioning(Versioning versioning) throws IOException {
+        if (versioning == null) {
+            return;
+        }
+        validateVersionToken(versioning.getLatest());
+        validateVersionToken(versioning.getRelease());
+        for (SnapshotVersion snapshotVersion : versioning.getSnapshotVersions()) {
+            validateVersionToken(snapshotVersion.getVersion());
+        }
+        Snapshot snapshot = versioning.getSnapshot();
+        if (snapshot != null) {
+            validateVersionToken(snapshot.getTimestamp());
+        }
+    }
+
+    private static void validateVersionToken(String value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new IOException("Metadata contains an invalid version token: '" + value + "'");
+        }
     }
 
     private void invalidMetadata(

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSource.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSource.java
@@ -28,6 +28,7 @@ import org.apache.maven.repository.internal.MavenArtifactRelocationSource;
 import org.apache.maven.repository.internal.RelocatedArtifact;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.sisu.Priority;
 import org.slf4j.Logger;
@@ -50,11 +51,15 @@ public final class DistributionManagementArtifactRelocationSource implements Mav
 
     @Override
     public Artifact relocatedTarget(
-            RepositorySystemSession session, ArtifactDescriptorResult artifactDescriptorResult, Model model) {
+            RepositorySystemSession session, ArtifactDescriptorResult artifactDescriptorResult, Model model)
+            throws ArtifactDescriptorException {
         DistributionManagement distMgmt = model.getDistributionManagement();
         if (distMgmt != null) {
             Relocation relocation = distMgmt.getRelocation();
             if (relocation != null) {
+                validateCoordinateComponent(relocation.getGroupId(), "groupId", artifactDescriptorResult);
+                validateCoordinateComponent(relocation.getArtifactId(), "artifactId", artifactDescriptorResult);
+                validateCoordinateComponent(relocation.getVersion(), "version", artifactDescriptorResult);
                 Artifact result = new RelocatedArtifact(
                         artifactDescriptorResult.getRequest().getArtifact(),
                         relocation.getGroupId(),
@@ -72,5 +77,37 @@ public final class DistributionManagementArtifactRelocationSource implements Mav
             }
         }
         return null;
+    }
+
+    /**
+     * Checks that a relocation coordinate component is usable as an artifact coordinate. Components outside
+     * the coordinate character set are rejected so that only well-formed coordinates enter resolution.
+     */
+    private static void validateCoordinateComponent(
+            String value, String component, ArtifactDescriptorResult artifactDescriptorResult)
+            throws ArtifactDescriptorException {
+        if (value == null || value.isEmpty()) {
+            return; // component is not relocated: the original artifact's value is kept
+        }
+        if (isInvalidCoordinateComponent(value)) {
+            IllegalArgumentException cause = new IllegalArgumentException("Invalid relocation " + component + " '"
+                    + value + "' in artifact descriptor for "
+                    + artifactDescriptorResult.getRequest().getArtifact()
+                    + ": not a valid artifact coordinate component");
+            artifactDescriptorResult.addException(cause);
+            throw new ArtifactDescriptorException(artifactDescriptorResult, cause.getMessage(), cause);
+        }
+    }
+
+    private static boolean isInvalidCoordinateComponent(String value) {
+        if ("..".equals(value) || value.contains("/") || value.contains("\\") || value.contains(":")) {
+            return true;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isISOControl(value.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
@@ -20,19 +20,25 @@ package org.apache.maven.repository.internal;
 
 import javax.inject.Inject;
 
+import java.io.File;
 import java.net.MalformedURLException;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Parent;
+import org.apache.maven.model.Repository;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.testing.PlexusTest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.impl.ArtifactResolver;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.repository.LocalRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -194,6 +200,41 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTest {
 
     @Inject
     private RemoteRepositoryManager remoteRepositoryManager;
+
+    @Test
+    public void testConstructionSuppliedRepositoryKeepsPrecedence(@TempDir Path localRepository) throws Exception {
+        // An empty local repository, so resolution has to consult the remote repository list
+        // rather than a copy cached by another test in this class.
+        final DefaultRepositorySystemSession isolatedSession = MavenRepositorySystemUtils.newSession();
+        isolatedSession.setLocalRepositoryManager(
+                system.newLocalRepositoryManager(isolatedSession, new LocalRepository(localRepository.toFile())));
+
+        final ModelResolver resolver = new DefaultModelResolver(
+                isolatedSession,
+                null,
+                this.getClass().getName(),
+                artifactResolver,
+                versionRangeResolver,
+                remoteRepositoryManager,
+                Arrays.asList(newTestRepository()));
+
+        // A model-declared repository that reuses the external repository's id; the external
+        // repository must keep its slot.
+        final Repository repository = new Repository();
+        repository.setId("repo");
+        repository.setUrl(new File("target/no-such-repository").toURI().toURL().toString());
+
+        resolver.addRepository(repository);
+        resolver.addRepository(repository, true);
+
+        final Parent parent = new Parent();
+        parent.setGroupId("ut.simple");
+        parent.setArtifactId("artifact");
+        parent.setVersion("1.0");
+
+        // The external repository kept its slot, so the artifact still resolves.
+        assertNotNull(resolver.resolveModel(parent));
+    }
 
     private ModelResolver newModelResolver() throws ComponentLookupException, MalformedURLException {
         return new DefaultModelResolver(

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.repository.internal;
+
+import javax.inject.Inject;
+
+import java.nio.file.Path;
+
+import org.codehaus.plexus.testing.PlexusTest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.apache.maven.repository.internal.AbstractRepositoryTest.newTestRepository;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@PlexusTest
+public class DefaultVersionRangeResolverTest {
+
+    @Inject
+    private RepositorySystem system;
+
+    @Inject
+    private VersionRangeResolver versionRangeResolver;
+
+    private RepositorySystemSession session;
+
+    // Each test gets its own local repository (rather than the module-wide target/local-repo) so that a
+    // previously cached resolution from another test cannot mask this test's outcome.
+    @BeforeEach
+    void setUp(@TempDir Path localRepoDir) {
+        DefaultRepositorySystemSession newSession = MavenRepositorySystemUtils.newSession();
+        LocalRepository localRepo = new LocalRepository(localRepoDir.toFile());
+        newSession.setLocalRepositoryManager(system.newLocalRepositoryManager(newSession, localRepo));
+        session = newSession;
+    }
+
+    @Test
+    void testRangeResolutionWithInvalidTokenInMetadataIsRejected() throws Exception {
+        VersionRangeRequest request = new VersionRangeRequest();
+        request.addRepository(newTestRepository());
+        request.setArtifact(new DefaultArtifact("org.apache.maven.its", "dep-invalid-range", "jar", "[1.0,2.0]"));
+
+        VersionRangeResult result = versionRangeResolver.resolveVersionRange(session, request);
+
+        // The metadata carries a versions[] entry that is not a valid coordinate component, so the whole
+        // document is treated as invalid and none of its versions (including the otherwise-valid 1.0 and 2.0)
+        // are offered as candidates for the range.
+        assertTrue(result.getVersions().isEmpty(), "expected no versions, got " + result.getVersions());
+    }
+}

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
@@ -78,4 +78,31 @@ public class DefaultVersionResolverTest extends AbstractRepositoryTest {
         VersionResult resultB = versionResolver.resolveVersion(session, requestB);
         assertEquals(versionB, resultB.getVersion());
     }
+
+    @Test
+    public void testSnapshotVersionFromMetadataWithInvalidTokenIsRejected() throws Exception {
+        VersionRequest request = new VersionRequest();
+        request.addRepository(newTestRepository());
+        Artifact artifact = new DefaultArtifact("org.apache.maven.its", "dep-invalid-sv", "", "jar", "1.0-SNAPSHOT");
+        request.setArtifact(artifact);
+
+        VersionResult result = versionResolver.resolveVersion(session, request);
+
+        // The metadata carries a snapshotVersion value that is not a valid coordinate component, so the
+        // metadata is treated as invalid and resolution falls back to the requested base version.
+        assertEquals("1.0-SNAPSHOT", result.getVersion());
+    }
+
+    @Test
+    public void testSnapshotTimestampFromMetadataWithInvalidTokenIsRejected() throws Exception {
+        VersionRequest request = new VersionRequest();
+        request.addRepository(newTestRepository());
+        Artifact artifact = new DefaultArtifact("org.apache.maven.its", "dep-invalid-ts", "", "jar", "1.0-SNAPSHOT");
+        request.setArtifact(artifact);
+
+        VersionResult result = versionResolver.resolveVersion(session, request);
+
+        // The metadata carries a snapshot timestamp that is not a valid coordinate component, so the
+        assertEquals("1.0-SNAPSHOT", result.getVersion());
+    }
 }

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSourceTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSourceTest.java
@@ -71,10 +71,24 @@ class DistributionManagementArtifactRelocationSourceTest {
     }
 
     @Test
+    void testRelocationGroupIdWithBackslashIsRejected() {
+        assertThrows(
+                ArtifactDescriptorException.class,
+                () -> source.relocatedTarget(null, newResult(), newModel("a\\b", null, null)));
+    }
+
+    @Test
     void testRelocationWithInvalidArtifactIdIsRejected() {
         assertThrows(
                 ArtifactDescriptorException.class,
                 () -> source.relocatedTarget(null, newResult(), newModel(null, "a/b", null)));
+    }
+
+    @Test
+    void testRelocationArtifactIdWithControlCharacterIsRejected() {
+        assertThrows(
+                ArtifactDescriptorException.class,
+                () -> source.relocatedTarget(null, newResult(), newModel(null, "a\nb", null)));
     }
 
     @Test

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSourceTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/relocation/DistributionManagementArtifactRelocationSourceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.repository.internal.relocation;
+
+import org.apache.maven.model.DistributionManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Relocation;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test cases for {@code DistributionManagementArtifactRelocationSource} coordinate handling.
+ */
+class DistributionManagementArtifactRelocationSourceTest {
+
+    private final DistributionManagementArtifactRelocationSource source =
+            new DistributionManagementArtifactRelocationSource();
+
+    private static ArtifactDescriptorResult newResult() {
+        final ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
+        request.setArtifact(new DefaultArtifact("ut.simple:artifact:1.0"));
+        return new ArtifactDescriptorResult(request);
+    }
+
+    private static Model newModel(String groupId, String artifactId, String version) {
+        final Relocation relocation = new Relocation();
+        relocation.setGroupId(groupId);
+        relocation.setArtifactId(artifactId);
+        relocation.setVersion(version);
+
+        final DistributionManagement distMgmt = new DistributionManagement();
+        distMgmt.setRelocation(relocation);
+
+        final Model model = new Model();
+        model.setDistributionManagement(distMgmt);
+        return model;
+    }
+
+    @Test
+    void testWellFormedRelocationIsApplied() throws Exception {
+        final Artifact relocated = source.relocatedTarget(null, newResult(), newModel("ut.moved", "artifact", "2.0"));
+
+        assertNotNull(relocated);
+        assertEquals("ut.moved", relocated.getGroupId());
+        assertEquals("artifact", relocated.getArtifactId());
+        assertEquals("2.0", relocated.getVersion());
+    }
+
+    @Test
+    void testRelocationWithInvalidArtifactIdIsRejected() {
+        assertThrows(
+                ArtifactDescriptorException.class,
+                () -> source.relocatedTarget(null, newResult(), newModel(null, "a/b", null)));
+    }
+
+    @Test
+    void testRelocationWithInvalidVersionIsRejected() {
+        assertThrows(
+                ArtifactDescriptorException.class,
+                () -> source.relocatedTarget(null, newResult(), newModel(null, null, "1.0:2.0")));
+    }
+
+    @Test
+    void testVersionWithTrailingDotsIsAccepted() throws Exception {
+        // only the exact ".." token is rejected; "1.." is an unusual but valid version string
+        final Artifact relocated = source.relocatedTarget(null, newResult(), newModel(null, null, "1.."));
+
+        assertNotNull(relocated);
+        assertEquals("1..", relocated.getVersion());
+    }
+}

--- a/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-range/maven-metadata.xml
+++ b/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-range/maven-metadata.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata xmlns="http://maven.apache.org/METADATA/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/METADATA/1.1.0 http://maven.apache.org/xsd/metadata-1.1.0.xsd"
+  modelVersion="1.1.0">
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-range</artifactId>
+  <versioning>
+    <latest>2.0</latest>
+    <release>2.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.0:2.0</version>
+      <version>2.0</version>
+    </versions>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-sv/1.0-SNAPSHOT/maven-metadata.xml
+++ b/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-sv/1.0-SNAPSHOT/maven-metadata.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata xmlns="http://maven.apache.org/METADATA/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/METADATA/1.1.0 http://maven.apache.org/xsd/metadata-1.1.0.xsd"
+  modelVersion="1.1.0">
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-sv</artifactId>
+  <version>1.0-SNAPSHOT</version><!-- metadata with an invalid snapshotVersion token -->
+  <versioning>
+    <snapshot>
+      <timestamp>20120809.112920</timestamp>
+      <buildNumber>1</buildNumber>
+    </snapshot>
+    <lastUpdated>20120809112920</lastUpdated>
+    <snapshotVersions>
+      <snapshotVersion>
+        <extension>jar</extension>
+        <value>1.0:2.0</value>
+        <updated>20120809112920</updated>
+      </snapshotVersion>
+    </snapshotVersions>
+  </versioning>
+</metadata>

--- a/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-ts/1.0-SNAPSHOT/maven-metadata.xml
+++ b/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-ts/1.0-SNAPSHOT/maven-metadata.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata xmlns="http://maven.apache.org/METADATA/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/METADATA/1.1.0 http://maven.apache.org/xsd/metadata-1.1.0.xsd"
+  modelVersion="1.1.0">
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-ts</artifactId>
+  <version>1.0-SNAPSHOT</version><!-- metadata with an invalid snapshot timestamp token -->
+  <versioning>
+    <snapshot>
+      <timestamp>20120809.112920:1</timestamp>
+      <buildNumber>1</buildNumber>
+    </snapshot>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Coordinates and repository lists arriving from a resolved artifact descriptor are validated before use.

- **Repository precedence.** Repositories declared by a resolved model no longer replace a same-id repository supplied by the request or session. A repository the model itself declared is still refreshed in place, for example once its URL is interpolated.
- **Relocation coordinates.** Relocation `groupId`/`artifactId`/`version` are checked against the artifact-coordinate character set before a `RelocatedArtifact` is built; malformed components fail the descriptor read rather than entering resolution. A follow-up commit covers the remaining rejected character classes.
- **Metadata version tokens.** Version and snapshot-timestamp tokens read from `maven-metadata.xml` are validated before being spliced into a resolved version, so malformed metadata fails the read rather than producing a malformed coordinate. The rejection message names the field.

Each change is a separate commit.

---

*Draft while related code paths are reviewed — the same validation may be needed in sibling implementations of these interfaces, and I would rather establish that before asking for review time.*

*A `systemPath` change was removed from this PR: it broke `MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest`, which covers deliberate MNG-4379 behaviour — a dependency resolved from a repository declaring its own `system`-scope dependency with the path interpolated from an environment variable.*
