### PR TITLE
mvnup: upgrade BND plugins to fix ConcurrentModificationException on JDK 17.0.13+

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -155,7 +155,21 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     DEFAULT_MAVEN_PLUGIN_GROUP_ID,
                     "maven-ear-plugin",
                     "3.4.0",
-                    "Older versions use plexus-archiver reflection blocked by JDK 17+ module system"));
+                    "Older versions use plexus-archiver reflection blocked by JDK 17+ module system"),
+            new PluginUpgrade(
+                    "org.apache.felix",
+                    "maven-bundle-plugin",
+                    "5.1.1",
+                    "Versions before 5.1.1 use bndlib < 5.1.0 whose Jar.putResource() modifies a TreeMap inside"
+                            + " computeIfAbsent(), throwing ConcurrentModificationException on JDK 17.0.13+"
+                            + " (FELIX-6259, JDK-8259535)"),
+            new PluginUpgrade(
+                    "biz.aQute.bnd",
+                    "bnd-maven-plugin",
+                    "5.1.0",
+                    "Versions before 5.1.0 have a Jar.putResource() bug that modifies a TreeMap inside"
+                            + " computeIfAbsent(), throwing ConcurrentModificationException on JDK 17.0.13+"
+                            + " (FELIX-6259, JDK-8259535)"));
 
     private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
             "org.codehaus.mojo",

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -160,16 +160,14 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     "org.apache.felix",
                     "maven-bundle-plugin",
                     "5.1.1",
-                    "Versions before 5.1.1 use bndlib < 5.1.0 whose Jar.putResource() modifies a TreeMap inside"
-                            + " computeIfAbsent(), throwing ConcurrentModificationException on JDK 17.0.13+"
-                            + " (FELIX-6259, JDK-8259535)"),
+                    "Versions before 5.1.1 use bndlib < 5.1.0 which has internal collection mutation bugs"
+                            + " (FELIX-6259) that throw ConcurrentModificationException on JDK 17+"),
             new PluginUpgrade(
                     "biz.aQute.bnd",
                     "bnd-maven-plugin",
                     "5.1.0",
-                    "Versions before 5.1.0 have a Jar.putResource() bug that modifies a TreeMap inside"
-                            + " computeIfAbsent(), throwing ConcurrentModificationException on JDK 17.0.13+"
-                            + " (FELIX-6259, JDK-8259535)"));
+                    "Versions before 5.1.0 have internal collection mutation bugs (FELIX-6259)"
+                            + " that throw ConcurrentModificationException on JDK 17+"));
 
     private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
             "org.codehaus.mojo",

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategyTest.java
@@ -504,6 +504,72 @@ class PluginUpgradeStrategyTest {
         }
 
         @Test
