### PR TITLE
Document illegal windows filesystem characters

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -82,13 +82,13 @@ public class DefaultModelValidator implements ModelValidator {
     private static final Pattern CI_FRIENDLY_EXPRESSION = Pattern.compile("\\$\\{(.+?)}");
     private static final Pattern EXPRESSION_PROJECT_NAME_PATTERN = Pattern.compile("\\$\\{(project.+?)}");
 
-    private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
+    private static final String ILLEGAL_NTFS_FILENAME_CHARS = "\\/:\"<>|?*";
 
-    private static final String ILLEGAL_RELATIVE_PATH_CHARS = ":\"<>|?*";
+    private static final String ILLEGAL_WINDOWS_PATH_CHARS = ":\"<>|?*";
 
-    private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
+    private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_NTFS_FILENAME_CHARS;
 
-    private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_FS_CHARS;
+    private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_NTFS_FILENAME_CHARS;
 
     private static final String EMPTY = "";
 
@@ -175,7 +175,7 @@ public class DefaultModelValidator implements ModelValidator {
                         parent.getRelativePath(),
                         null,
                         parent,
-                        ILLEGAL_RELATIVE_PATH_CHARS);
+                    ILLEGAL_WINDOWS_PATH_CHARS);
             }
 
             // [MNG-6074] Maven should produce an error if no model version has been set in a POM file used to build an

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java
@@ -175,7 +175,7 @@ public class DefaultModelValidator implements ModelValidator {
                         parent.getRelativePath(),
                         null,
                         parent,
-                    ILLEGAL_WINDOWS_PATH_CHARS);
+                        ILLEGAL_WINDOWS_PATH_CHARS);
             }
 
             // [MNG-6074] Maven should produce an error if no model version has been set in a POM file used to build an

