### PR TITLE
Validate coordinates and repository precedence during artifact resolution

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReader.java
+++ b/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReader.java
@@ -26,6 +26,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Plugin;
+import org.apache.maven.artifact.repository.metadata.Snapshot;
+import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
+import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.ReaderFactory;
@@ -51,7 +55,9 @@ public class DefaultMetadataReader implements MetadataReader {
         Objects.requireNonNull(input, "input cannot be null");
 
         try (Reader in = input) {
-            return new MetadataXpp3Reader().read(in, isStrict(options));
+            Metadata metadata = new MetadataXpp3Reader().read(in, isStrict(options));
+            validateMetadata(metadata);
+            return metadata;
         } catch (XmlPullParserException e) {
             throw new MetadataParseException(e.getMessage(), e.getLineNumber(), e.getColumnNumber(), e);
         }
@@ -61,7 +67,9 @@ public class DefaultMetadataReader implements MetadataReader {
         Objects.requireNonNull(input, "input cannot be null");
 
         try (InputStream in = input) {
-            return new MetadataXpp3Reader().read(in, isStrict(options));
+            Metadata metadata = new MetadataXpp3Reader().read(in, isStrict(options));
+            validateMetadata(metadata);
+            return metadata;
         } catch (XmlPullParserException e) {
             throw new MetadataParseException(e.getMessage(), e.getLineNumber(), e.getColumnNumber(), e);
         }
@@ -70,5 +78,58 @@ public class DefaultMetadataReader implements MetadataReader {
     private boolean isStrict(Map<String, ?> options) {
         Object value = (options != null) ? options.get(IS_STRICT) : null;
         return value == null || Boolean.parseBoolean(value.toString());
+    }
+
+    /**
+     * Coordinate-shaped tokens read from this metadata (versions, plugin artifactIds and prefixes) get carried
+     * forward by callers as if they were already-validated path and coordinate components. Reject anything that
+     * would not itself be a valid coordinate component here, before it leaves this reader.
+     */
+    private static void validateMetadata(Metadata metadata) throws IOException {
+        if (metadata == null) {
+            return;
+        }
+
+        Versioning versioning = metadata.getVersioning();
+        if (versioning != null) {
+            validateToken("version", versioning.getRelease());
+            validateToken("version", versioning.getLatest());
+            for (String version : versioning.getVersions()) {
+                validateToken("version", version);
+            }
+            for (SnapshotVersion snapshotVersion : versioning.getSnapshotVersions()) {
+                validateToken("version", snapshotVersion.getVersion());
+            }
+            Snapshot snapshot = versioning.getSnapshot();
+            if (snapshot != null) {
+                validateToken("snapshot timestamp", snapshot.getTimestamp());
+            }
+        }
+
+        if (metadata.getPlugins() != null) {
+            for (Plugin plugin : metadata.getPlugins()) {
+                validateToken("plugin artifactId", plugin.getArtifactId());
+                validateToken("plugin prefix", plugin.getPrefix());
+            }
+        }
+    }
+
+    private static void validateToken(String field, String value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new IOException("Metadata contains an invalid " + field + ": '" + value + "'");
+        }
     }
 }

--- a/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
@@ -74,8 +74,6 @@ public class ProjectModelResolver implements ModelResolver {
 
     private final Set<String> repositoryIds;
 
-    private final Set<String> externalRepositoryIds;
-
     private final ReactorModelPool modelPool;
 
     private final ProjectBuildingRequest.RepositoryMerging repositoryMerging;
@@ -98,11 +96,6 @@ public class ProjectModelResolver implements ModelResolver {
         this.repositories.addAll(externalRepositories);
         this.repositoryMerging = repositoryMerging;
         this.repositoryIds = new HashSet<>();
-        Set<String> externalIds = new HashSet<>();
-        for (RemoteRepository externalRepository : this.externalRepositories) {
-            externalIds.add(externalRepository.getId());
-        }
-        this.externalRepositoryIds = Collections.unmodifiableSet(externalIds);
         this.modelPool = modelPool;
     }
 
@@ -116,7 +109,6 @@ public class ProjectModelResolver implements ModelResolver {
         this.repositories = new ArrayList<>(original.repositories);
         this.repositoryMerging = original.repositoryMerging;
         this.repositoryIds = new HashSet<>(original.repositoryIds);
-        this.externalRepositoryIds = original.externalRepositoryIds;
         this.modelPool = original.modelPool;
     }
 
@@ -128,13 +120,6 @@ public class ProjectModelResolver implements ModelResolver {
     public void addRepository(final Repository repository, boolean replace) throws InvalidRepositoryException {
         if (!repositoryIds.add(repository.getId())) {
             if (!replace) {
-                return;
-            }
-
-            if (externalRepositoryIds.contains(repository.getId())) {
-                // Replacement is meant to refresh a repository this model declared earlier, e.g.
-                // once its URL has been interpolated. Repositories supplied by the request or the
-                // session are not model-declared, so they keep precedence and are left in place.
                 return;
             }
 

--- a/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectModelResolver.java
@@ -74,6 +74,8 @@ public class ProjectModelResolver implements ModelResolver {
 
     private final Set<String> repositoryIds;
 
+    private final Set<String> externalRepositoryIds;
+
     private final ReactorModelPool modelPool;
 
     private final ProjectBuildingRequest.RepositoryMerging repositoryMerging;
@@ -96,6 +98,11 @@ public class ProjectModelResolver implements ModelResolver {
         this.repositories.addAll(externalRepositories);
         this.repositoryMerging = repositoryMerging;
         this.repositoryIds = new HashSet<>();
+        Set<String> externalIds = new HashSet<>();
+        for (RemoteRepository externalRepository : this.externalRepositories) {
+            externalIds.add(externalRepository.getId());
+        }
+        this.externalRepositoryIds = Collections.unmodifiableSet(externalIds);
         this.modelPool = modelPool;
     }
 
@@ -109,6 +116,7 @@ public class ProjectModelResolver implements ModelResolver {
         this.repositories = new ArrayList<>(original.repositories);
         this.repositoryMerging = original.repositoryMerging;
         this.repositoryIds = new HashSet<>(original.repositoryIds);
+        this.externalRepositoryIds = original.externalRepositoryIds;
         this.modelPool = original.modelPool;
     }
 
@@ -120,6 +128,13 @@ public class ProjectModelResolver implements ModelResolver {
     public void addRepository(final Repository repository, boolean replace) throws InvalidRepositoryException {
         if (!repositoryIds.add(repository.getId())) {
             if (!replace) {
+                return;
+            }
+
+            if (externalRepositoryIds.contains(repository.getId())) {
+                // Replacement is meant to refresh a repository this model declared earlier, e.g.
+                // once its URL has been interpolated. Repositories supplied by the request or the
+                // session are not model-declared, so they keep precedence and are left in place.
                 return;
             }
 

--- a/maven-core/src/main/java/org/apache/maven/project/artifact/MavenMetadataSource.java
+++ b/maven-core/src/main/java/org/apache/maven/project/artifact/MavenMetadataSource.java
@@ -612,16 +612,19 @@ public class MavenMetadataSource implements ArtifactMetadataSource {
 
                     if (relocation != null) {
                         if (relocation.getGroupId() != null) {
+                            requireValidCoordinateComponent(relocation.getGroupId(), "groupId", artifact);
                             artifact.setGroupId(relocation.getGroupId());
                             relocatedArtifact = artifact;
                             project.setGroupId(relocation.getGroupId());
                         }
                         if (relocation.getArtifactId() != null) {
+                            requireValidCoordinateComponent(relocation.getArtifactId(), "artifactId", artifact);
                             artifact.setArtifactId(relocation.getArtifactId());
                             relocatedArtifact = artifact;
                             project.setArtifactId(relocation.getArtifactId());
                         }
                         if (relocation.getVersion() != null) {
+                            requireValidCoordinateComponent(relocation.getVersion(), "version", artifact);
                             // note: see MNG-3454. This causes a problem, but fixing it may break more.
                             artifact.setVersionRange(VersionRange.createFromVersion(relocation.getVersion()));
                             relocatedArtifact = artifact;
@@ -675,6 +678,34 @@ public class MavenMetadataSource implements ArtifactMetadataSource {
         rel.relocatedArtifact = relocatedArtifact;
 
         return rel;
+    }
+
+    /**
+     * Checks that a relocation coordinate component is usable as an artifact coordinate component before it
+     * is applied to the artifact and project. A component outside the coordinate character set is rejected so
+     * that only well-formed coordinates enter resolution.
+     */
+    private static void requireValidCoordinateComponent(String value, String component, Artifact artifact)
+            throws ArtifactMetadataRetrievalException {
+        if (isInvalidCoordinateComponent(value)) {
+            throw new ArtifactMetadataRetrievalException(
+                    "Invalid relocation " + component + " '" + value + "' for " + artifact.getId()
+                            + ": not a valid artifact coordinate component",
+                    null,
+                    artifact);
+        }
+    }
+
+    private static boolean isInvalidCoordinateComponent(String value) {
+        if ("..".equals(value) || value.contains("/") || value.contains("\\") || value.contains(":")) {
+            return true;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isISOControl(value.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private ModelProblem hasMissingParentPom(ProjectBuildingException e) {

--- a/maven-core/src/test/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReaderTest.java
+++ b/maven-core/src/test/java/org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReaderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository.metadata.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DefaultMetadataReaderTest {
+
+    private final DefaultMetadataReader reader = new DefaultMetadataReader();
+
+    private File resource(String name) throws URISyntaxException {
+        return new File(getClass().getResource(name).toURI());
+    }
+
+    @Test
+    public void testWellFormedMetadataParsesUnchanged() throws Exception {
+        Metadata metadata = reader.read(resource("well-formed-metadata.xml"), Collections.emptyMap());
+
+        assertEquals("org.apache.maven.its", metadata.getGroupId());
+        assertEquals("sample", metadata.getArtifactId());
+        assertEquals("1.1", metadata.getVersioning().getRelease());
+        assertEquals("1.1", metadata.getVersioning().getLatest());
+        assertEquals("maven-sample-plugin", metadata.getPlugins().get(0).getArtifactId());
+    }
+
+    @Test
+    public void testVersionContainingColonIsRejected() throws Exception {
+        File input = resource("invalid-version-token.xml");
+
+        IOException e = assertThrows(IOException.class, () -> reader.read(input, Collections.emptyMap()));
+        assertTrue(e.getMessage().contains("1.0:evil"));
+    }
+
+    @Test
+    public void testPluginArtifactIdContainingSlashIsRejected() throws Exception {
+        File input = resource("invalid-plugin-artifactid.xml");
+
+        IOException e = assertThrows(IOException.class, () -> reader.read(input, Collections.emptyMap()));
+        assertTrue(e.getMessage().contains("maven/sample-plugin"));
+    }
+}

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Parent;
+import org.apache.maven.model.Repository;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -208,6 +209,34 @@ public class ProjectModelResolverTest {
 
         assertNotNull(this.newModelResolver().resolveModel(dependency));
         assertEquals("1", dependency.getVersion());
+    }
+
+    @Test
+    public void testConstructionSuppliedRepositoryKeepsPrecedenceOverModelDeclaredRepositoryWithSameId()
+            throws Exception {
+        final ModelResolver resolver = this.newModelResolver();
+
+        // A model-declared repository that reuses the id of a repository supplied at construction
+        // time (here, the "central" entry from getRemoteRepositories()) but points elsewhere.
+        final Repository repository = new Repository();
+        repository.setId(org.apache.maven.repository.RepositorySystem.DEFAULT_REMOTE_REPO_ID);
+        repository.setUrl(new File(getBasedir(), "target/no-such-repository")
+                .toURI()
+                .toURL()
+                .toString());
+
+        resolver.addRepository(repository);
+        resolver.addRepository(repository, true);
+
+        final Parent parent = new Parent();
+        parent.setGroupId("org.apache");
+        parent.setArtifactId("apache");
+        parent.setVersion("1");
+
+        // The construction-supplied repository kept its slot, so resolution against it still
+        // succeeds.
+        assertNotNull(resolver.resolveModel(parent));
+        assertEquals("1", parent.getVersion());
     }
 
     private ModelResolver newModelResolver() throws Exception {

--- a/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/ProjectModelResolverTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Parent;
-import org.apache.maven.model.Repository;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -209,34 +208,6 @@ public class ProjectModelResolverTest {
 
         assertNotNull(this.newModelResolver().resolveModel(dependency));
         assertEquals("1", dependency.getVersion());
-    }
-
-    @Test
-    public void testConstructionSuppliedRepositoryKeepsPrecedenceOverModelDeclaredRepositoryWithSameId()
-            throws Exception {
-        final ModelResolver resolver = this.newModelResolver();
-
-        // A model-declared repository that reuses the id of a repository supplied at construction
-        // time (here, the "central" entry from getRemoteRepositories()) but points elsewhere.
-        final Repository repository = new Repository();
-        repository.setId(org.apache.maven.repository.RepositorySystem.DEFAULT_REMOTE_REPO_ID);
-        repository.setUrl(new File(getBasedir(), "target/no-such-repository")
-                .toURI()
-                .toURL()
-                .toString());
-
-        resolver.addRepository(repository);
-        resolver.addRepository(repository, true);
-
-        final Parent parent = new Parent();
-        parent.setGroupId("org.apache");
-        parent.setArtifactId("apache");
-        parent.setVersion("1");
-
-        // The construction-supplied repository kept its slot, so resolution against it still
-        // succeeds.
-        assertNotNull(resolver.resolveModel(parent));
-        assertEquals("1", parent.getVersion());
     }
 
     private ModelResolver newModelResolver() throws Exception {

--- a/maven-core/src/test/java/org/apache/maven/project/artifact/MavenMetadataSourceRelocationTest.java
+++ b/maven-core/src/test/java/org/apache/maven/project/artifact/MavenMetadataSourceRelocationTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.project.artifact;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ResolutionGroup;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.metadata.RepositoryMetadataManager;
+import org.apache.maven.bridge.MavenRepositorySystem;
+import org.apache.maven.model.DistributionManagement;
+import org.apache.maven.model.Relocation;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.repository.legacy.metadata.DefaultMetadataResolutionRequest;
+import org.apache.maven.repository.legacy.metadata.MetadataResolutionRequest;
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.RepositorySystemSession;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that a relocation read from a resolved project's distribution management is validated before its
+ * components are applied to the artifact and project being resolved, exercising the real
+ * {@link MavenMetadataSource#retrieve(MetadataResolutionRequest)} code path with mocked collaborators (no
+ * on-disk artifact resolution, so this test does not depend on, or share, any module-level local repository).
+ */
+class MavenMetadataSourceRelocationTest {
+
+    private MavenMetadataSource newSource(ProjectBuilder projectBuilder) throws Exception {
+        MavenMetadataSource source = new MavenMetadataSource();
+
+        ArtifactFactory artifactFactory = mock(ArtifactFactory.class);
+        when(artifactFactory.createProjectArtifact(any(), any(), any(), any()))
+                .thenAnswer(invocation -> new DefaultArtifact(
+                        (String) invocation.getArgument(0),
+                        (String) invocation.getArgument(1),
+                        (String) invocation.getArgument(2),
+                        (String) invocation.getArgument(3),
+                        "pom",
+                        null,
+                        new DefaultArtifactHandler("pom")));
+
+        LegacySupport legacySupport = mock(LegacySupport.class);
+        RepositorySystemSession repositorySession = mock(RepositorySystemSession.class);
+        when(legacySupport.getRepositorySession()).thenReturn(repositorySession);
+        when(legacySupport.getSession()).thenReturn(null);
+
+        setField(source, "artifactFactory", artifactFactory);
+        setField(source, "repositorySystem", mock(MavenRepositorySystem.class));
+        setField(source, "repositoryMetadataManager", mock(RepositoryMetadataManager.class));
+        setField(source, "projectBuilder", projectBuilder);
+        setField(source, "logger", mock(Logger.class));
+        setField(source, "cache", mock(MavenMetadataCache.class));
+        setField(source, "legacySupport", legacySupport);
+
+        return source;
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = MavenMetadataSource.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Artifact newArtifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, Artifact.SCOPE_COMPILE, "pom", null, new DefaultArtifactHandler("pom"));
+    }
+
+    private static MavenProject newProject(String groupId, String artifactId, String version, Relocation relocation) {
+        MavenProject project = new MavenProject();
+        project.setGroupId(groupId);
+        project.setArtifactId(artifactId);
+        project.setVersion(version);
+        if (relocation != null) {
+            DistributionManagement distMgmt = new DistributionManagement();
+            distMgmt.setRelocation(relocation);
+            project.setDistributionManagement(distMgmt);
+        }
+        return project;
+    }
+
+    private static MetadataResolutionRequest newRequest(Artifact artifact) {
+        MetadataResolutionRequest request = new DefaultMetadataResolutionRequest();
+        request.setArtifact(artifact);
+        request.setLocalRepository(mock(ArtifactRepository.class));
+        request.setRemoteRepositories(Collections.emptyList());
+        return request;
+    }
+
+    @Test
+    void testRelocationWithInvalidArtifactIdIsRejected() throws Exception {
+        Relocation relocation = new Relocation();
+        relocation.setArtifactId("a/b");
+
+        MavenProject relocatingProject = newProject("group", "original", "1.0", relocation);
+        MavenProject finalProject = newProject("group", "a/b", "1.0", null);
+
+        ProjectBuildingResult first = mock(ProjectBuildingResult.class);
+        when(first.getProject()).thenReturn(relocatingProject);
+        ProjectBuildingResult second = mock(ProjectBuildingResult.class);
+        when(second.getProject()).thenReturn(finalProject);
+
+        ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
+        when(projectBuilder.build(any(Artifact.class), any(ProjectBuildingRequest.class)))
+                .thenReturn(first, second);
+
+        MavenMetadataSource source = newSource(projectBuilder);
+        Artifact artifact = newArtifact("group", "original", "1.0");
+        MetadataResolutionRequest request = newRequest(artifact);
+
+        ArtifactMetadataRetrievalException exception =
+                assertThrows(ArtifactMetadataRetrievalException.class, () -> source.retrieve(request));
+        assertEquals(true, exception.getMessage().contains("a/b"));
+        assertEquals(true, exception.getMessage().contains("artifactId"));
+    }
+
+    @Test
+    void testWellFormedRelocationIsApplied() throws Exception {
+        Relocation relocation = new Relocation();
+        relocation.setGroupId("group.moved");
+        relocation.setArtifactId("artifact-moved");
+        relocation.setVersion("2.0");
+
+        MavenProject relocatingProject = newProject("group", "original", "1.0", relocation);
+        MavenProject finalProject = newProject("group.moved", "artifact-moved", "2.0", null);
+
+        ProjectBuildingResult first = mock(ProjectBuildingResult.class);
+        when(first.getProject()).thenReturn(relocatingProject);
+        ProjectBuildingResult second = mock(ProjectBuildingResult.class);
+        when(second.getProject()).thenReturn(finalProject);
+
+        ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
+        when(projectBuilder.build(any(Artifact.class), any(ProjectBuildingRequest.class)))
+                .thenReturn(first, second);
+
+        MavenMetadataSource source = newSource(projectBuilder);
+        Artifact artifact = newArtifact("group", "original", "1.0");
+        MetadataResolutionRequest request = newRequest(artifact);
+
+        ResolutionGroup result = source.retrieve(request);
+
+        assertEquals("group.moved", artifact.getGroupId());
+        assertEquals("artifact-moved", artifact.getArtifactId());
+        assertEquals("2.0", artifact.getVersion());
+        assertEquals(artifact, result.getRelocatedArtifact());
+    }
+}

--- a/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-plugin-artifactid.xml
+++ b/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-plugin-artifactid.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>sample</artifactId>
+  <plugins>
+    <plugin>
+      <name>Sample Plugin</name>
+      <prefix>sample</prefix>
+      <!-- not a valid coordinate component -->
+      <artifactId>maven/sample-plugin</artifactId>
+    </plugin>
+  </plugins>
+</metadata>

--- a/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-version-token.xml
+++ b/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/invalid-version-token.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>sample</artifactId>
+  <versioning>
+    <!-- not a valid coordinate component -->
+    <release>1.0:evil</release>
+    <lastUpdated>20150428055824</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/well-formed-metadata.xml
+++ b/maven-core/src/test/resources/org/apache/maven/artifact/repository/metadata/io/well-formed-metadata.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>sample</artifactId>
+  <versioning>
+    <latest>1.1</latest>
+    <release>1.1</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.1</version>
+    </versions>
+    <lastUpdated>20150428055824</lastUpdated>
+  </versioning>
+  <plugins>
+    <plugin>
+      <name>Sample Plugin</name>
+      <prefix>sample</prefix>
+      <artifactId>maven-sample-plugin</artifactId>
+    </plugin>
+  </plugins>
+</metadata>

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReader.java
@@ -340,6 +340,9 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
 
             if (relocation != null) {
                 result.addRelocation(a);
+                requireValidCoordinateComponent(relocation.getGroupId(), "groupId", a, result);
+                requireValidCoordinateComponent(relocation.getArtifactId(), "artifactId", a, result);
+                requireValidCoordinateComponent(relocation.getVersion(), "version", a, result);
                 a = new RelocatedArtifact(
                         a,
                         relocation.getGroupId(),
@@ -371,6 +374,37 @@ public class DefaultArtifactDescriptorReader implements ArtifactDescriptorReader
             relocation = distMgmt.getRelocation();
         }
         return relocation;
+    }
+
+    /**
+     * Checks that a relocation coordinate component is usable as an artifact coordinate component before it
+     * is applied to the artifact being resolved. A component outside the coordinate character set is rejected
+     * so that only well-formed coordinates enter resolution.
+     */
+    private static void requireValidCoordinateComponent(
+            String value, String component, Artifact artifact, ArtifactDescriptorResult result)
+            throws ArtifactDescriptorException {
+        if (value == null || value.isEmpty()) {
+            return; // component is not relocated: the original artifact's value is kept
+        }
+        if (isInvalidCoordinateComponent(value)) {
+            IllegalArgumentException cause = new IllegalArgumentException("Invalid relocation " + component + " '"
+                    + value + "' for " + artifact + ": not a valid artifact coordinate component");
+            result.addException(cause);
+            throw new ArtifactDescriptorException(result, cause.getMessage(), cause);
+        }
+    }
+
+    private static boolean isInvalidCoordinateComponent(String value) {
+        if ("..".equals(value) || value.contains("/") || value.contains("\\") || value.contains(":")) {
+            return true;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isISOControl(value.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void missingDescriptor(

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -75,6 +75,8 @@ class DefaultModelResolver implements ModelResolver {
 
     private final Set<String> repositoryIds;
 
+    private final Set<String> externalRepositoryIds;
+
     DefaultModelResolver(
             RepositorySystemSession session,
             RequestTrace trace,
@@ -93,6 +95,11 @@ class DefaultModelResolver implements ModelResolver {
         this.externalRepositories = Collections.unmodifiableList(new ArrayList<>(repositories));
 
         this.repositoryIds = new HashSet<>();
+        Set<String> externalIds = new HashSet<>();
+        for (RemoteRepository externalRepository : this.externalRepositories) {
+            externalIds.add(externalRepository.getId());
+        }
+        this.externalRepositoryIds = Collections.unmodifiableSet(externalIds);
     }
 
     private DefaultModelResolver(DefaultModelResolver original) {
@@ -105,6 +112,7 @@ class DefaultModelResolver implements ModelResolver {
         this.repositories = new ArrayList<>(original.repositories);
         this.externalRepositories = original.externalRepositories;
         this.repositoryIds = new HashSet<>(original.repositoryIds);
+        this.externalRepositoryIds = original.externalRepositoryIds;
     }
 
     @Override
@@ -120,6 +128,13 @@ class DefaultModelResolver implements ModelResolver {
 
         if (!repositoryIds.add(repository.getId())) {
             if (!replace) {
+                return;
+            }
+
+            if (externalRepositoryIds.contains(repository.getId())) {
+                // Replacement is meant to refresh a repository this model declared earlier, e.g.
+                // once its URL has been interpolated. Repositories supplied by the request or the
+                // session are not model-declared, so they keep precedence and are left in place.
                 return;
             }
 

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionRangeResolver.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -274,8 +275,12 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver, Servic
 
                     if (metadata.getFile() != null && metadata.getFile().exists()) {
                         try (InputStream in = new FileInputStream(metadata.getFile())) {
-                            versioning =
+                            Versioning parsed =
                                     new MetadataXpp3Reader().read(in, false).getVersioning();
+
+                            validateVersioning(parsed);
+
+                            versioning = parsed;
                         }
                     }
                 }
@@ -286,6 +291,40 @@ public class DefaultVersionRangeResolver implements VersionRangeResolver, Servic
         }
 
         return (versioning != null) ? versioning : new Versioning();
+    }
+
+    /**
+     * Version tokens adopted from repository metadata must be valid coordinate components; metadata carrying
+     * anything else is treated as invalid.
+     */
+    private static void validateVersioning(Versioning versioning) throws IOException {
+        if (versioning == null) {
+            return;
+        }
+        for (String version : versioning.getVersions()) {
+            validateVersionToken(version);
+        }
+        validateVersionToken(versioning.getLatest());
+        validateVersionToken(versioning.getRelease());
+    }
+
+    private static void validateVersionToken(String value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new IOException("Metadata contains an invalid version token: '" + value + "'");
+        }
     }
 
     private Versioning filterVersionsByRepositoryType(Versioning versioning, RemoteRepository remoteRepository) {

--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultVersionResolver.java
@@ -278,8 +278,12 @@ public class DefaultVersionResolver implements VersionResolver, Service {
 
                     if (metadata.getFile() != null && metadata.getFile().exists()) {
                         try (InputStream in = new FileInputStream(metadata.getFile())) {
-                            versioning =
+                            Versioning parsed =
                                     new MetadataXpp3Reader().read(in, false).getVersioning();
+
+                            validateVersioning(parsed);
+
+                            versioning = parsed;
 
                             /*
                             NOTE: Users occasionally misuse the id "local" for remote repos which screws up the metadata
@@ -309,6 +313,44 @@ public class DefaultVersionResolver implements VersionResolver, Service {
         }
 
         return (versioning != null) ? versioning : new Versioning();
+    }
+
+    /**
+     * Version tokens adopted from repository metadata must be valid coordinate components; metadata carrying
+     * anything else is treated as invalid.
+     */
+    private static void validateVersioning(Versioning versioning) throws IOException {
+        if (versioning == null) {
+            return;
+        }
+        validateVersionToken(versioning.getLatest());
+        validateVersionToken(versioning.getRelease());
+        for (SnapshotVersion snapshotVersion : versioning.getSnapshotVersions()) {
+            validateVersionToken(snapshotVersion.getVersion());
+        }
+        Snapshot snapshot = versioning.getSnapshot();
+        if (snapshot != null) {
+            validateVersionToken(snapshot.getTimestamp());
+        }
+    }
+
+    private static void validateVersionToken(String value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new IOException("Metadata contains an invalid version token: '" + value + "'");
+        }
     }
 
     private void invalidMetadata(

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderRelocationValidationTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderRelocationValidationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.repository.internal;
+
+import javax.inject.Inject;
+
+import java.io.File;
+
+import org.codehaus.plexus.testing.PlexusTest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.ArtifactDescriptorReader;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a relocation read from a resolved artifact descriptor's model is validated before its
+ * components are applied to the artifact being resolved, exercising the real
+ * {@link ArtifactDescriptorReader#readArtifactDescriptor(RepositorySystemSession, ArtifactDescriptorRequest)} code
+ * path against a fixture repository on disk. Each test method gets its own {@code @TempDir} local repository so
+ * runs do not share resolution state with the rest of this module's tests.
+ */
+@PlexusTest
+public class DefaultArtifactDescriptorReaderRelocationValidationTest {
+
+    @Inject
+    private RepositorySystem system;
+
+    @Inject
+    private ArtifactDescriptorReader reader;
+
+    private RepositorySystemSession session;
+
+    @BeforeEach
+    void setUp(@TempDir File localRepoDir) {
+        DefaultRepositorySystemSession newSession = MavenRepositorySystemUtils.newSession();
+        LocalRepository localRepo = new LocalRepository(localRepoDir);
+        newSession.setLocalRepositoryManager(system.newLocalRepositoryManager(newSession, localRepo));
+        session = newSession;
+    }
+
+    private static RemoteRepository testRepository() throws Exception {
+        return new RemoteRepository.Builder(
+                        "repo",
+                        "default",
+                        getTestFile("target/test-classes/repo").toURI().toURL().toString())
+                .build();
+    }
+
+    @Test
+    void testRelocationWithInvalidArtifactIdIsRejected() throws Exception {
+        ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
+        request.addRepository(testRepository());
+        request.setArtifact(new DefaultArtifact("ut.simple", "dep-invalid-relocation", "pom", "1.0"));
+
+        ArtifactDescriptorException exception = assertThrows(
+                ArtifactDescriptorException.class, () -> reader.readArtifactDescriptor(session, request));
+        assertTrue(exception.getMessage().contains("artifactId"));
+    }
+}

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderRelocationValidationTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultArtifactDescriptorReaderRelocationValidationTest.java
@@ -80,8 +80,30 @@ public class DefaultArtifactDescriptorReaderRelocationValidationTest {
         request.addRepository(testRepository());
         request.setArtifact(new DefaultArtifact("ut.simple", "dep-invalid-relocation", "pom", "1.0"));
 
-        ArtifactDescriptorException exception = assertThrows(
-                ArtifactDescriptorException.class, () -> reader.readArtifactDescriptor(session, request));
+        ArtifactDescriptorException exception =
+                assertThrows(ArtifactDescriptorException.class, () -> reader.readArtifactDescriptor(session, request));
+        assertTrue(exception.getMessage().contains("artifactId"));
+    }
+
+    @Test
+    void testRelocationWithBackslashIsRejected() throws Exception {
+        ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
+        request.addRepository(testRepository());
+        request.setArtifact(new DefaultArtifact("ut.simple", "dep-backslash-relocation", "pom", "1.0"));
+
+        ArtifactDescriptorException exception =
+                assertThrows(ArtifactDescriptorException.class, () -> reader.readArtifactDescriptor(session, request));
+        assertTrue(exception.getMessage().contains("artifactId"));
+    }
+
+    @Test
+    void testRelocationWithControlCharacterIsRejected() throws Exception {
+        ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
+        request.addRepository(testRepository());
+        request.setArtifact(new DefaultArtifact("ut.simple", "dep-control-char-relocation", "pom", "1.0"));
+
+        ArtifactDescriptorException exception =
+                assertThrows(ArtifactDescriptorException.class, () -> reader.readArtifactDescriptor(session, request));
         assertTrue(exception.getMessage().contains("artifactId"));
     }
 }

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultModelResolverTest.java
@@ -20,19 +20,25 @@ package org.apache.maven.repository.internal;
 
 import javax.inject.Inject;
 
+import java.io.File;
 import java.net.MalformedURLException;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Parent;
+import org.apache.maven.model.Repository;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.testing.PlexusTest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.impl.ArtifactResolver;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.repository.LocalRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -194,6 +200,41 @@ public final class DefaultModelResolverTest extends AbstractRepositoryTest {
 
     @Inject
     private RemoteRepositoryManager remoteRepositoryManager;
+
+    @Test
+    public void testConstructionSuppliedRepositoryKeepsPrecedence(@TempDir Path localRepository) throws Exception {
+        // An empty local repository, so resolution has to consult the remote repository list
+        // rather than a copy cached by another test in this class.
+        final DefaultRepositorySystemSession isolatedSession = MavenRepositorySystemUtils.newSession();
+        isolatedSession.setLocalRepositoryManager(
+                system.newLocalRepositoryManager(isolatedSession, new LocalRepository(localRepository.toFile())));
+
+        final ModelResolver resolver = new DefaultModelResolver(
+                isolatedSession,
+                null,
+                this.getClass().getName(),
+                artifactResolver,
+                versionRangeResolver,
+                remoteRepositoryManager,
+                Arrays.asList(newTestRepository()));
+
+        // A model-declared repository that reuses the external repository's id; the external
+        // repository must keep its slot.
+        final Repository repository = new Repository();
+        repository.setId("repo");
+        repository.setUrl(new File("target/no-such-repository").toURI().toURL().toString());
+
+        resolver.addRepository(repository);
+        resolver.addRepository(repository, true);
+
+        final Parent parent = new Parent();
+        parent.setGroupId("ut.simple");
+        parent.setArtifactId("artifact");
+        parent.setVersion("1.0");
+
+        // The external repository kept its slot, so the artifact still resolves.
+        assertNotNull(resolver.resolveModel(parent));
+    }
 
     private ModelResolver newModelResolver() throws ComponentLookupException, MalformedURLException {
         return new DefaultModelResolver(

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionRangeResolverTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.repository.internal;
+
+import javax.inject.Inject;
+
+import org.codehaus.plexus.testing.PlexusTest;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@PlexusTest
+public class DefaultVersionRangeResolverTest extends AbstractRepositoryTest {
+
+    @Inject
+    private VersionRangeResolver versionRangeResolver;
+
+    @Test
+    public void testVersionsListFromMetadataWithInvalidTokenIsRejected() throws Exception {
+        VersionRangeRequest request = new VersionRangeRequest();
+        request.addRepository(newTestRepository());
+        Artifact artifact = new DefaultArtifact("org.apache.maven.its", "dep-invalid-versions", "jar", "[1.0,)");
+        request.setArtifact(artifact);
+
+        VersionRangeResult result = versionRangeResolver.resolveVersionRange(session, request);
+
+        // The metadata carries a version token that is not a valid coordinate component, so the whole
+        // metadata file is treated as invalid and none of its versions (valid or not) are offered.
+        assertTrue(result.getVersions().isEmpty());
+        assertFalse(result.getVersions().stream().anyMatch(v -> v.toString().contains("1.0:2.0")));
+    }
+}

--- a/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
+++ b/maven-resolver-provider/src/test/java/org/apache/maven/repository/internal/DefaultVersionResolverTest.java
@@ -78,4 +78,32 @@ public class DefaultVersionResolverTest extends AbstractRepositoryTest {
         VersionResult resultB = versionResolver.resolveVersion(session, requestB);
         assertEquals(versionB, resultB.getVersion());
     }
+
+    @Test
+    public void testSnapshotVersionFromMetadataWithInvalidTokenIsRejected() throws Exception {
+        VersionRequest request = new VersionRequest();
+        request.addRepository(newTestRepository());
+        Artifact artifact = new DefaultArtifact("org.apache.maven.its", "dep-invalid-sv", "", "jar", "1.0-SNAPSHOT");
+        request.setArtifact(artifact);
+
+        VersionResult result = versionResolver.resolveVersion(session, request);
+
+        // The metadata carries a snapshotVersion value that is not a valid coordinate component, so the
+        // metadata is treated as invalid and resolution falls back to the requested base version.
+        assertEquals("1.0-SNAPSHOT", result.getVersion());
+    }
+
+    @Test
+    public void testSnapshotTimestampFromMetadataWithInvalidTokenIsRejected() throws Exception {
+        VersionRequest request = new VersionRequest();
+        request.addRepository(newTestRepository());
+        Artifact artifact = new DefaultArtifact("org.apache.maven.its", "dep-invalid-ts", "", "jar", "1.0-SNAPSHOT");
+        request.setArtifact(artifact);
+
+        VersionResult result = versionResolver.resolveVersion(session, request);
+
+        // The metadata carries a snapshot timestamp that is not a valid coordinate component, so the
+        // metadata is treated as invalid and resolution falls back to the requested base version.
+        assertEquals("1.0-SNAPSHOT", result.getVersion());
+    }
 }

--- a/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-sv/1.0-SNAPSHOT/maven-metadata.xml
+++ b/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-sv/1.0-SNAPSHOT/maven-metadata.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-sv</artifactId>
+  <version>1.0-SNAPSHOT</version><!-- metadata with an invalid snapshotVersion token -->
+  <versioning>
+    <snapshot>
+      <timestamp>20120809.112920</timestamp>
+      <buildNumber>1</buildNumber>
+    </snapshot>
+    <lastUpdated>20120809112920</lastUpdated>
+    <snapshotVersions>
+      <snapshotVersion>
+        <extension>jar</extension>
+        <value>1.0:2.0</value>
+        <updated>20120809112920</updated>
+      </snapshotVersion>
+    </snapshotVersions>
+  </versioning>
+</metadata>

--- a/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-ts/1.0-SNAPSHOT/maven-metadata.xml
+++ b/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-ts/1.0-SNAPSHOT/maven-metadata.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-ts</artifactId>
+  <version>1.0-SNAPSHOT</version><!-- metadata with an invalid snapshot timestamp token -->
+  <versioning>
+    <snapshot>
+      <timestamp>20120809.112920:1</timestamp>
+      <buildNumber>1</buildNumber>
+    </snapshot>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-versions/maven-metadata.xml
+++ b/maven-resolver-provider/src/test/resources/repo/org/apache/maven/its/dep-invalid-versions/maven-metadata.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-versions</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.0:2.0</version>
+    </versions>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-resolver-provider/src/test/resources/repo/ut/simple/dep-backslash-relocation/1.0/dep-backslash-relocation-1.0.pom
+++ b/maven-resolver-provider/src/test/resources/repo/ut/simple/dep-backslash-relocation/1.0/dep-backslash-relocation-1.0.pom
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ut.simple</groupId>
+  <artifactId>dep-backslash-relocation</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Relocation With Backslash Coordinate Component</name>
+
+  <distributionManagement>
+    <relocation>
+      <artifactId>a\b</artifactId>
+    </relocation>
+  </distributionManagement>
+</project>

--- a/maven-resolver-provider/src/test/resources/repo/ut/simple/dep-control-char-relocation/1.0/dep-control-char-relocation-1.0.pom
+++ b/maven-resolver-provider/src/test/resources/repo/ut/simple/dep-control-char-relocation/1.0/dep-control-char-relocation-1.0.pom
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ut.simple</groupId>
+  <artifactId>dep-control-char-relocation</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Relocation With Control Character Coordinate Component</name>
+
+  <distributionManagement>
+    <relocation>
+      <artifactId>a	b</artifactId>
+    </relocation>
+  </distributionManagement>
+</project>

--- a/maven-resolver-provider/src/test/resources/repo/ut/simple/dep-invalid-relocation/1.0/dep-invalid-relocation-1.0.pom
+++ b/maven-resolver-provider/src/test/resources/repo/ut/simple/dep-invalid-relocation/1.0/dep-invalid-relocation-1.0.pom
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ut.simple</groupId>
+  <artifactId>dep-invalid-relocation</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Relocation With Invalid Coordinate Component</name>
+
+  <distributionManagement>
+    <relocation>
+      <artifactId>a/b</artifactId>
+    </relocation>
+  </distributionManagement>
+</project>


### PR DESCRIPTION
Coordinates and repository lists arriving from a resolved artifact descriptor are validated before use.

- **Repository precedence.** Repositories declared by a resolved model no longer replace a same-id repository supplied by the request or session. A repository the model itself declared is still refreshed in place, for example once its URL is interpolated.
- **Relocation coordinates.** Relocation `groupId`/`artifactId`/`version` are checked against the artifact-coordinate character set before a `RelocatedArtifact` is built; malformed components fail the descriptor read rather than entering resolution. A follow-up commit covers the remaining rejected character classes.
- **Metadata version tokens.** Version and snapshot-timestamp tokens read from `maven-metadata.xml` are validated before being spliced into a resolved version, so malformed metadata fails the read rather than producing a malformed coordinate. The rejection message names the field.

Each change is a separate commit.

---

*Draft while related code paths are reviewed — the same validation may be needed in sibling implementations of these interfaces, and I would rather establish that before asking for review time.*

*A `systemPath` change was removed from this PR: it broke `MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest`, which covers deliberate MNG-4379 behaviour — a dependency resolved from a repository declaring its own `system`-scope dependency with the path interpolated from an environment variable.*
