### PR TITLE
[MNG-8633] mvnup: inject standalone Nashorn for antrun JavaScript compatibility

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
@@ -74,7 +74,7 @@ public class NashornCompatibilityStrategy extends AbstractUpgradeStrategy {
     static final String ANTRUN_ARTIFACT_ID = "maven-antrun-plugin";
     static final String NASHORN_GROUP_ID = "org.openjdk.nashorn";
     static final String NASHORN_ARTIFACT_ID = "nashorn-core";
-    static final String NASHORN_VERSION = "15.4";
+    static final String NASHORN_VERSION = "15.7";
 
     private static final String SCRIPT = "script";
     private static final String LANGUAGE = "language";

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnup.goals;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.Element;
+import org.apache.maven.api.cli.mvnup.UpgradeOptions;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Priority;
+import org.apache.maven.api.di.Singleton;
+import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
+
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.ARTIFACT_ID;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.BUILD;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.DEPENDENCIES;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.GROUP_ID;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGIN;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGINS;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGIN_MANAGEMENT;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PROFILE;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PROFILES;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Plugins.DEFAULT_MAVEN_PLUGIN_GROUP_ID;
+
+/**
+ * Strategy for injecting the standalone OpenJDK Nashorn engine as a plugin dependency
+ * when {@code maven-antrun-plugin} uses inline JavaScript via {@code <script language="javascript">}.
+ *
+ * <p>Maven 4 requires JDK 17+, but the built-in Nashorn JavaScript engine was removed in JDK 15.
+ * Plugins executing JavaScript in-process (particularly {@code maven-antrun-plugin} with
+ * {@code <script language="javascript">}) fail with:
+ * <pre>
+ * [ERROR] Unable to create javax script engine for javascript
+ * </pre>
+ *
+ * <p>Toolchains cannot help because the script runs in Maven's own JVM, not in a forked process.
+ * The standalone OpenJDK Nashorn ({@code org.openjdk.nashorn:nashorn-core}) provides a drop-in
+ * replacement that registers via {@code ServiceLoader} and restores JavaScript support.
+ *
+ * @see <a href="https://github.com/apache/maven/issues/12988">#12988</a>
+ */
+@Named
+@Singleton
+@Priority(19)
+public class NashornCompatibilityStrategy extends AbstractUpgradeStrategy {
+
+    static final String ANTRUN_ARTIFACT_ID = "maven-antrun-plugin";
+    static final String NASHORN_GROUP_ID = "org.openjdk.nashorn";
+    static final String NASHORN_ARTIFACT_ID = "nashorn-core";
+    static final String NASHORN_VERSION = "15.4";
+
+    private static final String SCRIPT = "script";
+    private static final String LANGUAGE = "language";
+    private static final String JAVASCRIPT = "javascript";
+
+    @Override
+    public boolean isApplicable(UpgradeContext context) {
+        UpgradeOptions options = getOptions(context);
+
+        // Handle --all option (overrides individual options)
+        boolean useAll = options.all().orElse(false);
+        if (useAll) {
+            return true;
+        }
+
+        // Apply default behavior: if no specific options are provided, enable by default
+        boolean noOptionsSpecified = options.all().isEmpty()
+                && options.infer().isEmpty()
+                && options.model().isEmpty()
+                && options.plugins().isEmpty()
+                && options.modelVersion().isEmpty();
+
+        boolean allOptionsDisabled = options.all().map(v -> !v).orElse(false)
+                && options.infer().map(v -> !v).orElse(false)
+                && options.model().map(v -> !v).orElse(false)
+                && options.plugins().map(v -> !v).orElse(false)
+                && options.modelVersion().isEmpty();
+
+        if (noOptionsSpecified || allOptionsDisabled) {
+            return true;
+        }
+
+        // Check if --model is explicitly set (this is a compatibility fix)
+        if (options.model().isPresent()) {
+            return options.model().get();
+        }
+
+        return false;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Injecting standalone Nashorn for antrun JavaScript compatibility";
+    }
+
+    @Override
+    protected UpgradeResult doApply(UpgradeContext context, Map<Path, Document> pomMap) {
+        Set<Path> processedPoms = new HashSet<>();
+        Set<Path> modifiedPoms = new HashSet<>();
+        Set<Path> errorPoms = new HashSet<>();
+
+        for (Map.Entry<Path, Document> entry : pomMap.entrySet()) {
+            Path pomPath = entry.getKey();
+            Document pomDocument = entry.getValue();
+            processedPoms.add(pomPath);
+
+            context.info(pomPath + " (checking for antrun JavaScript usage)");
+            context.indent();
+
+            try {
+                boolean modified = injectNashornForAntrunJavaScript(pomDocument, context);
+
+                if (modified) {
+                    context.success("Injected standalone Nashorn dependency for antrun JavaScript");
+                    modifiedPoms.add(pomPath);
+                } else {
+                    context.success("No antrun JavaScript usage found");
+                }
+            } catch (Exception e) {
+                context.failure("Failed to process antrun JavaScript compatibility: " + e.getMessage());
+                errorPoms.add(pomPath);
+            } finally {
+                context.unindent();
+            }
+        }
+
+        return new UpgradeResult(processedPoms, modifiedPoms, errorPoms);
+    }
+
+    /**
+     * Scans all plugin declarations for maven-antrun-plugin with JavaScript scripts
+     * and injects the standalone Nashorn dependency where needed.
+     *
+     * @return true if any modifications were made
+     */
+    private boolean injectNashornForAntrunJavaScript(Document pomDocument, UpgradeContext context) {
+        Element root = pomDocument.root();
+        List<Element> antrunPlugins = findAntrunPluginsWithJavaScript(root);
+
+        boolean modified = false;
+        for (Element pluginElement : antrunPlugins) {
+            if (!hasNashornDependency(pluginElement)) {
+                addNashornDependency(pluginElement, context);
+                modified = true;
+            } else {
+                context.detail("Nashorn dependency already present on maven-antrun-plugin");
+            }
+        }
+
+        return modified;
+    }
+
+    /**
+     * Finds all maven-antrun-plugin declarations that contain JavaScript script executions.
+     * Searches in build/plugins, build/pluginManagement/plugins, and profile builds.
+     */
+    List<Element> findAntrunPluginsWithJavaScript(Element root) {
+        List<Element> result = new ArrayList<>();
+
+        // Collect all plugin containers: build/plugins, build/pluginManagement/plugins,
+        // and the same within profiles
+        Stream<Element> pluginContainers = Stream.concat(
+                root.childElement(BUILD).stream()
+                        .flatMap(build -> Stream.concat(
+                                build.childElement(PLUGINS).stream(),
+                                build.childElement(PLUGIN_MANAGEMENT).stream()
+                                        .flatMap(pm -> pm.childElement(PLUGINS).stream()))),
+                root.childElement(PROFILES).stream()
+                        .flatMap(profiles -> profiles.childElements(PROFILE))
+                        .flatMap(profile -> profile.childElement(BUILD).stream())
+                        .flatMap(build -> Stream.concat(
+                                build.childElement(PLUGINS).stream(),
+                                build.childElement(PLUGIN_MANAGEMENT).stream()
+                                        .flatMap(pm -> pm.childElement(PLUGINS).stream()))));
+
+        pluginContainers.forEach(pluginsElement -> pluginsElement
+                .childElements(PLUGIN)
+                .forEach(pluginElement -> {
+                    if (isAntrunPlugin(pluginElement) && containsJavaScriptScript(pluginElement)) {
+                        result.add(pluginElement);
+                    }
+                }));
+
+        return result;
+    }
+
+    /**
+     * Checks if a plugin element is maven-antrun-plugin.
+     */
+    static boolean isAntrunPlugin(Element pluginElement) {
+        String artifactId = pluginElement.childText(ARTIFACT_ID);
+        if (!ANTRUN_ARTIFACT_ID.equals(artifactId)) {
+            return false;
+        }
+
+        String groupId = pluginElement.childText(GROUP_ID);
+        // If groupId is absent, Maven defaults to org.apache.maven.plugins
+        return groupId == null || DEFAULT_MAVEN_PLUGIN_GROUP_ID.equals(groupId);
+    }
+
+    /**
+     * Recursively searches a plugin element for {@code <script language="javascript">} elements.
+     * The script element can appear at any depth within the plugin's configuration or executions.
+     */
+    static boolean containsJavaScriptScript(Element element) {
+        // Check if this element is a <script language="javascript">
+        if (SCRIPT.equals(element.name())) {
+            String lang = element.attribute(LANGUAGE);
+            if (lang != null && JAVASCRIPT.equalsIgnoreCase(lang)) {
+                return true;
+            }
+        }
+
+        // Recursively check children
+        return element.childElements().anyMatch(NashornCompatibilityStrategy::containsJavaScriptScript);
+    }
+
+    /**
+     * Checks if the antrun plugin already has nashorn-core as a dependency.
+     */
+    static boolean hasNashornDependency(Element pluginElement) {
+        return pluginElement
+                .childElement(DEPENDENCIES)
+                .map(deps -> deps.childElements("dependency").anyMatch(dep -> {
+                    String gid = dep.childText(GROUP_ID);
+                    String aid = dep.childText(ARTIFACT_ID);
+                    return NASHORN_GROUP_ID.equals(gid) && NASHORN_ARTIFACT_ID.equals(aid);
+                }))
+                .orElse(false);
+    }
+
+    /**
+     * Adds the standalone Nashorn dependency to the antrun plugin element.
+     */
+    private void addNashornDependency(Element pluginElement, UpgradeContext context) {
+        Element dependenciesElement = pluginElement
+                .childElement(DEPENDENCIES)
+                .orElseGet(() -> DomUtils.insertNewElement(DEPENDENCIES, pluginElement));
+
+        DomUtils.createDependency(dependenciesElement, NASHORN_GROUP_ID, NASHORN_ARTIFACT_ID, NASHORN_VERSION);
+
+        context.detail("Added " + NASHORN_GROUP_ID + ":" + NASHORN_ARTIFACT_ID + ":" + NASHORN_VERSION
+                + " as plugin dependency of " + ANTRUN_ARTIFACT_ID);
+    }
+}

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
@@ -74,7 +74,7 @@ public class NashornCompatibilityStrategy extends AbstractUpgradeStrategy {
     static final String ANTRUN_ARTIFACT_ID = "maven-antrun-plugin";
     static final String NASHORN_GROUP_ID = "org.openjdk.nashorn";
     static final String NASHORN_ARTIFACT_ID = "nashorn-core";
-    static final String NASHORN_VERSION = "15.6";
+    static final String NASHORN_VERSION = "15.7";
 
     private static final String SCRIPT = "script";
     private static final String LANGUAGE = "language";

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
@@ -60,6 +60,10 @@ import static eu.maveniverse.domtrip.maven.MavenPomElements.Plugins.DEFAULT_MAVE
  * The standalone OpenJDK Nashorn ({@code org.openjdk.nashorn:nashorn-core}) provides a drop-in
  * replacement that registers via {@code ServiceLoader} and restores JavaScript support.
  *
+ * <p>This strategy both <strong>injects</strong> the Nashorn dependency as a quick fix and
+ * <strong>warns</strong> that users should consider migrating to GraalVM JavaScript
+ * ({@code org.graalvm.js:js-scriptengine}) for long-term support.
+ *
  * @see <a href="https://github.com/apache/maven/issues/12988">#12988</a>
  */
 @Named
@@ -163,6 +167,10 @@ public class NashornCompatibilityStrategy extends AbstractUpgradeStrategy {
         boolean modified = false;
         for (Element pluginElement : antrunPlugins) {
             if (!hasNashornDependency(pluginElement)) {
+                context.warning("maven-antrun-plugin uses inline JavaScript which requires a standalone"
+                        + " script engine on JDK 17+. Adding org.openjdk.nashorn:nashorn-core as a"
+                        + " quick fix. Consider migrating to GraalVM JavaScript"
+                        + " (org.graalvm.js:js-scriptengine + org.graalvm.js:js) for long-term support.");
                 addNashornDependency(pluginElement, context);
                 modified = true;
             } else {

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategy.java
@@ -74,7 +74,7 @@ public class NashornCompatibilityStrategy extends AbstractUpgradeStrategy {
     static final String ANTRUN_ARTIFACT_ID = "maven-antrun-plugin";
     static final String NASHORN_GROUP_ID = "org.openjdk.nashorn";
     static final String NASHORN_ARTIFACT_ID = "nashorn-core";
-    static final String NASHORN_VERSION = "15.7";
+    static final String NASHORN_VERSION = "15.6";
 
     private static final String SCRIPT = "script";
     private static final String LANGUAGE = "language";

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
@@ -1,0 +1,712 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnup.goals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+
+import eu.maveniverse.domtrip.Document;
+import org.apache.maven.api.cli.mvnup.UpgradeOptions;
+import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link NashornCompatibilityStrategy} class.
+ * Tests detection of antrun JavaScript usage and injection of standalone Nashorn dependency.
+ *
+ * @see <a href="https://github.com/apache/maven/issues/12988">#12988</a>
+ */
+@DisplayName("NashornCompatibilityStrategy")
+class NashornCompatibilityStrategyTest {
+
+    private NashornCompatibilityStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new NashornCompatibilityStrategy();
+    }
+
+    private UpgradeContext createMockContext() {
+        return TestUtils.createMockContext();
+    }
+
+    @Nested
+    @DisplayName("Applicability")
+    class ApplicabilityTests {
+
+        @Test
+        @DisplayName("should be applicable when --model option is true")
+        void shouldBeApplicableWhenModelOptionTrue() {
+            UpgradeOptions options = mock(UpgradeOptions.class);
+            when(options.model()).thenReturn(Optional.of(true));
+            when(options.all()).thenReturn(Optional.empty());
+
+            UpgradeContext context = TestUtils.createMockContext(options);
+
+            assertTrue(strategy.isApplicable(context), "Strategy should be applicable when --model is true");
+        }
+
+        @Test
+        @DisplayName("should be applicable when --all option is specified")
+        void shouldBeApplicableWhenAllOptionSpecified() {
+            UpgradeOptions options = mock(UpgradeOptions.class);
+            when(options.all()).thenReturn(Optional.of(true));
+            when(options.model()).thenReturn(Optional.empty());
+
+            UpgradeContext context = TestUtils.createMockContext(options);
+
+            assertTrue(strategy.isApplicable(context), "Strategy should be applicable when --all is specified");
+        }
+
+        @Test
+        @DisplayName("should be applicable by default when no specific options provided")
+        void shouldBeApplicableByDefaultWhenNoSpecificOptions() {
+            UpgradeOptions options = TestUtils.createDefaultOptions();
+
+            UpgradeContext context = TestUtils.createMockContext(options);
+
+            assertTrue(strategy.isApplicable(context), "Strategy should be applicable by default");
+        }
+
+        @Test
+        @DisplayName("should not be applicable when --model option is false")
+        void shouldNotBeApplicableWhenModelOptionFalse() {
+            UpgradeOptions options = mock(UpgradeOptions.class);
+            when(options.model()).thenReturn(Optional.of(false));
+            when(options.all()).thenReturn(Optional.empty());
+
+            UpgradeContext context = TestUtils.createMockContext(options);
+
+            assertFalse(strategy.isApplicable(context), "Strategy should not be applicable when --model is false");
+        }
+    }
+
+    @Nested
+    @DisplayName("Antrun JavaScript Detection and Nashorn Injection")
+    class AntrunJavaScriptTests {
+
+        @Test
+        @DisplayName("should inject nashorn-core when antrun plugin uses JavaScript script")
+        void shouldInjectNashornWhenAntrunUsesJavaScript() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <executions>
+                                    <execution>
+                                        <id>set-bree</id>
+                                        <phase>initialize</phase>
+                                        <configuration>
+                                            <target>
+                                                <script language="javascript"><![CDATA[
+                                                    var System = java.lang.System;
+                                                    var bree = "J2SE-1.5";
+                                                    project.setProperty("sling.bree", bree);
+                                                ]]></script>
+                                            </target>
+                                        </configuration>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have modified the POM");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
+            assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
+            assertTrue(xml.contains("15.4"), "Should contain nashorn version");
+        }
+
+        @Test
+        @DisplayName("should inject nashorn-core when antrun plugin has no explicit groupId")
+        void shouldInjectNashornWhenAntrunHasNoGroupId() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <executions>
+                                    <execution>
+                                        <configuration>
+                                            <target>
+                                                <script language="javascript"><![CDATA[
+                                                    project.setProperty("foo", "bar");
+                                                ]]></script>
+                                            </target>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have modified the POM");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(xml.contains("nashorn-core"), "Should contain nashorn dependency");
+        }
+
+        @Test
+        @DisplayName("should inject nashorn-core in pluginManagement")
+        void shouldInjectNashornInPluginManagement() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-antrun-plugin</artifactId>
+                                    <configuration>
+                                        <target>
+                                            <script language="javascript"><![CDATA[
+                                                project.setProperty("foo", "bar");
+                                            ]]></script>
+                                        </target>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have modified the POM");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(xml.contains("nashorn-core"), "Should contain nashorn dependency");
+        }
+
+        @Test
+        @DisplayName("should inject nashorn-core in profile build")
+        void shouldInjectNashornInProfile() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <profiles>
+                        <profile>
+                            <id>legacy</id>
+                            <build>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-antrun-plugin</artifactId>
+                                        <executions>
+                                            <execution>
+                                                <configuration>
+                                                    <target>
+                                                        <script language="javascript"><![CDATA[
+                                                            var x = 1;
+                                                        ]]></script>
+                                                    </target>
+                                                </configuration>
+                                            </execution>
+                                        </executions>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                        </profile>
+                    </profiles>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have modified the POM");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(xml.contains("nashorn-core"), "Should contain nashorn dependency in profile");
+        }
+
+        @Test
+        @DisplayName("should handle case-insensitive JavaScript language attribute")
+        void shouldHandleCaseInsensitiveLanguage() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <configuration>
+                                    <target>
+                                        <script language="JavaScript"><![CDATA[
+                                            project.setProperty("foo", "bar");
+                                        ]]></script>
+                                    </target>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should detect JavaScript regardless of case");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(xml.contains("nashorn-core"), "Should contain nashorn dependency");
+        }
+    }
+
+    @Nested
+    @DisplayName("No-op Scenarios")
+    class NoOpTests {
+
+        @Test
+        @DisplayName("should not modify POM without antrun plugin")
+        void shouldNotModifyPomWithoutAntrun() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.11.0</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not have modified the POM");
+        }
+
+        @Test
+        @DisplayName("should not modify POM when antrun plugin has no JavaScript scripts")
+        void shouldNotModifyWhenNoJavaScript() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <executions>
+                                    <execution>
+                                        <configuration>
+                                            <target>
+                                                <echo message="Hello"/>
+                                            </target>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not have modified the POM");
+
+            String xml = DomUtils.toXml(document);
+            assertFalse(xml.contains("nashorn"), "Should not contain nashorn dependency");
+        }
+
+        @Test
+        @DisplayName("should not modify POM when antrun uses non-JavaScript script language")
+        void shouldNotModifyWhenNonJavaScriptLanguage() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <configuration>
+                                    <target>
+                                        <script language="groovy"><![CDATA[
+                                            println "Hello from Groovy"
+                                        ]]></script>
+                                    </target>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not have modified the POM for Groovy");
+
+            String xml = DomUtils.toXml(document);
+            assertFalse(xml.contains("nashorn"), "Should not contain nashorn dependency");
+        }
+
+        @Test
+        @DisplayName("should not modify POM when nashorn dependency already exists")
+        void shouldNotModifyWhenNashornAlreadyPresent() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.openjdk.nashorn</groupId>
+                                        <artifactId>nashorn-core</artifactId>
+                                        <version>15.4</version>
+                                    </dependency>
+                                </dependencies>
+                                <configuration>
+                                    <target>
+                                        <script language="javascript"><![CDATA[
+                                            project.setProperty("foo", "bar");
+                                        ]]></script>
+                                    </target>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not have modified the POM");
+        }
+
+        @Test
+        @DisplayName("should not modify POM without build section")
+        void shouldNotModifyPomWithoutBuild() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not have modified the POM");
+        }
+
+        @Test
+        @DisplayName("should not inject for non-maven-plugins groupId antrun")
+        void shouldNotInjectForNonMavenPluginsGroupId() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>com.example</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <configuration>
+                                    <target>
+                                        <script language="javascript"><![CDATA[
+                                            var x = 1;
+                                        ]]></script>
+                                    </target>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertEquals(0, result.modifiedCount(), "Should not inject for non-standard groupId");
+        }
+    }
+
+    @Nested
+    @DisplayName("Sling Parent POM Pattern")
+    class SlingPatternTests {
+
+        @Test
+        @DisplayName("should handle the real Sling parent POM pattern with BREE script")
+        void shouldHandleSlingBreePattern() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.apache.sling</groupId>
+                    <artifactId>sling</artifactId>
+                    <version>22</version>
+                    <packaging>pom</packaging>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <executions>
+                                    <execution>
+                                        <id>set-bundle-required-execution-environment</id>
+                                        <phase>initialize</phase>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                        <configuration>
+                                            <exportAntProperties>true</exportAntProperties>
+                                            <target>
+                                                <script language="javascript"><![CDATA[
+                                                    var System = java.lang.System;
+                                                    var bree = "J2SE-1.5";
+                                                    var slingJavaVersion = System.getProperty("sling.java.version");
+                                                    if (slingJavaVersion == "6" || slingJavaVersion == "1.6") {
+                                                        bree = "JavaSE-1.6";
+                                                    } else if (slingJavaVersion == "7" || slingJavaVersion == "1.7") {
+                                                        bree = "JavaSE-1.7";
+                                                    } else if (slingJavaVersion == "8" || slingJavaVersion == "1.8") {
+                                                        bree = "JavaSE-1.8";
+                                                    }
+                                                    project.setProperty("sling.bree", bree);
+                                                ]]></script>
+                                            </target>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have modified the Sling POM");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
+            assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
+            assertTrue(xml.contains("15.4"), "Should contain nashorn version");
+        }
+
+        @Test
+        @DisplayName("should handle antrun with existing dependencies and add nashorn")
+        void shouldAddNashornToExistingDependencies() throws Exception {
+            String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>some.other</groupId>
+                                        <artifactId>lib</artifactId>
+                                        <version>1.0</version>
+                                    </dependency>
+                                </dependencies>
+                                <configuration>
+                                    <target>
+                                        <script language="javascript"><![CDATA[
+                                            project.setProperty("foo", "bar");
+                                        ]]></script>
+                                    </target>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+            Document document = Document.of(pomXml);
+            Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+            UpgradeContext context = createMockContext();
+            UpgradeResult result = strategy.doApply(context, pomMap);
+
+            assertTrue(result.success(), "Strategy should succeed");
+            assertTrue(result.modifiedCount() > 0, "Should have modified the POM");
+
+            String xml = DomUtils.toXml(document);
+            assertTrue(xml.contains("nashorn-core"), "Should contain nashorn dependency");
+            assertTrue(xml.contains("some.other"), "Should preserve existing dependency");
+        }
+    }
+
+    @Nested
+    @DisplayName("Strategy Description")
+    class StrategyDescriptionTests {
+
+        @Test
+        @DisplayName("should provide meaningful description")
+        void shouldProvideMeaningfulDescription() {
+            String description = strategy.getDescription();
+
+            assertNotNull(description, "Description should not be null");
+            assertFalse(description.trim().isEmpty(), "Description should not be empty");
+            assertTrue(
+                    description.toLowerCase().contains("nashorn")
+                            || description.toLowerCase().contains("antrun")
+                            || description.toLowerCase().contains("javascript"),
+                    "Description should mention nashorn, antrun, or javascript");
+        }
+    }
+}

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
@@ -164,7 +164,7 @@ class NashornCompatibilityStrategyTest {
             String xml = DomUtils.toXml(document);
             assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
             assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
-            assertTrue(xml.contains("15.4"), "Should contain nashorn version");
+            assertTrue(xml.contains("15.7"), "Should contain nashorn version");
         }
 
         @Test
