### PR TITLE
Fix #12991: skip shade-plugin upgrade when custom ResourceTransformers are present

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -700,7 +700,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 // has shade-plugin with custom transformers, exclude shade-plugin
                 // from upgrades for this module only
                 Map<String, PluginUpgrade> pluginUpgrades = basePluginUpgrades;
-                if (hasCustomTransformersInPomOrParents(originalPomPath, pomMap, tempDir, commonRoot)) {
+                if (hasCustomTransformersInPomOrParents(context, originalPomPath, pomMap, tempDir, commonRoot)) {
                     pluginUpgrades = new HashMap<>(basePluginUpgrades);
                     pluginUpgrades.remove(shadePluginKey);
                     context.warning("Skipping maven-shade-plugin in effective-model analysis for " + originalPomPath
@@ -746,7 +746,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
      * This is a per-module check, unlike a global check across all POMs.
      */
     private boolean hasCustomTransformersInPomOrParents(
-            Path pomPath, Map<Path, Document> pomMap, Path tempDir, Path commonRoot) {
+            UpgradeContext context, Path pomPath, Map<Path, Document> pomMap, Path tempDir, Path commonRoot) {
         // Check the current POM
         Document doc = pomMap.get(pomPath);
         if (doc != null && hasCustomTransformersInDocument(doc)) {
@@ -757,7 +757,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         if (doc != null) {
             try {
                 Path tempPomPath = tempDir.resolve(commonRoot.relativize(pomPath));
-                Model effectiveModel = buildEffectiveModel(tempPomPath);
+                Model effectiveModel = buildEffectiveModel(context, tempPomPath);
                 Model currentModel = effectiveModel;
 
                 while (currentModel.getParent() != null) {
@@ -769,7 +769,7 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                             return true;
                         }
                         Path parentTempPath = tempDir.resolve(commonRoot.relativize(parentPath));
-                        currentModel = buildEffectiveModel(parentTempPath);
+                        currentModel = buildEffectiveModel(context, parentTempPath);
                     } else {
                         break;
                     }

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -19,12 +19,14 @@
 package org.apache.maven.cling.invoker.mvnup.goals;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Editor;
@@ -406,6 +408,20 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             return false;
         }
 
+        // For shade-plugin, check for custom ResourceTransformer implementations before upgrading.
+        // Custom transformers may depend on transitive dependencies (e.g. org.jdom:jdom) that
+        // are no longer present in newer shade-plugin versions, breaking the build.
+        if (isShadePlugin(upgrade.groupId, upgrade.artifactId)) {
+            List<String> customTransformers = findCustomTransformerClasses(pluginElement);
+            if (!customTransformers.isEmpty()) {
+                context.warning("Skipping maven-shade-plugin upgrade: plugin configuration uses custom "
+                        + "ResourceTransformer(s) " + customTransformers
+                        + " that may depend on transitive dependencies not available in version "
+                        + upgrade.minVersion + ". Upgrade manually after verifying compatibility.");
+                return false;
+            }
+        }
+
         // For Quarkus plugins, check the platform version before upgrading.
         // Upgrading quarkus-maven-plugin to 3.x when the project uses Quarkus 2.x
         // causes NoSuchMethodError and build failures.
@@ -670,6 +686,15 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         Map<Path, Set<String>> directOverrideResult = new HashMap<>();
         Map<String, PluginUpgrade> pluginUpgrades = getPluginUpgradesAsMap();
 
+        // Pre-check: if any local POM has shade-plugin with custom transformers,
+        // exclude it from effective model upgrades to avoid breaking the build
+        String shadePluginKey = DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-shade-plugin";
+        boolean shadeHasCustomTransformers = hasCustomTransformersInAnyPom(pomMap);
+        if (shadeHasCustomTransformers) {
+            pluginUpgrades = new HashMap<>(pluginUpgrades);
+            pluginUpgrades.remove(shadePluginKey);
+        }
+
         for (Map.Entry<Path, Document> entry : pomMap.entrySet()) {
             Path originalPomPath = entry.getKey();
 
@@ -710,6 +735,50 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         }
 
         return new PluginAnalysisResults(managementResult, directOverrideResult);
+    }
+
+    /**
+     * Checks if any POM document in the project contains a shade-plugin configuration
+     * with custom ResourceTransformer implementations.
+     */
+    private boolean hasCustomTransformersInAnyPom(Map<Path, Document> pomMap) {
+        for (Document doc : pomMap.values()) {
+            Element root = doc.root();
+            Element buildElement = root.childElement(BUILD).orElse(null);
+            if (buildElement != null) {
+                // Check both build/plugins and build/pluginManagement/plugins
+                boolean found = Stream.concat(
+                                collectShadePluginElements(
+                                        buildElement.childElement(PLUGINS).orElse(null)),
+                                collectShadePluginElements(buildElement
+                                        .childElement(PLUGIN_MANAGEMENT)
+                                        .flatMap(pm -> pm.childElement(PLUGINS))
+                                        .orElse(null)))
+                        .anyMatch(pluginElement ->
+                                !findCustomTransformerClasses(pluginElement).isEmpty());
+                if (found) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Collects shade-plugin {@code <plugin>} elements from a {@code <plugins>} element.
+     */
+    private Stream<Element> collectShadePluginElements(Element pluginsElement) {
+        if (pluginsElement == null) {
+            return Stream.empty();
+        }
+        return pluginsElement.childElements(PLUGIN).filter(pluginElement -> {
+            String groupId = getChildText(pluginElement, GROUP_ID);
+            String artifactId = getChildText(pluginElement, ARTIFACT_ID);
+            if (groupId == null && artifactId != null && artifactId.startsWith(MAVEN_PLUGIN_PREFIX)) {
+                groupId = DEFAULT_MAVEN_PLUGIN_GROUP_ID;
+            }
+            return isShadePlugin(groupId, artifactId);
+        });
     }
 
     /**
@@ -1052,6 +1121,68 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
 
     private record PluginAnalysisResults(
             Map<Path, Set<String>> pluginsNeedingManagement, Map<Path, Set<String>> pluginsNeedingDirectOverride) {}
+
+    /**
+     * Checks if the given plugin is the maven-shade-plugin.
+     */
+    private boolean isShadePlugin(String groupId, String artifactId) {
+        return "maven-shade-plugin".equals(artifactId) && DEFAULT_MAVEN_PLUGIN_GROUP_ID.equals(groupId);
+    }
+
+    /**
+     * The package prefix for standard ResourceTransformer implementations shipped with maven-shade-plugin.
+     * Any transformer class not starting with this prefix is considered custom and may depend on
+     * transitive dependencies that differ between shade-plugin versions.
+     */
+    private static final String SHADE_RESOURCE_PACKAGE = "org.apache.maven.plugins.shade.resource.";
+
+    /**
+     * Finds custom (non-standard) ResourceTransformer implementation classes in a shade-plugin
+     * configuration. Inspects both top-level {@code <configuration>} and per-execution
+     * {@code <executions>/<execution>/<configuration>} blocks.
+     *
+     * <p>A transformer is considered "custom" if its {@code implementation} attribute does not
+     * start with {@code org.apache.maven.plugins.shade.resource.}.</p>
+     *
+     * @param pluginElement the shade-plugin {@code <plugin>} element
+     * @return a list of fully-qualified class names of custom transformers, empty if none found
+     */
+    List<String> findCustomTransformerClasses(Element pluginElement) {
+        List<String> customClasses = new ArrayList<>();
+
+        // Check top-level <configuration>
+        pluginElement
+                .childElement("configuration")
+                .ifPresent(config -> collectCustomTransformers(config, customClasses));
+
+        // Check <executions>/<execution>/<configuration>
+        pluginElement
+                .childElement("executions")
+                .ifPresent(executions -> executions
+                        .childElements("execution")
+                        .forEach(execution -> execution
+                                .childElement("configuration")
+                                .ifPresent(config -> collectCustomTransformers(config, customClasses))));
+
+        return customClasses;
+    }
+
+    /**
+     * Collects custom transformer class names from a {@code <configuration>} element.
+     * Looks for {@code <transformers>/<transformer implementation="...">} entries.
+     */
+    private void collectCustomTransformers(Element configElement, List<String> customClasses) {
+        configElement
+                .childElement("transformers")
+                .ifPresent(transformers -> transformers
+                        .childElements("transformer")
+                        .forEach(transformer -> {
+                            String impl = transformer.attribute("implementation");
+                            if (impl != null && !impl.isEmpty() && !impl.startsWith(SHADE_RESOURCE_PACKAGE)) {
+                                customClasses.add(impl);
+                            }
+                        }));
+    }
 
     /**
      * Checks if the given plugin is a Quarkus Maven plugin.

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -684,16 +684,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             UpgradeContext context, Map<Path, Document> pomMap, Path tempDir) {
         Map<Path, Set<String>> managementResult = new HashMap<>();
         Map<Path, Set<String>> directOverrideResult = new HashMap<>();
-        Map<String, PluginUpgrade> pluginUpgrades = getPluginUpgradesAsMap();
-
-        // Pre-check: if any local POM has shade-plugin with custom transformers,
-        // exclude it from effective model upgrades to avoid breaking the build
+        Map<String, PluginUpgrade> basePluginUpgrades = getPluginUpgradesAsMap();
         String shadePluginKey = DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-shade-plugin";
-        boolean shadeHasCustomTransformers = hasCustomTransformersInAnyPom(pomMap);
-        if (shadeHasCustomTransformers) {
-            pluginUpgrades = new HashMap<>(pluginUpgrades);
-            pluginUpgrades.remove(shadePluginKey);
-        }
 
         for (Map.Entry<Path, Document> entry : pomMap.entrySet()) {
             Path originalPomPath = entry.getKey();
@@ -703,6 +695,17 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 Path commonRoot = findCommonRoot(pomMap.keySet());
                 Path relativePath = commonRoot.relativize(originalPomPath);
                 Path tempPomPath = tempDir.resolve(relativePath);
+
+                // Per-module check: if this POM or any of its local parent POMs
+                // has shade-plugin with custom transformers, exclude shade-plugin
+                // from upgrades for this module only
+                Map<String, PluginUpgrade> pluginUpgrades = basePluginUpgrades;
+                if (hasCustomTransformersInPomOrParents(originalPomPath, pomMap, tempDir, commonRoot)) {
+                    pluginUpgrades = new HashMap<>(basePluginUpgrades);
+                    pluginUpgrades.remove(shadePluginKey);
+                    context.warning("Skipping maven-shade-plugin in effective-model analysis for " + originalPomPath
+                            + ": custom ResourceTransformer(s) found in project POMs");
+                }
 
                 // Build effective model using Maven 4 API
                 PluginAnalysis analysis = analyzeEffectiveModelForPlugins(context, tempPomPath, pluginUpgrades);
@@ -738,28 +741,65 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
     }
 
     /**
-     * Checks if any POM document in the project contains a shade-plugin configuration
+     * Checks if a specific POM or any of its local parent POMs (within pomMap)
+     * contains a shade-plugin configuration with custom ResourceTransformer implementations.
+     * This is a per-module check, unlike a global check across all POMs.
+     */
+    private boolean hasCustomTransformersInPomOrParents(
+            Path pomPath, Map<Path, Document> pomMap, Path tempDir, Path commonRoot) {
+        // Check the current POM
+        Document doc = pomMap.get(pomPath);
+        if (doc != null && hasCustomTransformersInDocument(doc)) {
+            return true;
+        }
+
+        // Walk up the parent hierarchy within the local pomMap
+        if (doc != null) {
+            try {
+                Path tempPomPath = tempDir.resolve(commonRoot.relativize(pomPath));
+                Model effectiveModel = buildEffectiveModel(tempPomPath);
+                Model currentModel = effectiveModel;
+
+                while (currentModel.getParent() != null) {
+                    Parent parent = currentModel.getParent();
+                    Path parentPath = findParentInPomMap(parent, pomMap);
+                    if (parentPath != null) {
+                        Document parentDoc = pomMap.get(parentPath);
+                        if (parentDoc != null && hasCustomTransformersInDocument(parentDoc)) {
+                            return true;
+                        }
+                        Path parentTempPath = tempDir.resolve(commonRoot.relativize(parentPath));
+                        currentModel = buildEffectiveModel(parentTempPath);
+                    } else {
+                        break;
+                    }
+                }
+            } catch (Exception e) {
+                // If we can't resolve parents, be conservative and check just this POM
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if a single POM document contains a shade-plugin configuration
      * with custom ResourceTransformer implementations.
      */
-    private boolean hasCustomTransformersInAnyPom(Map<Path, Document> pomMap) {
-        for (Document doc : pomMap.values()) {
-            Element root = doc.root();
-            Element buildElement = root.childElement(BUILD).orElse(null);
-            if (buildElement != null) {
-                // Check both build/plugins and build/pluginManagement/plugins
-                boolean found = Stream.concat(
-                                collectShadePluginElements(
-                                        buildElement.childElement(PLUGINS).orElse(null)),
-                                collectShadePluginElements(buildElement
-                                        .childElement(PLUGIN_MANAGEMENT)
-                                        .flatMap(pm -> pm.childElement(PLUGINS))
-                                        .orElse(null)))
-                        .anyMatch(pluginElement ->
-                                !findCustomTransformerClasses(pluginElement).isEmpty());
-                if (found) {
-                    return true;
-                }
-            }
+    private boolean hasCustomTransformersInDocument(Document doc) {
+        Element root = doc.root();
+        Element buildElement = root.childElement(BUILD).orElse(null);
+        if (buildElement != null) {
+            // Check both build/plugins and build/pluginManagement/plugins
+            return Stream.concat(
+                            collectShadePluginElements(
+                                    buildElement.childElement(PLUGINS).orElse(null)),
+                            collectShadePluginElements(buildElement
+                                    .childElement(PLUGIN_MANAGEMENT)
+                                    .flatMap(pm -> pm.childElement(PLUGINS))
+                                    .orElse(null)))
+                    .anyMatch(pluginElement ->
+                            !findCustomTransformerClasses(pluginElement).isEmpty());
         }
         return false;
     }

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeShadeTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeShadeTest.java
@@ -1,0 +1,536 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnup.goals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.Editor;
+import eu.maveniverse.domtrip.Element;
+import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for shade-plugin custom ResourceTransformer detection in {@link PluginUpgradeStrategy}.
+ * Verifies that mvnup skips shade-plugin upgrades when custom transformers are present
+ * (see <a href="https://github.com/apache/maven/issues/12991">MAVEN-12991</a>).
+ */
+@DisplayName("PluginUpgradeStrategy — Shade Plugin Custom Transformers")
+class PluginUpgradeShadeTest {
+
+    private PluginUpgradeStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new PluginUpgradeStrategy();
+    }
+
+    private UpgradeContext createMockContext() {
+        return TestUtils.createMockContext();
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade when custom ResourceTransformer is present")
+    void shouldSkipUpgradeWithCustomTransformer() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <executions>
+                                    <execution>
+                                        <goals>
+                                            <goal>shade</goal>
+                                        </goals>
+                                        <configuration>
+                                            <transformers>
+                                                <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                            </transformers>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        UpgradeResult result = strategy.doApply(context, pomMap);
+
+        assertTrue(result.success(), "Strategy should succeed without errors");
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+
+        // Verify a warning was logged
+        verify(context.logger, atLeastOnce())
+                .warn(argThat(msg -> msg.contains("Skipping maven-shade-plugin upgrade")
+                        && msg.contains("custom ResourceTransformer")
+                        && msg.contains("BeansXmlTransformer")));
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade when custom transformer is in top-level configuration")
+    void shouldSkipUpgradeWithCustomTransformerInTopLevelConfig() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="com.example.CustomTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should upgrade shade-plugin when only standard transformers are present")
+    void shouldUpgradeWithStandardTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>com.example.Main</mainClass>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        UpgradeResult result = strategy.doApply(context, pomMap);
+
+        assertTrue(result.success(), "Plugin upgrade should succeed");
+        assertTrue(result.modifiedCount() > 0, "Should have upgraded shade plugin");
+
+        // Verify the version WAS upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("3.5.0", version, "Shade plugin version should be upgraded to 3.5.0");
+    }
+
+    @Test
+    @DisplayName("should upgrade shade-plugin when no transformers are configured")
+    void shouldUpgradeWithNoTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        UpgradeResult result = strategy.doApply(context, pomMap);
+
+        assertTrue(result.success(), "Plugin upgrade should succeed");
+        assertTrue(result.modifiedCount() > 0, "Should have upgraded shade plugin");
+
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("3.5.0", version, "Shade plugin version should be upgraded to 3.5.0");
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade with mixed standard and custom transformers")
+    void shouldSkipUpgradeWithMixedTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <executions>
+                                    <execution>
+                                        <configuration>
+                                            <transformers>
+                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                                <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                            </transformers>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade with property version and custom transformers")
+    void shouldSkipUpgradeWithPropertyVersionAndCustomTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <properties>
+                        <shade.plugin.version>1.3.3</shade.plugin.version>
+                    </properties>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>${shade.plugin.version}</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the property was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("properties", "shade.plugin.version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin property should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade without explicit groupId when custom transformers present")
+    void shouldSkipUpgradeWithoutGroupIdAndCustomTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="com.example.CustomTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should detect custom transformers in pluginManagement section")
+    void shouldSkipUpgradeWithCustomTransformerInPluginManagement() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-shade-plugin</artifactId>
+                                    <version>1.3.3</version>
+                                    <configuration>
+                                        <transformers>
+                                            <transformer implementation="com.example.CustomTransformer"/>
+                                        </transformers>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "pluginManagement", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version in pluginManagement should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("findCustomTransformerClasses should return custom class names")
+    void findCustomTransformerClassesShouldReturnCustomClassNames() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <executions>
+                                    <execution>
+                                        <configuration>
+                                            <transformers>
+                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                                <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                                <transformer implementation="com.example.AnotherTransformer"/>
+                                            </transformers>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Element pluginElement =
+                document.root().path("build", "plugins", "plugin").orElseThrow();
+
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+
+        assertEquals(2, customTransformers.size(), "Should find exactly 2 custom transformers");
+        assertTrue(
+                customTransformers.contains("org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"),
+                "Should contain BeansXmlTransformer");
+        assertTrue(customTransformers.contains("com.example.AnotherTransformer"), "Should contain AnotherTransformer");
+    }
+
+    @Test
+    @DisplayName("findCustomTransformerClasses should return empty for standard transformers only")
+    void findCustomTransformerClassesShouldReturnEmptyForStandardTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Element pluginElement =
+                document.root().path("build", "plugins", "plugin").orElseThrow();
+
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+
+        assertTrue(customTransformers.isEmpty(), "Should not find any custom transformers");
+    }
+
+    @Test
+    @DisplayName("findCustomTransformerClasses should return empty when no transformers configured")
+    void findCustomTransformerClassesShouldReturnEmptyWhenNoTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Element pluginElement =
+                document.root().path("build", "plugins", "plugin").orElseThrow();
+
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+
+        assertTrue(customTransformers.isEmpty(), "Should not find any custom transformers");
+    }
+}


### PR DESCRIPTION
## Summary

- Detects custom (non-standard) `ResourceTransformer` implementations in `maven-shade-plugin` configuration before upgrading the plugin version
- Skips the upgrade and emits a warning when custom transformers are found, preventing silent build breakage
- Covers both direct POM declarations and effective model analysis (inherited plugins)

## Problem

`mvnup` upgrades `maven-shade-plugin` from old versions (e.g. 1.3.3) to 3.5.0 for Maven 4 compatibility. However, projects using custom `ResourceTransformer` implementations (e.g. `BeansXmlTransformer` in myfaces-extcdi) may depend on transitive dependencies like `org.jdom:jdom` that were available in old shade-plugin versions but removed in newer ones. The upgrade silently breaks these projects.

## Solution

Added detection logic (following the existing Quarkus plugin skip pattern) that inspects `<configuration>/<transformers>/<transformer implementation="...">` elements in both top-level and per-execution configurations. Transformers whose `implementation` class does not start with `org.apache.maven.plugins.shade.resource.` are considered custom. When found, the upgrade is skipped with a warning message advising manual upgrade.

## Test plan

- [x] 11 new tests in `PluginUpgradeShadeTest` covering all scenarios
- [x] Custom transformer in execution config → skip upgrade
- [x] Custom transformer in top-level config → skip upgrade
- [x] Standard transformers only → upgrade proceeds
- [x] No transformers → upgrade proceeds
- [x] Mixed standard + custom → skip upgrade
- [x] Property-based version with custom transformers → skip upgrade
- [x] Without explicit groupId + custom transformers → skip upgrade
- [x] Custom transformers in pluginManagement → skip upgrade
- [x] Unit tests for `findCustomTransformerClasses` method
- [x] All 42 existing `PluginUpgradeStrategyTest` tests pass
- [x] All 10 existing `PluginUpgradeQuarkusTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)