### PR TITLE
[Backport 4.0.x] Fix #12985: Upgrade toolchains-plugin when adding select-jdk-toolchain execution

### DIFF
--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/PluginUpgradeStrategy.java
@@ -178,7 +178,12 @@ public class PluginUpgradeStrategy extends AbstractUpgradeStrategy {
                     "3.6.0",
                     null,
                     MAVEN_4_COMPATIBILITY_REASON,
-                    21));
+                    21),
+            new PluginUpgrade(
+                    DEFAULT_MAVEN_PLUGIN_GROUP_ID,
+                    "maven-toolchains-plugin",
+                    "3.2.0",
+                    "Versions before 3.2.0 do not have the select-jdk-toolchain goal"));
 
     private static final List<PluginUpgrade> PLUGIN_DEPENDENCY_UPGRADES = List.of(new PluginUpgrade(
             "org.codehaus.mojo",

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategy.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategy.java
@@ -69,6 +69,13 @@ public class ToolchainPluginStrategy extends AbstractUpgradeStrategy {
     static final String TOOLCHAINS_PLUGIN_GROUP_ID = "org.apache.maven.plugins";
     static final String SELECT_JDK_TOOLCHAIN_GOAL = "select-jdk-toolchain";
 
+    /**
+     * Minimum toolchains-plugin version that contains the {@code select-jdk-toolchain} goal.
+     * Older versions (e.g. 1.1) only have {@code help} and {@code toolchain} goals, so adding
+     * a {@code select-jdk-toolchain} execution without upgrading would break the build.
+     */
+    static final String TOOLCHAINS_PLUGIN_MIN_VERSION = "3.2.0";
+
     private static final String MAVEN_COMPILER_RELEASE = "maven.compiler.release";
     private static final String MAVEN_COMPILER_SOURCE = "maven.compiler.source";
     private static final String MAVEN_COMPILER_PLUGIN = "maven-compiler-plugin";
@@ -292,10 +299,7 @@ public class ToolchainPluginStrategy extends AbstractUpgradeStrategy {
         }
 
         for (Element plugin : pluginsElement.childElements(PLUGIN).toList()) {
-            String artifactId = plugin.childTextTrimmed(ARTIFACT_ID);
-            String groupId = plugin.childTextTrimmed(GROUP_ID);
-            if (MAVEN_TOOLCHAINS_PLUGIN.equals(artifactId)
-                    && (groupId == null || groupId.isEmpty() || TOOLCHAINS_PLUGIN_GROUP_ID.equals(groupId))) {
+            if (isToolchainsPlugin(plugin)) {
                 // Check if it has the select-jdk-toolchain goal in any execution
                 Element executions = plugin.childElement("executions").orElse(null);
                 if (executions != null) {
@@ -322,6 +326,11 @@ public class ToolchainPluginStrategy extends AbstractUpgradeStrategy {
      * to the POM's {@code <build><plugins>} section, configured with a version constraint
      * so the plugin selects a JDK that supports the project's source level.
      *
+     * <p>If the plugin already exists in the POM (e.g. with the older {@code toolchain} goal),
+     * the {@code select-jdk-toolchain} execution is appended to the existing entry.
+     * Version upgrades are handled by {@link PluginUpgradeStrategy}, which runs before
+     * this strategy and ensures the plugin is at least version {@value #TOOLCHAINS_PLUGIN_MIN_VERSION}.
+     *
      * @param pomDocument the POM document to modify
      * @param maxJdkVersion the latest JDK major version that supports the source level
      */
@@ -330,13 +339,49 @@ public class ToolchainPluginStrategy extends AbstractUpgradeStrategy {
         Element build = root.childElement(BUILD).orElseGet(() -> DomUtils.insertNewElement(BUILD, root));
         Element plugins = build.childElement(PLUGINS).orElseGet(() -> DomUtils.insertNewElement(PLUGINS, build));
 
-        Element plugin = DomUtils.createPlugin(plugins, TOOLCHAINS_PLUGIN_GROUP_ID, MAVEN_TOOLCHAINS_PLUGIN, null);
-        Element executions = DomUtils.insertNewElement("executions", plugin);
+        // Look for an existing toolchains-plugin entry (may have only the older 'toolchain' goal).
+        // If present, its version has already been upgraded by PluginUpgradeStrategy (priority 10).
+        Element existingPlugin = findToolchainsPlugin(plugins);
+        final Element plugin;
+        if (existingPlugin != null) {
+            plugin = existingPlugin;
+        } else {
+            // New plugin entry — set version to the minimum that has select-jdk-toolchain
+            plugin = DomUtils.createPlugin(
+                    plugins, TOOLCHAINS_PLUGIN_GROUP_ID, MAVEN_TOOLCHAINS_PLUGIN, TOOLCHAINS_PLUGIN_MIN_VERSION);
+        }
+
+        Element executions =
+                plugin.childElement("executions").orElseGet(() -> DomUtils.insertNewElement("executions", plugin));
         Element execution = DomUtils.insertNewElement("execution", executions);
         Element goals = DomUtils.insertNewElement("goals", execution);
         DomUtils.insertContentElement(goals, "goal", SELECT_JDK_TOOLCHAIN_GOAL);
         Element configuration = DomUtils.insertNewElement(CONFIGURATION, execution);
         DomUtils.insertContentElement(configuration, "version", "(," + maxJdkVersion + "]");
+    }
+
+    /**
+     * Checks whether a plugin element is the {@code maven-toolchains-plugin}.
+     */
+    private static boolean isToolchainsPlugin(Element plugin) {
+        String artifactId = plugin.childTextTrimmed(ARTIFACT_ID);
+        String groupId = plugin.childTextTrimmed(GROUP_ID);
+        return MAVEN_TOOLCHAINS_PLUGIN.equals(artifactId)
+                && (groupId == null || groupId.isEmpty() || TOOLCHAINS_PLUGIN_GROUP_ID.equals(groupId));
+    }
+
+    /**
+     * Finds an existing {@code maven-toolchains-plugin} element in a plugins section.
+     *
+     * @return the plugin element, or {@code null} if not found
+     */
+    private Element findToolchainsPlugin(Element pluginsElement) {
+        for (Element plugin : pluginsElement.childElements(PLUGIN).toList()) {
+            if (isToolchainsPlugin(plugin)) {
+                return plugin;
+            }
+        }
+        return null;
     }
 
     /**

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategyTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvnup/goals/ToolchainPluginStrategyTest.java
@@ -359,6 +359,8 @@ class ToolchainPluginStrategyTest {
             assertTrue(strategy.hasToolchainsPluginWithSelectGoal(doc));
             String output = doc.toXml();
             assertTrue(output.contains("<version>(,11]</version>"), "Expected version constraint in output: " + output);
+            assertTrue(
+                    output.contains("<version>3.2.0</version>"), "Expected plugin version 3.2.0 in output: " + output);
         }
 
         @Test
@@ -386,6 +388,85 @@ class ToolchainPluginStrategyTest {
             assertTrue(strategy.hasToolchainsPluginWithSelectGoal(doc));
             String output = doc.toXml();
             assertTrue(output.contains("<version>(,8]</version>"), "Expected version constraint in output: " + output);
+            assertTrue(
+                    output.contains("<version>3.2.0</version>"), "Expected plugin version 3.2.0 in output: " + output);
+        }
+
+        @Test
+        @DisplayName("should reuse existing toolchains-plugin and not create a duplicate")
+        void reuseExistingToolchainsPlugin() {
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-toolchains-plugin</artifactId>
+                                    <version>3.2.0</version>
+                                    <executions>
+                                        <execution>
+                                            <goals>
+                                                <goal>toolchain</goal>
+                                            </goals>
+                                        </execution>
+                                    </executions>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            strategy.addToolchainsPlugin(doc, 11);
+
+            assertTrue(strategy.hasToolchainsPluginWithSelectGoal(doc));
+            String output = doc.toXml();
+            // Should NOT create a duplicate plugin entry
+            assertEquals(
+                    1,
+                    output.split("maven-toolchains-plugin").length - 1,
+                    "Should have exactly one toolchains-plugin entry: " + output);
+            // Old toolchain goal should still be present
+            assertTrue(
+                    output.contains("<goal>toolchain</goal>"), "Old toolchain goal should still be present: " + output);
+            // New select-jdk-toolchain goal should be added
+            assertTrue(
+                    output.contains("<goal>select-jdk-toolchain</goal>"),
+                    "New select-jdk-toolchain goal should be present: " + output);
+        }
+
+        @Test
+        @DisplayName("should not change existing version when reusing plugin")
+        void preserveExistingVersion() {
+            String pomXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0</version>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-toolchains-plugin</artifactId>
+                                    <version>3.3.0</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """;
+            Document doc = Document.of(pomXml);
+            strategy.addToolchainsPlugin(doc, 11);
+
+            String output = doc.toXml();
+            // Version should remain 3.3.0 — ToolchainPluginStrategy does not touch versions;
+            // version upgrades are handled by PluginUpgradeStrategy
+            assertTrue(output.contains("<version>3.3.0</version>"), "Version 3.3.0 should not be changed: " + output);
         }
     }
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITMvnupToolchainPluginStrategyTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITMvnupToolchainPluginStrategyTest.java
@@ -82,6 +82,9 @@ public class MavenITMvnupToolchainPluginStrategyTest extends AbstractMavenIntegr
         assertTrue(
                 pomContent.contains("<version>(,8]</version>"),
                 "POM should contain version constraint (,8] for source 5 after mvnup apply");
+        assertTrue(
+                pomContent.contains("<version>3.2.0</version>"),
+                "POM should contain plugin version 3.2.0 (minimum for select-jdk-toolchain goal)");
 
         // Second run — should be idempotent (skip, already present)
         verifier = newVerifier(testDir.getAbsolutePath());


### PR DESCRIPTION
Backport of #12999 to `maven-4.0.x`.

## Summary

- When `ToolchainPluginStrategy` adds a `select-jdk-toolchain` execution, it now ensures the `maven-toolchains-plugin` version is >= 3.2.0 (the first version containing that goal)
- Previously, the plugin was added without a version, causing builds to fail when the project inherited an older version like 1.1 (which only has `help` and `toolchain` goals)
- Reuses existing toolchains-plugin entries instead of creating duplicates, and upgrades versions in both `build/plugins` and `build/pluginManagement/plugins`