### PR TITLE
Fix #12991: skip shade-plugin upgrade when custom ResourceTransformers are present (backport to 4.0.x)

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -1198,11 +1198,9 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         // Check <executions>/<execution>/<configuration>
         pluginElement
                 .childElement("executions")
-                .ifPresent(executions -> executions
-                        .childElements("execution")
-                        .forEach(execution -> execution
-                                .childElement("configuration")
-                                .ifPresent(config -> collectCustomTransformers(config, customClasses))));
+                .ifPresent(executions -> executions.childElements("execution").forEach(execution -> execution
+                        .childElement("configuration")
+                        .ifPresent(config -> collectCustomTransformers(config, customClasses))));
 
         return customClasses;
     }
@@ -1212,16 +1210,14 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
      * Looks for {@code <transformers>/<transformer implementation="...">} entries.
      */
     private void collectCustomTransformers(Element configElement, List<String> customClasses) {
-        configElement
-                .childElement("transformers")
-                .ifPresent(transformers -> transformers
-                        .childElements("transformer")
-                        .forEach(transformer -> {
-                            String impl = transformer.attribute("implementation");
-                            if (impl != null && !impl.isEmpty() && !impl.startsWith(SHADE_RESOURCE_PACKAGE)) {
-                                customClasses.add(impl);
-                            }
-                        }));
+        configElement.childElement("transformers").ifPresent(transformers -> transformers
+                .childElements("transformer")
+                .forEach(transformer -> {
+                    String impl = transformer.attribute("implementation");
+                    if (impl != null && !impl.isEmpty() && !impl.startsWith(SHADE_RESOURCE_PACKAGE)) {
+                        customClasses.add(impl);
+                    }
+                }));
     }
 
     /**

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -19,12 +19,14 @@
 package org.apache.maven.cling.invoker.mvnup.goals;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Editor;
@@ -406,6 +408,20 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             return false;
         }
 
+        // For shade-plugin, check for custom ResourceTransformer implementations before upgrading.
+        // Custom transformers may depend on transitive dependencies (e.g. org.jdom:jdom) that
+        // are no longer present in newer shade-plugin versions, breaking the build.
+        if (isShadePlugin(upgrade.groupId, upgrade.artifactId)) {
+            List<String> customTransformers = findCustomTransformerClasses(pluginElement);
+            if (!customTransformers.isEmpty()) {
+                context.warning("Skipping maven-shade-plugin upgrade: plugin configuration uses custom "
+                        + "ResourceTransformer(s) " + customTransformers
+                        + " that may depend on transitive dependencies not available in version "
+                        + upgrade.minVersion + ". Upgrade manually after verifying compatibility.");
+                return false;
+            }
+        }
+
         // For Quarkus plugins, check the platform version before upgrading.
         // Upgrading quarkus-maven-plugin to 3.x when the project uses Quarkus 2.x
         // causes NoSuchMethodError and build failures.
@@ -668,7 +684,8 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
             UpgradeContext context, Map<Path, Document> pomMap, Path tempDir) {
         Map<Path, Set<String>> managementResult = new HashMap<>();
         Map<Path, Set<String>> directOverrideResult = new HashMap<>();
-        Map<String, PluginUpgrade> pluginUpgrades = getPluginUpgradesAsMap();
+        Map<String, PluginUpgrade> basePluginUpgrades = getPluginUpgradesAsMap();
+        String shadePluginKey = DEFAULT_MAVEN_PLUGIN_GROUP_ID + ":maven-shade-plugin";
 
         for (Map.Entry<Path, Document> entry : pomMap.entrySet()) {
             Path originalPomPath = entry.getKey();
@@ -678,6 +695,17 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                 Path commonRoot = findCommonRoot(pomMap.keySet());
                 Path relativePath = commonRoot.relativize(originalPomPath);
                 Path tempPomPath = tempDir.resolve(relativePath);
+
+                // Per-module check: if this POM or any of its local parent POMs
+                // has shade-plugin with custom transformers, exclude shade-plugin
+                // from upgrades for this module only
+                Map<String, PluginUpgrade> pluginUpgrades = basePluginUpgrades;
+                if (hasCustomTransformersInPomOrParents(context, originalPomPath, pomMap, tempDir, commonRoot)) {
+                    pluginUpgrades = new HashMap<>(basePluginUpgrades);
+                    pluginUpgrades.remove(shadePluginKey);
+                    context.warning("Skipping maven-shade-plugin in effective-model analysis for " + originalPomPath
+                            + ": custom ResourceTransformer(s) found in project POMs");
+                }
 
                 // Build effective model using Maven 4 API
                 PluginAnalysis analysis = analyzeEffectiveModelForPlugins(context, tempPomPath, pluginUpgrades);
@@ -710,6 +738,87 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
         }
 
         return new PluginAnalysisResults(managementResult, directOverrideResult);
+    }
+
+    /**
+     * Checks if a specific POM or any of its local parent POMs (within pomMap)
+     * contains a shade-plugin configuration with custom ResourceTransformer implementations.
+     * This is a per-module check, unlike a global check across all POMs.
+     */
+    private boolean hasCustomTransformersInPomOrParents(
+            UpgradeContext context, Path pomPath, Map<Path, Document> pomMap, Path tempDir, Path commonRoot) {
+        // Check the current POM
+        Document doc = pomMap.get(pomPath);
+        if (doc != null && hasCustomTransformersInDocument(doc)) {
+            return true;
+        }
+
+        // Walk up the parent hierarchy within the local pomMap
+        if (doc != null) {
+            try {
+                Path tempPomPath = tempDir.resolve(commonRoot.relativize(pomPath));
+                Model effectiveModel = buildEffectiveModel(context, tempPomPath);
+                Model currentModel = effectiveModel;
+
+                while (currentModel.getParent() != null) {
+                    Parent parent = currentModel.getParent();
+                    Path parentPath = findParentInPomMap(parent, pomMap);
+                    if (parentPath != null) {
+                        Document parentDoc = pomMap.get(parentPath);
+                        if (parentDoc != null && hasCustomTransformersInDocument(parentDoc)) {
+                            return true;
+                        }
+                        Path parentTempPath = tempDir.resolve(commonRoot.relativize(parentPath));
+                        currentModel = buildEffectiveModel(context, parentTempPath);
+                    } else {
+                        break;
+                    }
+                }
+            } catch (Exception e) {
+                // If we can't resolve parents, be conservative and check just this POM
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if a single POM document contains a shade-plugin configuration
+     * with custom ResourceTransformer implementations.
+     */
+    private boolean hasCustomTransformersInDocument(Document doc) {
+        Element root = doc.root();
+        Element buildElement = root.childElement(BUILD).orElse(null);
+        if (buildElement != null) {
+            // Check both build/plugins and build/pluginManagement/plugins
+            return Stream.concat(
+                            collectShadePluginElements(
+                                    buildElement.childElement(PLUGINS).orElse(null)),
+                            collectShadePluginElements(buildElement
+                                    .childElement(PLUGIN_MANAGEMENT)
+                                    .flatMap(pm -> pm.childElement(PLUGINS))
+                                    .orElse(null)))
+                    .anyMatch(pluginElement ->
+                            !findCustomTransformerClasses(pluginElement).isEmpty());
+        }
+        return false;
+    }
+
+    /**
+     * Collects shade-plugin {@code <plugin>} elements from a {@code <plugins>} element.
+     */
+    private Stream<Element> collectShadePluginElements(Element pluginsElement) {
+        if (pluginsElement == null) {
+            return Stream.empty();
+        }
+        return pluginsElement.childElements(PLUGIN).filter(pluginElement -> {
+            String groupId = getChildText(pluginElement, GROUP_ID);
+            String artifactId = getChildText(pluginElement, ARTIFACT_ID);
+            if (groupId == null && artifactId != null && artifactId.startsWith(MAVEN_PLUGIN_PREFIX)) {
+                groupId = DEFAULT_MAVEN_PLUGIN_GROUP_ID;
+            }
+            return isShadePlugin(groupId, artifactId);
+        });
     }
 
     /**
@@ -1052,6 +1161,68 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
 
     private record PluginAnalysisResults(
             Map<Path, Set<String>> pluginsNeedingManagement, Map<Path, Set<String>> pluginsNeedingDirectOverride) {}
+
+    /**
+     * Checks if the given plugin is the maven-shade-plugin.
+     */
+    private boolean isShadePlugin(String groupId, String artifactId) {
+        return "maven-shade-plugin".equals(artifactId) && DEFAULT_MAVEN_PLUGIN_GROUP_ID.equals(groupId);
+    }
+
+    /**
+     * The package prefix for standard ResourceTransformer implementations shipped with maven-shade-plugin.
+     * Any transformer class not starting with this prefix is considered custom and may depend on
+     * transitive dependencies that differ between shade-plugin versions.
+     */
+    private static final String SHADE_RESOURCE_PACKAGE = "org.apache.maven.plugins.shade.resource.";
+
+    /**
+     * Finds custom (non-standard) ResourceTransformer implementation classes in a shade-plugin
+     * configuration. Inspects both top-level {@code <configuration>} and per-execution
+     * {@code <executions>/<execution>/<configuration>} blocks.
+     *
+     * <p>A transformer is considered "custom" if its {@code implementation} attribute does not
+     * start with {@code org.apache.maven.plugins.shade.resource.}.</p>
+     *
+     * @param pluginElement the shade-plugin {@code <plugin>} element
+     * @return a list of fully-qualified class names of custom transformers, empty if none found
+     */
+    List<String> findCustomTransformerClasses(Element pluginElement) {
+        List<String> customClasses = new ArrayList<>();
+
+        // Check top-level <configuration>
+        pluginElement
+                .childElement("configuration")
+                .ifPresent(config -> collectCustomTransformers(config, customClasses));
+
+        // Check <executions>/<execution>/<configuration>
+        pluginElement
+                .childElement("executions")
+                .ifPresent(executions -> executions
+                        .childElements("execution")
+                        .forEach(execution -> execution
+                                .childElement("configuration")
+                                .ifPresent(config -> collectCustomTransformers(config, customClasses))));
+
+        return customClasses;
+    }
+
+    /**
+     * Collects custom transformer class names from a {@code <configuration>} element.
+     * Looks for {@code <transformers>/<transformer implementation="...">} entries.
+     */
+    private void collectCustomTransformers(Element configElement, List<String> customClasses) {
+        configElement
+                .childElement("transformers")
+                .ifPresent(transformers -> transformers
+                        .childElements("transformer")
+                        .forEach(transformer -> {
+                            String impl = transformer.attribute("implementation");
+                            if (impl != null && !impl.isEmpty() && !impl.startsWith(SHADE_RESOURCE_PACKAGE)) {
+                                customClasses.add(impl);
+                            }
+                        }));
+    }
 
     /**
      * Checks if the given plugin is a Quarkus Maven plugin.

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeShadeTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeShadeTest.java
@@ -1,0 +1,524 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvnup.goals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.Editor;
+import eu.maveniverse.domtrip.Element;
+import org.apache.maven.cling.invoker.mvnup.UpgradeContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for shade-plugin custom ResourceTransformer detection in {@link PluginUpgradeStrategy}.
+ * Verifies that mvnup skips shade-plugin upgrades when custom transformers are present
+ * (see <a href="https://github.com/apache/maven/issues/12991">MAVEN-12991</a>).
+ */
+@DisplayName("PluginUpgradeStrategy — Shade Plugin Custom Transformers")
+class PluginUpgradeShadeTest {
+
+    private PluginUpgradeStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new PluginUpgradeStrategy();
+    }
+
+    private UpgradeContext createMockContext() {
+        return TestUtils.createMockContext();
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade when custom ResourceTransformer is present")
+    void shouldSkipUpgradeWithCustomTransformer() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <executions>
+                                    <execution>
+                                        <goals>
+                                            <goal>shade</goal>
+                                        </goals>
+                                        <configuration>
+                                            <transformers>
+                                                <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                            </transformers>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        UpgradeResult result = strategy.doApply(context, pomMap);
+
+        assertTrue(result.success(), "Strategy should succeed without errors");
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+
+        // Verify a warning was logged
+        verify(context.logger, atLeastOnce())
+                .warn(argThat(msg -> msg.contains("Skipping maven-shade-plugin upgrade")
+                        && msg.contains("custom ResourceTransformer")
+                        && msg.contains("BeansXmlTransformer")));
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade when custom transformer is in top-level configuration")
+    void shouldSkipUpgradeWithCustomTransformerInTopLevelConfig() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="com.example.CustomTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should not detect custom transformers when only standard transformers are present")
+    void shouldUpgradeWithStandardTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>com.example.Main</mainClass>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        // Verify no custom transformers are detected — standard transformers should not
+        // block the shade-plugin upgrade
+        Document document = Document.of(pomXml);
+        Element pluginElement = document.root()
+                .childElement("build")
+                .flatMap(b -> b.childElement("plugins"))
+                .flatMap(p -> p.childElement("plugin"))
+                .orElseThrow();
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+        assertTrue(customTransformers.isEmpty(), "Standard transformers should not be detected as custom");
+    }
+
+    @Test
+    @DisplayName("should not detect custom transformers when no transformers are configured")
+    void shouldUpgradeWithNoTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        // Verify no custom transformers are detected when no transformers are configured
+        Document document = Document.of(pomXml);
+        Element pluginElement = document.root()
+                .childElement("build")
+                .flatMap(b -> b.childElement("plugins"))
+                .flatMap(p -> p.childElement("plugin"))
+                .orElseThrow();
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+        assertTrue(customTransformers.isEmpty(), "No transformers configured should return empty list");
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade with mixed standard and custom transformers")
+    void shouldSkipUpgradeWithMixedTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <executions>
+                                    <execution>
+                                        <configuration>
+                                            <transformers>
+                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                                <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                            </transformers>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade with property version and custom transformers")
+    void shouldSkipUpgradeWithPropertyVersionAndCustomTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <properties>
+                        <shade.plugin.version>1.3.3</shade.plugin.version>
+                    </properties>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>${shade.plugin.version}</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the property was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("properties", "shade.plugin.version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin property should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should skip shade-plugin upgrade without explicit groupId when custom transformers present")
+    void shouldSkipUpgradeWithoutGroupIdAndCustomTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="com.example.CustomTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("should detect custom transformers in pluginManagement section")
+    void shouldSkipUpgradeWithCustomTransformerInPluginManagement() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-shade-plugin</artifactId>
+                                    <version>1.3.3</version>
+                                    <configuration>
+                                        <transformers>
+                                            <transformer implementation="com.example.CustomTransformer"/>
+                                        </transformers>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Map<Path, Document> pomMap = Map.of(Paths.get("pom.xml"), document);
+
+        UpgradeContext context = createMockContext();
+        strategy.doApply(context, pomMap);
+
+        // Verify the version was NOT upgraded
+        Editor editor = new Editor(document);
+        String version = editor.root()
+                .path("build", "pluginManagement", "plugins", "plugin", "version")
+                .map(Element::textContentTrimmed)
+                .orElse(null);
+        assertEquals("1.3.3", version, "Shade plugin version in pluginManagement should remain unchanged");
+    }
+
+    @Test
+    @DisplayName("findCustomTransformerClasses should return custom class names")
+    void findCustomTransformerClassesShouldReturnCustomClassNames() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>1.3.3</version>
+                                <executions>
+                                    <execution>
+                                        <configuration>
+                                            <transformers>
+                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                                <transformer implementation="org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"/>
+                                                <transformer implementation="com.example.AnotherTransformer"/>
+                                            </transformers>
+                                        </configuration>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Element pluginElement =
+                document.root().path("build", "plugins", "plugin").orElseThrow();
+
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+
+        assertEquals(2, customTransformers.size(), "Should find exactly 2 custom transformers");
+        assertTrue(
+                customTransformers.contains("org.apache.myfaces.extensions.cdi.maven.BeansXmlTransformer"),
+                "Should contain BeansXmlTransformer");
+        assertTrue(customTransformers.contains("com.example.AnotherTransformer"), "Should contain AnotherTransformer");
+    }
+
+    @Test
+    @DisplayName("findCustomTransformerClasses should return empty for standard transformers only")
+    void findCustomTransformerClassesShouldReturnEmptyForStandardTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Element pluginElement =
+                document.root().path("build", "plugins", "plugin").orElseThrow();
+
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+
+        assertTrue(customTransformers.isEmpty(), "Should not find any custom transformers");
+    }
+
+    @Test
+    @DisplayName("findCustomTransformerClasses should return empty when no transformers configured")
+    void findCustomTransformerClassesShouldReturnEmptyWhenNoTransformers() throws Exception {
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.0.0</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """;
+
+        Document document = Document.of(pomXml);
+        Element pluginElement =
+                document.root().path("build", "plugins", "plugin").orElseThrow();
+
+        List<String> customTransformers = strategy.findCustomTransformerClasses(pluginElement);
+
+        assertTrue(customTransformers.isEmpty(), "Should not find any custom transformers");
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #12997 to `maven-4.0.x`.

- mvnup detects custom `ResourceTransformer` classes in shade-plugin configuration and skips the upgrade when found
- Per-module check in multi-module builds — unaffected modules can still be upgraded
- Warning logged with the list of custom transformers found

## Test plan

- [x] All 11 shade-plugin tests pass on 4.0.x branch
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)