### PR TITLE
Fix #12983: ToolchainPluginStrategy handles inherited source levels

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategy.java
@@ -29,6 +29,7 @@ import org.apache.maven.api.cli.mvnup.UpgradeOptions;
 import org.apache.maven.api.di.Named;
 import org.apache.maven.api.di.Priority;
 import org.apache.maven.api.di.Singleton;
+import org.apache.maven.api.model.Model;
 import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
 import org.apache.maven.impl.JdkSourceLevelSupport;
 
@@ -48,9 +49,10 @@ import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PROPERTIES;
  *
  * <p>This strategy detects the project's source level from:
  * <ol>
- *   <li>{@code maven.compiler.release} property</li>
- *   <li>{@code maven.compiler.source} property</li>
- *   <li>Compiler plugin {@code <configuration><release>} or {@code <source>}</li>
+ *   <li>{@code maven.compiler.release} property (local POM)</li>
+ *   <li>{@code maven.compiler.source} property (local POM)</li>
+ *   <li>Compiler plugin {@code <configuration><release>} or {@code <source>} (local POM)</li>
+ *   <li>Effective model resolution (inherited properties from parent POMs)</li>
  * </ol>
  *
  * <p>If the running JDK does not support the detected source level (per JEP 182 retirement
@@ -132,7 +134,11 @@ public class ToolchainPluginStrategy extends AbstractUpgradeStrategy {
             try {
                 int sourceLevel = detectSourceLevel(pomDocument);
                 if (sourceLevel <= 0) {
-                    context.success("No source level configured");
+                    // Try effective model resolution (handles inherited properties from parent POMs)
+                    sourceLevel = detectEffectiveSourceLevel(context, pomPath);
+                }
+                if (sourceLevel <= 0) {
+                    context.success("No source level configured (local or inherited)");
                     continue;
                 }
 
@@ -337,6 +343,69 @@ public class ToolchainPluginStrategy extends AbstractUpgradeStrategy {
         DomUtils.insertContentElement(goals, "goal", SELECT_JDK_TOOLCHAIN_GOAL);
         Element configuration = DomUtils.insertNewElement(CONFIGURATION, execution);
         DomUtils.insertContentElement(configuration, "version", "(," + maxJdkVersion + "]");
+    }
+
+    /**
+     * Detects the project's source level by building the effective Maven model,
+     * which resolves inherited properties from parent POMs.
+     *
+     * <p>This is the fallback path used when the fast DOM-based detection
+     * ({@link #detectSourceLevel(Document)}) finds no source level in the local POM.
+     * It handles cases like projects inheriting {@code maven.compiler.source=1.5}
+     * from a parent POM (e.g., geronimo-genesis).
+     *
+     * @param context the upgrade context for logging
+     * @param pomPath the path to the POM file on disk
+     * @return the source level as a major version, or {@code -1} if none is configured
+     */
+    int detectEffectiveSourceLevel(UpgradeContext context, Path pomPath) {
+        try {
+            Model effectiveModel = buildEffectiveModel(pomPath);
+            int level = detectSourceLevelFromEffectiveModel(effectiveModel);
+            if (level > 0) {
+                context.detail("Detected inherited source level " + level + " from effective model");
+            }
+            return level;
+        } catch (Exception e) {
+            context.debug("Could not resolve effective model for " + pomPath + ": " + e.getMessage());
+            return -1;
+        }
+    }
+
+    /**
+     * Extracts the source level from an effective Maven model's properties.
+     *
+     * <p>Checks (in order of precedence):
+     * <ol>
+     *   <li>{@code maven.compiler.release}</li>
+     *   <li>{@code maven.compiler.source}</li>
+     * </ol>
+     *
+     * @param effectiveModel the resolved effective model
+     * @return the source level as a major version, or {@code -1} if none is configured
+     */
+    static int detectSourceLevelFromEffectiveModel(Model effectiveModel) {
+        Map<String, String> properties = effectiveModel.getProperties();
+
+        // Check maven.compiler.release first (takes precedence)
+        String release = properties.get(MAVEN_COMPILER_RELEASE);
+        if (release != null && !release.isBlank()) {
+            int level = JdkSourceLevelSupport.normalizeSourceLevel(release.trim());
+            if (level > 0) {
+                return level;
+            }
+        }
+
+        // Check maven.compiler.source
+        String source = properties.get(MAVEN_COMPILER_SOURCE);
+        if (source != null && !source.isBlank()) {
+            int level = JdkSourceLevelSupport.normalizeSourceLevel(source.trim());
+            if (level > 0) {
+                return level;
+            }
+        }
+
+        return -1;
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategyTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 import eu.maveniverse.domtrip.Document;
+import org.apache.maven.api.model.Model;
 import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -526,6 +527,258 @@ class ToolchainPluginStrategyTest {
             UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
 
             assertEquals(0, result.modifiedPoms().size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Effective model source level detection")
+    class EffectiveModelSourceLevelTests {
+
+        @Test
+        @DisplayName("should detect source level from effective model maven.compiler.release")
+        void detectFromEffectiveRelease() {
+            Model model = Model.newBuilder()
+                    .properties(Map.of("maven.compiler.release", "6"))
+                    .build();
+            assertEquals(6, ToolchainPluginStrategy.detectSourceLevelFromEffectiveModel(model));
+        }
+
+        @Test
+        @DisplayName("should detect source level from effective model maven.compiler.source")
+        void detectFromEffectiveSource() {
+            Model model = Model.newBuilder()
+                    .properties(Map.of("maven.compiler.source", "1.5"))
+                    .build();
+            assertEquals(5, ToolchainPluginStrategy.detectSourceLevelFromEffectiveModel(model));
+        }
+
+        @Test
+        @DisplayName("release takes precedence over source in effective model")
+        void effectiveReleasePrecedence() {
+            Model model = Model.newBuilder()
+                    .properties(Map.of(
+                            "maven.compiler.release", "7",
+                            "maven.compiler.source", "6"))
+                    .build();
+            assertEquals(7, ToolchainPluginStrategy.detectSourceLevelFromEffectiveModel(model));
+        }
+
+        @Test
+        @DisplayName("should return -1 when effective model has no compiler properties")
+        void noEffectiveSourceLevel() {
+            Model model = Model.newBuilder()
+                    .properties(Map.of("some.other.property", "value"))
+                    .build();
+            assertEquals(-1, ToolchainPluginStrategy.detectSourceLevelFromEffectiveModel(model));
+        }
+
+        @Test
+        @DisplayName("should return -1 when effective model has empty properties")
+        void emptyEffectiveProperties() {
+            Model model = Model.newBuilder().properties(Map.of()).build();
+            assertEquals(-1, ToolchainPluginStrategy.detectSourceLevelFromEffectiveModel(model));
+        }
+
+        @Test
+        @DisplayName("should handle legacy 1.x format in effective model")
+        void legacyFormatInEffectiveModel() {
+            Model model = Model.newBuilder()
+                    .properties(Map.of("maven.compiler.source", "1.6"))
+                    .build();
+            assertEquals(6, ToolchainPluginStrategy.detectSourceLevelFromEffectiveModel(model));
+        }
+
+        @Test
+        @DisplayName("should add plugin when source level is inherited from parent POM via effective model")
+        void addsPluginWhenSourceInherited() {
+            // Simulate running JDK 21, source level inherited from parent (not in local POM)
+            ToolchainPluginStrategy strategy = new ToolchainPluginStrategy() {
+                @Override
+                int getRunningJdkMajor() {
+                    return 21;
+                }
+
+                @Override
+                int detectEffectiveSourceLevel(UpgradeContext context, Path pomPath) {
+                    // Simulate parent POM setting maven.compiler.source=1.5
+                    return 5;
+                }
+            };
+
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>org.apache.geronimo.genesis</groupId>
+                            <artifactId>genesis</artifactId>
+                            <version>1.0</version>
+                        </parent>
+                        <artifactId>test-child</artifactId>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(1, result.modifiedPoms().size());
+            assertTrue(strategy.hasToolchainsPluginWithSelectGoal(doc));
+            String output = doc.toXml();
+            assertTrue(output.contains("<version>(,8]</version>"), "Expected JDK 8 constraint for source 5: " + output);
+        }
+
+        @Test
+        @DisplayName("should not modify POM when inherited source level is compatible with running JDK")
+        void noModificationWhenInheritedLevelCompatible() {
+            // Simulate running JDK 17, inherited source level 11 (still supported)
+            ToolchainPluginStrategy strategy = new ToolchainPluginStrategy() {
+                @Override
+                int getRunningJdkMajor() {
+                    return 17;
+                }
+
+                @Override
+                int detectEffectiveSourceLevel(UpgradeContext context, Path pomPath) {
+                    return 11;
+                }
+            };
+
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.example</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>1.0</version>
+                        </parent>
+                        <artifactId>child</artifactId>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(0, result.modifiedPoms().size());
+        }
+
+        @Test
+        @DisplayName("should fall back gracefully when effective model resolution fails")
+        void fallbackWhenEffectiveModelFails() {
+            // Simulate effective model resolution failure
+            ToolchainPluginStrategy strategy = new ToolchainPluginStrategy() {
+                @Override
+                int getRunningJdkMajor() {
+                    return 21;
+                }
+
+                @Override
+                int detectEffectiveSourceLevel(UpgradeContext context, Path pomPath) {
+                    return -1; // Simulate failure
+                }
+            };
+
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.example</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>1.0</version>
+                        </parent>
+                        <artifactId>child</artifactId>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            // Should not modify POM and not fail
+            assertEquals(0, result.modifiedPoms().size());
+            assertEquals(0, result.errorPoms().size());
+        }
+
+        @Test
+        @DisplayName("local POM source level takes precedence over effective model")
+        void localTakesPrecedenceOverEffective() {
+            // Local POM has source=11, but effective model would return 6
+            // Local should win — effective model is only consulted when local returns -1
+            ToolchainPluginStrategy strategy = new ToolchainPluginStrategy() {
+                @Override
+                int getRunningJdkMajor() {
+                    return 21;
+                }
+
+                @Override
+                int detectEffectiveSourceLevel(UpgradeContext context, Path pomPath) {
+                    // This should NOT be consulted because local detection succeeds
+                    return 6;
+                }
+            };
+
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <properties>
+                            <maven.compiler.release>11</maven.compiler.release>
+                        </properties>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            // Source 11 is supported by JDK 21, so no modification
+            assertEquals(0, result.modifiedPoms().size());
+        }
+
+        @Test
+        @DisplayName("should add plugin with correct JDK constraint for inherited source 6")
+        void correctJdkConstraintForSource6() {
+            ToolchainPluginStrategy strategy = new ToolchainPluginStrategy() {
+                @Override
+                int getRunningJdkMajor() {
+                    return 21;
+                }
+
+                @Override
+                int detectEffectiveSourceLevel(UpgradeContext context, Path pomPath) {
+                    return 6; // Inherited source level 6 (e.g., geronimo-genesis)
+                }
+            };
+
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>org.apache.geronimo.genesis</groupId>
+                            <artifactId>genesis</artifactId>
+                            <version>2.0</version>
+                        </parent>
+                        <artifactId>test-module</artifactId>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(1, result.modifiedPoms().size());
+            assertTrue(strategy.hasToolchainsPluginWithSelectGoal(doc));
+            String output = doc.toXml();
+            // Source level 6 requires JDK <= 11
+            assertTrue(
+                    output.contains("<version>(,11]</version>"), "Expected JDK 11 constraint for source 6: " + output);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds effective model resolution as a fallback when `ToolchainPluginStrategy` finds no source level in the local POM DOM
- When `maven.compiler.source`/`target` is inherited from a parent POM (e.g., `geronimo-genesis` sets `source=1.5`), `mvnup` now resolves the effective source level via `buildEffectiveModel()` and configures the auto-toolchain for JDK 8/11 compilation
- This fixes the 12 Apache projects (ftpserver, geronimo-genesis, aries-tx-control, etc.) that fail with `"Source option N is no longer supported"` under Maven 4

## Design

The fix follows the same pattern used by `CompatibilityFixStrategy.collectEffectiveProperties()`:

1. **Fast path** (unchanged): inspect the local POM DOM for `maven.compiler.release`, `maven.compiler.source`, or compiler plugin config
2. **Fallback path** (new): if the fast path returns -1, build the effective Maven model which resolves all inherited properties from parent POMs, then check `maven.compiler.release` and `maven.compiler.source` from the effective properties
3. Failures in effective model resolution are caught and logged at debug level — the strategy degrades gracefully

## Test plan

- [x] Unit tests for `detectSourceLevelFromEffectiveModel()` (6 tests): release property, source property, precedence, legacy 1.x format, empty properties, no compiler properties
- [x] Integration-style tests for `doApply()` with inherited source levels (5 tests): plugin added for inherited incompatible source, no modification for compatible inherited source, graceful fallback on resolution failure, local takes precedence over effective, correct JDK constraint (source 6 → JDK 11)
- [x] All 31 tests pass, format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)