### PR TITLE
[MNG-8129] Clarify relativePath validation comment

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -157,6 +157,9 @@ public class DefaultModelValidator implements ModelValidator {
         } else if (request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
             Severity errOn30 = getSeverity(request, ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0);
 
+            // [MNG-8129] Validate that relativePath does not contain characters reserved on Windows (NTFS).
+            // These cause InvalidPathException in Maven 4 when resolved via java.nio.file.Path, and typically
+            // indicate the user put a GAV coordinate (e.g. "g:a:v") instead of an actual filesystem path.
             if (parent != null
                     && parent.getRelativePath() != null
                     && !parent.getRelativePath().isEmpty()) {


### PR DESCRIPTION
## Summary
- Clarify the comment on the relativePath validation check: the banned characters are those reserved on Windows (NTFS), not universally illegal across all filesystems
- Addresses review feedback from @elharo on #12743

## Changes
Comment-only change — no behavior change.

Replaces #12743 (closed due to stale GitHub merge state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)