### PR TITLE
Fix #13068: make PluginDependenciesResolver methods default

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDependenciesResolver.java
@@ -74,6 +74,12 @@ public interface PluginDependenciesResolver {
 
     /**
      * Resolves the runtime dependencies of the specified core extension (as {@link Plugin} as GAV carrier).
+     * <p>
+     * The default implementation delegates to
+     * {@link #resolvePlugin(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)} so that
+     * implementations written against Maven 4.0.0-rc-5 and earlier keep working. Implementations should override
+     * this method: unlike the default, a dedicated implementation is expected to read the extension's artifact
+     * descriptor first, applying relocations and dependency validation.
      *
      * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
      * @param dependencyFilter A filter to exclude artifacts from resolution (but not collection), may be {@code null}.
@@ -83,15 +89,21 @@ public interface PluginDependenciesResolver {
      * @throws PluginResolutionException If any dependency could not be resolved.
      * @since 3.10.0
      */
-    DependencyResult resolveCoreExtensionAndFlatten(
+    default DependencyResult resolveCoreExtensionAndFlatten(
             Plugin plugin,
             DependencyFilter dependencyFilter,
             List<RemoteRepository> repositories,
             RepositorySystemSession session)
-            throws PluginResolutionException;
+            throws PluginResolutionException {
+        return resolvePlugin(plugin, null, dependencyFilter, repositories, session);
+    }
 
     /**
      * Resolves the runtime dependencies of the specified plugin.
+     * <p>
+     * Implementations must not delegate to
+     * {@link #resolvePluginAndFlatten(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)} without
+     * also overriding it: the default implementation of that method delegates back here.
      *
      * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
      * @param artifact The plugin's main artifact, may be {@code null}.
@@ -114,6 +126,10 @@ public interface PluginDependenciesResolver {
 
     /**
      * Resolves the runtime dependencies of the specified plugin.
+     * <p>
+     * The default implementation delegates to
+     * {@link #resolvePlugin(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)}, which this method
+     * supersedes, so that implementations written against Maven 4.0.0-rc-5 and earlier keep working.
      *
      * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
      * @param pluginArtifact The plugin's main artifact, may be {@code null}.
@@ -124,11 +140,13 @@ public interface PluginDependenciesResolver {
      * @throws PluginResolutionException If any dependency could not be resolved.
      * @since 3.10.0
      */
-    DependencyResult resolvePluginAndFlatten(
+    default DependencyResult resolvePluginAndFlatten(
             Plugin plugin,
             Artifact pluginArtifact,
             DependencyFilter dependencyFilter,
             List<RemoteRepository> repositories,
             RepositorySystemSession session)
-            throws PluginResolutionException;
+            throws PluginResolutionException {
+        return resolvePlugin(plugin, pluginArtifact, dependencyFilter, repositories, session);
+    }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDependenciesResolverDefaultMethodsTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDependenciesResolverDefaultMethodsTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.PluginResolutionException;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link PluginDependenciesResolver} is documented as internal, but tools that embed Maven — most visibly
+ * IntelliJ IDEA's {@code Maven40PluginDependenciesResolver} — implement it out of tree and are compiled against
+ * one Maven version while running against another. When {@code resolveCoreExtensionAndFlatten} and
+ * {@code resolvePluginAndFlatten} were forward-ported from Maven 3.10.0 as <em>abstract</em> methods, every such
+ * implementation started failing with {@code AbstractMethodError} as soon as core invoked them.
+ *
+ * <p>These tests pin the compatibility contract: an implementation providing only the methods that existed before
+ * the forward port must remain a legal implementation, and the two newer methods must stay {@code default}.
+ */
+class PluginDependenciesResolverDefaultMethodsTest {
+
+    private static final DependencyResult RESULT = new DependencyResult(new DependencyRequest());
+
+    /**
+     * Implements exactly the method set of the pre-forward-port interface — nothing more. This class failing to
+     * compile <em>is</em> the regression: it means the two newer methods went back to being abstract.
+     */
+    private static final class LegacyResolver implements PluginDependenciesResolver {
+
+        private Plugin plugin;
+        private Artifact pluginArtifact;
+        private DependencyFilter dependencyFilter;
+        private List<RemoteRepository> repositories;
+        private RepositorySystemSession session;
+
+        @Override
+        public Artifact resolve(Plugin plugin, List<RemoteRepository> repositories, RepositorySystemSession session) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.eclipse.aether.graph.DependencyNode resolve(
+                Plugin plugin,
+                Artifact pluginArtifact,
+                DependencyFilter dependencyFilter,
+                List<RemoteRepository> repositories,
+                RepositorySystemSession session) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DependencyResult resolvePlugin(
+                Plugin plugin,
+                Artifact pluginArtifact,
+                DependencyFilter dependencyFilter,
+                List<RemoteRepository> repositories,
+                RepositorySystemSession session) {
+            this.plugin = plugin;
+            this.pluginArtifact = pluginArtifact;
+            this.dependencyFilter = dependencyFilter;
+            this.repositories = repositories;
+            this.session = session;
+            return RESULT;
+        }
+    }
+
+    @Test
+    void resolvePluginAndFlattenDelegatesToResolvePlugin() throws PluginResolutionException {
+        LegacyResolver resolver = new LegacyResolver();
+        Plugin plugin = new Plugin();
+        Artifact artifact = new DefaultArtifact("g:a:1.0");
+        DependencyFilter filter = (node, parents) -> true;
+        List<RemoteRepository> repositories = List.of();
+
+        assertSame(RESULT, resolver.resolvePluginAndFlatten(plugin, artifact, filter, repositories, null));
+
+        assertSame(plugin, resolver.plugin);
+        assertSame(artifact, resolver.pluginArtifact);
+        assertSame(filter, resolver.dependencyFilter);
+        assertSame(repositories, resolver.repositories);
+        assertNull(resolver.session);
+    }
+
+    @Test
+    void resolveCoreExtensionAndFlattenDelegatesToResolvePlugin() throws PluginResolutionException {
+        LegacyResolver resolver = new LegacyResolver();
+        Plugin plugin = new Plugin();
+        DependencyFilter filter = (node, parents) -> true;
+        List<RemoteRepository> repositories = List.of();
+
+        assertSame(RESULT, resolver.resolveCoreExtensionAndFlatten(plugin, filter, repositories, null));
+
+        assertSame(plugin, resolver.plugin);
+        assertNull(resolver.pluginArtifact, "the extension's main artifact is resolved from the plugin GAV");
+        assertSame(filter, resolver.dependencyFilter);
+        assertSame(repositories, resolver.repositories);
+    }
+
+    /**
+     * Guards the property that actually broke IntelliJ IDEA: these methods are invoked on implementations compiled
+     * against an older Maven, so they must carry an implementation in the interface itself. Turning either back into
+     * an abstract method reintroduces {@code AbstractMethodError} for every out-of-tree implementation.
+     */
+    @Test
+    void newerMethodsAreDefaultMethods() throws NoSuchMethodException {
+        Method resolveCoreExtensionAndFlatten = PluginDependenciesResolver.class.getMethod(
+                "resolveCoreExtensionAndFlatten",
+                Plugin.class,
+                DependencyFilter.class,
+                List.class,
+                RepositorySystemSession.class);
+        Method resolvePluginAndFlatten = PluginDependenciesResolver.class.getMethod(
+                "resolvePluginAndFlatten",
+                Plugin.class,
+                Artifact.class,
+                DependencyFilter.class,
+                List.class,
+                RepositorySystemSession.class);
+
+        assertTrue(
+                resolveCoreExtensionAndFlatten.isDefault(),
+                "resolveCoreExtensionAndFlatten must stay a default method");
+        assertTrue(resolvePluginAndFlatten.isDefault(), "resolvePluginAndFlatten must stay a default method");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh13068LegacyPluginDependenciesResolverTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh13068LegacyPluginDependenciesResolverTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for <a href="https://github.com/apache/maven/issues/13068">apache/maven#13068</a>.
+ * The forward port in <a href="https://github.com/apache/maven/pull/12335">apache/maven#12335</a> added
+ * {@code resolveCoreExtensionAndFlatten} and {@code resolvePluginAndFlatten} to
+ * {@code PluginDependenciesResolver} as abstract methods in 4.0.0-rc-6.
+ * <p>
+ * That interface is documented as internal, but it is the only hook Maven offers for influencing plugin
+ * resolution, and every major Java IDE overrides it: IntelliJ IDEA, Eclipse m2e and NetBeans. Because such
+ * implementations live out of tree and are compiled against one Maven while running on another, adding
+ * abstract methods turns every plugin resolution into an {@code AbstractMethodError}.
+ * <p>
+ * This test builds a core extension against maven-core 4.0.0-rc-5 — the last release before those methods
+ * existed — installs it, and then runs a build that uses it. If the newer interface methods are abstract,
+ * the build fails before any goal executes.
+ */
+class MavenITgh13068LegacyPluginDependenciesResolverTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITgh13068LegacyPluginDependenciesResolverTest() {
+        // resolvePluginAndFlatten / resolveCoreExtensionAndFlatten were introduced in 4.0.0-rc-6
+        super("[4.0.0-rc-6,)");
+    }
+
+    @Test
+    void legacyImplementationStillWorks() throws Exception {
+        File testDir = extractResources("/gh-13068-legacy-plugin-dependencies-resolver");
+
+        Verifier extensionVerifier = newVerifier(new File(testDir, "extension").getPath());
+        extensionVerifier.deleteArtifacts("org.apache.maven.its.gh-13068");
+        extensionVerifier.addCliArgument("install");
+        extensionVerifier.execute();
+        extensionVerifier.verifyErrorFreeLog();
+
+        Verifier clientVerifier = newVerifier(new File(testDir, "client").getPath());
+        clientVerifier.setAutoclean(false);
+        clientVerifier.addCliArgument("clean");
+        clientVerifier.execute();
+        clientVerifier.verifyErrorFreeLog();
+
+        // the extension must actually have displaced the default component, otherwise this test
+        // would pass without ever exercising the interface
+        clientVerifier.verifyTextInLog("[gh-13068] legacy PluginDependenciesResolver installed");
+        clientVerifier.verifyTextInLog("[gh-13068] resolvePlugin reached for maven-clean-plugin");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -103,6 +103,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITgh13068LegacyPluginDependenciesResolverTest.class);
         suite.addTestSuite(MavenITmdep0590ClassifiedPomArtifactFromReactorTest.class);
         suite.addTestSuite(MavenITgh12660BomVersionFromImportedBomTest.class);
         suite.addTestSuite(MavenITgh11346DependencyManagementOverrideTest.class);

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/.mvn/extensions.xml
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/.mvn/extensions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.its.gh-13068</groupId>
+    <artifactId>legacy-plugin-dependencies-resolver</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </extension>
+</extensions>

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh-13068</groupId>
+  <artifactId>client</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: gh-13068 :: client</name>
+  <description>
+    Builds with a core extension that overrides PluginDependenciesResolver with a pre-4.0.0-rc-6
+    implementation. Resolving any plugin routes through that extension.
+  </description>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh-13068</groupId>
+  <artifactId>legacy-plugin-dependencies-resolver</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: legacy-plugin-dependencies-resolver</name>
+  <description>
+    A core extension that overrides PluginDependenciesResolver implementing only the method set that
+    existed up to Maven 4.0.0-rc-5. It is deliberately compiled against maven-core 4.0.0-rc-5, the last
+    release before resolveCoreExtensionAndFlatten and resolvePluginAndFlatten were added, so that it
+    reproduces the situation every out-of-tree implementation is in: built against one Maven, run on another.
+  </description>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>4.0.0-rc-5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <version>1.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <executions>
+          <execution>
+            <id>index-project</id>
+            <goals>
+              <goal>main-index</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/src/main/java/org/apache/maven/its/gh13068/LegacyPluginDependenciesResolver.java
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/src/main/java/org/apache/maven/its/gh13068/LegacyPluginDependenciesResolver.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.gh13068;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.List;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.PluginResolutionException;
+import org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver;
+import org.apache.maven.plugin.internal.PluginDependenciesResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.sisu.Priority;
+
+/**
+ * A decorating {@link PluginDependenciesResolver} that implements only the methods which existed up to
+ * Maven 4.0.0-rc-5, delegating everything to the default implementation. This mirrors how IDEs embed
+ * Maven, most visibly IntelliJ IDEA's {@code Maven40PluginDependenciesResolver}.
+ * <p>
+ * Compiled against maven-core 4.0.0-rc-5 (see this module's POM) and run against the Maven under test,
+ * so the newer interface methods have no implementation here. They must therefore be resolved through
+ * {@code default} methods on the interface; if they are abstract, plugin resolution dies with
+ * {@code AbstractMethodError} before a single goal runs.
+ */
+@Named
+@Singleton
+@Priority(10)
+public class LegacyPluginDependenciesResolver implements PluginDependenciesResolver {
+
+    private final PluginDependenciesResolver delegate;
+
+    @Inject
+    public LegacyPluginDependenciesResolver(DefaultPluginDependenciesResolver delegate) {
+        this.delegate = delegate;
+        System.out.println("[gh-13068] legacy PluginDependenciesResolver installed");
+    }
+
+    @Override
+    public Artifact resolve(Plugin plugin, List<RemoteRepository> repositories, RepositorySystemSession session)
+            throws PluginResolutionException {
+        return delegate.resolve(plugin, repositories, session);
+    }
+
+    @Override
+    public DependencyNode resolve(
+            Plugin plugin,
+            Artifact pluginArtifact,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException {
+        return delegate.resolve(plugin, pluginArtifact, dependencyFilter, repositories, session);
+    }
+
+    @Override
+    public DependencyResult resolvePlugin(
+            Plugin plugin,
+            Artifact pluginArtifact,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException {
+        System.out.println("[gh-13068] resolvePlugin reached for " + plugin.getArtifactId());
+        return delegate.resolvePlugin(plugin, pluginArtifact, dependencyFilter, repositories, session);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #13068.

4.0.0-rc-6 added `resolveCoreExtensionAndFlatten` and `resolvePluginAndFlatten` to the internal `PluginDependenciesResolver` as **abstract** methods (#12335). Implementations that live out of tree — IntelliJ IDEA, Eclipse m2e, NetBeans all have one — are compiled against a different Maven than they run on, so the first plugin resolution dies with `AbstractMethodError`.

This is the fix @gnodet announced for rc-7 [in reply to the rc-6 vote](https://lists.apache.org/thread/mtt7kg632lfs2hxcx0nv9bn4omkgbvt6).

## Change

Both methods become `default` and delegate to the pre-existing `resolvePlugin`, which `DefaultPluginDependenciesResolver` already treats as an alias — there, `resolvePlugin` delegates to `resolvePluginAndFlatten`.

`resolvePlugin` stays abstract on purpose: giving it a default too would let an implementation that overrides neither method recurse infinitely. There is an `@implSpec` note warning against delegating back.

The default for `resolveCoreExtensionAndFlatten` is documented as best effort — a dedicated implementation additionally reads the extension's artifact descriptor to apply relocations and run `MavenPluginDependenciesValidator`. If you would rather not guess there, I am happy to make it throw `UnsupportedOperationException`; say the word.

## Tests

**Unit** — `PluginDependenciesResolverDefaultMethodsTest`:

* a resolver implementing exactly the pre-forward-port method set; its compiling *is* the compatibility assertion
* both defaults asserted to delegate to `resolvePlugin` with the expected arguments
* a `Method.isDefault()` guard, so re-abstracting either method fails the build

**Integration** — `MavenITgh13068LegacyPluginDependenciesResolverTest`: builds a core extension that overrides `PluginDependenciesResolver` with only the pre-rc-6 method set, deliberately compiled against `maven-core:4.0.0-rc-5`, installs it, and runs a build that uses it via `.mvn/extensions.xml`. It asserts an error-free build *and* two marker lines, so it cannot pass without actually exercising the extension.

Both were verified red without the change. Reverting only the interface gives:

```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0 <<< FAILURE!
Caused by: java.lang.AbstractMethodError: Receiver class
  org.apache.maven.its.gh13068.LegacyPluginDependenciesResolver does not define or inherit
  an implementation of the resolved method 'abstract ... resolvePluginAndFlatten(...)'
  at DefaultMavenPluginManager.createPluginRealm(DefaultMavenPluginManager.java:421)
```

## Real-world verification

@chrisdutz confirmed that a `maven-4.0.x` build carrying this patch imports Apache PLC4X in IntelliJ IDEA cleanly, where stock rc-6 produces a cascade of errors. PLC4X is affected via `resolveCoreExtensionAndFlatten` because it declares core extensions in `.mvn/extensions.xml`.

Worth noting the JetBrains side does not make this unnecessary: `resolveCoreExtensionAndFlatten` is implemented only on their master and is absent from IntelliJ IDEA 2026.2.2, the current release.

## Note on the base branch

This targets `maven-4.0.x` because that is where the regression shipped and where rc-7 / GA come from. Happy to open the equivalent against `master` first if you prefer that order — the change applies unmodified, the baselines are identical.
