### PR TITLE
[MNG-8708] Backport parent inference fix to maven-4.0.x

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -694,9 +694,11 @@ public class DefaultModelBuilder implements ModelBuilder {
 
         //
         // Transform raw model to build pom.
-        // Infer inner reactor dependencies version
+        // Infer missing coordinates from models in the reactor
         //
         Model transformFileToRaw(Model model) {
+            Parent newParent = inferParentVersion(model);
+
             List<Dependency> newDeps = null;
             boolean depsChanged = false;
             if (!model.getDependencies().isEmpty()) {
@@ -712,10 +714,13 @@ public class DefaultModelBuilder implements ModelBuilder {
                 managedDepsChanged = inferDependencies(model, depMgmt.getDependencies(), newManagedDeps);
             }
 
-            if (!depsChanged && !managedDepsChanged) {
+            if (newParent == null && !depsChanged && !managedDepsChanged) {
                 return model;
             }
             Model.Builder builder = Model.newBuilder(model);
+            if (newParent != null) {
+                builder.parent(newParent);
+            }
             if (depsChanged) {
                 builder.dependencies(newDeps);
             }
@@ -723,6 +728,34 @@ public class DefaultModelBuilder implements ModelBuilder {
                 builder.dependencyManagement(depMgmt.withDependencies(newManagedDeps));
             }
             return builder.build();
+        }
+
+        private Parent inferParentVersion(Model model) {
+            Parent parent = model.getParent();
+            if (parent == null
+                    || parent.getVersion() != null
+                    || parent.getGroupId() == null
+                    || parent.getArtifactId() == null) {
+                return null;
+            }
+
+            Model parentModel = getRawModel(model.getPomFile(), parent.getGroupId(), parent.getArtifactId());
+            if (parentModel == null) {
+                return null;
+            }
+
+            String version = parentModel.getVersion();
+            InputLocation versionLocation = parentModel.getLocation("version");
+            if (version == null && parentModel.getParent() != null) {
+                version = parentModel.getParent().getVersion();
+                versionLocation = parentModel.getParent().getLocation("version");
+            }
+            return version != null
+                    ? parent.with()
+                            .version(version)
+                            .location("version", versionLocation)
+                            .build()
+                    : null;
         }
 
         /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -747,6 +747,9 @@ public class DefaultModelBuilder implements ModelBuilder {
             String version = parentModel.getVersion();
             InputLocation versionLocation = parentModel.getLocation("version");
             if (version == null && parentModel.getParent() != null) {
+                // Parent model inherits its version from its own parent (grandparent).
+                // versionLocation may be null if the grandparent has no explicit <version>;
+                // Builder.location() silently ignores null values, which is safe here.
                 version = parentModel.getParent().getVersion();
                 versionLocation = parentModel.getParent().getLocation("version");
             }

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelValidator.java
@@ -339,9 +339,7 @@ public class DefaultModelValidator implements ModelValidator {
 
             if (parent.getRelativePath() != null
                     && !parent.getRelativePath().isEmpty()
-                    && (parent.getGroupId() != null && !parent.getGroupId().isEmpty()
-                            || parent.getArtifactId() != null
-                                    && !parent.getArtifactId().isEmpty())
+                    && (parent.getLocation("groupId") != null || parent.getLocation("artifactId") != null)
                     && validationLevel >= ModelValidator.VALIDATION_LEVEL_MAVEN_4_0
                     && ModelBuilder.KNOWN_MODEL_VERSIONS.contains(m.getModelVersion())
                     && !Objects.equals(m.getModelVersion(), ModelBuilder.MODEL_VERSION_4_0_0)) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8708">MNG-8708</a>.
+ *
+ * @since 4.1.0
+ */
+class MavenITmng8708ParentInferenceTest extends AbstractMavenIntegrationTestCase {
+
+    private static final String PARENT_DECLARATION_WARNING =
+            "'parent.relativePath' only specify relativePath or groupId/artifactId in modelVersion 4.1.0";
+
+    @Test
+    void testSupportedParentInference() throws Exception {
+        Path testDir = extractResources("mng-8708-parent-inference/supported");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextNotInLog(PARENT_DECLARATION_WARNING);
+    }
+
+    @Test
+    void testExplicitPathAndCoordinatesStillWarn() throws Exception {
+        Path testDir = extractResources("mng-8708-parent-inference/explicit-both");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog(PARENT_DECLARATION_WARNING);
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.it;
 
-import java.nio.file.Path;
+import java.io.File;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,14 +29,18 @@ import org.junit.jupiter.api.Test;
  */
 class MavenITmng8708ParentInferenceTest extends AbstractMavenIntegrationTestCase {
 
+    MavenITmng8708ParentInferenceTest() {
+        super("[4.0.0-rc-7,)");
+    }
+
     private static final String PARENT_DECLARATION_WARNING =
             "'parent.relativePath' only specify relativePath or groupId/artifactId in modelVersion 4.1.0";
 
     @Test
     void testSupportedParentInference() throws Exception {
-        Path testDir = extractResources("mng-8708-parent-inference/supported");
+        File testDir = extractResources("/mng-8708-parent-inference/supported");
 
-        Verifier verifier = newVerifier(testDir);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -51,9 +55,9 @@ class MavenITmng8708ParentInferenceTest extends AbstractMavenIntegrationTestCase
      */
     @Test
     void testThreeLevelParentInference() throws Exception {
-        Path testDir = extractResources("mng-8708-parent-inference/three-level");
+        File testDir = extractResources("/mng-8708-parent-inference/three-level");
 
-        Verifier verifier = newVerifier(testDir);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -62,9 +66,9 @@ class MavenITmng8708ParentInferenceTest extends AbstractMavenIntegrationTestCase
 
     @Test
     void testExplicitPathAndCoordinatesStillWarn() throws Exception {
-        Path testDir = extractResources("mng-8708-parent-inference/explicit-both");
+        File testDir = extractResources("/mng-8708-parent-inference/explicit-both");
 
-        Verifier verifier = newVerifier(testDir);
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.addCliArgument("validate");
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8708ParentInferenceTest.java
@@ -43,6 +43,23 @@ class MavenITmng8708ParentInferenceTest extends AbstractMavenIntegrationTestCase
         verifier.verifyTextNotInLog(PARENT_DECLARATION_WARNING);
     }
 
+    /**
+     * Three-level hierarchy: grandparent (with version) → versionless mid parent → child.
+     * The child specifies only groupId/artifactId for the mid parent, which itself
+     * inherits its version from the grandparent. Exercises the fallback path in
+     * {@code inferParentVersion} where the parent model's version comes from its own parent.
+     */
+    @Test
+    void testThreeLevelParentInference() throws Exception {
+        Path testDir = extractResources("mng-8708-parent-inference/three-level");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.addCliArgument("validate");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextNotInLog(PARENT_DECLARATION_WARNING);
+    }
+
     @Test
     void testExplicitPathAndCoordinatesStillWarn() throws Exception {
         Path testDir = extractResources("mng-8708-parent-inference/explicit-both");

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/modules/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/modules/child/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng8708</groupId>
+    <artifactId>parent</artifactId>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>child</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/explicit-both/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8708</groupId>
+  <artifactId>parent</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/child</subproject>
+  </subprojects>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/gav-only/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/gav-only/pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng8708</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+
+  <artifactId>gav-only</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/path-only/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/modules/path-only/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>path-only</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/supported/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8708</groupId>
+  <artifactId>parent</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/path-only</subproject>
+    <subproject>modules/gav-only</subproject>
+  </subprojects>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/modules/child/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/modules/child/pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng8708</groupId>
+    <artifactId>mid</artifactId>
+  </parent>
+
+  <artifactId>child</artifactId>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/modules/mid/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>mid</artifactId>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/child</subproject>
+  </subprojects>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8708-parent-inference/three-level/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+  <groupId>org.apache.maven.its.mng8708</groupId>
+  <artifactId>grandparent</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <subprojects>
+    <subproject>modules/mid</subproject>
+  </subprojects>
+</project>


### PR DESCRIPTION
## Summary

Backport of #12703 to `maven-4.0.x` (targeting 4.0.0-rc-7).

- Cherry-picked both commits from the original PR
- Resolved conflict: dropped the mixin validation alignment (mixins are a 4.2.0/master-only feature, not present on 4.0.x)
- All other changes apply cleanly: `inferParentVersion`, location-based parent validator check, defensive comment, and three-level integration test

## Changes

- **`DefaultModelBuilder`**: adds `inferParentVersion()` to infer missing parent version from reactor models, with defensive comment on grandparent fallback
- **`DefaultModelValidator`**: switches parent relativePath warning from value-based to location-based check, preventing false positives when coordinates are inferred via `relativePath` resolution
- **Integration tests**: path-only, gav-only, explicit-both, and three-level (grandparent → versionless parent → child) scenarios

## Test plan

- [x] `maven-impl` unit tests: 571 passed, 0 failures
- [ ] CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)