### PR TITLE
deps: Bump Mimir to 0.12.3 (#13048)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,8 @@ concurrency:
 permissions: {}
 
 env:
-  MIMIR_VERSION: 0.12.1
+  # Keep in sync with mimir testing version in pom.xml
+  MIMIR_VERSION: 0.12.3
   MIMIR_BASEDIR: ~/.mimir
   MIMIR_LOCAL: ~/.mimir/local
   MAVEN_OPTS: -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/java_heapdump.hprof

--- a/pom.xml
+++ b/pom.xml
@@ -707,7 +707,7 @@ under the License.
       <dependency>
         <groupId>eu.maveniverse.maven.mimir</groupId>
         <artifactId>testing</artifactId>
-        <version>0.12.1</version>
+        <version>0.12.3</version>
       </dependency>
     </dependencies>
     <!--bootstrap-start-comment-->


### PR DESCRIPTION
Release notes:
https://github.com/maveniverse/mimir/releases/tag/release-0.12.2

Backport of
cb59b97a516a13dd9594c069c88f1b7f740bf2cc
