### PR TITLE
Honour configured policy and validate inputs on the legacy compat paths

### DIFF
--- a/maven-compat/src/main/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManager.java
+++ b/maven-compat/src/main/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManager.java
@@ -35,6 +35,7 @@ import org.apache.maven.artifact.repository.DefaultRepositoryRequest;
 import org.apache.maven.artifact.repository.RepositoryRequest;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
 import org.apache.maven.repository.internal.metadata.ValidatingMetadataXpp3Reader;
+import org.apache.maven.repository.legacy.ChecksumFailedException;
 import org.apache.maven.repository.legacy.UpdateCheckManager;
 import org.apache.maven.repository.legacy.WagonManager;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
@@ -114,6 +115,17 @@ public class DefaultRepositoryMetadataManager extends AbstractLogEnabled impleme
                     getLogger().info(metadata.getKey() + ": checking for updates from " + repository.getId());
                     try {
                         wagonManager.getArtifactMetadata(metadata, repository, file, policy.getChecksumPolicy());
+                        updateCheckManager.touch(metadata, repository, file);
+                    } catch (ChecksumFailedException e) {
+                        // ChecksumFailedException is only thrown by the wagon manager under
+                        // CHECKSUM_POLICY_FAIL: honor the strict policy by failing metadata resolution
+                        // instead of downgrading the integrity failure to a warning. The update
+                        // tracking file is deliberately not touched, so the next build retries
+                        // immediately instead of trusting stale metadata for a full update interval.
+                        throw new RepositoryMetadataResolutionException(
+                                metadata + " failed checksum verification against repository: " + repository.getId()
+                                        + " due to an error: " + e.getMessage(),
+                                e);
                     } catch (ResourceDoesNotExistException e) {
                         getLogger().debug(metadata + " could not be found on repository: " + repository.getId());
 
@@ -129,12 +141,12 @@ public class DefaultRepositoryMetadataManager extends AbstractLogEnabled impleme
                                 file.delete(); // if this fails, forget about it
                             }
                         }
+                        updateCheckManager.touch(metadata, repository, file);
                     } catch (TransferFailedException e) {
                         getLogger()
                                 .warn(metadata + " could not be retrieved from repository: " + repository.getId()
                                         + " due to an error: " + e.getMessage());
                         getLogger().debug("Exception", e);
-                    } finally {
                         updateCheckManager.touch(metadata, repository, file);
                     }
                 }
@@ -279,7 +291,55 @@ public class DefaultRepositoryMetadataManager extends AbstractLogEnabled impleme
             throw new RepositoryMetadataReadException(
                     "Cannot read metadata from '" + mappingFile + "': " + e.getMessage(), e);
         }
+
+        validateVersioning(result);
+
         return result;
