### PR TITLE
[Backport 4.0.x] Fix modello velocity phase for concurrent builder compatibility

### DIFF
--- a/api/maven-api-settings/pom.xml
+++ b/api/maven-api-settings/pom.xml
@@ -76,6 +76,12 @@ under the License.
             <id>modello</id>
             <goals>
               <goal>velocity</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+          <execution>
+            <id>modello-docs</id>
+            <goals>
               <goal>xdoc</goal>
               <goal>xsd</goal>
             </goals>

--- a/api/maven-api-toolchain/pom.xml
+++ b/api/maven-api-toolchain/pom.xml
@@ -67,6 +67,12 @@ under the License.
             <id>modello</id>
             <goals>
               <goal>velocity</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+          <execution>
+            <id>modello-docs</id>
+            <goals>
               <goal>xdoc</goal>
               <goal>xsd</goal>
             </goals>


### PR DESCRIPTION
## Summary

Backport of #12687 to `maven-4.0.x`.

- Split modello plugin executions in `maven-api-settings` and `maven-api-toolchain` so the `velocity` goal (Java source generation) runs at `generate-sources` instead of `generate-resources`, while `xdoc`/`xsd` (documentation) remain at `generate-resources`
- Fixes a race condition in the concurrent builder (`-b concurrent`) where `COMPILE` could start before `velocity` finished generating Java source files, causing `"package does not exist"` compilation errors

## Details

In Maven 4's graph lifecycle model, `SOURCES` and `RESOURCES` are parallel siblings under `BUILD`, and `COMPILE` is ordered `after(SOURCES)` but **not** `after(RESOURCES)`. The modello `velocity` goal generates Java source files but was bound to `generate-resources` (→ `RESOURCES` phase), creating a race where `COMPILE` could start before source generation finished.

Cherry-picked cleanly from master (852e66a).

## Test plan

- [ ] CI passes on `maven-4.0.x`


🤖 Generated with [Claude Code](https://claude.com/claude-code)