### PR TITLE
Apply session authentication to descriptor repositories by provenance

### DIFF
--- a/api/maven-api-core/src/main/java/org/apache/maven/api/services/RepositoryFactory.java
+++ b/api/maven-api-core/src/main/java/org/apache/maven/api/services/RepositoryFactory.java
@@ -52,4 +52,36 @@ public interface RepositoryFactory extends Service {
             @Nonnull List<RemoteRepository> dominant,
             @Nonnull List<RemoteRepository> recessive,
             boolean processRecessive);
+
+    /**
+     * Aggregates repository definitions by merging duplicate repositories and optionally applying mirror, proxy and
+     * authentication settings from the session, additionally distinguishing the provenance of the recessive
+     * repository definitions. Repositories declared by a model that was resolved from a repository (a dependency
+     * POM, or one of its parents or imports) are remotely supplied input: session authentication is applied to them
+     * only when an operator-defined mirror has been selected for them. Repositories supplied by the build itself
+     * (the project's own POM and parents, request or settings repositories) keep receiving mirror, proxy and
+     * authentication settings as documented for {@link #aggregate(Session, List, List, boolean)}.
+     * <p>
+     * The default implementation ignores the provenance hint and delegates to
+     * {@link #aggregate(Session, List, List, boolean)}.
+     *
+     * @param session the session during which the repositories will be accessed
+     * @param dominant the current list of remote repositories to merge the new definitions into
+     * @param recessive the remote repositories to merge into the existing list
+     * @param processRecessive {@code true} if the recessive repository definitions have not yet been subjected to
+     *            mirror, proxy and authentication settings, {@code false} otherwise
+     * @param recessiveFromDescriptor {@code true} if the recessive repository definitions were declared by a model
+     *            resolved from a repository rather than by the build itself, {@code false} otherwise
+     * @return the aggregated list of remote repositories
+     * @since 4.1.0
+     */
+    @Nonnull
+    default List<RemoteRepository> aggregate(
+            @Nonnull Session session,
+            @Nonnull List<RemoteRepository> dominant,
+            @Nonnull List<RemoteRepository> recessive,
+            boolean processRecessive,
+            boolean recessiveFromDescriptor) {
+        return aggregate(session, dominant, recessive, processRecessive);
+    }
 }

--- a/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
+++ b/compat/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java
@@ -145,7 +145,12 @@ class DefaultModelResolver implements ModelResolver {
         List<RemoteRepository> newRepositories =
                 Collections.singletonList(ArtifactDescriptorUtils.toRemoteRepository(repository));
 
-        this.repositories = remoteRepositoryManager.aggregateRepositories(session, repositories, newRepositories, true);
+        // The model being built is an artifact descriptor resolved from a repository, so the
+        // repositories it declares are remotely supplied input: they are merged recessively and
+        // flagged as descriptor-declared, which lets the repository manager withhold session
+        // authentication from them unless an operator-defined mirror captures them.
+        this.repositories =
+                remoteRepositoryManager.aggregateRepositories(session, repositories, newRepositories, true, true);
     }
 
     private static void removeMatchingRepository(Iterable<RemoteRepository> repositories, final String id) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRepositoryFactory.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/DefaultRepositoryFactory.java
@@ -71,12 +71,23 @@ public class DefaultRepositoryFactory implements RepositoryFactory {
             List<RemoteRepository> dominant,
             List<RemoteRepository> recessive,
             boolean processRecessive) {
+        return aggregate(session, dominant, recessive, processRecessive, false);
+    }
+
+    @Override
+    public List<RemoteRepository> aggregate(
+            Session session,
+            List<RemoteRepository> dominant,
+            List<RemoteRepository> recessive,
+            boolean processRecessive,
+            boolean recessiveFromDescriptor) {
         InternalSession internalSession = InternalSession.from(requireNonNull(session, "session"));
         List<org.eclipse.aether.repository.RemoteRepository> repos = remoteRepositoryManager.aggregateRepositories(
                 internalSession.getSession(),
                 internalSession.toRepositories(requireNonNull(dominant, "dominant")),
                 internalSession.toRepositories(requireNonNull(recessive, "recessive")),
-                processRecessive);
+                processRecessive,
+                recessiveFromDescriptor);
         return repos.stream()
                 .<RemoteRepository>map(DefaultRemoteRepository::new)
                 .toList();

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -695,12 +695,17 @@ public class DefaultModelBuilder implements ModelBuilder {
                 repos = repos.stream().filter(r -> !ids.contains(r.getId())).toList();
             }
 
