### PR TITLE
[4.0.x] Replace deprecated Terminal.getWidth/getHeight with getColumns/getRows

### DIFF
--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/FastTerminal.java
@@ -266,13 +266,13 @@ public class FastTerminal implements TerminalExt {
     }
 
     @Override
-    public int getWidth() {
-        return getTerminal().getWidth();
+    public int getColumns() {
+        return getTerminal().getColumns();
     }
 
     @Override
-    public int getHeight() {
-        return getTerminal().getHeight();
+    public int getRows() {
+        return getTerminal().getRows();
     }
 
     @Override

--- a/impl/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
+++ b/impl/maven-jline/src/main/java/org/apache/maven/jline/MessageUtils.java
@@ -119,7 +119,7 @@ public class MessageUtils {
     }
 
     public static int getTerminalWidth() {
-        return terminal != null ? terminal.getWidth() : -1;
+        return terminal != null ? terminal.getColumns() : -1;
     }
 
     public static MessageBuilder builder() {

--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * builder callable, and the consumer that runs before the terminal is published.
  * <p>
  * JLine 4.4.0's FFM provider initialization ({@code CLibrary.<clinit>}) can reach back through
- * other terminal methods (e.g. {@code getName()}, {@code getWidth()}, {@code encoding()}) on the
+ * other terminal methods (e.g. {@code getName()}, {@code getColumns()}, {@code encoding()}) on the
  * build thread, so the fallback must cover all delegate methods, not just {@code writer()} and
  * {@code getType()}.
  * <p>


### PR DESCRIPTION
## Summary
Backport of #12968 to `maven-4.0.x`.

- JLine 4.4.0 replaced `Sized.getWidth()`/`getHeight()` with `getColumns()`/`getRows()`
- Updates `FastTerminal` overrides, `MessageUtils.getTerminalWidth()` delegate call, and a Javadoc reference in `FastTerminalReentrancyTest`

## Test plan
- [ ] Existing tests pass (`FastTerminalReentrancyTest` exercises the affected code paths)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)