### PR TITLE
[MNG-5359] Do not activate pluginManagement executions through lifecycle bindings

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
@@ -25,10 +25,12 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.LifeCyclePluginAnalyzer;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
@@ -51,13 +53,13 @@ import org.apache.maven.model.merge.MavenModelMerger;
 @Singleton
 public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInjector {
 
-    private final LifecycleBindingsMerger merger = new LifecycleBindingsMerger();
-
     private final LifeCyclePluginAnalyzer lifecycle;
+    private final DefaultLifecycles lifecycles;
 
     @Inject
-    public DefaultLifecycleBindingsInjector(LifeCyclePluginAnalyzer lifecycle) {
+    public DefaultLifecycleBindingsInjector(LifeCyclePluginAnalyzer lifecycle, DefaultLifecycles lifecycles) {
         this.lifecycle = lifecycle;
+        this.lifecycles = lifecycles;
     }
 
     @Override
@@ -75,8 +77,16 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
             lifecycleModel.setBuild(new Build());
             lifecycleModel.getBuild().getPlugins().addAll(defaultPlugins);
 
-            merger.merge(model, lifecycleModel);
+            new LifecycleBindingsMerger(getPhaseToLifecycleMap()).merge(model, lifecycleModel);
         }
+    }
+
+    private Map<String, String> getPhaseToLifecycleMap() {
+        Map<String, String> phaseToLifecycle = new HashMap<>();
+        lifecycles
+                .getPhaseToLifecycleMap()
+                .forEach((phase, lifecycle) -> phaseToLifecycle.put(phase, lifecycle.getId()));
+        return phaseToLifecycle;
     }
 
     /**
@@ -85,6 +95,12 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
     protected static class LifecycleBindingsMerger extends MavenModelMerger {
 
         private static final String PLUGIN_MANAGEMENT = "plugin-management";
+
+        private final Map<String, String> phaseToLifecycle;
+
+        LifecycleBindingsMerger(Map<String, String> phaseToLifecycle) {
+            this.phaseToLifecycle = phaseToLifecycle;
+        }
 
         public void merge(Model target, Model source) {
             if (target.getBuild() == null) {
@@ -132,7 +148,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                             Object key = getPluginKey(managedPlugin);
                             Plugin addedPlugin = added.get(key);
                             if (addedPlugin != null) {
-                                merged.put(key, mergePluginManagement(addedPlugin, managedPlugin));
+                                merged.put(key, mergePluginManagement(addedPlugin, managedPlugin, sourceDominant));
                             }
                         }
                     }
@@ -144,12 +160,24 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
             }
         }
 
-        private Plugin mergePluginManagement(Plugin lifecyclePlugin, Plugin managedPlugin) {
-            Plugin plugin = lifecyclePlugin.clone();
-            Map<Object, Object> context = Collections.emptyMap();
-            mergePlugin_Version(plugin, managedPlugin, true, context);
-            mergeConfigurationContainer_Configuration(plugin, managedPlugin, true, context);
+        private Plugin mergePluginManagement(Plugin lifecyclePlugin, Plugin managedPlugin, boolean sourceDominant) {
+            Plugin plugin = managedPlugin.clone();
+            plugin.getExecutions().removeIf(execution -> !isFromSameLifecycle(lifecyclePlugin, execution));
+            mergePlugin(plugin, lifecyclePlugin, sourceDominant, Collections.emptyMap());
             return plugin;
+        }
+
+        private boolean isFromSameLifecycle(Plugin lifecyclePlugin, PluginExecution managedExecution) {
+            String managedPhase = managedExecution.getPhase();
+            if (managedPhase == null) {
+                return true;
+            }
+
+            String managedLifecycle = phaseToLifecycle.get(managedPhase);
+            return lifecyclePlugin.getExecutions().stream()
+                    .anyMatch(execution -> managedPhase.equals(execution.getPhase())
+                            || managedLifecycle != null
+                                    && managedLifecycle.equals(phaseToLifecycle.get(execution.getPhase())));
         }
 
         @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
@@ -132,9 +132,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                             Object key = getPluginKey(managedPlugin);
                             Plugin addedPlugin = added.get(key);
                             if (addedPlugin != null) {
-                                Plugin plugin = managedPlugin.clone();
-                                mergePlugin(plugin, addedPlugin, sourceDominant, Collections.emptyMap());
-                                merged.put(key, plugin);
+                                merged.put(key, mergePluginManagement(addedPlugin, managedPlugin));
                             }
                         }
                     }
@@ -144,6 +142,14 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
 
                 target.setPlugins(result);
             }
+        }
+
+        private Plugin mergePluginManagement(Plugin lifecyclePlugin, Plugin managedPlugin) {
+            Plugin plugin = lifecyclePlugin.clone();
+            Map<Object, Object> context = Collections.emptyMap();
+            mergePlugin_Version(plugin, managedPlugin, true, context);
+            mergeConfigurationContainer_Configuration(plugin, managedPlugin, true, context);
+            return plugin;
         }
 
         @Override

--- a/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector.java
@@ -82,6 +82,8 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
     }
 
     private Map<String, String> getPhaseToLifecycleMap() {
+        // Extensions may register lifecycles after this injector is constructed, so do not cache this map.
+        // DefaultLifecycles includes both computed phases and aliases from its LifecycleRegistry delegate.
         Map<String, String> phaseToLifecycle = new HashMap<>();
         lifecycles
                 .getPhaseToLifecycleMap()
@@ -174,6 +176,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
             }
 
             String managedLifecycle = phaseToLifecycle.get(managedPhase);
+            // An unregistered phase has no known lifecycle; retain it only for an exact phase match.
             return lifecyclePlugin.getExecutions().stream()
                     .anyMatch(execution -> managedPhase.equals(execution.getPhase())
                             || managedLifecycle != null

--- a/impl/maven-core/src/test/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjectorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjectorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.plugin;
+
+import java.util.List;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.InputLocation;
+import org.apache.maven.model.InputSource;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.model.PluginManagement;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DefaultLifecycleBindingsInjectorTest {
+
+    @Test
+    void mergePluginManagementDoesNotActivateManagedExecutions() {
+        InputSource lifecycleSource = inputSource("lifecycle");
+        InputSource managementSource = inputSource("plugin-management");
+
+        PluginExecution lifecycleExecution = execution("default-clean", "clean", lifecycleSource);
+        Plugin lifecyclePlugin = plugin("lifecycle-version", lifecycleExecution, lifecycleSource);
+        lifecyclePlugin.setConfiguration(configuration("shared", "lifecycle", "lifecycle", "default"));
+
+        PluginExecution managedExecution = execution("custom-clean", "initialize", managementSource);
+        Plugin managedPlugin = plugin("managed-version", managedExecution, managementSource);
+        managedPlugin.setConfiguration(configuration("shared", "managed", "managed", "configured"));
+        managedPlugin.setExtensions(true);
+        managedPlugin.setInherited(false);
+        managedPlugin.addDependency(dependency("managed-dependency"));
+
+        Model target = modelWithPluginManagement(managedPlugin);
+        Model source = modelWithPlugin(lifecyclePlugin);
+
+        new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger().merge(target, source);
+
+        Plugin result = target.getBuild().getPlugins().get(0);
+        Xpp3Dom resultConfiguration = (Xpp3Dom) result.getConfiguration();
+
+        assertEquals("managed-version", result.getVersion());
+        assertEquals("managed", resultConfiguration.getChild("shared").getValue());
+        assertEquals("configured", resultConfiguration.getChild("managed").getValue());
+        assertEquals("default", resultConfiguration.getChild("lifecycle").getValue());
+        assertEquals(
+                List.of("default-clean"),
+                result.getExecutions().stream().map(PluginExecution::getId).toList());
+        assertEquals(List.of(), result.getDependencies());
+        assertNull(result.getExtensions());
+        assertNull(result.getInherited());
+        assertEquals("lifecycle", result.getLocation("").getSource().getModelId());
+        assertEquals(
+                "plugin-management", result.getLocation("version").getSource().getModelId());
+        assertEquals(
+                "lifecycle",
+                result.getExecutions().get(0).getLocation("").getSource().getModelId());
+    }
+
+    private static Model modelWithPlugin(Plugin plugin) {
+        Build build = new Build();
+        build.addPlugin(plugin);
+        Model model = new Model();
+        model.setBuild(build);
+        return model;
+    }
+
+    private static Model modelWithPluginManagement(Plugin plugin) {
+        PluginManagement management = new PluginManagement();
+        management.addPlugin(plugin);
+        Build build = new Build();
+        build.setPluginManagement(management);
+        Model model = new Model();
+        model.setBuild(build);
+        return model;
+    }
+
+    private static Plugin plugin(String version, PluginExecution execution, InputSource source) {
+        Plugin plugin = new Plugin();
+        plugin.setArtifactId("maven-clean-plugin");
+        plugin.setVersion(version);
+        plugin.addExecution(execution);
+        plugin.setLocation("", new InputLocation(1, 1, source));
+        plugin.setLocation("version", new InputLocation(2, 1, source));
+        return plugin;
+    }
+
+    private static PluginExecution execution(String id, String phase, InputSource source) {
+        PluginExecution execution = new PluginExecution();
+        execution.setId(id);
+        execution.setPhase(phase);
+        execution.addGoal("clean");
+        execution.setLocation("", new InputLocation(3, 1, source));
+        return execution;
+    }
+
+    private static Dependency dependency(String artifactId) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId("org.apache.maven.test");
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion("1");
+        return dependency;
+    }
+
+    private static Xpp3Dom configuration(String name, String value, String secondName, String secondValue) {
+        Xpp3Dom configuration = new Xpp3Dom("configuration");
+        Xpp3Dom child = new Xpp3Dom(name);
+        child.setValue(value);
+        configuration.addChild(child);
+        child = new Xpp3Dom(secondName);
+        child.setValue(secondValue);
+        configuration.addChild(child);
+        return configuration;
+    }
+
+    private static InputSource inputSource(String modelId) {
+        InputSource source = new InputSource();
+        source.setModelId(modelId);
+        return source;
+    }
+}

--- a/impl/maven-core/src/test/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjectorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjectorTest.java
@@ -19,6 +19,9 @@
 package org.apache.maven.model.plugin;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
@@ -32,12 +35,11 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DefaultLifecycleBindingsInjectorTest {
 
     @Test
-    void mergePluginManagementDoesNotActivateManagedExecutions() {
+    void mergePluginManagementOnlyActivatesExecutionsFromTheSameLifecycle() {
         InputSource lifecycleSource = inputSource("lifecycle");
         InputSource managementSource = inputSource("plugin-management");
 
@@ -45,8 +47,15 @@ class DefaultLifecycleBindingsInjectorTest {
         Plugin lifecyclePlugin = plugin("lifecycle-version", lifecycleExecution, lifecycleSource);
         lifecyclePlugin.setConfiguration(configuration("shared", "lifecycle", "lifecycle", "default"));
 
-        PluginExecution managedExecution = execution("custom-clean", "initialize", managementSource);
-        Plugin managedPlugin = plugin("managed-version", managedExecution, managementSource);
+        PluginExecution sameLifecycleExecution = execution("managed-clean", "clean", managementSource);
+        PluginExecution crossLifecycleExecution = execution("managed-initialize", "initialize", managementSource);
+        PluginExecution defaultPhaseExecution = execution("managed-default-phase", null, managementSource);
+        Plugin managedPlugin = plugin(
+                "managed-version",
+                managementSource,
+                sameLifecycleExecution,
+                crossLifecycleExecution,
+                defaultPhaseExecution);
         managedPlugin.setConfiguration(configuration("shared", "managed", "managed", "configured"));
         managedPlugin.setExtensions(true);
         managedPlugin.setInherited(false);
@@ -55,7 +64,8 @@ class DefaultLifecycleBindingsInjectorTest {
         Model target = modelWithPluginManagement(managedPlugin);
         Model source = modelWithPlugin(lifecyclePlugin);
 
-        new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger().merge(target, source);
+        new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger(Map.of("clean", "clean", "initialize", "default"))
+                .merge(target, source);
 
         Plugin result = target.getBuild().getPlugins().get(0);
         Xpp3Dom resultConfiguration = (Xpp3Dom) result.getConfiguration();
@@ -64,18 +74,27 @@ class DefaultLifecycleBindingsInjectorTest {
         assertEquals("managed", resultConfiguration.getChild("shared").getValue());
         assertEquals("configured", resultConfiguration.getChild("managed").getValue());
         assertEquals("default", resultConfiguration.getChild("lifecycle").getValue());
+        assertEquals(3, result.getExecutions().size());
         assertEquals(
-                List.of("default-clean"),
-                result.getExecutions().stream().map(PluginExecution::getId).toList());
-        assertEquals(List.of(), result.getDependencies());
-        assertNull(result.getExtensions());
-        assertNull(result.getInherited());
-        assertEquals("lifecycle", result.getLocation("").getSource().getModelId());
+                Set.of("default-clean", "managed-clean", "managed-default-phase"),
+                result.getExecutions().stream().map(PluginExecution::getId).collect(Collectors.toSet()));
+        assertEquals(
+                List.of("managed-dependency"),
+                result.getDependencies().stream().map(Dependency::getArtifactId).toList());
+        assertEquals("true", result.getExtensions());
+        assertEquals("false", result.getInherited());
+        assertEquals("plugin-management", result.getLocation("").getSource().getModelId());
         assertEquals(
                 "plugin-management", result.getLocation("version").getSource().getModelId());
         assertEquals(
                 "lifecycle",
-                result.getExecutions().get(0).getLocation("").getSource().getModelId());
+                result.getExecutions().stream()
+                        .filter(execution -> "default-clean".equals(execution.getId()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getLocation("")
+                        .getSource()
+                        .getModelId());
     }
 
     private static Model modelWithPlugin(Plugin plugin) {
@@ -97,10 +116,16 @@ class DefaultLifecycleBindingsInjectorTest {
     }
 
     private static Plugin plugin(String version, PluginExecution execution, InputSource source) {
+        return plugin(version, source, execution);
+    }
+
+    private static Plugin plugin(String version, InputSource source, PluginExecution... executions) {
         Plugin plugin = new Plugin();
         plugin.setArtifactId("maven-clean-plugin");
         plugin.setVersion(version);
-        plugin.addExecution(execution);
+        for (PluginExecution execution : executions) {
+            plugin.addExecution(execution);
+        }
         plugin.setLocation("", new InputLocation(1, 1, source));
         plugin.setLocation("version", new InputLocation(2, 1, source));
         return plugin;

--- a/impl/maven-core/src/test/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjectorTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/model/plugin/DefaultLifecycleBindingsInjectorTest.java
@@ -22,7 +22,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.maven.api.Lifecycle;
+import org.apache.maven.api.services.LifecycleRegistry;
+import org.apache.maven.api.services.Lookup;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.LifeCyclePluginAnalyzer;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.InputLocation;
@@ -35,6 +41,9 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DefaultLifecycleBindingsInjectorTest {
 
@@ -75,6 +84,9 @@ class DefaultLifecycleBindingsInjectorTest {
         assertEquals("configured", resultConfiguration.getChild("managed").getValue());
         assertEquals("default", resultConfiguration.getChild("lifecycle").getValue());
         assertEquals(3, result.getExecutions().size());
+        assertFalse(
+                result.getExecutions().stream().anyMatch(e -> "managed-initialize".equals(e.getId())),
+                "Cross-lifecycle managed execution should be filtered out");
         assertEquals(
                 Set.of("default-clean", "managed-clean", "managed-default-phase"),
                 result.getExecutions().stream().map(PluginExecution::getId).collect(Collectors.toSet()));
@@ -113,6 +125,70 @@ class DefaultLifecycleBindingsInjectorTest {
         Model model = new Model();
         model.setBuild(build);
         return model;
+    }
+
+    @Test
+    void retainsDifferentPhasesInRegisteredLifecycle() {
+        assertManagedPhaseRetained("custom-prepare", "custom-finish", true, true);
+    }
+
+    @Test
+    void excludesNonmatchingUnknownPhase() {
+        assertManagedPhaseRetained("custom-prepare", "custom-finish", false, false);
+    }
+
+    @Test
+    void retainsMatchingUnknownPhase() {
+        assertManagedPhaseRetained("custom-prepare", "custom-prepare", false, true);
+    }
+
+    private void assertManagedPhaseRetained(
+            String boundPhase, String managedPhase, boolean registered, boolean retained) {
+        Map<String, String> phases =
+                registered ? Map.of("custom-prepare", "custom", "custom-finish", "custom") : Map.of();
+        InputSource source = inputSource("test");
+        Model result = modelWithPluginManagement(plugin("1", execution("managed", managedPhase, source), source));
+        Model lifecycleModel = modelWithPlugin(plugin("1", execution("lifecycle", boundPhase, source), source));
+        new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger(phases).merge(result, lifecycleModel);
+        assertEquals(
+                retained,
+                result.getBuild().getPlugins().get(0).getExecutions().stream()
+                        .anyMatch(e -> "managed".equals(e.getId())));
+    }
+
+    @Test
+    void readsAliasesAndNewlyRegisteredPhases() {
+        Lifecycle lifecycle = mock(Lifecycle.class);
+        Lifecycle.Alias alias = mock(Lifecycle.Alias.class);
+        LifecycleRegistry registry = mock(LifecycleRegistry.class);
+        when(lifecycle.id()).thenReturn("custom");
+        when(lifecycle.aliases()).thenReturn(List.of(alias));
+        when(alias.v3Phase()).thenReturn("custom-alias");
+        when(registry.stream()).thenAnswer(invocation -> Stream.of(lifecycle));
+        when(registry.computePhases(lifecycle)).thenReturn(List.of("custom-start"));
+        InputSource source = inputSource("test");
+        Plugin lifecyclePlugin = plugin("1", execution("lifecycle", "custom-start", source), source);
+        Plugin managedPlugin = plugin(
+                "1", source, execution("alias", "custom-alias", source), execution("late", "custom-finish", source));
+        LifeCyclePluginAnalyzer analyzer = mock(LifeCyclePluginAnalyzer.class);
+        when(analyzer.getPluginsBoundByDefaultToAllLifecycles("jar")).thenReturn(Set.of(lifecyclePlugin));
+        DefaultLifecycles lifecycles = new DefaultLifecycles(registry, mock(Lookup.class));
+        DefaultLifecycleBindingsInjector injector = new DefaultLifecycleBindingsInjector(analyzer, lifecycles);
+        Model first = modelWithPluginManagement(managedPlugin);
+        injector.injectLifecycleBindings(first, null, null);
+        when(registry.computePhases(lifecycle)).thenReturn(List.of("custom-start", "custom-finish"));
+        Model second = modelWithPluginManagement(managedPlugin);
+        injector.injectLifecycleBindings(second, null, null);
+        assertEquals(
+                Set.of("lifecycle", "alias"),
+                first.getBuild().getPlugins().get(0).getExecutions().stream()
+                        .map(PluginExecution::getId)
+                        .collect(Collectors.toSet()));
+        assertEquals(
+                Set.of("lifecycle", "alias", "late"),
+                second.getBuild().getPlugins().get(0).getExecutions().stream()
+                        .map(PluginExecution::getId)
+                        .collect(Collectors.toSet()));
     }
 
     private static Plugin plugin(String version, PluginExecution execution, InputSource source) {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
@@ -51,8 +51,6 @@ import org.apache.maven.api.services.model.LifecycleBindingsInjector;
 @Singleton
 public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInjector {
 
-    private final LifecycleBindingsMerger merger = new LifecycleBindingsMerger();
-
     private final LifecycleRegistry lifecycleRegistry;
     private final PackagingRegistry packagingRegistry;
 
@@ -86,8 +84,17 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
             Model lifecycleModel = Model.newBuilder()
                     .build(Build.newBuilder().plugins(allPlugins.values()).build())
                     .build();
-            return merger.merge(model, lifecycleModel);
+            return new LifecycleBindingsMerger(getPhaseToLifecycleMap()).merge(model, lifecycleModel);
         }
+    }
+
+    private Map<String, String> getPhaseToLifecycleMap() {
+        Map<String, String> phaseToLifecycle = new HashMap<>();
+        lifecycleRegistry.stream().forEach(lifecycle -> {
+            lifecycleRegistry.computePhases(lifecycle).forEach(phase -> phaseToLifecycle.put(phase, lifecycle.id()));
+            lifecycle.aliases().forEach(alias -> phaseToLifecycle.put(alias.v3Phase(), lifecycle.id()));
+        });
+        return phaseToLifecycle;
     }
 
     private void addPlugin(Map<Plugin, Plugin> plugins, Plugin plugin) {
@@ -113,6 +120,12 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
     protected static class LifecycleBindingsMerger extends MavenModelMerger {
 
         private static final String PLUGIN_MANAGEMENT = "plugin-management";
+
+        private final Map<String, String> phaseToLifecycle;
+
+        LifecycleBindingsMerger(Map<String, String> phaseToLifecycle) {
+            this.phaseToLifecycle = phaseToLifecycle;
+        }
 
         public Model merge(Model target, Model source) {
             Build targetBuild = target.getBuild();
@@ -168,7 +181,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                             Object key = getPluginKey().apply(managedPlugin);
                             Plugin addedPlugin = added.get(key);
                             if (addedPlugin != null) {
-                                merged.put(key, mergePluginManagement(addedPlugin, managedPlugin));
+                                merged.put(key, mergePluginManagement(addedPlugin, managedPlugin, sourceDominant));
                             }
                         }
                     }
@@ -180,12 +193,24 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
             }
         }
 
-        private Plugin mergePluginManagement(Plugin lifecyclePlugin, Plugin managedPlugin) {
-            Plugin.Builder builder = Plugin.newBuilder(lifecyclePlugin);
-            Map<Object, Object> context = Collections.emptyMap();
-            mergePlugin_Version(builder, lifecyclePlugin, managedPlugin, true, context);
-            mergeConfigurationContainer_Configuration(builder, lifecyclePlugin, managedPlugin, true, context);
-            return builder.build();
+        private Plugin mergePluginManagement(Plugin lifecyclePlugin, Plugin managedPlugin, boolean sourceDominant) {
+            Plugin filteredManagedPlugin = managedPlugin.withExecutions(managedPlugin.getExecutions().stream()
+                    .filter(execution -> isFromSameLifecycle(lifecyclePlugin, execution))
+                    .toList());
+            return mergePlugin(filteredManagedPlugin, lifecyclePlugin, sourceDominant, Collections.emptyMap());
+        }
+
+        private boolean isFromSameLifecycle(Plugin lifecyclePlugin, PluginExecution managedExecution) {
+            String managedPhase = managedExecution.getPhase();
+            if (managedPhase == null) {
+                return true;
+            }
+
+            String managedLifecycle = phaseToLifecycle.get(managedPhase);
+            return lifecyclePlugin.getExecutions().stream()
+                    .anyMatch(execution -> managedPhase.equals(execution.getPhase())
+                            || managedLifecycle != null
+                                    && managedLifecycle.equals(phaseToLifecycle.get(execution.getPhase())));
         }
 
         @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
@@ -168,9 +168,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
                             Object key = getPluginKey().apply(managedPlugin);
                             Plugin addedPlugin = added.get(key);
                             if (addedPlugin != null) {
-                                Plugin plugin =
-                                        mergePlugin(managedPlugin, addedPlugin, sourceDominant, Collections.emptyMap());
-                                merged.put(key, plugin);
+                                merged.put(key, mergePluginManagement(addedPlugin, managedPlugin));
                             }
                         }
                     }
@@ -180,6 +178,14 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
 
                 builder.plugins(result);
             }
+        }
+
+        private Plugin mergePluginManagement(Plugin lifecyclePlugin, Plugin managedPlugin) {
+            Plugin.Builder builder = Plugin.newBuilder(lifecyclePlugin);
+            Map<Object, Object> context = Collections.emptyMap();
+            mergePlugin_Version(builder, lifecyclePlugin, managedPlugin, true, context);
+            mergeConfigurationContainer_Configuration(builder, lifecyclePlugin, managedPlugin, true, context);
+            return builder.build();
         }
 
         @Override

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjector.java
@@ -89,6 +89,8 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
     }
 
     private Map<String, String> getPhaseToLifecycleMap() {
+        // Extensions may register lifecycles after this injector is constructed, so do not cache this map.
+        // Include aliases, as DefaultLifecycles does for the legacy model injector.
         Map<String, String> phaseToLifecycle = new HashMap<>();
         lifecycleRegistry.stream().forEach(lifecycle -> {
             lifecycleRegistry.computePhases(lifecycle).forEach(phase -> phaseToLifecycle.put(phase, lifecycle.id()));
@@ -207,6 +209,7 @@ public class DefaultLifecycleBindingsInjector implements LifecycleBindingsInject
             }
 
             String managedLifecycle = phaseToLifecycle.get(managedPhase);
+            // An unregistered phase has no known lifecycle; retain it only for an exact phase match.
             return lifecyclePlugin.getExecutions().stream()
                     .anyMatch(execution -> managedPhase.equals(execution.getPhase())
                             || managedLifecycle != null

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjectorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjectorTest.java
@@ -19,6 +19,9 @@
 package org.apache.maven.impl.model;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.Dependency;
@@ -32,12 +35,11 @@ import org.apache.maven.api.xml.XmlNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DefaultLifecycleBindingsInjectorTest {
 
     @Test
-    void mergePluginManagementDoesNotActivateManagedExecutions() {
+    void mergePluginManagementOnlyActivatesExecutionsFromTheSameLifecycle() {
         InputSource lifecycleSource = InputSource.of("lifecycle", "lifecycle.xml");
         InputSource managementSource = InputSource.of("plugin-management", "pom.xml");
 
@@ -45,8 +47,15 @@ class DefaultLifecycleBindingsInjectorTest {
         Plugin lifecyclePlugin = plugin("lifecycle-version", lifecycleExecution, lifecycleSource)
                 .withConfiguration(configuration("shared", "lifecycle", "lifecycle", "default"));
 
-        PluginExecution managedExecution = execution("custom-clean", "initialize", managementSource);
-        Plugin managedPlugin = Plugin.newBuilder(plugin("managed-version", managedExecution, managementSource))
+        PluginExecution sameLifecycleExecution = execution("managed-clean", "clean", managementSource);
+        PluginExecution crossLifecycleExecution = execution("managed-initialize", "initialize", managementSource);
+        PluginExecution defaultPhaseExecution = execution("managed-default-phase", null, managementSource);
+        Plugin managedPlugin = Plugin.newBuilder(plugin(
+                        "managed-version",
+                        managementSource,
+                        sameLifecycleExecution,
+                        crossLifecycleExecution,
+                        defaultPhaseExecution))
                 .configuration(configuration("shared", "managed", "managed", "configured"))
                 .extensions("true")
                 .inherited("false")
@@ -68,7 +77,9 @@ class DefaultLifecycleBindingsInjectorTest {
                 .build(Build.newBuilder().plugins(List.of(lifecyclePlugin)).build())
                 .build();
 
-        Model resultModel = new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger().merge(target, source);
+        Model resultModel = new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger(
+                        Map.of("clean", "clean", "initialize", "default"))
+                .merge(target, source);
 
         Plugin result = resultModel.getBuild().getPlugins().get(0);
         XmlNode resultConfiguration = result.getConfiguration();
@@ -77,25 +88,38 @@ class DefaultLifecycleBindingsInjectorTest {
         assertEquals("managed", resultConfiguration.child("shared").value());
         assertEquals("configured", resultConfiguration.child("managed").value());
         assertEquals("default", resultConfiguration.child("lifecycle").value());
+        assertEquals(3, result.getExecutions().size());
         assertEquals(
-                List.of("default-clean"),
-                result.getExecutions().stream().map(PluginExecution::getId).toList());
-        assertEquals(List.of(), result.getDependencies());
-        assertNull(result.getExtensions());
-        assertNull(result.getInherited());
-        assertEquals("lifecycle", result.getLocation("").getSource().getModelId());
+                Set.of("default-clean", "managed-clean", "managed-default-phase"),
+                result.getExecutions().stream().map(PluginExecution::getId).collect(Collectors.toSet()));
+        assertEquals(
+                List.of("managed-dependency"),
+                result.getDependencies().stream().map(Dependency::getArtifactId).toList());
+        assertEquals("true", result.getExtensions());
+        assertEquals("false", result.getInherited());
+        assertEquals("plugin-management", result.getLocation("").getSource().getModelId());
         assertEquals(
                 "plugin-management", result.getLocation("version").getSource().getModelId());
         assertEquals(
                 "lifecycle",
-                result.getExecutions().get(0).getLocation("").getSource().getModelId());
+                result.getExecutions().stream()
+                        .filter(execution -> "default-clean".equals(execution.getId()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getLocation("")
+                        .getSource()
+                        .getModelId());
     }
 
     private static Plugin plugin(String version, PluginExecution execution, InputSource source) {
+        return plugin(version, source, execution);
+    }
+
+    private static Plugin plugin(String version, InputSource source, PluginExecution... executions) {
         return Plugin.newBuilder()
                 .artifactId("maven-clean-plugin")
                 .version(version)
-                .executions(List.of(execution))
+                .executions(List.of(executions))
                 .location("", InputLocation.of(1, 1, source))
                 .location("version", InputLocation.of(2, 1, source))
                 .build();

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjectorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjectorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl.model;
+
+import java.util.List;
+
+import org.apache.maven.api.model.Build;
+import org.apache.maven.api.model.Dependency;
+import org.apache.maven.api.model.InputLocation;
+import org.apache.maven.api.model.InputSource;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.model.Plugin;
+import org.apache.maven.api.model.PluginExecution;
+import org.apache.maven.api.model.PluginManagement;
+import org.apache.maven.api.xml.XmlNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DefaultLifecycleBindingsInjectorTest {
+
+    @Test
+    void mergePluginManagementDoesNotActivateManagedExecutions() {
+        InputSource lifecycleSource = InputSource.of("lifecycle", "lifecycle.xml");
+        InputSource managementSource = InputSource.of("plugin-management", "pom.xml");
+
+        PluginExecution lifecycleExecution = execution("default-clean", "clean", lifecycleSource);
+        Plugin lifecyclePlugin = plugin("lifecycle-version", lifecycleExecution, lifecycleSource)
+                .withConfiguration(configuration("shared", "lifecycle", "lifecycle", "default"));
+
+        PluginExecution managedExecution = execution("custom-clean", "initialize", managementSource);
+        Plugin managedPlugin = Plugin.newBuilder(plugin("managed-version", managedExecution, managementSource))
+                .configuration(configuration("shared", "managed", "managed", "configured"))
+                .extensions("true")
+                .inherited("false")
+                .dependencies(List.of(Dependency.newBuilder()
+                        .groupId("org.apache.maven.test")
+                        .artifactId("managed-dependency")
+                        .version("1")
+                        .build()))
+                .build();
+
+        Model target = Model.newBuilder()
+                .build(Build.newBuilder()
+                        .pluginManagement(PluginManagement.newBuilder()
+                                .plugins(List.of(managedPlugin))
+                                .build())
+                        .build())
+                .build();
+        Model source = Model.newBuilder()
+                .build(Build.newBuilder().plugins(List.of(lifecyclePlugin)).build())
+                .build();
+
+        Model resultModel = new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger().merge(target, source);
+
+        Plugin result = resultModel.getBuild().getPlugins().get(0);
+        XmlNode resultConfiguration = result.getConfiguration();
+
+        assertEquals("managed-version", result.getVersion());
+        assertEquals("managed", resultConfiguration.child("shared").value());
+        assertEquals("configured", resultConfiguration.child("managed").value());
+        assertEquals("default", resultConfiguration.child("lifecycle").value());
+        assertEquals(
+                List.of("default-clean"),
+                result.getExecutions().stream().map(PluginExecution::getId).toList());
+        assertEquals(List.of(), result.getDependencies());
+        assertNull(result.getExtensions());
+        assertNull(result.getInherited());
+        assertEquals("lifecycle", result.getLocation("").getSource().getModelId());
+        assertEquals(
+                "plugin-management", result.getLocation("version").getSource().getModelId());
+        assertEquals(
+                "lifecycle",
+                result.getExecutions().get(0).getLocation("").getSource().getModelId());
+    }
+
+    private static Plugin plugin(String version, PluginExecution execution, InputSource source) {
+        return Plugin.newBuilder()
+                .artifactId("maven-clean-plugin")
+                .version(version)
+                .executions(List.of(execution))
+                .location("", InputLocation.of(1, 1, source))
+                .location("version", InputLocation.of(2, 1, source))
+                .build();
+    }
+
+    private static PluginExecution execution(String id, String phase, InputSource source) {
+        return PluginExecution.newBuilder()
+                .id(id)
+                .phase(phase)
+                .goals(List.of("clean"))
+                .location("", InputLocation.of(3, 1, source))
+                .build();
+    }
+
+    private static XmlNode configuration(String name, String value, String secondName, String secondValue) {
+        return XmlNode.newBuilder()
+                .name("configuration")
+                .children(List.of(XmlNode.newInstance(name, value), XmlNode.newInstance(secondName, secondValue)))
+                .build();
+    }
+}

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjectorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultLifecycleBindingsInjectorTest.java
@@ -20,21 +20,31 @@ package org.apache.maven.impl.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.maven.api.Lifecycle;
+import org.apache.maven.api.Packaging;
 import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.Dependency;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Plugin;
+import org.apache.maven.api.model.PluginContainer;
 import org.apache.maven.api.model.PluginExecution;
 import org.apache.maven.api.model.PluginManagement;
+import org.apache.maven.api.services.LifecycleRegistry;
+import org.apache.maven.api.services.PackagingRegistry;
 import org.apache.maven.api.xml.XmlNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DefaultLifecycleBindingsInjectorTest {
 
@@ -89,6 +99,9 @@ class DefaultLifecycleBindingsInjectorTest {
         assertEquals("configured", resultConfiguration.child("managed").value());
         assertEquals("default", resultConfiguration.child("lifecycle").value());
         assertEquals(3, result.getExecutions().size());
+        assertFalse(
+                result.getExecutions().stream().anyMatch(e -> "managed-initialize".equals(e.getId())),
+                "Cross-lifecycle managed execution should be filtered out");
         assertEquals(
                 Set.of("default-clean", "managed-clean", "managed-default-phase"),
                 result.getExecutions().stream().map(PluginExecution::getId).collect(Collectors.toSet()));
@@ -109,6 +122,93 @@ class DefaultLifecycleBindingsInjectorTest {
                         .getLocation("")
                         .getSource()
                         .getModelId());
+    }
+
+    @Test
+    void retainsDifferentPhasesInRegisteredLifecycle() {
+        assertManagedPhaseRetained("custom-prepare", "custom-finish", true, true);
+    }
+
+    @Test
+    void excludesNonmatchingUnknownPhase() {
+        assertManagedPhaseRetained("custom-prepare", "custom-finish", false, false);
+    }
+
+    @Test
+    void retainsMatchingUnknownPhase() {
+        assertManagedPhaseRetained("custom-prepare", "custom-prepare", false, true);
+    }
+
+    private void assertManagedPhaseRetained(
+            String boundPhase, String managedPhase, boolean registered, boolean retained) {
+        Map<String, String> phases =
+                registered ? Map.of("custom-prepare", "custom", "custom-finish", "custom") : Map.of();
+        InputSource source = InputSource.of("test", "test.xml");
+        Model target = Model.newBuilder()
+                .build(Build.newBuilder()
+                        .pluginManagement(PluginManagement.newBuilder()
+                                .plugins(List.of(plugin("1", execution("managed", managedPhase, source), source)))
+                                .build())
+                        .build())
+                .build();
+        Model lifecycleModel = Model.newBuilder()
+                .build(Build.newBuilder()
+                        .plugins(List.of(plugin("1", execution("lifecycle", boundPhase, source), source)))
+                        .build())
+                .build();
+        Model result =
+                new DefaultLifecycleBindingsInjector.LifecycleBindingsMerger(phases).merge(target, lifecycleModel);
+        assertEquals(
+                retained,
+                result.getBuild().getPlugins().get(0).getExecutions().stream()
+                        .anyMatch(e -> "managed".equals(e.getId())));
+    }
+
+    @Test
+    void readsAliasesAndNewlyRegisteredPhases() {
+        Lifecycle lifecycle = mock(Lifecycle.class);
+        Lifecycle.Alias alias = mock(Lifecycle.Alias.class);
+        LifecycleRegistry registry = mock(LifecycleRegistry.class);
+        when(lifecycle.id()).thenReturn("custom");
+        when(lifecycle.aliases()).thenReturn(List.of(alias));
+        when(alias.v3Phase()).thenReturn("custom-alias");
+        when(registry.stream()).thenAnswer(invocation -> Stream.of(lifecycle));
+        when(registry.computePhases(lifecycle)).thenReturn(List.of("custom-start"));
+        InputSource source = InputSource.of("test", "test.xml");
+        Plugin lifecyclePlugin = plugin("1", execution("lifecycle", "custom-start", source), source);
+        Plugin managedPlugin = plugin(
+                "1", source, execution("alias", "custom-alias", source), execution("late", "custom-finish", source));
+        Packaging packaging = mock(Packaging.class);
+        PackagingRegistry packagingRegistry = mock(PackagingRegistry.class);
+        when(packagingRegistry.lookup("jar")).thenReturn(Optional.of(packaging));
+        when(packaging.plugins())
+                .thenReturn(Map.of(
+                        "custom",
+                        PluginContainer.newBuilder()
+                                .plugins(List.of(lifecyclePlugin))
+                                .build()));
+        DefaultLifecycleBindingsInjector injector = new DefaultLifecycleBindingsInjector(registry, packagingRegistry);
+        Model model = Model.newBuilder()
+                .packaging("jar")
+                .build(Build.newBuilder()
+                        .pluginManagement(PluginManagement.newBuilder()
+                                .plugins(List.of(managedPlugin))
+                                .build())
+                        .build())
+                .build();
+        Model first = injector.injectLifecycleBindings(model, null, null);
+        when(registry.computePhases(lifecycle)).thenReturn(List.of("custom-start", "custom-finish"));
+        Model second = injector.injectLifecycleBindings(model, null, null);
+        assertEquals(
+                Set.of("lifecycle", "alias"),
+                first.getBuild().getPlugins().get(0).getExecutions().stream()
+                        .map(PluginExecution::getId)
+                        .collect(Collectors.toSet()));
+        assertEquals(
+                Set.of("lifecycle", "alias", "late"),
+                second.getBuild().getPlugins().get(0).getExecutions().stream()
+                        .map(PluginExecution::getId)
+                        .collect(Collectors.toSet()));
     }
 
     private static Plugin plugin(String version, PluginExecution execution, InputSource source) {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5359PluginManagementExecutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5359PluginManagementExecutionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that executions declared only in {@code pluginManagement} are not activated by default lifecycle bindings.
+ *
+ * @see <a href="https://github.com/apache/maven/issues/6918">MNG-5359</a>
+ * @since 4.1.0
+ */
+class MavenITmng5359PluginManagementExecutionTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void testManagedExecutionRequiresPluginDeclaration() throws Exception {
+        Path testDir = extractResources("mng-5359");
+
+        Verifier verifier = newVerifier(testDir);
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.addCliArgument("package");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyFileNotPresent("target/managed-clean.txt");
+
+        verifier = newVerifier(testDir);
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.addCliArgument("-Pactivate-clean-plugin");
+        verifier.addCliArgument("package");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyFilePresent("target/managed-clean.txt");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5359PluginManagementExecutionTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5359PluginManagementExecutionTest.java
@@ -18,12 +18,14 @@
  */
 package org.apache.maven.it;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that executions declared only in {@code pluginManagement} are not activated by default lifecycle bindings.
+ * Verifies that cross-lifecycle executions in {@code pluginManagement} require an explicit plugin declaration.
  *
  * @see <a href="https://github.com/apache/maven/issues/6918">MNG-5359</a>
  * @since 4.1.0
@@ -31,9 +33,9 @@ import org.junit.jupiter.api.Test;
 class MavenITmng5359PluginManagementExecutionTest extends AbstractMavenIntegrationTestCase {
 
     @Test
-    void testManagedExecutionRequiresPluginDeclaration() throws Exception {
-        Path testDir = extractResources("mng-5359");
-
+    void testManagedExecutionNotActivatedWithoutDeclaration() throws Exception {
+        Path testDir = prepareProject("management-only");
+        // The clean plugin is introduced by the clean lifecycle, but the managed execution targets package.
         Verifier verifier = newVerifier(testDir);
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
@@ -41,8 +43,12 @@ class MavenITmng5359PluginManagementExecutionTest extends AbstractMavenIntegrati
         verifier.execute();
         verifier.verifyErrorFreeLog();
         verifier.verifyFileNotPresent("target/managed-clean.txt");
+    }
 
-        verifier = newVerifier(testDir);
+    @Test
+    void testManagedExecutionActivatedWithExplicitDeclaration() throws Exception {
+        Path testDir = prepareProject("explicit-plugin");
+        Verifier verifier = newVerifier(testDir);
         verifier.setAutoclean(false);
         verifier.deleteDirectory("target");
         verifier.addCliArgument("-Pactivate-clean-plugin");
@@ -50,5 +56,13 @@ class MavenITmng5359PluginManagementExecutionTest extends AbstractMavenIntegrati
         verifier.execute();
         verifier.verifyErrorFreeLog();
         verifier.verifyFilePresent("target/managed-clean.txt");
+    }
+
+    private Path prepareProject(String scenario) throws Exception {
+        Path testDir = extractResources("mng-5359");
+        Path project = testDir.resolve(scenario);
+        Files.createDirectories(project);
+        Files.copy(testDir.resolve("pom.xml"), project.resolve("pom.xml"), StandardCopyOption.REPLACE_EXISTING);
+        return project;
     }
 }

--- a/its/core-it-suite/src/test/resources/mng-5359/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-5359/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng5359</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Maven Integration Test :: MNG-5359</name>
+  <description>
+    Verifies that a pluginManagement execution is activated only when the plugin is explicitly declared.
+  </description>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>0.1-stub-SNAPSHOT</version>
+          <executions>
+            <execution>
+              <id>managed-clean</id>
+              <phase>package</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+              <configuration>
+                <pathname>target/managed-clean.txt</pathname>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>activate-clean-plugin</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
Fixes #6918.

## Problem

Lifecycle-binding injection can activate a managed execution from a different lifecycle even when the plugin is not declared in `build/plugins`. For example, a managed clean-plugin execution bound to `package` runs during `mvn package`.

## Change

- Filter cross-lifecycle managed executions when a plugin is introduced only by lifecycle bindings.
- Preserve managed executions in the same lifecycle, executions without an explicit phase, and normal plugin-management merging for explicitly declared plugins.
- Preserve managed version, configuration, dependencies, and input locations.
- Apply the same rules to the legacy mutable model and the Maven 4 immutable model.
- Resolve phases and aliases from the current lifecycle registry. Do not cache the map, since extensions can register lifecycles later. Unknown phases are retained only on an exact phase match.

## Tests

- Ten unit tests cover both model implementations, including cross-lifecycle exclusion, same-lifecycle retention, unknown phases, aliases, and phases registered after injector construction.
- Two independent Core IT cases check management-only and explicitly declared plugins.
- `mvn -Prun-its -Dits.test=MavenITmng5359PluginManagementExecutionTest verify`: passed.
- Full `mvn -Prun-its verify`: 1,075 Core IT tests, zero assertion failures, two errors, and 43 skipped. The two DI fixtures (`MavenITgh11055DIServiceInjectionTest` and `MavenITmng8525MavenDIPlugin`) fail to load `PathTranslator`; the same errors reproduce on the earlier PR revision before this follow-up. The new Core IT cases pass.

## Scope

This changes lifecycle-binding injection only and adds no public API. Explicit plugin declarations retain normal plugin-management behavior.

Following this checklist to help us incorporate the contribution quickly and easily:

- [x] This pull request addresses one issue without unrelated changes.
- [x] The description explains what the pull request does, how, and why.
- [x] Each commit has a meaningful subject line and body.
- [x] Unit tests cover the behavioral changes.
- [x] `mvn verify` passes as part of the targeted Core IT reactor run.
- [ ] The complete Core IT suite passed. See the two fixture errors above.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, I have filed an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