+    }
+
+    /**
+     * Version tokens adopted from repository metadata must be valid coordinate components; metadata carrying
+     * anything else is treated as invalid.
+     */
+    private static void validateVersioning(Metadata metadata) throws RepositoryMetadataReadException {
+        if (metadata == null) {
+            return;
+        }
+        Versioning versioning = metadata.getVersioning();
+        if (versioning == null) {
+            return;
+        }
+        validateVersionToken(versioning.getLatest());
+        validateVersionToken(versioning.getRelease());
+        for (String version : versioning.getVersions()) {
+            validateVersionToken(version);
+        }
+        for (SnapshotVersion snapshotVersion : versioning.getSnapshotVersions()) {
+            validateVersionToken(snapshotVersion.getVersion());
+        }
+        Snapshot snapshot = versioning.getSnapshot();
+        if (snapshot != null) {
+            validateVersionToken(snapshot.getTimestamp());
+        }
+    }
+
+    private static void validateVersionToken(String value) throws RepositoryMetadataReadException {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        boolean valid = !"..".equals(value);
+        if (valid) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '/' || c == '\\' || c == ':' || Character.isISOControl(c)) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            throw new RepositoryMetadataReadException("Metadata contains an invalid version token: '" + value + "'");
+        }
     }
 
     /**
@@ -354,7 +414,7 @@ public class DefaultRepositoryMetadataManager extends AbstractLogEnabled impleme
 
         try {
             wagonManager.getArtifactMetadataFromDeploymentRepository(
-                    metadata, remoteRepository, file, ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN);
+                    metadata, remoteRepository, file, getChecksumPolicy(metadata, remoteRepository));
         } catch (ResourceDoesNotExistException e) {
             getLogger()
                     .info(metadata + " could not be found on repository: " + remoteRepository.getId()
@@ -378,6 +438,22 @@ public class DefaultRepositoryMetadataManager extends AbstractLogEnabled impleme
             }
         }
         return file;
+    }
+
+    /**
+     * Determines the effective checksum policy for a transfer from the given repository. The
+     * operator-configured policy (e.g. {@code fail} via {@code -C}/{@code --strict-checksums} or a
+     * per-repository {@code checksumPolicy}) must govern every remote transfer, so it must not be
+     * hardcoded at the call sites.
+     */
+    private String getChecksumPolicy(ArtifactMetadata metadata, ArtifactRepository repository) {
+        if (metadata instanceof RepositoryMetadata) {
+            ArtifactRepositoryPolicy policy = ((RepositoryMetadata) metadata).getPolicy(repository);
+            if (policy != null && policy.getChecksumPolicy() != null) {
+                return policy.getChecksumPolicy();
+            }
+        }
+        return ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN;
     }
 
     public void deploy(

--- a/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
+++ b/maven-compat/src/main/java/org/apache/maven/repository/legacy/LegacyRepositorySystem.java
@@ -662,12 +662,45 @@ public class LegacyRepositorySystem implements RepositorySystem {
                     destination,
                     remotePath,
                     TransferListenerAdapter.newAdapter(transferListener),
-                    ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN,
+                    getChecksumPolicy(repository),
                     true);
         } catch (org.apache.maven.wagon.TransferFailedException e) {
             throw new ArtifactTransferFailedException(getMessage(e, "Error transferring artifact."), e);
         } catch (org.apache.maven.wagon.ResourceDoesNotExistException e) {
             throw new ArtifactDoesNotExistException(getMessage(e, "Requested artifact does not exist."), e);
+        }
+    }
+
+    /**
+     * Determines the effective checksum policy for a generic retrieval from the given repository.
+     * The operator-configured policy (e.g. {@code fail} via {@code -C}/{@code --strict-checksums})
+     * must govern every remote transfer instead of a hardcoded lenient default. A generic remote
+     * path cannot be classified as release or snapshot, so the stricter of the two configured
+     * policies applies.
+     */
+    private static String getChecksumPolicy(ArtifactRepository repository) {
+        String releases =
+                (repository.getReleases() != null) ? repository.getReleases().getChecksumPolicy() : null;
+        String snapshots =
+                (repository.getSnapshots() != null) ? repository.getSnapshots().getChecksumPolicy() : null;
+        String policy;
+        if (releases == null) {
+            policy = snapshots;
+        } else if (snapshots == null || checksumRank(releases) >= checksumRank(snapshots)) {
+            policy = releases;
+        } else {
+            policy = snapshots;
+        }
+        return (policy != null) ? policy : ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN;
+    }
+
+    private static int checksumRank(String policy) {
+        if (ArtifactRepositoryPolicy.CHECKSUM_POLICY_FAIL.equals(policy)) {
+            return 2;
+        } else if (ArtifactRepositoryPolicy.CHECKSUM_POLICY_IGNORE.equals(policy)) {
+            return 0;
+        } else {
+            return 1;
         }
     }
 

