### PR TITLE
Optimize computeLocations() and simplify ModelObjectPool location handling

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelObjectPool.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelObjectPool.java
@@ -253,29 +253,8 @@ public class DefaultModelObjectPool implements ModelObjectProcessor {
                     && Objects.equals(dep1.getSystemPath(), dep2.getSystemPath())
                     && Objects.equals(dep1.getExclusions(), dep2.getExclusions())
                     && Objects.equals(dep1.getOptional(), dep2.getOptional())
-                    && Objects.equals(dep1.getLocationKeys(), dep2.getLocationKeys())
-                    && locationsEqual(dep1, dep2)
+                    && Objects.equals(dep1.getLocations(), dep2.getLocations())
                     && Objects.equals(dep1.getImportedFrom(), dep2.getImportedFrom());
-        }
-
-        /**
-         * Compare locations maps for two dependencies.
-         */
-        private static boolean locationsEqual(
-                org.apache.maven.api.model.Dependency dep1, org.apache.maven.api.model.Dependency dep2) {
-            var keys1 = dep1.getLocationKeys();
-            var keys2 = dep2.getLocationKeys();
-
-            if (!Objects.equals(keys1, keys2)) {
-                return false;
-            }
-
-            for (Object key : keys1) {
-                if (!Objects.equals(dep1.getLocation(key), dep2.getLocation(key))) {
-                    return false;
-                }
-            }
-            return true;
         }
 
         /**
@@ -303,22 +282,9 @@ public class DefaultModelObjectPool implements ModelObjectProcessor {
             h = 31 * h + Objects.hashCode(dep.getSystemPath());
             h = 31 * h + Objects.hashCode(dep.getExclusions());
             h = 31 * h + Objects.hashCode(dep.getOptional());
-            h = 31 * h + Objects.hashCode(dep.getLocationKeys());
-            h = 31 * h + locationsHashCode(dep);
+            h = 31 * h + Objects.hashCode(dep.getLocations());
             h = 31 * h + Objects.hashCode(dep.getImportedFrom());
             return h;
-        }
-
-        /**
-         * Compute hash code for locations map.
-         */
-        private static int locationsHashCode(org.apache.maven.api.model.Dependency dep) {
-            int hash = 1;
-            for (Object key : dep.getLocationKeys()) {
-                hash = 31 * hash + Objects.hashCode(key);
-                hash = 31 * hash + Objects.hashCode(dep.getLocation(key));
-            }
-            return hash;
         }
     }
 

--- a/src/mdo/model.vm
+++ b/src/mdo/model.vm
@@ -265,6 +265,15 @@ public class ${class.name}
     }
 
     /**
+     * Gets the locations map directly for bulk comparison and hashing.
+     *
+     * @return an unmodifiable map of locations, never {@code null}
+     */
+    public Map<Object, InputLocation> getLocations() {
+        return locations;
+    }
+
+    /**
      * Gets the input location that caused this model to be read.
      */
     public InputLocation getImportedFrom() {
@@ -518,14 +527,16 @@ public class ${class.name}
             Map<Object, InputLocation> newlocs = locations != null ? locations : Map.of();
             Map<Object, InputLocation> oldlocs = base != null ? base.locations : Map.of();
             if (newlocs.isEmpty()) {
-                return Map.copyOf(oldlocs);
+                return oldlocs;
             }
             if (oldlocs.isEmpty()) {
                 return Map.copyOf(newlocs);
             }
-            return Stream.concat(newlocs.entrySet().stream(), oldlocs.entrySet().stream())
-                    // Keep value from newlocs in case of duplicates
-                    .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1));
+            // Use HashMap.putAll instead of Stream.concat().collect() to avoid
+            // Stream allocation and intermediate Map.Entry iteration overhead
+            HashMap<Object, InputLocation> merged = new HashMap<>(oldlocs);
+            merged.putAll(newlocs); // newlocs entries override oldlocs (same semantics as before)
+            return Map.copyOf(merged);
         }
     #end
     }


### PR DESCRIPTION
## Summary

Two targeted optimizations in the model building pipeline:

### 1. `computeLocations()` — replace Stream with HashMap (`model.vm`)

Replace `Stream.concat().collect(Collectors.toUnmodifiableMap(...))` with `HashMap.putAll()` + `Map.copyOf()`, reducing intermediate `KeyValueHolder` allocations from stream-based map construction.

Also return `oldlocs` directly when `newlocs` is empty — the base locations map is already immutable, so the `Map.copyOf()` was redundant.

### 2. Add `getLocations()` accessor and simplify `DefaultModelObjectPool` (`model.vm` + `DefaultModelObjectPool.java`)

The original `PoolKey` code used `getLocationKeys()` + `getLocation(key)` to iterate locations entry by entry because the model had no direct map accessor. This required:
- A separate `locationsEqual()` method iterating keys one by one
- A separate `locationsHashCode()` method doing the same for hashing
- A redundant `Objects.equals(dep1.getLocationKeys(), dep2.getLocationKeys())` check

Fix: add `getLocations()` to the generated model, then replace all of the above with:
- `Objects.equals(dep1.getLocations(), dep2.getLocations())` for equality
- `dep.getLocations().hashCode()` for hashing

### Changes

| File | Insertions | Deletions | Net |
|------|-----------|-----------|-----|
| `src/mdo/model.vm` | +17 | -4 | +13 |
| `DefaultModelObjectPool.java` | +2 | -38 | -36 |
| **Total** | **+19** | **-42** | **-23** |
