### PR TITLE
Fix reactor BOM imports in also-make graph

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
@@ -113,6 +113,25 @@ public class ProjectSorter {
                         false);
             }
 
+            org.apache.maven.model.Model originalModel = project.getOriginalModel();
+            if (originalModel != null && originalModel.getDependencyManagement() != null) {
+                for (org.apache.maven.model.Dependency dependency :
+                        originalModel.getDependencyManagement().getDependencies()) {
+                    if ("import".equals(dependency.getScope()) && "pom".equals(dependency.getType())) {
+                        addEdge(
+                                projectMap,
+                                vertexMap,
+                                project,
+                                projectVertex,
+                                dependency.getGroupId(),
+                                dependency.getArtifactId(),
+                                resolveImportVersion(project, dependency.getVersion()),
+                                false,
+                                false);
+                    }
+                }
+            }
+
             Parent parent = project.getModel().getDelegate().getParent();
 
             if (parent != null) {
@@ -178,6 +197,19 @@ public class ProjectSorter {
         this.sortedProjects = sortedProjectLabels.stream()
                 .map(id -> projectMap.get(id))
                 .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+    }
+
+    private String resolveImportVersion(MavenProject project, String version) {
+        if ("${project.version}".equals(version) || "${pom.version}".equals(version)) {
+            return project.getVersion();
+        }
+        if (version != null && version.startsWith("${") && version.endsWith("}")) {
+            String property = project.getProperties().getProperty(version.substring(2, version.length() - 1));
+            if (property != null) {
+                return property;
+            }
+        }
+        return version;
     }
 
     @SuppressWarnings("checkstyle:parameternumber")

--- a/impl/maven-core/src/test/java/org/apache/maven/project/ProjectSorterDependencyManagementTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/project/ProjectSorterDependencyManagementTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.project;
+
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProjectSorterDependencyManagementTest {
+    @Test
+    void importedReactorBomPrecedesConsumer() throws Exception {
+        MavenProject bom = createProject("org.example", "test-bom", "1-SNAPSHOT");
+        MavenProject consumer = createProject("org.example", "test-consumer", "1-SNAPSHOT");
+
+        Dependency importedBom = new Dependency();
+        importedBom.setGroupId("org.example");
+        importedBom.setArtifactId("test-bom");
+        importedBom.setVersion("${project.version}");
+        importedBom.setType("pom");
+        importedBom.setScope("import");
+
+        DependencyManagement dependencyManagement = new DependencyManagement();
+        dependencyManagement.addDependency(importedBom);
+        consumer.getOriginalModel().setDependencyManagement(dependencyManagement);
+
+        ProjectSorter sorter = new ProjectSorter(List.of(consumer, bom));
+
+        assertEquals(List.of(ProjectSorter.getId(bom)), sorter.getDependencies(ProjectSorter.getId(consumer)));
+        assertEquals(List.of(bom, consumer), sorter.getSortedProjects());
+    }
+
+    private static MavenProject createProject(String groupId, String artifactId, String version) {
+        Model model = new Model();
+        model.setModelVersion("4.0.0");
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+        MavenProject project = new MavenProject(model);
+        project.setOriginalModel(model);
+        return project;
+    }
+}


### PR DESCRIPTION
Fixes #11397.

ProjectSorter builds the reactor dependency graph used by -am, but imported BOMs declared under <dependencyManagement> were not represented as reactor edges.

As a result, when one reactor module imports another reactor module as a BOM, for example:

<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>org.example</groupId>
      <artifactId>example-bom</artifactId>
      <version>${project.version}</version>
      <type>pom</type>
      <scope>import</scope>
    </dependency>
  </dependencies>
</dependencyManagement>

running:

mvn -am -pl example-consumer ...

could omit example-bom from the selected reactor even though the consumer depends on it for its effective model. This can cause Maven to use a stale locally installed BOM or fail when the BOM is not already available.

Change

Treat imported BOMs from the project’s original model as reactor graph edges.

The original model is used because BOM import declarations are no longer available in the same form after dependency-management model processing.

Before matching the imported BOM against reactor coordinates, the change resolves:

* ${project.version}
* ${pom.version}
* exact ${property} references available from the project properties

Literal versions continue to be matched directly.

This keeps the behavior in ProjectSorter, so -am and other consumers of the reactor graph see the same dependency relationship rather than adding special handling only to project selection.

Tests

Adds a focused regression test where:

* the consumer is intentionally supplied to ProjectSorter before the BOM;
* the consumer imports the BOM from <dependencyManagement>;
* the BOM version is ${project.version};
* the resulting graph must contain the BOM as an upstream dependency;
* the BOM must sort before the consumer.

Without the reactor edge, the test fails because the imported BOM is absent from the consumer’s graph dependencies and the original input order is retained.

Verification

Full local mvn verify and the Core IT suite have not been run in this environment because the available shell cannot access external dependencies. Repository CI can perform the full verification.

<!--
Please open pull requests against one of the following branches:
- master — default target for all changes (new features + bug fixes).
  If the change should also go to maven-4.0.x, request a backport in the PR.
- maven-3.10.x — target for 3.x changes (new features + bug fixes).
  If the change should also go to maven-3.9.x, request a backport in the PR.
  maven-3.9.x should receive only serious bug fixes, as it is approaching EOL.
Backports are typically handled by maintainers;
however, after agreement you may open a separate backport PR to the target maintenance branch.
-->

Following this checklist to help us incorporate your
contribution quickly and easily:

* [x]	Your pull request should address just one issue, without pulling in other changes.
* [x]	Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x]	Each commit in the pull request should have a meaningful subject line and body.
    Note that commits might be squashed by a maintainer on merge.
* [x]	Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
    This may not always be possible but is a best-practice.
* [ ]	Run mvn verify to make sure basic checks pass.
    A more thorough check will be performed on your pull request automatically.
* [ ]	You have run the [Core IT](https://maven.apache.org/core-its/core-it-suite/) successfully.

If your pull request is about ~20 lines of code you don’t need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

* [x]	I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
* [ ]	In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).