--- a/maven-compat/src/test/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManagerTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManagerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository.metadata;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.apache.maven.artifact.AbstractArtifactComponentTest;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getBasedir;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests {@link DefaultRepositoryMetadataManager}.
+ */
+@PlexusTest
+@Deprecated
+class DefaultRepositoryMetadataManagerTest extends AbstractArtifactComponentTest {
+
+    @Inject
+    private RepositoryMetadataManager repositoryMetadataManager;
+
+    @Inject
+    @Named("default")
+    private ArtifactRepositoryLayout layout;
+
+    @Override
+    protected String component() {
+        return "repositoryMetadataManager";
+    }
+
+    @Test
+    void testResolveHonorsConfiguredFailChecksumPolicy() throws Exception {
+        RepositoryMetadata metadata = new GroupRepositoryMetadata("checksum-policy-test-group");
+
+        ArtifactRepositoryPolicy failPolicy = new ArtifactRepositoryPolicy(
+                true, ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS, ArtifactRepositoryPolicy.CHECKSUM_POLICY_FAIL);
+
+        File remoteBase = new File(getBasedir(), "target/test-repositories/" + component() + "/remote-repository");
+        FileUtils.deleteDirectory(remoteBase);
+
+        ArtifactRepository remoteRepo = artifactRepositoryFactory.createArtifactRepository(
+                "test", "file://" + remoteBase.getPath(), layout, failPolicy, failPolicy);
+
+        String remotePath = remoteRepo.pathOfRemoteRepositoryMetadata(metadata);
+        File remoteFile = new File(remoteBase, remotePath);
+        remoteFile.getParentFile().mkdirs();
+        FileUtils.fileWrite(remoteFile.getAbsolutePath(), "<metadata/>");
+        FileUtils.fileWrite(remoteFile.getAbsolutePath() + ".sha1", "0000000000000000000000000000000000000000");
+
+        ArtifactRepository localRepo = localRepository();
+        FileUtils.deleteDirectory(new File(localRepo.getBasedir()));
+
+        assertThrows(
+                RepositoryMetadataResolutionException.class,
+                () -> repositoryMetadataManager.resolve(metadata, Collections.singletonList(remoteRepo), localRepo));
+    }
+}

--- a/maven-compat/src/test/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManagerValidationTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManagerValidationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository.metadata;
+
+import java.io.File;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@link DefaultRepositoryMetadataManager} rejects repository metadata carrying version tokens that
+ * are not valid coordinate components, on the legacy read path used when metadata is loaded for merging.
+ */
+class DefaultRepositoryMetadataManagerValidationTest {
+
+    private final DefaultRepositoryMetadataManager manager = new DefaultRepositoryMetadataManager();
+
+    @Test
+    void testMetadataWithInvalidVersionTokenIsRejected() {
+        File metadataFile = testFile("metadata-invalid-token/maven-metadata.xml");
+
+        RepositoryMetadataReadException exception =
+                assertThrows(RepositoryMetadataReadException.class, () -> manager.readMetadata(metadataFile));
+
+        assertTrue(exception.getMessage().contains("invalid version token"), exception.getMessage());
+    }
+
+    @Test
+    void testMetadataWithInvalidSnapshotTimestampIsRejected() {
+        File metadataFile = testFile("metadata-invalid-timestamp/maven-metadata.xml");
+
+        RepositoryMetadataReadException exception =
+                assertThrows(RepositoryMetadataReadException.class, () -> manager.readMetadata(metadataFile));
+
+        assertTrue(exception.getMessage().contains("invalid version token"), exception.getMessage());
+    }
+
+    private static File testFile(String resource) {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(resource);
+        assertNotNull(url, "test resource not found: " + resource);
+        return new File(url.getFile());
+    }
+}

--- a/maven-compat/src/test/java/org/apache/maven/repository/legacy/LegacyRepositorySystemTest.java
+++ b/maven-compat/src/test/java/org/apache/maven/repository/legacy/LegacyRepositorySystemTest.java
@@ -21,17 +21,22 @@ package org.apache.maven.repository.legacy;
 import javax.inject.Inject;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.Authentication;
