### PR TITLE
Forward port #12915 + #12940: fix and IT for #12660 BOM version from imported BOM

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
@@ -83,6 +83,17 @@ public class DefaultDependencyManagementImporter implements DependencyManagement
                                         + toString(present) + ". Add the conflicting managed dependency directly "
                                         + "to the dependencyManagement section of the POM.");
                     }
+                    if (present != null
+                            && directDependencies.contains(key)
+                            && present.getVersion() == null
+                            && dependency.getVersion() != null) {
+                        dependencies.put(
+                                key,
+                                Dependency.newBuilder(present)
+                                        .version(dependency.getVersion())
+                                        .location("version", dependency.getLocation("version"))
+                                        .build());
+                    }
                     if (present == null && request.isLocationTracking()) {
                         Dependency updatedDependency = updateWithImportedFrom(dependency, source);
                         dependencies.put(key, updatedDependency);

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultDependencyManagementImporterTest.java
@@ -18,14 +18,20 @@
  */
 package org.apache.maven.impl.model;
 
+import java.util.List;
+
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.DependencyManagement;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputSource;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.services.ModelBuilderRequest;
+import org.apache.maven.api.services.ModelProblemCollector;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 class DefaultDependencyManagementImporterTest {
     @Test
@@ -137,5 +143,45 @@ class DefaultDependencyManagementImporterTest {
                 expectedImportedFrom,
                 actualImportedFrom,
                 "Expected importedFrom to be " + expectedImportedFrom + " but was " + actualImportedFrom);
+    }
+
+    @Test
+    void testImportManagementInheritsVersionFromImportedBomWhenLocalEntryHasNoVersion() {
+        // A locally-declared dep mgmt entry with scope=provided but no version
+        Dependency localDep = Dependency.newBuilder()
+                .groupId("org.junit.jupiter")
+                .artifactId("junit-jupiter-api")
+                .scope("provided")
+                .build();
+
+        Model target = Model.newBuilder()
+                .dependencyManagement(DependencyManagement.newBuilder()
+                        .dependencies(List.of(localDep))
+                        .build())
+                .build();
+
+        // An imported BOM providing the same dependency with a version
+        Dependency importedDep = Dependency.newBuilder()
+                .groupId("org.junit.jupiter")
+                .artifactId("junit-jupiter-api")
+                .version("5.10.0")
+                .build();
+
+        DependencyManagement importedBom = DependencyManagement.newBuilder()
+                .dependencies(List.of(importedDep))
+                .build();
+
+        DefaultDependencyManagementImporter importer = new DefaultDependencyManagementImporter();
+        Model result = importer.importManagement(
+                target, List.of(importedBom), mock(ModelBuilderRequest.class), mock(ModelProblemCollector.class));
+
+        List<Dependency> resultDeps = result.getDependencyManagement().getDependencies();
+        assertEquals(1, resultDeps.size());
+
+        Dependency merged = resultDeps.get(0);
+        assertEquals("org.junit.jupiter", merged.getGroupId());
+        assertEquals("junit-jupiter-api", merged.getArtifactId());
+        assertEquals("5.10.0", merged.getVersion());
+        assertEquals("provided", merged.getScope());
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12660BomVersionFromImportedBomTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12660BomVersionFromImportedBomTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a BOM's consumer POM inherits the version from an imported BOM
+ * when the local dependency management entry declares only a scope but no version.
+ * <p>
+ * Reproducer for <a href="https://github.com/apache/maven/issues/12660">#12660</a>:
+ * when a BOM module declares a managed dependency with {@code scope=provided} but
+ * no version, and the version is expected to come from an imported BOM, the consumer
+ * POM was generated without the version. The fix in
+ * {@code DefaultDependencyManagementImporter.importManagement()} now merges the
+ * version from the imported entry into the local entry when the local version is null.
+ *
+ * @since 4.0.0
+ */
+class MavenITgh12660BomVersionFromImportedBomTest extends AbstractMavenIntegrationTestCase {
+
+    /**
+     * Verify that the BOM consumer POM contains the version inherited from the
+     * imported BOM for a locally-declared dependency with no version.
+     * <p>
+     * The BOM module imports {@code ext-bom} (which declares {@code ext-lib} version
+     * {@code 3.0.0}) and locally declares {@code ext-lib} with {@code scope=provided}
+     * but no version. The consumer POM must contain {@code ext-lib} with version
+     * {@code 3.0.0} and scope {@code provided}.
+     */
+    @Test
+    void testBomConsumerPomInheritsVersionFromImportedBom() throws Exception {
+        Path basedir = extractResources("/gh-12660-bom-version-from-imported-bom");
+
+        Verifier verifier = newVerifier(basedir);
+        verifier.deleteArtifacts("org.apache.maven.its.gh12660");
+        verifier.addCliArguments("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Read the consumer POM that was installed to the local repo
+        Path consumerPomPath =
+                verifier.getArtifactPath("org.apache.maven.its.gh12660", "bom", "1.0.0-SNAPSHOT", "pom");
+
+        assertTrue(Files.exists(consumerPomPath), "Consumer POM not found at " + consumerPomPath);
+
+        String content = Files.readString(consumerPomPath);
+
+        // 1. Packaging must be "pom" (not "bom")
+        assertTrue(content.contains("<packaging>pom</packaging>"), "Consumer POM packaging should be 'pom'");
+
+        // 2. Must contain the declared entries: mod-1, mod-2, and ext-lib
+        assertTrue(
+                content.contains("<artifactId>mod-1</artifactId>"),
+                "Consumer POM must contain mod-1.\nActual:\n" + content);
+        assertTrue(
+                content.contains("<artifactId>mod-2</artifactId>"),
+                "Consumer POM must contain mod-2.\nActual:\n" + content);
+        assertTrue(
+                content.contains("<artifactId>ext-lib</artifactId>"),
+                "Consumer POM must contain ext-lib.\nActual:\n" + content);
+
+        // 3. ext-lib must have version 3.0.0 (inherited from the imported ext-bom)
+        // This is the core assertion for the #12660 fix
+        assertTrue(
+                content.contains("<version>3.0.0</version>"),
+                "Consumer POM must contain ext-lib with version 3.0.0 from imported BOM.\nActual:\n" + content);
+
+        // 4. ext-lib must preserve scope=provided
+        assertTrue(
+                content.contains("<scope>provided</scope>"),
+                "Consumer POM must preserve ext-lib scope=provided.\nActual:\n" + content);
+
+        // 5. Must not contain unresolved property references
+        assertFalse(
+                content.contains("${"),
+                "Consumer POM must not contain unresolved property references.\nActual:\n" + content);
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/bom/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bom</artifactId>
+  <packaging>bom</packaging>
+
+  <name>GH-12660 :: BOM</name>
+
+  <!--
+    Reproducer for GH-12660: a BOM project that imports ext-bom and declares
+    ext-lib with scope=provided but NO version. The version should be
+    inherited from the imported ext-bom. Before the fix, the consumer POM
+    was generated without a version for ext-lib.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>ext-bom</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>mod-1</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>mod-2</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>ext-lib</artifactId>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/ext-bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/ext-bom/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>ext-bom</artifactId>
+  <packaging>pom</packaging>
+
+  <name>GH-12660 :: External BOM</name>
+
+  <!--
+    This POM acts as an external BOM that provides version management for
+    ext-lib. The child BOM module imports this BOM and declares ext-lib
+    with scope=provided but no version; the version should be inherited
+    from this import.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.gh12660</groupId>
+        <artifactId>ext-lib</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-1/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-1/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-1</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Module 1</name>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-2/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/mod-2/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.gh12660</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-2</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Module 2</name>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-12660-bom-version-from-imported-bom/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh12660</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>GH-12660: BOM version from imported BOM test</name>
+
+  <modules>
+    <module>ext-bom</module>
+    <module>mod-1</module>
+    <module>mod-2</module>
+    <module>bom</module>
+  </modules>
+</project>


### PR DESCRIPTION
## Summary
- Forward port of #12915 (code fix) and #12940 (integration test) from `maven-4.0.x` to `master`
- Fixes #12660: when a BOM module declares a managed dependency with `scope` but no `version`, and the version is expected to come from an imported BOM, the consumer POM was generated without the version
- Adds the end-to-end integration test verifying the fix
- Cherry-picked the code fix and adapted the unit test for master's API (no assertj dependency, uses JUnit assertions)
- Adapted the IT for master's `AbstractMavenIntegrationTestCase` API (`Path`-based, no version-range constructor, pattern-based `TestSuiteOrdering`)

## Test plan
- [x] Unit test `DefaultDependencyManagementImporterTest` passes locally
- [x] Integration test `MavenITgh12660BomVersionFromImportedBomTest` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)