### PR TITLE
[MNG-8129] Clarify relativePath validation comment

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -160,7 +160,9 @@ public class DefaultModelValidator implements ModelValidator {
             Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
             Severity errOn31 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_1);
 
-            // [MNG-8129] Validate that relativePath does not contain characters that are illegal in filesystem paths
+            // [MNG-8129] Validate that relativePath does not contain characters reserved on Windows (NTFS).
+            // These cause InvalidPathException when resolved via java.nio.file.Path, and typically
+            // indicate the user put a GAV coordinate (e.g. "g:a:v") instead of an actual filesystem path.
             if (parent != null
                     && parent.getRelativePath() != null
                     && !parent.getRelativePath().isEmpty()) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -483,7 +483,9 @@ public class DefaultModelValidator implements ModelValidator {
             Severity errOn30 = getSeverity(validationLevel, ModelValidator.VALIDATION_LEVEL_MAVEN_3_0);
             Severity errOn31 = getSeverity(validationLevel, ModelValidator.VALIDATION_LEVEL_MAVEN_3_1);
 
-            // [MNG-8129] Validate that relativePath does not contain characters that are illegal in filesystem paths
+            // [MNG-8129] Validate that relativePath does not contain characters reserved on Windows (NTFS).
+            // These cause InvalidPathException when resolved via java.nio.file.Path, and typically
+            // indicate the user put a GAV coordinate (e.g. "g:a:v") instead of an actual filesystem path.
             if (parent != null
                     && parent.getRelativePath() != null
                     && !parent.getRelativePath().isEmpty()) {


### PR DESCRIPTION
## Summary
- Clarify the comment on the relativePath validation check: the banned characters are those reserved on Windows (NTFS), not universally illegal across all filesystems
- Addresses review feedback from @elharo on #12743

## Changes
Comment-only change in both `impl` and `compat` validators — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)