+import org.apache.maven.repository.ArtifactTransferFailedException;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Server;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link LegacyRepositorySystem}.
@@ -65,5 +70,27 @@ public class LegacyRepositorySystemTest {
         assertNotNull(authentication);
         assertEquals("jason", authentication.getUsername());
         assertEquals("abc123", authentication.getPassword());
+    }
+
+    @Test
+    void testRetrieveHonorsConfiguredFailChecksumPolicy(@TempDir File tempDir) throws Exception {
+        File remoteBase = new File(tempDir, "remote");
+        remoteBase.mkdirs();
+        File remoteFile = new File(remoteBase, "sample.txt");
+        Files.write(remoteFile.toPath(), "content".getBytes());
+        Files.write(
+                new File(remoteBase, "sample.txt.sha1").toPath(),
+                "0000000000000000000000000000000000000000".getBytes());
+
+        ArtifactRepositoryPolicy failPolicy = new ArtifactRepositoryPolicy(
+                true, ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS, ArtifactRepositoryPolicy.CHECKSUM_POLICY_FAIL);
+        ArtifactRepository repository = repositorySystem.createArtifactRepository(
+                "test", "file://" + remoteBase.getAbsolutePath(), null, failPolicy, failPolicy);
+
+        File destination = new File(tempDir, "sample.txt");
+
+        assertThrows(
+                ArtifactTransferFailedException.class,
+                () -> repositorySystem.retrieve(repository, destination, "sample.txt", null));
     }
 }

--- a/maven-compat/src/test/resources/metadata-invalid-timestamp/maven-metadata.xml
+++ b/maven-compat/src/test/resources/metadata-invalid-timestamp/maven-metadata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-timestamp</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <versioning>
+    <snapshot>
+      <timestamp>20120809.112920:1</timestamp>
+      <buildNumber>1</buildNumber>
+    </snapshot>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-compat/src/test/resources/metadata-invalid-token/maven-metadata.xml
+++ b/maven-compat/src/test/resources/metadata-invalid-token/maven-metadata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<metadata>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>dep-invalid-token</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <versioning>
+    <release>1.0:2.0</release>
+    <lastUpdated>20120809112920</lastUpdated>
+  </versioning>
+</metadata>