+        @DisplayName("should upgrade maven-bundle-plugin when below minimum")
+        void shouldUpgradeBundlePluginWhenBelowMinimum() throws Exception {
+            Document doc = PomBuilder.create()
+                    .plugin("org.apache.felix", "maven-bundle-plugin", "4.2.1")
+                    .buildDocument();
+            UpgradeResult result = strategy.doApply(createMockContext(), Map.of(Paths.get("pom.xml"), doc));
+
+            assertTrue(result.success() && result.modifiedCount() > 0, "Should have upgraded maven-bundle-plugin");
+            String version = new Editor(doc)
+                    .root()
+                    .path("build", "plugins", "plugin", "version")
+                    .map(Element::textContentTrimmed)
+                    .orElse(null);
+            assertEquals("5.1.1", version, "maven-bundle-plugin should be upgraded to 5.1.1");
+        }
+
+        @Test
+        @DisplayName("should not upgrade maven-bundle-plugin when version is already sufficient")
+        void shouldNotUpgradeBundlePluginWhenSufficient() throws Exception {
+            Document doc = PomBuilder.create()
+                    .plugin("org.apache.felix", "maven-bundle-plugin", "5.1.9")
+                    .buildDocument();
+            strategy.doApply(createMockContext(), Map.of(Paths.get("pom.xml"), doc));
+
+            String version = new Editor(doc)
+                    .root()
+                    .path("build", "plugins", "plugin", "version")
+                    .map(Element::textContentTrimmed)
+                    .orElse(null);
+            assertEquals("5.1.9", version, "maven-bundle-plugin 5.1.9 should not be downgraded");
+        }
+
+        @Test
+        @DisplayName("should upgrade bnd-maven-plugin when below minimum")
+        void shouldUpgradeBndMavenPluginWhenBelowMinimum() throws Exception {
+            Document doc = PomBuilder.create()
+                    .plugin("biz.aQute.bnd", "bnd-maven-plugin", "4.1.0")
+                    .buildDocument();
+            UpgradeResult result = strategy.doApply(createMockContext(), Map.of(Paths.get("pom.xml"), doc));
+
+            assertTrue(result.success() && result.modifiedCount() > 0, "Should have upgraded bnd-maven-plugin");
+            String version = new Editor(doc)
+                    .root()
+                    .path("build", "plugins", "plugin", "version")
+                    .map(Element::textContentTrimmed)
+                    .orElse(null);
+            assertEquals("5.1.0", version, "bnd-maven-plugin should be upgraded to 5.1.0");
+        }
+
+        @Test
+        @DisplayName("should not upgrade bnd-maven-plugin when version is already sufficient")
+        void shouldNotUpgradeBndMavenPluginWhenSufficient() throws Exception {
+            Document doc = PomBuilder.create()
+                    .plugin("biz.aQute.bnd", "bnd-maven-plugin", "7.0.0")
+                    .buildDocument();
+            strategy.doApply(createMockContext(), Map.of(Paths.get("pom.xml"), doc));
+
+            String version = new Editor(doc)
+                    .root()
+                    .path("build", "plugins", "plugin", "version")
+                    .map(Element::textContentTrimmed)
+                    .orElse(null);
+            assertEquals("7.0.0", version, "bnd-maven-plugin 7.0.0 should not be downgraded");
+        }
+
+        @Test
         @DisplayName("should not upgrade when version is already higher")
         void shouldNotUpgradeWhenVersionAlreadyHigher() throws Exception {
             String pomXml = """
@@ -813,7 +879,9 @@ class PluginUpgradeStrategyTest {
                     "maven-failsafe-plugin",
                     "maven-surefire-report-plugin",
                     "maven-war-plugin",
-                    "maven-ear-plugin")) {
+                    "maven-ear-plugin",
+                    "maven-bundle-plugin",
+                    "bnd-maven-plugin")) {
                 assertTrue(
                         upgrades.stream().anyMatch(u -> expected.equals(u.artifactId())),
                         "Should include " + expected + " upgrade");


### PR DESCRIPTION
## Summary

- Add `maven-bundle-plugin` (≥ 5.1.1) and `bnd-maven-plugin` (≥ 5.1.0) to mvnup's `PluginUpgradeStrategy` so that `mvn mvnup:check` / `mvn mvnup:apply` detects and upgrades these plugins automatically
- bndlib < 5.1.0 has a bug ([FELIX-6259](https://issues.apache.org/jira/browse/FELIX-6259)) where `Jar.putResource()` modifies a `TreeMap` inside its own `computeIfAbsent()` call — JDK 17.0.13+ backported CME detection ([JDK-8259535](https://bugs.openjdk.org/browse/JDK-8259535)) that correctly rejects this, causing `ConcurrentModificationException` on every Maven 4 build using old BND plugins
- Affects 7+ Apache projects (geronimo-health, geronimo-metrics, geronimo-opentracing, geronimo-config, geronimo-jcache-simple, aries-journaled-events, aries-tx-control)

Fixes #12987

## Test plan

- [x] 4 new unit tests in `PluginUpgradeStrategyTest`: upgrade when below minimum + no-op when already sufficient, for both plugins
- [x] Updated `shouldHavePredefinedPluginUpgrades` configuration test to include both new plugins
- [x] All 46 tests in `PluginUpgradeStrategyTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)