### PR TITLE
Update NOTICE file in distribution packages

### DIFF
--- a/apache-maven/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/apache-maven/src/main/appended-resources/META-INF/NOTICE.vm
@@ -16,6 +16,12 @@
 ## specific language governing permissions and limitations
 ## under the License.
 ##
+Apache Maven
+Copyright ${projectTimespan} The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
 This software bundles the following NOTICE files from third party library providers:
 
 META-INF/NOTICE in archive lib/guice-5.1.0.jar


### PR DESCRIPTION
Backport of apache/maven#13033 to `maven-3.10.x`.

Adds the required ASF header to the binary distribution `NOTICE` template,
allowing it to pass RAT validation.