### PR TITLE
fix: remove stale PathTranslator reference from DefaultModelBuilderTest

### DIFF
--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelBuilderTest.java
@@ -216,7 +216,6 @@ class DefaultModelBuilderTest {
     private DefaultProfileActivationContext parentActivationContext(Map<String, String> systemProperties) {
         org.apache.maven.api.services.Lookup lookup = session.getService(org.apache.maven.api.services.Lookup.class);
         return new DefaultProfileActivationContext(
-                lookup.lookup(org.apache.maven.api.services.model.PathTranslator.class),
                 lookup.lookup(org.apache.maven.api.services.model.RootLocator.class),
                 lookup.lookup(org.apache.maven.api.services.Interpolator.class),
                 List.of(),


### PR DESCRIPTION
The MNG-8749 commit (589c1ebfee) removed `PathTranslator` from the public API and from the `DefaultProfileActivationContext` constructor, but `DefaultModelBuilderTest.parentActivationContext()` still passed it as a constructor argument, causing a compilation error on master.

One-line fix: remove the stale `lookup.lookup(PathTranslator.class)` argument.