### PR TITLE
[MNG-8450] Report BOM import warnings only at declaration sites

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultDependencyManagementImporter.java
@@ -81,7 +81,8 @@ public class DefaultDependencyManagementImporter implements DependencyManagement
                                 Version.V40,
                                 "Ignored POM import for: " + toString(dependency) + " as already imported "
                                         + toString(present) + ". Add the conflicting managed dependency directly "
-                                        + "to the dependencyManagement section of the POM.");
+                                        + "to the dependencyManagement section of the POM.",
+                                source.getImportedFrom());
                     }
                     if (present == null && request.isLocationTracking()) {
                         Dependency updatedDependency = updateWithImportedFrom(dependency, source);

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -234,7 +234,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                     mainSession = new ModelBuilderSessionState(request);
                     session = mainSession;
                 } else {
-                    session = mainSession.derive(
+                    session = mainSession.deriveTopLevel(
                             request,
                             new DefaultModelBuilderResult(request, ProblemCollector.create(mainSession.session)));
                 }
@@ -269,6 +269,8 @@ public class DefaultModelBuilder implements ModelBuilder {
         final DefaultModelBuilderResult result;
         final Graph dag;
         final Map<GAKey, Set<ModelSource>> mappedSources;
+        final Set<ImportWarningKey> reportedImportWarnings;
+        final Map<String, ProblemCollector<ModelProblem>> reactorProblemCollectors;
 
         String source;
         Model sourceModel;
@@ -297,6 +299,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                     new DefaultModelBuilderResult(request, ProblemCollector.create(request.getSession())),
                     new Graph(),
                     new ConcurrentHashMap<>(64),
+                    ConcurrentHashMap.newKeySet(),
+                    new ConcurrentHashMap<>(),
                     List.of(),
                     repos(request),
                     repos(request),
@@ -373,6 +377,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                 DefaultModelBuilderResult result,
                 Graph dag,
                 Map<GAKey, Set<ModelSource>> mappedSources,
+                Set<ImportWarningKey> reportedImportWarnings,
+                Map<String, ProblemCollector<ModelProblem>> reactorProblemCollectors,
                 List<RemoteRepository> pomRepositories,
                 List<RemoteRepository> externalRepositories,
                 List<RemoteRepository> repositories,
@@ -382,6 +388,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             this.result = result;
             this.dag = dag;
             this.mappedSources = mappedSources;
+            this.reportedImportWarnings = reportedImportWarnings;
+            this.reactorProblemCollectors = reactorProblemCollectors;
             this.pomRepositories = pomRepositories;
             this.externalRepositories = externalRepositories;
             this.repositories = repositories;
@@ -405,6 +413,18 @@ public class DefaultModelBuilder implements ModelBuilder {
         }
 
         ModelBuilderSessionState derive(ModelBuilderRequest request, DefaultModelBuilderResult result) {
+            return derive(request, result, reportedImportWarnings, reactorProblemCollectors);
+        }
+
+        ModelBuilderSessionState deriveTopLevel(ModelBuilderRequest request, DefaultModelBuilderResult result) {
+            return derive(request, result, ConcurrentHashMap.newKeySet(), new ConcurrentHashMap<>());
+        }
+
+        private ModelBuilderSessionState derive(
+                ModelBuilderRequest request,
+                DefaultModelBuilderResult result,
+                Set<ImportWarningKey> reportedImportWarnings,
+                Map<String, ProblemCollector<ModelProblem>> reactorProblemCollectors) {
             if (session != request.getSession()) {
                 throw new IllegalArgumentException("Session mismatch");
             }
@@ -433,6 +453,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                     result,
                     dag,
                     mappedSources,
+                    reportedImportWarnings,
+                    reactorProblemCollectors,
                     pomRepositories,
                     derivedExtRepos,
                     derivedRepos,
@@ -986,6 +1008,8 @@ public class DefaultModelBuilder implements ModelBuilder {
                         top,
                         root);
                 mappedSources.clear();
+                reportedImportWarnings.clear();
+                reactorProblemCollectors.clear();
                 loadFromRoot(top, top);
             }
         }
@@ -998,6 +1022,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 Model model = derive(src, r).readFileModel();
                 // keep all loaded file models in memory, those will be needed
                 // during the raw to build transformation
+                registerReactorProblemCollector(src, r.getProblemCollector());
                 putSource(getGroupId(model), model.getArtifactId(), src);
                 Model activated = activateFileModel(model);
                 for (String subproject : getSubprojects(activated)) {
@@ -2178,7 +2203,92 @@ public class DefaultModelBuilder implements ModelBuilder {
             model = model.withDependencyManagement(
                     model.getDependencyManagement().withDependencies(deps));
 
-            return dependencyManagementImporter.importManagement(model, importMgmts, request, this);
+            return dependencyManagementImporter.importManagement(
+                    model, importMgmts, request, deduplicatingImportProblemCollector());
+        }
+
+        private ModelProblemCollector deduplicatingImportProblemCollector() {
+            return new ModelProblemCollector() {
+                @Override
+                public ProblemCollector<ModelProblem> getProblemCollector() {
+                    return ModelBuilderSessionState.this.getProblemCollector();
+                }
+
+                @Override
+                public void add(
+                        BuilderProblem.Severity severity,
+                        ModelProblem.Version version,
+                        String message,
+                        InputLocation location,
+                        Exception exception) {
+                    if (severity == Severity.WARNING && location != null && location.getSource() != null) {
+                        var source = location.getSource();
+                        ImportWarningKey key = new ImportWarningKey(
+                                message,
+                                source.getLocation(),
+                                source.getModelId(),
+                                location.getLineNumber(),
+                                location.getColumnNumber());
+                        if (!reportedImportWarnings.add(key)) {
+                            return;
+                        }
+                        ProblemCollector<ModelProblem> collector = reactorProblemCollectors.get(source.getLocation());
+                        if (collector != null) {
+                            collector.reportProblem(new DefaultModelProblem(
+                                    message,
+                                    severity,
+                                    version,
+                                    source.getLocation(),
+                                    location.getLineNumber(),
+                                    location.getColumnNumber(),
+                                    source.getModelId(),
+                                    exception));
+                            return;
+                        }
+                    }
+                    ModelBuilderSessionState.this.add(severity, version, message, location, exception);
+                }
+
+                @Override
+                public ModelBuilderException newModelBuilderException() {
+                    return ModelBuilderSessionState.this.newModelBuilderException();
+                }
+
+                @Override
+                public void setSource(String location) {
+                    ModelBuilderSessionState.this.setSource(location);
+                }
+
+                @Override
+                public void setSource(Model model) {
+                    ModelBuilderSessionState.this.setSource(model);
+                }
+
+                @Override
+                public String getSource() {
+                    return ModelBuilderSessionState.this.getSource();
+                }
+
+                @Override
+                public void setRootModel(Model model) {
+                    ModelBuilderSessionState.this.setRootModel(model);
+                }
+
+                @Override
+                public Model getRootModel() {
+                    return ModelBuilderSessionState.this.getRootModel();
+                }
+            };
+        }
+
+        private void registerReactorProblemCollector(
+                ModelSource source, ProblemCollector<ModelProblem> problemCollector) {
+            if (source.getLocation() != null) {
+                reactorProblemCollectors.put(source.getLocation(), problemCollector);
+            }
+            if (source.getPath() != null) {
+                reactorProblemCollectors.put(source.getPath().toUri().toString(), problemCollector);
+            }
         }
 
         private DependencyManagement loadDependencyManagement(Dependency dependency, Collection<String> importIds) {
@@ -2251,7 +2361,9 @@ public class DefaultModelBuilder implements ModelBuilder {
                 importMgmt = importMgmt.withDependencies(dependencies);
             }
 
-            return importMgmt;
+            return DependencyManagement.newBuilder(importMgmt, true)
+                    .importedFrom(dependency.getLocation(""))
+                    .build();
         }
 
         @SuppressWarnings("checkstyle:parameternumber")
@@ -2569,6 +2681,9 @@ public class DefaultModelBuilder implements ModelBuilder {
     }
 
     record GAKey(String groupId, String artifactId) {}
+
+    private record ImportWarningKey(
+            String message, String sourceLocation, String sourceModelId, int lineNumber, int columnNumber) {}
 
     public record RgavCacheKey(
             Session session,

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2208,81 +2208,99 @@ public class DefaultModelBuilder implements ModelBuilder {
         }
 
         private ModelProblemCollector deduplicatingImportProblemCollector() {
-            return new ModelProblemCollector() {
-                @Override
-                public ProblemCollector<ModelProblem> getProblemCollector() {
-                    return ModelBuilderSessionState.this.getProblemCollector();
-                }
-
-                @Override
-                public void add(
-                        BuilderProblem.Severity severity,
-                        ModelProblem.Version version,
-                        String message,
-                        InputLocation location,
-                        Exception exception) {
-                    if (severity == Severity.WARNING && location != null && location.getSource() != null) {
-                        var source = location.getSource();
-                        String sourceLocation = source.getLocation();
-                        ImportWarningKey key = new ImportWarningKey(
-                                message,
-                                sourceLocation,
-                                source.getModelId(),
-                                location.getLineNumber(),
-                                location.getColumnNumber());
-                        if (!reportedImportWarnings.add(key)) {
-                            return;
-                        }
-                        ProblemCollector<ModelProblem> collector =
-                                sourceLocation != null ? reactorProblemCollectors.get(sourceLocation) : null;
-                        if (collector != null) {
-                            collector.reportProblem(new DefaultModelProblem(
-                                    message,
-                                    severity,
-                                    version,
-                                    sourceLocation,
-                                    location.getLineNumber(),
-                                    location.getColumnNumber(),
-                                    source.getModelId(),
-                                    exception));
-                            return;
-                        }
-                    }
-                    ModelBuilderSessionState.this.add(severity, version, message, location, exception);
-                }
-
-                @Override
-                public ModelBuilderException newModelBuilderException() {
-                    return ModelBuilderSessionState.this.newModelBuilderException();
-                }
-
-                @Override
-                public void setSource(String location) {
-                    ModelBuilderSessionState.this.setSource(location);
-                }
-
-                @Override
-                public void setSource(Model model) {
-                    ModelBuilderSessionState.this.setSource(model);
-                }
-
-                @Override
-                public String getSource() {
-                    return ModelBuilderSessionState.this.getSource();
-                }
-
-                @Override
-                public void setRootModel(Model model) {
-                    ModelBuilderSessionState.this.setRootModel(model);
-                }
-
-                @Override
-                public Model getRootModel() {
-                    return ModelBuilderSessionState.this.getRootModel();
-                }
-            };
+            return new DeduplicatingImportProblemCollector();
         }
 
+        /**
+         * A {@link ModelProblemCollector} wrapper that deduplicates BOM import conflict warnings
+         * within a single top-level build.  When a warning originates from a reactor module,
+         * it is routed to that module's own problem collector so the warning appears next to the
+         * declaration rather than being repeated for every inheriting child.  Non-warning problems
+         * and warnings without a resolvable source are forwarded to the enclosing
+         * {@link ModelBuilderSessionState} unchanged.
+         */
+        private class DeduplicatingImportProblemCollector implements ModelProblemCollector {
+            @Override
+            public ProblemCollector<ModelProblem> getProblemCollector() {
+                return ModelBuilderSessionState.this.getProblemCollector();
+            }
+
+            @Override
+            public void add(
+                    BuilderProblem.Severity severity,
+                    ModelProblem.Version version,
+                    String message,
+                    InputLocation location,
+                    Exception exception) {
+                if (severity == Severity.WARNING && location != null && location.getSource() != null) {
+                    var source = location.getSource();
+                    String sourceLocation = source.getLocation();
+                    ImportWarningKey key = new ImportWarningKey(
+                            message,
+                            sourceLocation,
+                            source.getModelId(),
+                            location.getLineNumber(),
+                            location.getColumnNumber());
+                    if (!reportedImportWarnings.add(key)) {
+                        return;
+                    }
+                    ProblemCollector<ModelProblem> collector =
+                            sourceLocation != null ? reactorProblemCollectors.get(sourceLocation) : null;
+                    if (collector != null) {
+                        collector.reportProblem(new DefaultModelProblem(
+                                message,
+                                severity,
+                                version,
+                                sourceLocation,
+                                location.getLineNumber(),
+                                location.getColumnNumber(),
+                                source.getModelId(),
+                                exception));
+                        return;
+                    }
+                }
+                ModelBuilderSessionState.this.add(severity, version, message, location, exception);
+            }
+
+            @Override
+            public ModelBuilderException newModelBuilderException() {
+                return ModelBuilderSessionState.this.newModelBuilderException();
+            }
+
+            @Override
+            public void setSource(String location) {
+                ModelBuilderSessionState.this.setSource(location);
+            }
+
+            @Override
+            public void setSource(Model model) {
+                ModelBuilderSessionState.this.setSource(model);
+            }
+
+            @Override
+            public String getSource() {
+                return ModelBuilderSessionState.this.getSource();
+            }
+
+            @Override
+            public void setRootModel(Model model) {
+                ModelBuilderSessionState.this.setRootModel(model);
+            }
+
+            @Override
+            public Model getRootModel() {
+                return ModelBuilderSessionState.this.getRootModel();
+            }
+        }
+
+        /**
+         * Registers the problem collector under both the location string (path form) and
+         * the URI form of the source.  Import warnings produced by
+         * {@link DefaultDependencyManagementImporter} carry whichever form the resolver
+         * happened to record, so both keys are registered as a safety net to ensure a
+         * lookup in {@link DeduplicatingImportProblemCollector#add} always finds the
+         * declaring model's collector.
+         */
         private void registerReactorProblemCollector(
                 ModelSource source, ProblemCollector<ModelProblem> problemCollector) {
             if (source.getLocation() != null) {
@@ -2684,6 +2702,11 @@ public class DefaultModelBuilder implements ModelBuilder {
 
     record GAKey(String groupId, String artifactId) {}
 
+    /**
+     * Composite key used to deduplicate BOM import conflict warnings within a single top-level build.
+     * Two warnings are considered duplicates when they share the same message text and originate
+     * from the same source location (file, model ID, line, and column).
+     */
     private record ImportWarningKey(
             String message, String sourceLocation, String sourceModelId, int lineNumber, int columnNumber) {}
 

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2223,22 +2223,24 @@ public class DefaultModelBuilder implements ModelBuilder {
                         Exception exception) {
                     if (severity == Severity.WARNING && location != null && location.getSource() != null) {
                         var source = location.getSource();
+                        String sourceLocation = source.getLocation();
                         ImportWarningKey key = new ImportWarningKey(
                                 message,
-                                source.getLocation(),
+                                sourceLocation,
                                 source.getModelId(),
                                 location.getLineNumber(),
                                 location.getColumnNumber());
                         if (!reportedImportWarnings.add(key)) {
                             return;
                         }
-                        ProblemCollector<ModelProblem> collector = reactorProblemCollectors.get(source.getLocation());
+                        ProblemCollector<ModelProblem> collector =
+                                sourceLocation != null ? reactorProblemCollectors.get(sourceLocation) : null;
                         if (collector != null) {
                             collector.reportProblem(new DefaultModelProblem(
                                     message,
                                     severity,
                                     version,
-                                    source.getLocation(),
+                                    sourceLocation,
                                     location.getLineNumber(),
                                     location.getColumnNumber(),
                                     source.getModelId(),

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.apache.maven.api.Constants;
 import org.apache.maven.api.RemoteRepository;
@@ -50,6 +51,7 @@ import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.services.ModelBuilder;
 import org.apache.maven.api.services.ModelBuilderRequest;
 import org.apache.maven.api.services.ModelBuilderResult;
+import org.apache.maven.api.services.ModelProblem;
 import org.apache.maven.api.services.ModelSource;
 import org.apache.maven.api.services.Sources;
 import org.apache.maven.impl.DefaultRemoteRepository;
@@ -965,6 +967,101 @@ class DefaultModelBuilderTest {
                 .orElse(null);
         assertNotNull(managed, "Managed dependency from type=bom import should be present");
         assertEquals("0.1", managed.getVersion());
+    }
+
+    @Test
+    void testBomImportWarningsReportedWhereImportsAreDeclared() {
+        Path pom = Paths.get("src/test/resources/poms/factory/mng-8450/pom.xml").toAbsolutePath();
+        for (String parallelism : List.of("1", "4")) {
+            ModelBuilderResult result = builder.newSession()
+                    .build(ModelBuilderRequest.builder()
+                            .session(session)
+                            .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                            .recursive(true)
+                            .userProperties(
+                                    Map.of(Constants.MAVEN_MODEL_BUILDER_PARALLELISM, parallelism, "revision", "1.0.0"))
+                            .source(Sources.buildSource(pom))
+                            .build());
+
+            List<ModelProblem> warnings = bomImportWarnings(result);
+
+            assertEquals(2, warnings.size(), warnings.toString());
+            assertEquals(
+                    Set.of(
+                            "org.apache.maven.test:mng-8450-parent:${revision}",
+                            "org.apache.maven.test:independent:1.0.0"),
+                    warnings.stream().map(ModelProblem::getModelId).collect(java.util.stream.Collectors.toSet()));
+            assertEquals(
+                    Map.of("mng-8450-parent", 1L, "independent", 1L),
+                    results(result)
+                            .filter(r -> directBomImportWarningCount(r) > 0)
+                            .collect(java.util.stream.Collectors.toMap(
+                                    r -> r.getEffectiveModel().getArtifactId(), this::directBomImportWarningCount)));
+        }
+    }
+
+    @Test
+    void testBomImportWarningFromNonReactorParentIsPreserved() {
+        Path basedir = Paths.get(System.getProperty("basedir", ""));
+        Path fixture = basedir.resolve("src/test/resources/poms/factory/mng-8450-standalone");
+        Session standaloneSession = ApiRunner.createSession(
+                injector -> injector.bindInstance(DefaultModelBuilderTest.class, this),
+                basedir.resolve("target/local-repo-mng-8450"));
+        standaloneSession = standaloneSession.withRemoteRepositories(List.of(standaloneSession.createRemoteRepository(
+                RemoteRepository.CENTRAL_ID, fixture.resolve("repo").toUri().toString())));
+
+        var modelBuilderSession =
+                standaloneSession.getService(ModelBuilder.class).newSession();
+        ModelBuilderRequest request = ModelBuilderRequest.builder()
+                .session(standaloneSession)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(fixture.resolve("child/pom.xml")))
+                .build();
+
+        for (int build = 0; build < 2; build++) {
+            ModelBuilderResult result = modelBuilderSession.build(request);
+            List<ModelProblem> warnings = bomImportWarnings(result);
+            assertEquals(1, warnings.size(), warnings.toString());
+            assertEquals(
+                    "org.apache.maven.test:standalone-parent:1.0.0",
+                    warnings.get(0).getModelId());
+        }
+    }
+
+    @Test
+    void testBomImportWarningFromParentProfileActivatedForChild() {
+        Path pom = Paths.get("src/test/resources/poms/factory/mng-8450-profile-context/pom.xml")
+                .toAbsolutePath();
+        ModelBuilderResult result = builder.newSession()
+                .build(ModelBuilderRequest.builder()
+                        .session(session)
+                        .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                        .recursive(true)
+                        .source(Sources.buildSource(pom))
+                        .build());
+
+        List<ModelProblem> warnings = bomImportWarnings(result);
+        assertEquals(1, warnings.size(), warnings.toString());
+        assertEquals(
+                "org.apache.maven.test:profile-parent:1.0.0", warnings.get(0).getModelId());
+    }
+
+    private List<ModelProblem> bomImportWarnings(ModelBuilderResult result) {
+        return results(result)
+                .flatMap(r -> r.getProblemCollector().problems())
+                .filter(p -> p.getMessage().startsWith("Ignored POM import for:"))
+                .toList();
+    }
+
+    private long directBomImportWarningCount(ModelBuilderResult result) {
+        return result.getProblemCollector()
+                .problems()
+                .filter(p -> p.getMessage().startsWith("Ignored POM import for:"))
+                .count();
+    }
+
+    private Stream<ModelBuilderResult> results(ModelBuilderResult result) {
+        return Stream.concat(Stream.of(result), result.getChildren().stream().flatMap(this::results));
     }
 
     private static DefaultProfileActivationContext.Record recordActiveProfile(

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.api.Constants;
@@ -990,12 +991,12 @@ class DefaultModelBuilderTest {
                     Set.of(
                             "org.apache.maven.test:mng-8450-parent:${revision}",
                             "org.apache.maven.test:independent:1.0.0"),
-                    warnings.stream().map(ModelProblem::getModelId).collect(java.util.stream.Collectors.toSet()));
+                    warnings.stream().map(ModelProblem::getModelId).collect(Collectors.toSet()));
             assertEquals(
                     Map.of("mng-8450-parent", 1L, "independent", 1L),
                     results(result)
                             .filter(r -> directBomImportWarningCount(r) > 0)
-                            .collect(java.util.stream.Collectors.toMap(
+                            .collect(Collectors.toMap(
                                     r -> r.getEffectiveModel().getArtifactId(), this::directBomImportWarningCount)));
         }
     }

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/bom-one/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/bom-one/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>profile-bom-one</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>managed</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/bom-two/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/bom-two/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>profile-bom-two</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>managed</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/child/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/child/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>profile-parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+  <artifactId>profile-child</artifactId>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/parent/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/parent/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.1.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>profile-parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <profiles>
+    <profile>
+      <id>child-imports</id>
+      <activation>
+        <packaging>jar</packaging>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.test</groupId>
+            <artifactId>profile-bom-one</artifactId>
+            <version>1.0.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.test</groupId>
+            <artifactId>profile-bom-two</artifactId>
+            <version>1.0.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-profile-context/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>mng-8450-profile-context</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>bom-one</module>
+    <module>bom-two</module>
+    <module>parent</module>
+    <module>child</module>
+  </modules>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/child/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/child/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>standalone-parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+  <artifactId>standalone-child</artifactId>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/parent/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/parent/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>standalone-parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>standalone-bom-one</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>standalone-bom-two</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/repo/org/apache/maven/test/standalone-bom-one/1.0.0/standalone-bom-one-1.0.0.pom
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/repo/org/apache/maven/test/standalone-bom-one/1.0.0/standalone-bom-one-1.0.0.pom
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>standalone-bom-one</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>managed</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/repo/org/apache/maven/test/standalone-bom-two/1.0.0/standalone-bom-two-1.0.0.pom
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450-standalone/repo/org/apache/maven/test/standalone-bom-two/1.0.0/standalone-bom-two-1.0.0.pom
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>standalone-bom-two</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>managed</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450/bom-one/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450/bom-one/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>bom-one</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>managed</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450/bom-two/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450/bom-two/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>bom-two</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>managed</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450/child-one/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450/child-one/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>mng-8450-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>child-one</artifactId>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450/child-two/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450/child-two/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.test</groupId>
+    <artifactId>mng-8450-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>child-two</artifactId>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450/independent/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450/independent/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>independent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>bom-one</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>bom-two</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/impl/maven-impl/src/test/resources/poms/factory/mng-8450/pom.xml
+++ b/impl/maven-impl/src/test/resources/poms/factory/mng-8450/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.test</groupId>
+  <artifactId>mng-8450-parent</artifactId>
+  <version>${revision}</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <revision>1.0.0</revision>
+  </properties>
+
+  <modules>
+    <module>bom-one</module>
+    <module>bom-two</module>
+    <module>child-one</module>
+    <module>child-two</module>
+    <module>independent</module>
+  </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>bom-one</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.test</groupId>
+        <artifactId>bom-two</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>


### PR DESCRIPTION
Fixes #10179

### Summary

Report conflicting BOM import warnings once at the model that declares the imports instead of repeating them for every inheriting child.

### Implementation

- Preserve each imported dependency-management source's declaration location.
- Deduplicate warnings by declaration location and message within one top-level build.
- Route warnings to the declaring reactor model's problem collector.
- Use concurrent constant-time lookup for parallel model building.
- Reset diagnostic state between top-level builds and during reactor-root fallback.
- Preserve warnings from independent declarations and non-reactor parents.

### Verification

- `mvn --batch-mode verify`
- Full `maven-impl` verification: 613 tests passed, 4 skipped
- Focused model-builder verification: 27 tests passed
- Coverage includes serial and parallel reactors, CI-friendly versions, child-activated parent profiles, repeated model-builder sessions, independent declarations, and non-reactor parents

Following this checklist to help us incorporate your contribution quickly and easily:

- [x] This pull request addresses one issue without unrelated changes.
- [x] The description explains what the change does, how, and why.
- [x] The commit has a meaningful subject and DCO sign-off.
- [x] Unit tests cover the behavioral changes.
- [x] `mvn verify` passes.
- [ ] The Core IT suite has been run successfully.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).