--- a/compat/maven-settings-builder/src/main/java/org/apache/maven/settings/validation/DefaultSettingsValidator.java
+++ b/compat/maven-settings-builder/src/main/java/org/apache/maven/settings/validation/DefaultSettingsValidator.java
@@ -46,7 +46,7 @@ public class DefaultSettingsValidator implements SettingsValidator {
     private static final String ID = "[\\w.-]+";
     private static final Pattern ID_REGEX = Pattern.compile(ID);
 
-    private static final String ILLEGAL_REPO_ID_CHARS = "\\/:\"<>|?*"; // ILLEGAL_FS_CHARS
+    private static final String ILLEGAL_NTFS_FILENAME_CHARS = "\\/:\"<>|?*";
 
     @Override
     public void validate(Settings settings, SettingsProblemCollector problems) {
@@ -119,7 +119,8 @@ public class DefaultSettingsValidator implements SettingsValidator {
                 validateStringNotEmpty(problems, "mirrors.mirror.id", mirror.getId(), mirror.getUrl());
 
                 validateBannedCharacters(
-                        problems, "mirrors.mirror.id", Severity.WARNING, mirror.getId(), null, ILLEGAL_REPO_ID_CHARS);
+                        problems, "mirrors.mirror.id", Severity.WARNING, mirror.getId(), null,
+                    ILLEGAL_NTFS_FILENAME_CHARS);
 
                 if ("local".equals(mirror.getId())) {
                     addViolation(
@@ -187,7 +188,8 @@ public class DefaultSettingsValidator implements SettingsValidator {
             validateStringNotEmpty(problems, prefix + ".id", repository.getId(), repository.getUrl());
 
             validateBannedCharacters(
-                    problems, prefix + ".id", Severity.WARNING, repository.getId(), null, ILLEGAL_REPO_ID_CHARS);
+                    problems, prefix + ".id", Severity.WARNING, repository.getId(), null,
+                ILLEGAL_NTFS_FILENAME_CHARS);
 
             if ("local".equals(repository.getId())) {
                 addViolation(

--- a/compat/maven-settings-builder/src/main/java/org/apache/maven/settings/validation/DefaultSettingsValidator.java
+++ b/compat/maven-settings-builder/src/main/java/org/apache/maven/settings/validation/DefaultSettingsValidator.java
@@ -119,8 +119,12 @@ public class DefaultSettingsValidator implements SettingsValidator {
                 validateStringNotEmpty(problems, "mirrors.mirror.id", mirror.getId(), mirror.getUrl());
 
                 validateBannedCharacters(
-                        problems, "mirrors.mirror.id", Severity.WARNING, mirror.getId(), null,
-                    ILLEGAL_NTFS_FILENAME_CHARS);
+                        problems,
+                        "mirrors.mirror.id",
+                        Severity.WARNING,
+                        mirror.getId(),
+                        null,
+                        ILLEGAL_NTFS_FILENAME_CHARS);
 
                 if ("local".equals(mirror.getId())) {
                     addViolation(
@@ -188,8 +192,7 @@ public class DefaultSettingsValidator implements SettingsValidator {
             validateStringNotEmpty(problems, prefix + ".id", repository.getId(), repository.getUrl());
 
             validateBannedCharacters(
-                    problems, prefix + ".id", Severity.WARNING, repository.getId(), null,
-                ILLEGAL_NTFS_FILENAME_CHARS);
+                    problems, prefix + ".id", Severity.WARNING, repository.getId(), null, ILLEGAL_NTFS_FILENAME_CHARS);
 
             if ("local".equals(repository.getId())) {
                 addViolation(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsValidator.java
@@ -157,7 +157,7 @@ public class DefaultSettingsValidator {
                         BuilderProblem.Severity.WARNING,
                         mirror.getId(),
                         null,
-                    ILLEGAL_NTFS_FILENAME_CHARS);
+                        ILLEGAL_NTFS_FILENAME_CHARS);
 
                 if ("local".equals(mirror.getId())) {
                     addViolation(
@@ -242,7 +242,7 @@ public class DefaultSettingsValidator {
                     BuilderProblem.Severity.WARNING,
                     repository.getId(),
                     null,
-                ILLEGAL_NTFS_FILENAME_CHARS);
+                    ILLEGAL_NTFS_FILENAME_CHARS);
 
             if ("local".equals(repository.getId())) {
                 addViolation(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultSettingsValidator.java
@@ -39,7 +39,7 @@ public class DefaultSettingsValidator {
     private static final String ID = "[\\w.-]+";
     private static final Pattern ID_REGEX = Pattern.compile(ID);
 
-    private static final String ILLEGAL_REPO_ID_CHARS = "\\/:\"<>|?*"; // ILLEGAL_FS_CHARS
+    private static final String ILLEGAL_NTFS_FILENAME_CHARS = "\\/:\"<>|?*";
 
     @SuppressWarnings("checkstyle:MethodLength")
     public void validate(Settings settings, boolean isProjectSettings, ProblemCollector<BuilderProblem> problems) {
@@ -157,7 +157,7 @@ public class DefaultSettingsValidator {
                         BuilderProblem.Severity.WARNING,
                         mirror.getId(),
                         null,
-                        ILLEGAL_REPO_ID_CHARS);
+                    ILLEGAL_NTFS_FILENAME_CHARS);
 
                 if ("local".equals(mirror.getId())) {
                     addViolation(
@@ -242,7 +242,7 @@ public class DefaultSettingsValidator {
                     BuilderProblem.Severity.WARNING,
                     repository.getId(),
                     null,
-                    ILLEGAL_REPO_ID_CHARS);
+                ILLEGAL_NTFS_FILENAME_CHARS);
 
             if ("local".equals(repository.getId())) {
                 addViolation(

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -92,13 +92,15 @@ public class DefaultModelValidator implements ModelValidator {
     private static final Pattern EXPRESSION_NAME_PATTERN = Pattern.compile("\\$\\{(.+?)}");
     private static final Pattern EXPRESSION_PROJECT_NAME_PATTERN = Pattern.compile("\\$\\{(project.+?)}");
 
-    private static final String ILLEGAL_FS_CHARS = "\\/:\"<>|?*";
+    /** Characters that cannot appear in a file or directory name on FAT or NTFS filesystems */
+    private static final String ILLEGAL_NTFS_FILENAME_CHARS = "\\/:\"<>|?*";
 
-    private static final String ILLEGAL_RELATIVE_PATH_CHARS = ":\"<>|?*";
+    /** same as above except that it allows the path separators / and \ */
+    private static final String ILLEGAL_WINDOWS_PATH_CHARS = ":\"<>|?*";
 
-    private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_FS_CHARS;
+    private static final String ILLEGAL_VERSION_CHARS = ILLEGAL_NTFS_FILENAME_CHARS;
 
-    private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_FS_CHARS;
+    private static final String ILLEGAL_REPO_ID_CHARS = ILLEGAL_NTFS_FILENAME_CHARS;
 
     private static final String EMPTY = "";
 
@@ -498,7 +500,7 @@ public class DefaultModelValidator implements ModelValidator {
                         parent.getRelativePath(),
                         null,
                         parent,
-                        ILLEGAL_RELATIVE_PATH_CHARS);
+                        ILLEGAL_WINDOWS_PATH_CHARS);
             }
 
             boolean isModelVersion41OrMore = !Objects.equals(ModelBuilder.MODEL_VERSION_4_0_0, model.getModelVersion());


### PR DESCRIPTION
I feel there's a missing layer of indirection somewhere. Repository IDs and version strings should not be tightly coupled to the vagaries of one filesystem. We might want to untangle that. But for the moment this change at least makes the nature of the concern more explicit. 