### PR TITLE
[3.9.x] Apply session authentication to descriptor repositories by provenance

### DIFF
--- a/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -144,7 +144,12 @@ class DefaultModelResolver implements ModelResolver {
         List<RemoteRepository> newRepositories =
                 Collections.singletonList(ArtifactDescriptorUtils.toRemoteRepository(repository));
 
-        this.repositories = remoteRepositoryManager.aggregateRepositories(session, repositories, newRepositories, true);
+        // The model being built is an artifact descriptor resolved from a repository, so the
+        // repositories it declares are remotely supplied input: they are merged recessively and
+        // flagged as descriptor-declared, which lets the repository manager withhold session
+        // authentication from them unless an operator-defined mirror captures them.
+        this.repositories =
+                remoteRepositoryManager.aggregateRepositories(session, repositories, newRepositories, true, true);
     }
 
     private static void removeMatchingRepository(Iterable<RemoteRepository> repositories, final String id) {

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ under the License.
     <!-- plexus-cipher 2.1.0 uses an incompatible KDF; ciphertext encrypted with 2.0 will no longer decrypt — see #12811. Do not bump on this branch. -->
     <cipherVersion>2.0</cipherVersion>
     <jxpathVersion>1.4.0</jxpathVersion>
-    <resolverVersion>1.9.27</resolverVersion>
+    <resolverVersion>1.9.28-SNAPSHOT</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <xmlunitVersion>2.13.0</xmlunitVersion>
     <powermockVersion>2.0.9</powermockVersion>


### PR DESCRIPTION
`DefaultModelResolver` in `maven-resolver-provider` builds the models of artifact descriptors resolved from repositories (dependency POMs and their parents and imports). The repositories those models declare are remotely supplied input, but they were aggregated with the same call as build-supplied repositories, so a `<server>` in `settings.xml` whose id matched a repository id in a downloaded POM had its credentials attached to that repository.

maven-resolver 1.9.28 (apache/maven-resolver#2092) adds an `aggregateRepositories` overload with a provenance flag: descriptor-declared repositories receive session authentication only when an operator-defined mirror captures them, and `aether.remoteRepositoryManager.authToDescriptorRepositories=true` restores the previous behaviour. This passes that flag from the one call site that builds descriptor models. `ProjectModelResolver` builds the project's own model and parents, which are operator-chosen, and keeps the four-argument call.

Blocked on the maven-resolver 1.9.28 release: the second commit bumps `resolverVersion` to `1.9.28-SNAPSHOT` as a build aid and must be dropped, and the first commit does not compile against 1.9.27.

Verified: `mvn -pl maven-resolver-provider,maven-core -am verify` against 1.9.28-SNAPSHOT → 363 tests, 0 failures.

*This change was created with AI assistance.*