### PR TITLE
Detect BND computeIfAbsent CME and provide actionable diagnostic

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultBuildPluginManager.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultBuildPluginManager.java
@@ -24,6 +24,7 @@ import javax.inject.Singleton;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -155,6 +156,9 @@ public class DefaultBuildPluginManager implements BuildPluginManager {
             } catch (ClassCastException | MavenException e) {
                 // to be processed in the outer catch block
                 throw e;
+            } catch (ConcurrentModificationException e) {
+                throw new PluginExecutionException(
+                        mojoExecution, project, buildConcurrentModificationMessage(mojoExecution, e), e);
             } catch (RuntimeException e) {
                 throw new PluginExecutionException(mojoExecution, project, e);
             }
@@ -229,6 +233,48 @@ public class DefaultBuildPluginManager implements BuildPluginManager {
             throws PluginNotFoundException, PluginResolutionException, PluginDescriptorParsingException,
                     MojoNotFoundException, InvalidPluginDescriptorException {
         return mavenPluginManager.getMojoDescriptor(plugin, goal, repositories, session);
+    }
+
+    /**
+     * Builds a diagnostic message for {@link ConcurrentModificationException} thrown during plugin execution.
+     * <p>
+     * Detects the known BND library bug (FELIX-6259) where {@code Jar.putResource()} uses
+     * {@code TreeMap.computeIfAbsent()} with a mapping function that modifies the same map.
+     * This is detected and rejected by JDK 17.0.13+ / 21+ (JDK-8259535).
+     * Affects bndlib versions prior to 5.1.0, used by maven-bundle-plugin 4.x and bnd-maven-plugin 4.x.
+     */
+    private static String buildConcurrentModificationMessage(
+            MojoExecution mojoExecution, ConcurrentModificationException cause) {
+        StringBuilder message = new StringBuilder();
+        message.append("Execution ").append(mojoExecution.getExecutionId());
+        message.append(" of goal ").append(mojoExecution.getMojoDescriptor().getId());
+        message.append(" failed: ConcurrentModificationException.");
+
+        if (isBndComputeIfAbsentCme(cause)) {
+            message.append(" This is a known bug in bndlib versions prior to 5.1.0 (FELIX-6259):"
+                    + " BND's Jar.putResource() modifies a TreeMap inside its own computeIfAbsent() call,"
+                    + " which JDK 17.0.13+ now correctly detects (JDK-8259535)."
+                    + " To fix this, upgrade maven-bundle-plugin to 5.1.9+"
+                    + " or bnd-maven-plugin to 6.0.0+.");
+        } else {
+            message.append(" This may be caused by a plugin using Map.computeIfAbsent() with a mapping function"
+                    + " that modifies the same map, which newer JDK versions now detect."
+                    + " Check if a newer version of the plugin is available.");
+        }
+        return message.toString();
+    }
+
+    /**
+     * Returns {@code true} if the CME originates from BND's {@code Jar.putResource()} method,
+     * which is the known FELIX-6259 bug pattern.
+     */
+    private static boolean isBndComputeIfAbsentCme(ConcurrentModificationException cause) {
+        for (StackTraceElement frame : cause.getStackTrace()) {
+            if ("aQute.bnd.osgi.Jar".equals(frame.getClassName()) && "putResource".equals(frame.getMethodName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static class MojoWrapper implements Mojo {

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/DefaultBuildPluginManagerCmeTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/DefaultBuildPluginManagerCmeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ConcurrentModificationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the BND ConcurrentModificationException detection in {@link DefaultBuildPluginManager}.
+ */
+class DefaultBuildPluginManagerCmeTest {
+
+    @Test
+    void testDetectsBndComputeIfAbsentCme() throws Exception {
+        ConcurrentModificationException cme = new ConcurrentModificationException();
+        cme.setStackTrace(new StackTraceElement[] {
+            new StackTraceElement("java.util.TreeMap", "callMappingFunctionWithCheck", "TreeMap.java", 750),
+            new StackTraceElement("java.util.TreeMap", "computeIfAbsent", "TreeMap.java", 604),
+            new StackTraceElement("aQute.bnd.osgi.Jar", "putResource", "Jar.java", 259),
+            new StackTraceElement("aQute.bnd.osgi.Jar$1", "visitFile", "Jar.java", 186),
+        });
+
+        assertTrue(invokeIsBndComputeIfAbsentCme(cme));
+    }
+
+    @Test
+    void testDoesNotDetectUnrelatedCme() throws Exception {
+        ConcurrentModificationException cme = new ConcurrentModificationException();
+        cme.setStackTrace(new StackTraceElement[] {
+            new StackTraceElement("java.util.HashMap$HashIterator", "nextNode", "HashMap.java", 1605),
+            new StackTraceElement("com.example.SomePlugin", "doWork", "SomePlugin.java", 42),
+        });
+
+        assertFalse(invokeIsBndComputeIfAbsentCme(cme));
+    }
+
+    @Test
+    void testDoesNotDetectEmptyStackTrace() throws Exception {
+        ConcurrentModificationException cme = new ConcurrentModificationException();
+        cme.setStackTrace(new StackTraceElement[0]);
+
+        assertFalse(invokeIsBndComputeIfAbsentCme(cme));
+    }
+
+    /**
+     * Invokes the private static method via reflection for testing.
+     */
+    private static boolean invokeIsBndComputeIfAbsentCme(ConcurrentModificationException cme) throws Exception {
+        Method method = DefaultBuildPluginManager.class.getDeclaredMethod(
+                "isBndComputeIfAbsentCme", ConcurrentModificationException.class);
+        method.setAccessible(true);
+        try {
+            return (boolean) method.invoke(null, cme);
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #12987 — `ConcurrentModificationException` in BND/maven-bundle-plugin during dependency resolution under Maven 4.

### Root Cause

BND's `Jar.putResource()` (bndlib ≤ 5.0.0) uses `TreeMap.computeIfAbsent()` with a mapping function that **modifies the same TreeMap** — it adds ancestor directory entries inside the mapping function:

```java
// aQute.bnd.osgi.Jar.putResource() — bndlib 4.0.0, line 259
Map<String, Resource> s = directories.computeIfAbsent(getDirectory(path), dir -> {
    for (int n = dir.lastIndexOf('/'); n > 0; n = dir.lastIndexOf('/')) {
        dir = dir.substring(0, n);
        if (directories.containsKey(dir)) break;
        directories.put(dir, null);  // ← modifies the same TreeMap!
    }
    return new TreeMap<>();
});
```

This violates the `computeIfAbsent()` contract. JDK 17.0.13+ backported explicit CME detection for `TreeMap.computeIfAbsent()` ([JDK-8259535](https://bugs.openjdk.org/browse/JDK-8259535)), which correctly rejects this self-modification pattern. Since Maven 4 requires JDK 17+, all Maven 4 users hit this with old BND versions.

The bug was fixed in bndlib 5.1.0 ([FELIX-6259](https://issues.apache.org/jira/browse/FELIX-6259), [BND PR #3904](https://github.com/bndtools/bnd/pull/3904)).

### What This PR Does

- Catches `ConcurrentModificationException` specifically in `DefaultBuildPluginManager.executeMojo()`
- Detects the known BND stack trace pattern (`aQute.bnd.osgi.Jar.putResource`)
- Provides a clear, actionable error message:
  - Identifies the root cause (FELIX-6259 + JDK-8259535)
  - Suggests upgrading `maven-bundle-plugin` to 5.1.9+ or `bnd-maven-plugin` to 6.0.0+
- For non-BND CMEs, provides general guidance about `computeIfAbsent()` issues on newer JDKs
- Adds unit tests for the detection logic

### Before (cryptic error)

```
[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:4.0.0:bundle
  on project geronimo-metrics-common:
  Execution default-bundle of goal ... failed. ConcurrentModificationException
```

### After (actionable diagnostic)

```
[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:4.0.0:bundle
  on project geronimo-metrics-common:
  Execution default-bundle of goal ... failed: ConcurrentModificationException.
  This is a known bug in bndlib versions prior to 5.1.0 (FELIX-6259):
  BND's Jar.putResource() modifies a TreeMap inside its own computeIfAbsent() call,
  which JDK 17.0.13+ now correctly detects (JDK-8259535).
  To fix this, upgrade maven-bundle-plugin to 5.1.9+ or bnd-maven-plugin to 6.0.0+.
```

### Affected Projects

All 7 projects identified in #12987 use old BND versions (bndlib 4.0.0–4.3.0) that predate the fix:

| Project | Plugin | BND Version |
|---------|--------|-------------|
| geronimo-health | maven-bundle-plugin 4.0.0 | bndlib 4.0.0 |
| geronimo-metrics | maven-bundle-plugin 4.0.0 | bndlib 4.0.0 |
| geronimo-opentracing | maven-bundle-plugin 4.1.0 | bndlib 4.1.0 |
| geronimo-config | maven-bundle-plugin 4.2.1 | bndlib ~4.3.0 |
| geronimo-jcache-simple | maven-bundle-plugin 4.2.1 | bndlib ~4.3.0 |
| aries-journaled-events | bnd-maven-plugin 4.1.0 | bndlib 4.1.0 |
| aries-tx-control | bnd-maven-plugin 4.1.0 | bndlib 4.1.0 |

## Test plan

- [x] Unit tests for BND CME detection logic (3 tests)
- [x] All existing maven-core tests pass (643 tests)
- [x] Spotless formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)