### PR TITLE
Update NOTICE file in distribution packages

### DIFF
--- a/apache-maven/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/apache-maven/src/main/appended-resources/META-INF/NOTICE.vm
@@ -17,7 +17,7 @@
 ## under the License.
 ##
 Apache Maven
-Copyright 2001-2026 The Apache Software Foundation
+Copyright ${projectTimespan} The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).


### PR DESCRIPTION
Backport of apache/maven#13033 to `maven-4.0.x`.

Replaces the existing static copyright year in the binary distribution `NOTICE`
template with `${projectTimespan}`, retaining the already-present ASF header
and allowing the generated NOTICE to remain current.