@@ -485,7 +485,7 @@ class NashornCompatibilityStrategyTest {
                                     <dependency>
                                         <groupId>org.openjdk.nashorn</groupId>
                                         <artifactId>nashorn-core</artifactId>
-                                        <version>15.4</version>
+                                        <version>15.7</version>
                                     </dependency>
                                 </dependencies>
                                 <configuration>
@@ -638,7 +638,7 @@ class NashornCompatibilityStrategyTest {
             String xml = DomUtils.toXml(document);
             assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
             assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
-            assertTrue(xml.contains("15.4"), "Should contain nashorn version");
+            assertTrue(xml.contains("15.7"), "Should contain nashorn version");
         }
 
         @Test

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
@@ -164,7 +164,7 @@ class NashornCompatibilityStrategyTest {
             String xml = DomUtils.toXml(document);
             assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
             assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
-            assertTrue(xml.contains("15.6"), "Should contain nashorn version");
+            assertTrue(xml.contains("15.7"), "Should contain nashorn version");
         }
 
         @Test
@@ -485,7 +485,7 @@ class NashornCompatibilityStrategyTest {
                                     <dependency>
                                         <groupId>org.openjdk.nashorn</groupId>
                                         <artifactId>nashorn-core</artifactId>
-                                        <version>15.6</version>
+                                        <version>15.7</version>
                                     </dependency>
                                 </dependencies>
                                 <configuration>
@@ -638,7 +638,7 @@ class NashornCompatibilityStrategyTest {
             String xml = DomUtils.toXml(document);
             assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
             assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
-            assertTrue(xml.contains("15.6"), "Should contain nashorn version");
+            assertTrue(xml.contains("15.7"), "Should contain nashorn version");
         }
 
         @Test

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/NashornCompatibilityStrategyTest.java
@@ -164,7 +164,7 @@ class NashornCompatibilityStrategyTest {
             String xml = DomUtils.toXml(document);
             assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
             assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
-            assertTrue(xml.contains("15.7"), "Should contain nashorn version");
+            assertTrue(xml.contains("15.6"), "Should contain nashorn version");
         }
 
         @Test
@@ -485,7 +485,7 @@ class NashornCompatibilityStrategyTest {
                                     <dependency>
                                         <groupId>org.openjdk.nashorn</groupId>
                                         <artifactId>nashorn-core</artifactId>
-                                        <version>15.7</version>
+                                        <version>15.6</version>
                                     </dependency>
                                 </dependencies>
                                 <configuration>
@@ -638,7 +638,7 @@ class NashornCompatibilityStrategyTest {
             String xml = DomUtils.toXml(document);
             assertTrue(xml.contains("org.openjdk.nashorn"), "Should contain nashorn groupId");
             assertTrue(xml.contains("nashorn-core"), "Should contain nashorn artifactId");
-            assertTrue(xml.contains("15.7"), "Should contain nashorn version");
+            assertTrue(xml.contains("15.6"), "Should contain nashorn version");
         }
 
         @Test

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/UpgradeWorkflowIntegrationTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/UpgradeWorkflowIntegrationTest.java
@@ -51,6 +51,7 @@ class UpgradeWorkflowIntegrationTest {
         List<UpgradeStrategy> strategies = List.of(
                 new ModelUpgradeStrategy(),
                 new CompatibilityFixStrategy(),
+                new NashornCompatibilityStrategy(),
                 new PluginUpgradeStrategy(),
                 new InferenceStrategy());
 
@@ -211,6 +212,156 @@ class UpgradeWorkflowIntegrationTest {
             // Verify both POMs exist (they may or may not be modified depending on strategies)
             assertTrue(Files.exists(parentPom), "Parent POM should exist");
             assertTrue(Files.exists(modulePom), "Module POM should exist");
+        }
+    }
+
+    @Nested
+    @DisplayName("Nashorn Compatibility")
+    class NashornCompatibilityTests {
+
+        @Test
+        @DisplayName("should inject nashorn-core when antrun uses JavaScript")
+        void shouldInjectNashornForAntrunJavaScript() throws Exception {
+            Path pomFile = tempDir.resolve("pom.xml");
+            String originalPom = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test-project</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-antrun-plugin</artifactId>
+                                    <executions>
+                                        <execution>
+                                            <id>run-js</id>
+                                            <phase>validate</phase>
+                                            <configuration>
+                                                <target>
+                                                    <script language="javascript">
+                                                        self.log("hello from antrun");
+                                                    </script>
+                                                </target>
+                                            </configuration>
+                                            <goals>
+                                                <goal>run</goal>
+                                            </goals>
+                                        </execution>
+                                    </executions>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Files.writeString(pomFile, originalPom);
+
+            UpgradeContext context = TestUtils.createMockContext(tempDir);
+
+            int result = applyGoal.execute(context);
+
+            assertEquals(0, result, "Apply should succeed");
+
+            String upgradedPom = Files.readString(pomFile);
+            assertTrue(
+                    upgradedPom.contains("nashorn-core"), "POM should contain nashorn-core dependency after upgrade");
+            assertTrue(upgradedPom.contains("org.openjdk.nashorn"), "POM should contain org.openjdk.nashorn groupId");
+        }
+
+        @Test
+        @DisplayName("should not modify POM when antrun has no JavaScript")
+        void shouldNotModifyPomWithoutJavaScript() throws Exception {
+            Path pomFile = tempDir.resolve("pom.xml");
+            String originalPom = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test-project</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-antrun-plugin</artifactId>
+                                    <executions>
+                                        <execution>
+                                            <id>copy-files</id>
+                                            <phase>process-resources</phase>
+                                            <configuration>
+                                                <target>
+                                                    <copy file="src/a.txt" tofile="target/a.txt"/>
+                                                </target>
+                                            </configuration>
+                                            <goals>
+                                                <goal>run</goal>
+                                            </goals>
+                                        </execution>
+                                    </executions>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Files.writeString(pomFile, originalPom);
+
+            UpgradeContext context = TestUtils.createMockContext(tempDir);
+
+            int result = applyGoal.execute(context);
+
+            assertEquals(0, result, "Apply should succeed");
+
+            String upgradedPom = Files.readString(pomFile);
+            assertTrue(
+                    !upgradedPom.contains("nashorn-core"),
+                    "POM should not contain nashorn-core when no JavaScript is used");
+        }
+
+        @Test
+        @DisplayName("check goal should detect but not modify antrun JavaScript POM")
+        void checkShouldDetectButNotModifyAntrunJavaScript() throws Exception {
+            Path pomFile = tempDir.resolve("pom.xml");
+            String originalPom = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test-project</artifactId>
+                        <version>1.0.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-antrun-plugin</artifactId>
+                                    <executions>
+                                        <execution>
+                                            <id>run-js</id>
+                                            <configuration>
+                                                <target>
+                                                    <script language="javascript">
+                                                        self.log("hello");
+                                                    </script>
+                                                </target>
+                                            </configuration>
+                                            <goals>
+                                                <goal>run</goal>
+                                            </goals>
+                                        </execution>
+                                    </executions>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Files.writeString(pomFile, originalPom);
+
+            UpgradeContext context = TestUtils.createMockContext(tempDir);
+
+            int result = checkGoal.execute(context);
+
+            assertEquals(0, result, "Check should succeed");
+
+            String pomContent = Files.readString(pomFile);
+            assertEquals(originalPom, pomContent, "Check should not modify POM files");
         }
     }
 

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -216,7 +216,6 @@ class DefaultModelBuilderTest {
     private DefaultProfileActivationContext parentActivationContext(Map<String, String> systemProperties) {
         org.apache.maven.api.services.Lookup lookup = session.getService(org.apache.maven.api.services.Lookup.class);
         return new DefaultProfileActivationContext(
-                lookup.lookup(org.apache.maven.api.services.model.PathTranslator.class),
                 lookup.lookup(org.apache.maven.api.services.model.RootLocator.class),
                 lookup.lookup(org.apache.maven.api.services.Interpolator.class),
                 List.of(),


### PR DESCRIPTION
## Summary

- Add `NashornCompatibilityStrategy` to mvnup that detects `maven-antrun-plugin` JavaScript execution (`<script language="javascript">`) and injects `org.openjdk.nashorn:nashorn-core:15.4` as a plugin dependency
- Searches build/plugins, build/pluginManagement/plugins, and profile builds for antrun JavaScript usage
- Idempotent: skips injection if nashorn-core is already present as a plugin dependency
- Includes 18 unit tests covering detection, injection, no-op scenarios, and the real Sling parent POM pattern

Fixes #12988

## Context

Maven 4 requires JDK 17+, but Nashorn was removed in JDK 15. The 14 affected Apache Sling projects inherit from `org.apache.sling:sling:22` which executes inline JavaScript via `maven-antrun-plugin`. Toolchains don't help because the script runs in Maven's own JVM.

The standalone OpenJDK Nashorn (`org.openjdk.nashorn:nashorn-core`) registers via `ServiceLoader` and provides a drop-in replacement.

## Test plan

- [x] All 18 new unit tests pass (detection, injection, idempotency, profiles, pluginManagement, case-insensitive language, non-JS languages, existing dependencies, Sling BREE pattern)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)