### PR TITLE
[Backport 4.0.x] Fix compatibility spelling in CLI help text

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/CLIManager.java
@@ -194,7 +194,7 @@ public class CLIManager {
                 .build());
         options.addOption(Option.builder(Character.toString(BATCH_MODE))
                 .longOpt("batch-mode")
-                .desc("Run in non-interactive mode. Alias for --non-interactive (kept for backwards compatability)")
+                .desc("Run in non-interactive mode. Alias for --non-interactive (kept for backwards compatibility)")
                 .build());
         options.addOption(Option.builder()
                 .longOpt(NON_INTERACTIVE)

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CommonsCliOptions.java
@@ -373,7 +373,7 @@ public class CommonsCliOptions implements Options {
                     .get());
             options.addOption(Option.builder(BATCH_MODE)
                     .longOpt("batch-mode")
-                    .desc("Run in non-interactive mode. Alias for --non-interactive (kept for backwards compatability)")
+                    .desc("Run in non-interactive mode. Alias for --non-interactive (kept for backwards compatibility)")
                     .get());
             options.addOption(Option.builder()
                     .longOpt(NON_INTERACTIVE)


### PR DESCRIPTION
## Summary
Backport of #12913 to `maven-4.0.x`.

- Fix "compatability" → "compatibility" typo in Maven 3 and Maven 4 CLI help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)