### PR TITLE
Fix flaky FastTerminalReentrancyTest by avoiding PTY creation

### DIFF
--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -52,9 +52,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The tests force {@code providers("exec")} so that the builder creates a lightweight
  * {@code ExternalTerminal} instead of a {@code PosixPtyTerminal} via FFM. The FFM provider calls
  * {@code CLibrary.openpty()} which creates a real PTY pair; the subsequent grapheme-cluster probe
- * ({@code ensureModesProbed()}) then blocks on the idle PTY master for the full probe timeout,
- * and the PTY's pump threads can stall {@code close()} during teardown &mdash; all of which makes
- * the tests flaky on slow CI machines.
+ * ({@code ensureModesProbed()}) reads from the PTY master via {@code FileInputStream.read0()}, a
+ * native blocking read. Although {@code VMIN=0, VTIME=0} attributes are set before probing, there
+ * is a race where the native read blocks indefinitely instead of respecting the timeout, causing
+ * the test to hang until the 30-second preemptive timeout fires.
  * <p>
  * The timeouts are preemptive on purpose: a regression parks the build thread forever, and only an
  * abandoning timeout turns that into a red test rather than a hung fork.

--- a/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
+++ b/impl/maven-jline/src/test/java/org/apache/maven/jline/FastTerminalReentrancyTest.java
@@ -49,6 +49,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * build thread, so the fallback must cover all delegate methods, not just {@code writer()} and
  * {@code getType()}.
  * <p>
+ * The tests force {@code providers("exec")} so that the builder creates a lightweight
+ * {@code ExternalTerminal} instead of a {@code PosixPtyTerminal} via FFM. The FFM provider calls
+ * {@code CLibrary.openpty()} which creates a real PTY pair; the subsequent grapheme-cluster probe
+ * ({@code ensureModesProbed()}) then blocks on the idle PTY master for the full probe timeout,
+ * and the PTY's pump threads can stall {@code close()} during teardown &mdash; all of which makes
+ * the tests flaky on slow CI machines.
+ * <p>
  * The timeouts are preemptive on purpose: a regression parks the build thread forever, and only an
  * abandoning timeout turns that into a red test rather than a hung fork.
  */
@@ -163,6 +170,7 @@ class FastTerminalReentrancyTest {
                     onBuilder.accept(builder);
                     builder.dumb(true)
                             .system(false)
+                            .providers("exec")
                             .streams(InputStream.nullInputStream(), OutputStream.nullOutputStream());
                 },
                 onTerminal);


### PR DESCRIPTION
## Summary

- Force `providers("exec")` in the test's `TerminalBuilder` configuration so JLine creates a lightweight `ExternalTerminal` instead of a `PosixPtyTerminal` via the FFM provider

## Root cause

With `system(false)`, `TerminalBuilder.doBuild()` enters the non-system path which ignores the `dumb(true)` flag and iterates FFM/JNI/exec providers. The FFM provider calls `CLibrary.openpty()`, creating a real PTY pair (`/dev/pts/N`) and a `PosixPtyTerminal`.

Then `build()` calls `supportsGraphemeClusterMode()` → `ensureModesProbed()` → `probeModes()` → `readTerminalResponse()` → `readProbeChar()`. This sends DECRQM/DA1 escape sequences to the PTY and reads responses via `NonBlockingReader.read(timeout)`, which delegates to `FileInputStream.read0()` — a **native blocking read on the PTY master fd**.

Although `VMIN=0, VTIME=0` terminal attributes are set before probing (which should make reads return immediately when no data is available), there is a race: on some iterations, the native read blocks **indefinitely** instead of respecting the timeout. Thread dump from a local reproduction:

```
fast-terminal-thread [RUNNABLE]
  at java.io.FileInputStream.read0(Native Method)       ← stuck in kernel read
  at java.io.FilterInputStream.read(FilterInputStream.java:71)
  at org.jline.terminal.impl.AbstractPty$1.read(AbstractPty.java:87)
  at ...NonBlockingInputStream.read(NonBlockingInputStream.java:195)
  at ...NonBlockingReader.read(NonBlockingReader.java:208)
  at ...AbstractTerminal.readProbeChar(AbstractTerminal.java:939)
  at ...AbstractTerminal.readTerminalResponse(AbstractTerminal.java:961)
  at ...AbstractTerminal.probeModes(AbstractTerminal.java:543)
  at ...AbstractTerminal.ensureModesProbed(AbstractTerminal.java:502)
  at ...AbstractTerminal.probeGraphemeClusterMode(AbstractTerminal.java:745)
  at ...AbstractTerminal.supportsGraphemeClusterMode(AbstractTerminal.java:686)
  at ...TerminalBuilder.build(TerminalBuilder.java:898)
```

The exec provider's `ExternalTerminal` avoids all of this: no PTY, no pump threads, and `supportsGraphemeClusterMode()` returns `false` without any I/O.

**Failed builds:** https://github.com/apache/maven/actions/runs/33349929091/job/99362003331

## Test plan

- [x] `mvn test -pl impl/maven-jline -Dtest=FastTerminalReentrancyTest` passes (5/5 tests, ~0.4s)
- [x] 10 consecutive runs: 10/10 pass with the fix; 1/10 hangs without the fix
- [x] Full `impl/maven-jline` module tests pass
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)