+            // Repositories declared by a model resolved from a repository (a dependency POM, or a
+            // parent or import reached from one) are remotely supplied input; flag them so that
+            // session authentication is applied to them only through an operator-defined mirror.
+            // Repositories declared by the project's own POM and its parents are build-supplied
+            // and keep receiving session authentication.
             RepositoryFactory repositoryFactory = session.getService(RepositoryFactory.class);
             if (request.getRepositoryMerging() == ModelBuilderRequest.RepositoryMerging.REQUEST_DOMINANT) {
-                repositories = repositoryFactory.aggregate(session, repositories, repos, true);
+                repositories = repositoryFactory.aggregate(session, repositories, repos, true, externalOrigin);
                 pomRepositories = repositories;
             } else {
-                pomRepositories = repositoryFactory.aggregate(session, pomRepositories, repos, true);
+                pomRepositories = repositoryFactory.aggregate(session, pomRepositories, repos, true, externalOrigin);
                 repositories = repositoryFactory.aggregate(session, pomRepositories, externalRepositories, false);
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ under the License.
     <plexusInterpolationVersion>1.30.0</plexusInterpolationVersion>
     <plexusTestingVersion>2.2.0</plexusTestingVersion>
     <plexusXmlVersion>4.2.0</plexusXmlVersion>
-    <resolverVersion>2.0.22</resolverVersion>
+    <resolverVersion>2.0.23-SNAPSHOT</resolverVersion>
     <securityDispatcherVersion>4.2.0</securityDispatcherVersion>
     <sisuVersion>1.1.0</sisuVersion>
     <slf4jVersion>2.0.18</slf4jVersion>


### PR DESCRIPTION
Repositories declared by a model that was resolved from a repository (a dependency POM, or a parent or import reached from one) are remotely supplied input, but they were aggregated with the same `aggregate` call as build-supplied repositories, so a `<server>` in `settings.xml` whose id matched a repository id in a downloaded POM had its credentials attached to that repository.

maven-resolver 2.0.23 (apache/maven-resolver#2090) adds an `aggregateRepositories` overload with a provenance flag: descriptor-declared repositories receive session authentication only when an operator-defined mirror captures them, and `aether.remoteRepositoryManager.authToDescriptorRepositories=true` restores the previous behaviour. This adds the matching five-argument `RepositoryFactory.aggregate` as a default method (delegating to the existing one, so other implementations are unaffected), passes the flag through `DefaultRepositoryFactory`, and sets it from `DefaultModelBuilder`'s existing `externalOrigin` and from the compat `DefaultModelResolver`, which only builds descriptor models. `ProjectModelResolver` builds the project's own model and parents, which are operator-chosen, and keeps the four-argument call.

Blocked on the maven-resolver 2.0.23 release: the second commit bumps `resolverVersion` to `2.0.23-SNAPSHOT` as a build aid and must be dropped, and the first commit does not compile against 2.0.22.

Verified: `mvn -pl api/maven-api-core,impl/maven-impl,compat/maven-resolver-provider -am -Dmaven.test.skip install` against 2.0.23-SNAPSHOT → compiles. The maven-impl test sources do not compile on current master independently of this change (`DistributionManagementArtifactRelocationSourceTest.noRelocationReturnsNull` calls a method that has declared `ArtifactDescriptorException` since #12950), so the module tests could not be run here.

*This change was created with AI assistance.*