--- a/maven-core/src/main/java/org/apache/maven/artifact/repository/LegacyLocalRepositoryManager.java
+++ b/maven-core/src/main/java/org/apache/maven/artifact/repository/LegacyLocalRepositoryManager.java
@@ -211,7 +211,7 @@ public class LegacyLocalRepositoryManager implements LocalRepositoryManager {
         }
 
         public String getLocalFilename(ArtifactRepository repository) {
-            return insertRepositoryKey(getRemoteFilename(), repository.getKey());
+            return insertRepositoryKey(getRemoteFilename(), validateRepositoryKey(repository.getKey()));
         }
 
         private String insertRepositoryKey(String filename, String repositoryKey) {
@@ -223,6 +223,32 @@ public class LegacyLocalRepositoryManager implements LocalRepositoryManager {
                 result = filename.substring(0, idx) + '-' + repositoryKey + filename.substring(idx);
             }
             return result;
+        }
+
+        /**
+         * The repository key (its id) is used verbatim as part of a local file name, so it must lie within
+         * the usual coordinate character set.
+         */
+        private static String validateRepositoryKey(String key) {
+            if (key == null || key.isEmpty()) {
+                return key;
+            }
+            if (isInvalidPathToken(key)) {
+                throw new IllegalArgumentException("Invalid repository key '" + key + "'");
+            }
+            return key;
+        }
+
+        private static boolean isInvalidPathToken(String value) {
+            if ("..".equals(value) || value.indexOf('/') >= 0 || value.indexOf('\\') >= 0 || value.indexOf(':') >= 0) {
+                return true;
+            }
+            for (int i = 0; i < value.length(); i++) {
+                if (Character.isISOControl(value.charAt(i))) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public void merge(org.apache.maven.repository.legacy.metadata.ArtifactMetadata metadata) {

--- a/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/AbstractRepositoryMetadata.java
+++ b/maven-core/src/main/java/org/apache/maven/artifact/repository/metadata/AbstractRepositoryMetadata.java
@@ -50,7 +50,33 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
     }
 
     public String getLocalFilename(ArtifactRepository repository) {
-        return "maven-metadata-" + repository.getKey() + ".xml";
+        return "maven-metadata-" + validateRepositoryKey(repository.getKey()) + ".xml";
+    }
+
+    /**
+     * The repository key (its id) is used verbatim as part of a local file name, so it must lie within
+     * the usual coordinate character set.
+     */
+    private static String validateRepositoryKey(String key) {
+        if (key == null || key.isEmpty()) {
+            return key;
+        }
+        if (isInvalidPathToken(key)) {
+            throw new IllegalArgumentException("Invalid repository key '" + key + "'");
+        }
+        return key;
+    }
+
+    private static boolean isInvalidPathToken(String value) {
+        if ("..".equals(value) || value.indexOf('/') >= 0 || value.indexOf('\\') >= 0 || value.indexOf(':') >= 0) {
+            return true;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isISOControl(value.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void storeInLocalRepository(ArtifactRepository localRepository, ArtifactRepository remoteRepository)

--- a/maven-core/src/test/java/org/apache/maven/artifact/repository/LegacyLocalRepositoryManagerTest.java
+++ b/maven-core/src/test/java/org/apache/maven/artifact/repository/LegacyLocalRepositoryManagerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository;
+
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LegacyLocalRepositoryManagerTest {
+
+    private static LegacyLocalRepositoryManager.ArtifactMetadataAdapter newAdapter() {
+        Metadata metadata =
+                new DefaultMetadata("g", "a", "1.0", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        return new LegacyLocalRepositoryManager.ArtifactMetadataAdapter(metadata);
+    }
+
+    private static ArtifactRepository repositoryWithId(String id) {
+        ArtifactRepository repo = mock(ArtifactRepository.class);
+        when(repo.getKey()).thenReturn(id);
+        return repo;
+    }
+
+    @Test
+    void getLocalFilenameKeepsWellFormedRepositoryKeyUnchanged() {
+        String filename = newAdapter().getLocalFilename(repositoryWithId("central"));
+
+        assertEquals("maven-metadata-central.xml", filename);
+    }
+
+    @Test
+    void getLocalFilenameRejectsRepositoryKeyContainingPathSeparator() {
+        assertThrows(
+                IllegalArgumentException.class, () -> newAdapter().getLocalFilename(repositoryWithId("repo/evil")));
+    }
+
+    @Test
+    void getLocalFilenameRejectsRepositoryKeyThatIsAParentDirectoryReference() {
+        assertThrows(IllegalArgumentException.class, () -> newAdapter().getLocalFilename(repositoryWithId("..")));
+    }
+}

--- a/maven-core/src/test/java/org/apache/maven/artifact/repository/metadata/AbstractRepositoryMetadataTest.java
+++ b/maven-core/src/test/java/org/apache/maven/artifact/repository/metadata/AbstractRepositoryMetadataTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository.metadata;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Ensures that a repository key which may originate from a downloaded POM's {@code <repositories>} section
+ * cannot select a local metadata file name outside the intended one.
+ */
+class AbstractRepositoryMetadataTest {
+
+    private static ArtifactRepository repository(String id) {
+        ArtifactRepository repo = mock(ArtifactRepository.class);
+        when(repo.getKey()).thenReturn(id);
+        return repo;
+    }
+
+    private static RepositoryMetadata createMetadata() {
+        Artifact artifact = mock(Artifact.class);
+        when(artifact.getGroupId()).thenReturn("org.test");
+        when(artifact.getArtifactId()).thenReturn("test-artifact");
+        when(artifact.getVersion()).thenReturn("1.0");
+        return new ArtifactRepositoryMetadata(artifact);
+    }
+
+    @Test
+    void repositoryKeyWithColonIsRejected() {
+        RepositoryMetadata metadata = createMetadata();
+        ArtifactRepository repo = repository("central:1.0");
+
+        assertThrows(IllegalArgumentException.class, () -> metadata.getLocalFilename(repo));
+    }
+
+    @Test
+    void repositoryKeyWithDotDotSegmentIsRejected() {
+        RepositoryMetadata metadata = createMetadata();
+        ArtifactRepository repo = repository("x/../../../../../../settings");
+
+        assertThrows(IllegalArgumentException.class, () -> metadata.getLocalFilename(repo));
+    }
+
+    @Test
+    void repositoryKeyWithBackslashIsRejected() {
+        RepositoryMetadata metadata = createMetadata();
+        ArtifactRepository repo = repository("x\\..\\..\\settings");
+
+        assertThrows(IllegalArgumentException.class, () -> metadata.getLocalFilename(repo));
+    }
+
+    @Test
+    void wellFormedRepositoryKeyProducesExpectedFilename() {
+        RepositoryMetadata metadata = createMetadata();
+        ArtifactRepository repo = repository("central");
+
+        assertEquals("maven-metadata-central.xml", metadata.getLocalFilename(repo));
+    }
+}


### PR DESCRIPTION
## Summary

Backport of the path traversal and checksum policy fixes from #12945 (maven-4.0.x) to maven-3.10.x.

- **Path traversal validation on repository keys**: `AbstractRepositoryMetadata.getLocalFilename` and `LegacyLocalRepositoryManager.ArtifactMetadataAdapter.getLocalFilename` now reject a repository key that is `..`, contains `/`, `\`, `:`, or an ISO control character before using it in a local file name.
- **Version token validation in metadata**: `DefaultRepositoryMetadataManager.readMetadata` validates every version token carried by parsed repository metadata (latest, release, versions, snapshot versions, snapshot timestamp) for the same path traversal characters.
- **Checksum policy enforcement**: `DefaultRepositoryMetadataManager.resolve` now catches `ChecksumFailedException` separately and fails metadata resolution under `checksumPolicy=fail` instead of downgrading to a warning. The update-check file is only touched on success, not-found, or generic transfer failure, so checksum failures are retried on the next build. `getArtifactMetadataFromDeploymentRepository` and `LegacyRepositorySystem.retrieve` resolve the effective policy from the repository configuration instead of hardcoding `warn`.

The proxy clone fix (`DefaultSettingsDecrypter`) is already present on maven-3.10.x and is therefore not included here.

Adapted for the 3.10.x module structure (no `compat/` prefix) and API differences (`MetadataXpp3Reader` instead of `MetadataStaxReader`, no pattern matching `instanceof`).

## Test plan

- [x] `AbstractRepositoryMetadataTest` (4 tests): repo keys with `/`, `\`, `..`, `:` are rejected; well-formed key produces correct filename
- [x] `LegacyLocalRepositoryManagerTest` (3 tests): repo keys with path separators and `..` are rejected in the inner adapter
- [x] `DefaultRepositoryMetadataManagerValidationTest` (2 tests): metadata with invalid version token (colon) and invalid snapshot timestamp (colon) are rejected
- [x] `DefaultRepositoryMetadataManagerTest` (1 test): `resolve()` throws `RepositoryMetadataResolutionException` when checksum policy is `fail` and checksums do not match
- [x] `LegacyRepositorySystemTest.testRetrieveHonorsConfiguredFailChecksumPolicy`: `retrieve()` throws `ArtifactTransferFailedException` when checksum policy is `fail`
- [x] `mvn verify -pl maven-core -B` passes
- [x] `mvn verify -pl maven-compat -B` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)