### PR TITLE
Fix #12912: assign FastTerminal before starting the build thread

### DIFF
--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
@@ -104,6 +104,20 @@ public class FastTerminal implements TerminalExt {
                 "fast-terminal-thread");
         // a wedged builder must not keep the JVM alive; everything waits on the future, not the thread
         this.buildThread.setDaemon(true);
+    }
+
+    /**
+     * Starts the build thread. Must be called <em>after</em> the caller has published this
+     * {@code FastTerminal} (e.g. assigned it to {@link MessageUtils#terminal}) so that code running
+     * on the build thread can obtain a non-null reference through {@link MessageUtils#getTerminal()}.
+     * <p>
+     * {@link Thread#start()} establishes a <em>happens-before</em> edge, so the assignment made by
+     * the caller before this method is visible to the build thread without additional
+     * synchronization.
+     *
+     * @see <a href="https://github.com/apache/maven/issues/12912">#12912</a>
+     */
+    public void start() {
         this.buildThread.start();
     }
 

--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
@@ -47,7 +47,11 @@ public class MessageUtils {
     }
 
     public static void systemInstall(Consumer<TerminalBuilder> builderConsumer, Consumer<Terminal> terminalConsumer) {
-        MessageUtils.terminal = new FastTerminal(
+        // Assign the FastTerminal to the field BEFORE starting the build thread so that code
+        // running on that thread (e.g. JLine's FFM provider init, logger calls) sees a non-null
+        // reference when it calls MessageUtils.getTerminal().  Thread.start() provides the
+        // happens-before edge that makes the assignment visible to the new thread.
+        FastTerminal ft = new FastTerminal(
                 () -> {
                     TerminalBuilder builder =
                             TerminalBuilder.builder().name("Maven").dumb(true);
@@ -64,6 +68,8 @@ public class MessageUtils {
                         terminalConsumer.accept(terminal);
                     }
                 });
+        MessageUtils.terminal = ft;
+        ft.start();
     }
 
     private static LineReader createReader(Terminal terminal) {

--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -123,6 +123,26 @@ class FastTerminalReentrancyTest {
     }
 
     /**
+     * Verifies that {@link MessageUtils#getTerminal()} is non-null when called from the builder
+     * callback. Before the fix, the {@code FastTerminal} constructor started its build thread
+     * before returning, so {@code MessageUtils.terminal} was still {@code null} when the build
+     * thread ran the builder callback &mdash; a race between the constructor returning and the
+     * thread scheduling. After the fix, {@code MessageUtils} assigns the field before calling
+     * {@link FastTerminal#start()}, and {@link Thread#start()} provides the happens-before edge.
+     *
+     * @see <a href="https://github.com/apache/maven/issues/12912">#12912</a>
+     */
+    @Test
+    void terminalAssignmentIsVisibleFromBuilderCallback() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            CompletableFuture<Terminal> observed = new CompletableFuture<>();
+            installAndAwait(builder -> observed.complete(MessageUtils.getTerminal()), terminal -> {});
+            assertNotNull(observed.get(), "MessageUtils.getTerminal() must not return null from the builder callback");
+            assertTrue(observed.get() instanceof FastTerminal, "terminal should be the FastTerminal wrapper");
+        });
+    }
+
+    /**
      * Both terminal calls a single log statement makes, run on the terminal building thread.
      */
     private static String[] probe() {


### PR DESCRIPTION
## Summary

Fixes a race condition introduced in #12921: the `FastTerminal` constructor started its build thread before returning, so `MessageUtils.terminal` was still `null` when the build thread ran the builder callback — a race between the constructor returning and the thread scheduling. This caused a `NullPointerException` in CI ([example](https://github.com/apache/maven/actions/runs/33327782193/job/99318899899)):

```
NullPointerException: Cannot invoke "org.jline.terminal.Terminal.getSize()" because "t" is null
```

The fix splits construction from start: `MessageUtils` now assigns the field **before** calling `FastTerminal.start()`, and `Thread.start()` provides the happens-before edge that makes the assignment visible to the build thread without additional synchronization.

- `FastTerminal`: extract `start()` method from constructor, document the publish-before-start contract  
- `MessageUtils.systemInstall()`: assign `terminal` field, then call `start()`  
- New test `terminalAssignmentIsVisibleFromBuilderCallback` that asserts `MessageUtils.getTerminal()` is non-null from the builder callback

## Test plan

- [x] `FastTerminalReentrancyTest` — all 5 tests pass (4 existing + 1 new)
- [x] Full `maven-jline` module test suite passes
- [ ] CI validates on Java 17/21/25


🤖 Generated with [Claude Code](https://claude.com/claude-code)