### PR TITLE
[MNG-12984] Backport: Fix invalid Automatic-Module-Name entries in mvnup plugin upgrades

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ModuleNameFixStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ModuleNameFixStrategy.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnup.goals;
+
+import javax.lang.model.SourceVersion;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.Element;
+import org.apache.maven.api.cli.mvnup.UpgradeOptions;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Priority;
+import org.apache.maven.api.di.Singleton;
+import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
+
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.ARTIFACT_ID;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.BUILD;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.CONFIGURATION;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.GROUP_ID;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGIN;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGINS;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PLUGIN_MANAGEMENT;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PROFILE;
+import static eu.maveniverse.domtrip.maven.MavenPomElements.Elements.PROFILES;
+
+/**
+ * Strategy for fixing invalid {@code Automatic-Module-Name} manifest entries in POM files.
+ *
+ * <p>Java module names (as validated by {@link SourceVersion#isName(CharSequence)}) must be
+ * dot-separated sequences of valid Java identifiers. Dashes ({@code -}) are the most common
+ * illegal character because Maven artifact IDs conventionally use them, and projects often
+ * copy the artifact ID into the {@code Automatic-Module-Name} manifest entry without
+ * sanitizing it.
+ *
+ * <p>Since {@code maven-archiver 3.3.0}
+ * (<a href="https://issues.apache.org/jira/browse/MSHARED-773">MSHARED-773</a>),
+ * the archiver validates {@code Automatic-Module-Name} entries and fails the build on
+ * invalid names. When {@code mvnup} upgrades {@code maven-jar-plugin} (or other packaging
+ * plugins) to versions that pull in the newer archiver, previously-unchecked invalid names
+ * surface as build failures.
+ *
+ * <p>This strategy scans all packaging plugin configurations for
+ * {@code <archive><manifestEntries><Automatic-Module-Name>} elements whose values
+ * contain dashes, and replaces the dashes with dots to produce a valid module name.
+ *
+ * @see <a href="https://github.com/apache/maven/issues/12984">MAVEN-12984</a>
+ */
+@Named
+@Singleton
+@Priority(12) // Run after plugin upgrades (10) but before compatibility fixes (20)
+public class ModuleNameFixStrategy extends AbstractUpgradeStrategy {
+
+    private static final String ARCHIVE = "archive";
+    private static final String MANIFEST_ENTRIES = "manifestEntries";
+    private static final String AUTOMATIC_MODULE_NAME = "Automatic-Module-Name";
+
+    /**
+     * Plugins that use {@code maven-archiver} and support
+     * {@code <configuration><archive><manifestEntries>}.
+     */
+    private static final Set<String> PACKAGING_PLUGINS = Set.of(
+            "maven-jar-plugin",
+            "maven-war-plugin",
+            "maven-ejb-plugin",
+            "maven-ear-plugin",
+            "maven-rar-plugin",
+            "maven-shade-plugin");
+
+    @Override
+    public boolean isApplicable(UpgradeContext context) {
+        UpgradeOptions options = getOptions(context);
+        return isOptionEnabled(options, options.plugins(), true);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Fixing invalid Automatic-Module-Name manifest entries";
+    }
+
+    @Override
+    protected UpgradeResult doApply(UpgradeContext context, Map<Path, Document> pomMap) {
+        Set<Path> processedPoms = new HashSet<>();
+        Set<Path> modifiedPoms = new HashSet<>();
+        Set<Path> errorPoms = new HashSet<>();
+
+        for (Map.Entry<Path, Document> entry : pomMap.entrySet()) {
+            Path pomPath = entry.getKey();
+            Document pomDocument = entry.getValue();
+            processedPoms.add(pomPath);
+
+            context.info(pomPath + " (checking Automatic-Module-Name entries)");
+            context.indent();
+
+            try {
+                boolean modified = fixModuleNames(pomDocument, context);
+                if (modified) {
+                    modifiedPoms.add(pomPath);
+                } else {
+                    context.success("No invalid Automatic-Module-Name entries found");
+                }
+            } catch (Exception e) {
+                context.failure("Failed to fix module names: " + e.getMessage());
+                errorPoms.add(pomPath);
+            } finally {
+                context.unindent();
+            }
+        }
+
+        return new UpgradeResult(processedPoms, modifiedPoms, errorPoms);
+    }
+
+    /**
+     * Scans all plugin configurations in the POM for invalid {@code Automatic-Module-Name}
+     * entries and fixes them.
+     *
+     * @return true if any entries were modified
+     */
+    private boolean fixModuleNames(Document pomDocument, UpgradeContext context) {
+        Element root = pomDocument.root();
+        boolean modified = false;
+
+        // Check <build><plugins> and <build><pluginManagement><plugins>
+        Element build = root.childElement(BUILD).orElse(null);
+        if (build != null) {
+            modified |= fixInPluginSection(build.childElement(PLUGINS).orElse(null), context);
+
+            Element pluginManagement = build.childElement(PLUGIN_MANAGEMENT).orElse(null);
+            if (pluginManagement != null) {
+                modified |= fixInPluginSection(
+                        pluginManagement.childElement(PLUGINS).orElse(null), context);
+            }
+        }
+
+        // Check profiles
+        Element profiles = root.childElement(PROFILES).orElse(null);
+        if (profiles != null) {
+            for (Element profile : profiles.childElements(PROFILE).toList()) {
+                Element profileBuild = profile.childElement(BUILD).orElse(null);
+                if (profileBuild != null) {
+                    modified |= fixInPluginSection(
+                            profileBuild.childElement(PLUGINS).orElse(null), context);
+
+                    Element profilePluginMgmt =
+                            profileBuild.childElement(PLUGIN_MANAGEMENT).orElse(null);
+                    if (profilePluginMgmt != null) {
+                        modified |= fixInPluginSection(
+                                profilePluginMgmt.childElement(PLUGINS).orElse(null), context);
+                    }
+                }
+            }
+        }
+
+        return modified;
+    }
+
+    private boolean fixInPluginSection(Element pluginsElement, UpgradeContext context) {
+        if (pluginsElement == null) {
+            return false;
+        }
+
+        boolean modified = false;
+        for (Element plugin : pluginsElement.childElements(PLUGIN).toList()) {
+            String artifactId = plugin.childTextTrimmed(ARTIFACT_ID);
+            String groupId = plugin.childTextTrimmed(GROUP_ID);
+
+            if (isPackagingPlugin(groupId, artifactId)) {
+                modified |= fixInPluginConfig(plugin, context, artifactId);
+            }
+        }
+        return modified;
+    }
+
+    private boolean fixInPluginConfig(Element plugin, UpgradeContext context, String pluginArtifactId) {
+        Element config = plugin.childElement(CONFIGURATION).orElse(null);
+        if (config == null) {
+            return false;
+        }
+
+        Element archive = config.childElement(ARCHIVE).orElse(null);
+        if (archive == null) {
+            return false;
+        }
+
+        Element manifestEntries = archive.childElement(MANIFEST_ENTRIES).orElse(null);
+        if (manifestEntries == null) {
+            return false;
+        }
+
+        Element moduleNameElement =
+                manifestEntries.childElement(AUTOMATIC_MODULE_NAME).orElse(null);
+        if (moduleNameElement == null) {
+            return false;
+        }
+
+        String moduleName = moduleNameElement.textContent();
+        if (moduleName == null || moduleName.isBlank()) {
+            return false;
+        }
+
+        moduleName = moduleName.trim();
+
+        // Skip property references — we cannot resolve ${...} expressions here
+        if (moduleName.startsWith("${")) {
+            return false;
+        }
+
+        if (SourceVersion.isName(moduleName)) {
+            return false; // Already valid
+        }
+
+        String fixed = sanitizeModuleName(moduleName);
+        if (fixed.equals(moduleName) || !SourceVersion.isName(fixed)) {
+            // Cannot fix automatically — warn
+            context.failure("Cannot automatically fix invalid Automatic-Module-Name '" + moduleName + "' in "
+                    + pluginArtifactId);
+            return false;
+        }
+
+        moduleNameElement.textContent(fixed);
+        context.success(
+                "Fixed Automatic-Module-Name in " + pluginArtifactId + ": '" + moduleName + "' → '" + fixed + "'");
+        return true;
+    }
+
+    /**
+     * Checks if the plugin is one of the packaging plugins that support
+     * {@code <archive><manifestEntries>}.
+     */
+    private static boolean isPackagingPlugin(String groupId, String artifactId) {
+        if (artifactId == null) {
+            return false;
+        }
+        // Accept both explicit groupId and implicit (null/empty = default)
+        if (groupId != null && !groupId.isEmpty() && !"org.apache.maven.plugins".equals(groupId)) {
+            return false;
+        }
+        return PACKAGING_PLUGINS.contains(artifactId);
+    }
+
+    /**
+     * Sanitizes a module name by replacing dashes with dots.
+     *
+     * <p>Java module names are dot-separated identifiers. Dashes are the most common
+     * illegal character because Maven artifact IDs use them as separators. Replacing
+     * dashes with dots is the standard convention (used by the JDK itself when deriving
+     * automatic module names from JAR file names).
+     *
+     * @param moduleName the original (possibly invalid) module name
+     * @return the sanitized module name
+     */
+    static String sanitizeModuleName(String moduleName) {
+        // Replace dashes with dots (standard convention for automatic module names)
+        String sanitized = moduleName.replace('-', '.');
+
+        // Collapse consecutive dots that may result from replacements like "foo--bar"
+        sanitized = sanitized.replaceAll("\\.{2,}", ".");
+
+        // Remove leading/trailing dots
+        if (sanitized.startsWith(".")) {
+            sanitized = sanitized.substring(1);
+        }
+        if (sanitized.endsWith(".")) {
+            sanitized = sanitized.substring(0, sanitized.length() - 1);
+        }
+
+        return sanitized;
+    }
+}

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/ModuleNameFixStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/ModuleNameFixStrategyTest.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnup.goals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import eu.maveniverse.domtrip.Document;
+import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the {@link ModuleNameFixStrategy} class.
+ */
+@DisplayName("ModuleNameFixStrategy")
+class ModuleNameFixStrategyTest {
+
+    private static final Path POM_PATH = Paths.get("/project/pom.xml");
+
+    @Nested
+    @DisplayName("sanitizeModuleName")
+    class SanitizeTests {
+
+        @Test
+        @DisplayName("should replace dashes with dots")
+        void replacesDashes() {
+            assertEquals(
+                    "org.apache.geronimo.arthur.integration.test",
+                    ModuleNameFixStrategy.sanitizeModuleName("org.apache.geronimo.arthur.integration-test"));
+        }
+
+        @Test
+        @DisplayName("should replace multiple dashes")
+        void replacesMultipleDashes() {
+            assertEquals(
+                    "org.apache.winegrower.cepages.winegrower.cepage.osgi.cdi",
+                    ModuleNameFixStrategy.sanitizeModuleName(
+                            "org.apache.winegrower.cepages.winegrower-cepage-osgi-cdi"));
+        }
+
+        @Test
+        @DisplayName("should collapse consecutive dots")
+        void collapsesConsecutiveDots() {
+            assertEquals("foo.bar", ModuleNameFixStrategy.sanitizeModuleName("foo--bar"));
+        }
+
+        @Test
+        @DisplayName("should leave valid names unchanged")
+        void leavesValidUnchanged() {
+            assertEquals("org.example.valid.name", ModuleNameFixStrategy.sanitizeModuleName("org.example.valid.name"));
+        }
+
+        @Test
+        @DisplayName("should handle leading dash")
+        void handlesLeadingDash() {
+            assertEquals("foo.bar", ModuleNameFixStrategy.sanitizeModuleName("-foo.bar"));
+        }
+
+        @Test
+        @DisplayName("should handle trailing dash")
+        void handlesTrailingDash() {
+            assertEquals("foo.bar", ModuleNameFixStrategy.sanitizeModuleName("foo.bar-"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Apply")
+    class ApplyTests {
+
+        @Test
+        @DisplayName("should fix Automatic-Module-Name with dashes in jar plugin config")
+        void fixesDashInJarPlugin() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>integration-test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-jar-plugin</artifactId>
+                                    <configuration>
+                                        <archive>
+                                            <manifestEntries>
+                                                <Automatic-Module-Name>org.example.integration-test</Automatic-Module-Name>
+                                            </manifestEntries>
+                                        </archive>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(1, result.modifiedPoms().size());
+            // Verify the fix was applied
+            String xml = doc.toXml();
+            assertTrue(xml.contains("org.example.integration.test"));
+            assertFalse(xml.contains("org.example.integration-test"));
+        }
+
+        @Test
+        @DisplayName("should not modify valid Automatic-Module-Name")
+        void noChangeForValid() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>my-module</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-jar-plugin</artifactId>
+                                    <configuration>
+                                        <archive>
+                                            <manifestEntries>
+                                                <Automatic-Module-Name>org.example.mymodule</Automatic-Module-Name>
+                                            </manifestEntries>
+                                        </archive>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(0, result.modifiedPoms().size());
+        }
+
+        @Test
+        @DisplayName("should fix in pluginManagement section")
+        void fixesInPluginManagement() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <pluginManagement>
+                                <plugins>
+                                    <plugin>
+                                        <artifactId>maven-jar-plugin</artifactId>
+                                        <configuration>
+                                            <archive>
+                                                <manifestEntries>
+                                                    <Automatic-Module-Name>org.example.my-lib</Automatic-Module-Name>
+                                                </manifestEntries>
+                                            </archive>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </pluginManagement>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(1, result.modifiedPoms().size());
+            assertTrue(doc.toXml().contains("org.example.my.lib"));
+        }
+
+        @Test
+        @DisplayName("should handle POM without any plugins")
+        void noPlugins() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(0, result.modifiedPoms().size());
+        }
+
+        @Test
+        @DisplayName("should fix in shade plugin configuration")
+        void fixesInShadePlugin() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-shade-plugin</artifactId>
+                                    <configuration>
+                                        <archive>
+                                            <manifestEntries>
+                                                <Automatic-Module-Name>org.example.shaded-lib</Automatic-Module-Name>
+                                            </manifestEntries>
+                                        </archive>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(1, result.modifiedPoms().size());
+            assertTrue(doc.toXml().contains("org.example.shaded.lib"));
+        }
+
+        @Test
+        @DisplayName("should ignore non-packaging plugins")
+        void ignoresNonPackagingPlugins() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>com.example</groupId>
+                                    <artifactId>custom-plugin</artifactId>
+                                    <configuration>
+                                        <archive>
+                                            <manifestEntries>
+                                                <Automatic-Module-Name>org.example.my-lib</Automatic-Module-Name>
+                                            </manifestEntries>
+                                        </archive>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(0, result.modifiedPoms().size());
+        }
+
+        @Test
+        @DisplayName("should fix in profile plugin configuration")
+        void fixesInProfile() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <profiles>
+                            <profile>
+                                <id>release</id>
+                                <build>
+                                    <plugins>
+                                        <plugin>
+                                            <artifactId>maven-jar-plugin</artifactId>
+                                            <configuration>
+                                                <archive>
+                                                    <manifestEntries>
+                                                        <Automatic-Module-Name>org.example.my-release</Automatic-Module-Name>
+                                                    </manifestEntries>
+                                                </archive>
+                                            </configuration>
+                                        </plugin>
+                                    </plugins>
+                                </build>
+                            </profile>
+                        </profiles>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(1, result.modifiedPoms().size());
+            assertTrue(doc.toXml().contains("org.example.my.release"));
+        }
+
+        @Test
+        @DisplayName("should skip property references")
+        void skipsPropertyReferences() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            // geronimo-arthur uses ${project.groupId}.${geronimo-arthur.shortname}
+            // which resolves to a hyphenated name — but we can't fix property references
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-jar-plugin</artifactId>
+                                    <configuration>
+                                        <archive>
+                                            <manifestEntries>
+                                                <Automatic-Module-Name>${project.groupId}.${project.artifactId}</Automatic-Module-Name>
+                                            </manifestEntries>
+                                        </archive>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            // Should not modify — cannot resolve property expressions
+            assertEquals(0, result.modifiedPoms().size());
+        }
+
+        @Test
+        @DisplayName("should fix multiple dashes like winegrower-cepage-osgi-cdi")
+        void fixesMultipleDashes() {
+            ModuleNameFixStrategy strategy = new ModuleNameFixStrategy();
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.apache.winegrower.cepages</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-jar-plugin</artifactId>
+                                    <configuration>
+                                        <archive>
+                                            <manifestEntries>
+                                                <Automatic-Module-Name>org.apache.winegrower.cepages.winegrower-cepage-osgi-cdi</Automatic-Module-Name>
+                                            </manifestEntries>
+                                        </archive>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            UpgradeContext context = TestUtils.createMockContext();
+            UpgradeResult result = strategy.doApply(context, Map.of(POM_PATH, doc));
+
+            assertEquals(1, result.modifiedPoms().size());
+            String xml = doc.toXml();
+            assertTrue(xml.contains("org.apache.winegrower.cepages.winegrower.cepage.osgi.cdi"));
+        }
+    }
+}


### PR DESCRIPTION
Backport of #12995 to `maven-4.0.x`.

## Summary

Add `ModuleNameFixStrategy` (Priority 12) that scans packaging plugin configurations for `Automatic-Module-Name` manifest entries containing hyphens and replaces them with dots. Since `maven-archiver 3.3.0` (MSHARED-773), the archiver validates module names via `SourceVersion.isName()` and rejects hyphens. When `mvnup` upgrades `maven-jar-plugin` to versions using the newer archiver, previously-unchecked invalid names surface as build failures.

Cherry-picked cleanly from 799c1ad7b4 — no conflicts.

Closes #12984