### PR TITLE
Fix #13068: make PluginDependenciesResolver methods default

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/PluginDependenciesResolver.java
@@ -74,6 +74,12 @@ public interface PluginDependenciesResolver {
 
     /**
      * Resolves the runtime dependencies of the specified core extension (as {@link Plugin} as GAV carrier).
+     * <p>
+     * The default implementation delegates to
+     * {@link #resolvePlugin(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)} so that
+     * implementations written against Maven 4.0.0-rc-5 and earlier keep working. Implementations should override
+     * this method: unlike the default, a dedicated implementation is expected to read the extension's artifact
+     * descriptor first, applying relocations and dependency validation.
      *
      * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
      * @param dependencyFilter A filter to exclude artifacts from resolution (but not collection), may be {@code null}.
@@ -83,15 +89,21 @@ public interface PluginDependenciesResolver {
      * @throws PluginResolutionException If any dependency could not be resolved.
      * @since 3.10.0
      */
-    DependencyResult resolveCoreExtensionAndFlatten(
+    default DependencyResult resolveCoreExtensionAndFlatten(
             Plugin plugin,
             DependencyFilter dependencyFilter,
             List<RemoteRepository> repositories,
             RepositorySystemSession session)
-            throws PluginResolutionException;
+            throws PluginResolutionException {
+        return resolvePlugin(plugin, null, dependencyFilter, repositories, session);
+    }
 
     /**
      * Resolves the runtime dependencies of the specified plugin.
+     * <p>
+     * Implementations must not delegate to
+     * {@link #resolvePluginAndFlatten(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)} without
+     * also overriding it: the default implementation of that method delegates back here.
      *
      * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
      * @param artifact The plugin's main artifact, may be {@code null}.
@@ -114,6 +126,10 @@ public interface PluginDependenciesResolver {
 
     /**
      * Resolves the runtime dependencies of the specified plugin.
+     * <p>
+     * The default implementation delegates to
+     * {@link #resolvePlugin(Plugin, Artifact, DependencyFilter, List, RepositorySystemSession)}, which this method
+     * supersedes, so that implementations written against Maven 4.0.0-rc-5 and earlier keep working.
      *
      * @param plugin The plugin for which to resolve the dependencies, must not be {@code null}.
      * @param pluginArtifact The plugin's main artifact, may be {@code null}.
@@ -124,11 +140,13 @@ public interface PluginDependenciesResolver {
      * @throws PluginResolutionException If any dependency could not be resolved.
      * @since 3.10.0
      */
-    DependencyResult resolvePluginAndFlatten(
+    default DependencyResult resolvePluginAndFlatten(
             Plugin plugin,
             Artifact pluginArtifact,
             DependencyFilter dependencyFilter,
             List<RemoteRepository> repositories,
             RepositorySystemSession session)
-            throws PluginResolutionException;
+            throws PluginResolutionException {
+        return resolvePlugin(plugin, pluginArtifact, dependencyFilter, repositories, session);
+    }
 }

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDependenciesResolverDefaultMethodsTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDependenciesResolverDefaultMethodsTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.internal;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.PluginResolutionException;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link PluginDependenciesResolver} is documented as internal, but tools that embed Maven — most visibly
+ * IntelliJ IDEA's {@code Maven40PluginDependenciesResolver} — implement it out of tree and are compiled against
+ * one Maven version while running against another. When {@code resolveCoreExtensionAndFlatten} and
+ * {@code resolvePluginAndFlatten} were forward-ported from Maven 3.10.0 as <em>abstract</em> methods, every such
+ * implementation started failing with {@code AbstractMethodError} as soon as core invoked them.
+ *
+ * <p>These tests pin the compatibility contract: an implementation providing only the methods that existed before
+ * the forward port must remain a legal implementation, and the two newer methods must stay {@code default}.
+ */
+class PluginDependenciesResolverDefaultMethodsTest {
+
+    private static final DependencyResult RESULT = new DependencyResult(new DependencyRequest());
+
+    /**
+     * Implements exactly the method set of the pre-forward-port interface — nothing more. This class failing to
+     * compile <em>is</em> the regression: it means the two newer methods went back to being abstract.
+     */
+    private static final class LegacyResolver implements PluginDependenciesResolver {
+
+        private Plugin plugin;
+        private Artifact pluginArtifact;
+        private DependencyFilter dependencyFilter;
+        private List<RemoteRepository> repositories;
+        private RepositorySystemSession session;
+
+        @Override
+        public Artifact resolve(Plugin plugin, List<RemoteRepository> repositories, RepositorySystemSession session) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.eclipse.aether.graph.DependencyNode resolve(
+                Plugin plugin,
+                Artifact pluginArtifact,
+                DependencyFilter dependencyFilter,
+                List<RemoteRepository> repositories,
+                RepositorySystemSession session) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DependencyResult resolvePlugin(
+                Plugin plugin,
+                Artifact pluginArtifact,
+                DependencyFilter dependencyFilter,
+                List<RemoteRepository> repositories,
+                RepositorySystemSession session) {
+            this.plugin = plugin;
+            this.pluginArtifact = pluginArtifact;
+            this.dependencyFilter = dependencyFilter;
+            this.repositories = repositories;
+            this.session = session;
+            return RESULT;
+        }
+    }
+
+    @Test
+    void resolvePluginAndFlattenDelegatesToResolvePlugin() throws PluginResolutionException {
+        LegacyResolver resolver = new LegacyResolver();
+        Plugin plugin = new Plugin();
+        Artifact artifact = new DefaultArtifact("g:a:1.0");
+        DependencyFilter filter = (node, parents) -> true;
+        List<RemoteRepository> repositories = List.of();
+
+        assertSame(RESULT, resolver.resolvePluginAndFlatten(plugin, artifact, filter, repositories, null));
+
+        assertSame(plugin, resolver.plugin);
+        assertSame(artifact, resolver.pluginArtifact);
+        assertSame(filter, resolver.dependencyFilter);
+        assertSame(repositories, resolver.repositories);
+        assertNull(resolver.session);
+    }
+
+    @Test
+    void resolveCoreExtensionAndFlattenDelegatesToResolvePlugin() throws PluginResolutionException {
+        LegacyResolver resolver = new LegacyResolver();
+        Plugin plugin = new Plugin();
+        DependencyFilter filter = (node, parents) -> true;
+        List<RemoteRepository> repositories = List.of();
+
+        assertSame(RESULT, resolver.resolveCoreExtensionAndFlatten(plugin, filter, repositories, null));
+
+        assertSame(plugin, resolver.plugin);
+        assertNull(resolver.pluginArtifact, "the extension's main artifact is resolved from the plugin GAV");
+        assertSame(filter, resolver.dependencyFilter);
+        assertSame(repositories, resolver.repositories);
+    }
+
+    /**
+     * Guards the property that actually broke IntelliJ IDEA: these methods are invoked on implementations compiled
+     * against an older Maven, so they must carry an implementation in the interface itself. Turning either back into
+     * an abstract method reintroduces {@code AbstractMethodError} for every out-of-tree implementation.
+     */
+    @Test
+    void newerMethodsAreDefaultMethods() throws NoSuchMethodException {
+        Method resolveCoreExtensionAndFlatten = PluginDependenciesResolver.class.getMethod(
+                "resolveCoreExtensionAndFlatten",
+                Plugin.class,
+                DependencyFilter.class,
+                List.class,
+                RepositorySystemSession.class);
+        Method resolvePluginAndFlatten = PluginDependenciesResolver.class.getMethod(
+                "resolvePluginAndFlatten",
+                Plugin.class,
+                Artifact.class,
+                DependencyFilter.class,
+                List.class,
+                RepositorySystemSession.class);
+
+        assertTrue(
+                resolveCoreExtensionAndFlatten.isDefault(),
+                "resolveCoreExtensionAndFlatten must stay a default method");
+        assertTrue(resolvePluginAndFlatten.isDefault(), "resolvePluginAndFlatten must stay a default method");
+    }
+}

--- a/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDependenciesResolverDefaultMethodsTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/plugin/internal/PluginDependenciesResolverDefaultMethodsTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * {@link PluginDependenciesResolver} is documented as internal, but tools that embed Maven — most visibly
@@ -100,14 +101,15 @@ class PluginDependenciesResolverDefaultMethodsTest {
         Artifact artifact = new DefaultArtifact("g:a:1.0");
         DependencyFilter filter = (node, parents) -> true;
         List<RemoteRepository> repositories = List.of();
+        RepositorySystemSession session = mock(RepositorySystemSession.class);
 
-        assertSame(RESULT, resolver.resolvePluginAndFlatten(plugin, artifact, filter, repositories, null));
+        assertSame(RESULT, resolver.resolvePluginAndFlatten(plugin, artifact, filter, repositories, session));
 
         assertSame(plugin, resolver.plugin);
         assertSame(artifact, resolver.pluginArtifact);
         assertSame(filter, resolver.dependencyFilter);
         assertSame(repositories, resolver.repositories);
-        assertNull(resolver.session);
+        assertSame(session, resolver.session);
     }
 
     @Test
@@ -116,13 +118,15 @@ class PluginDependenciesResolverDefaultMethodsTest {
         Plugin plugin = new Plugin();
         DependencyFilter filter = (node, parents) -> true;
         List<RemoteRepository> repositories = List.of();
+        RepositorySystemSession session = mock(RepositorySystemSession.class);
 
-        assertSame(RESULT, resolver.resolveCoreExtensionAndFlatten(plugin, filter, repositories, null));
+        assertSame(RESULT, resolver.resolveCoreExtensionAndFlatten(plugin, filter, repositories, session));
 
         assertSame(plugin, resolver.plugin);
         assertNull(resolver.pluginArtifact, "the extension's main artifact is resolved from the plugin GAV");
         assertSame(filter, resolver.dependencyFilter);
         assertSame(repositories, resolver.repositories);
+        assertSame(session, resolver.session);
     }
 
     /**

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh13068LegacyPluginDependenciesResolverTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh13068LegacyPluginDependenciesResolverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for <a href="https://github.com/apache/maven/issues/13068">apache/maven#13068</a>.
+ * The forward port in <a href="https://github.com/apache/maven/pull/12329">apache/maven#12329</a> added
+ * {@code resolveCoreExtensionAndFlatten} and {@code resolvePluginAndFlatten} to
+ * {@code PluginDependenciesResolver} as abstract methods.
+ * <p>
+ * That interface is documented as internal, but it is the only hook Maven offers for influencing plugin
+ * resolution, and every major Java IDE overrides it: IntelliJ IDEA, Eclipse m2e and NetBeans. Because such
+ * implementations live out of tree and are compiled against one Maven while running on another, adding
+ * abstract methods turns every plugin resolution into an {@code AbstractMethodError}.
+ * <p>
+ * This test builds a core extension against maven-core 4.0.0-rc-5 — the last release before those methods
+ * existed — installs it, and then runs a build that uses it. If the newer interface methods are abstract,
+ * the build fails before any goal executes.
+ */
+class MavenITgh13068LegacyPluginDependenciesResolverTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void legacyImplementationStillWorks() throws Exception {
+        Path testDir = extractResources("gh-13068-legacy-plugin-dependencies-resolver");
+
+        Verifier extensionVerifier = newVerifier(testDir.resolve("extension"));
+        extensionVerifier.deleteArtifacts("org.apache.maven.its.gh-13068");
+        extensionVerifier.addCliArgument("install");
+        extensionVerifier.execute();
+        extensionVerifier.verifyErrorFreeLog();
+
+        Verifier clientVerifier = newVerifier(testDir.resolve("client"));
+        clientVerifier.setAutoclean(false);
+        clientVerifier.addCliArgument("clean");
+        clientVerifier.execute();
+        clientVerifier.verifyErrorFreeLog();
+
+        // the extension must actually have displaced the default component, otherwise this test
+        // would pass without ever exercising the interface
+        clientVerifier.verifyTextInLog("[gh-13068] legacy PluginDependenciesResolver installed");
+        clientVerifier.verifyTextInLog("[gh-13068] resolvePlugin reached for maven-clean-plugin");
+    }
+}

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/.mvn/extensions.xml
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/.mvn/extensions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.its.gh-13068</groupId>
+    <artifactId>legacy-plugin-dependencies-resolver</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </extension>
+</extensions>

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/client/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh-13068</groupId>
+  <artifactId>client</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: gh-13068 :: client</name>
+  <description>
+    Builds with a core extension that overrides PluginDependenciesResolver with a pre-4.0.0-rc-6
+    implementation. Resolving any plugin routes through that extension.
+  </description>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.gh-13068</groupId>
+  <artifactId>legacy-plugin-dependencies-resolver</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: legacy-plugin-dependencies-resolver</name>
+  <description>
+    A core extension that overrides PluginDependenciesResolver implementing only the method set that
+    existed up to Maven 4.0.0-rc-5. It is deliberately compiled against maven-core 4.0.0-rc-5, the last
+    release before resolveCoreExtensionAndFlatten and resolvePluginAndFlatten were added, so that it
+    reproduces the situation every out-of-tree implementation is in: built against one Maven, run on another.
+  </description>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>4.0.0-rc-5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <version>1.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <executions>
+          <execution>
+            <id>index-project</id>
+            <goals>
+              <goal>main-index</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/src/main/java/org/apache/maven/its/gh13068/LegacyPluginDependenciesResolver.java
+++ b/its/core-it-suite/src/test/resources/gh-13068-legacy-plugin-dependencies-resolver/extension/src/main/java/org/apache/maven/its/gh13068/LegacyPluginDependenciesResolver.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.gh13068;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.List;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.PluginResolutionException;
+import org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver;
+import org.apache.maven.plugin.internal.PluginDependenciesResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.sisu.Priority;
+
+/**
+ * A decorating {@link PluginDependenciesResolver} that implements only the methods which existed up to
+ * Maven 4.0.0-rc-5, delegating everything to the default implementation. This mirrors how IDEs embed
+ * Maven, most visibly IntelliJ IDEA's {@code Maven40PluginDependenciesResolver}.
+ * <p>
+ * Compiled against maven-core 4.0.0-rc-5 (see this module's POM) and run against the Maven under test,
+ * so the newer interface methods have no implementation here. They must therefore be resolved through
+ * {@code default} methods on the interface; if they are abstract, plugin resolution dies with
+ * {@code AbstractMethodError} before a single goal runs.
+ */
+@Named
+@Singleton
+@Priority(10)
+public class LegacyPluginDependenciesResolver implements PluginDependenciesResolver {
+
+    private final PluginDependenciesResolver delegate;
+
+    @Inject
+    public LegacyPluginDependenciesResolver(DefaultPluginDependenciesResolver delegate) {
+        this.delegate = delegate;
+        System.out.println("[gh-13068] legacy PluginDependenciesResolver installed");
+    }
+
+    @Override
+    public Artifact resolve(Plugin plugin, List<RemoteRepository> repositories, RepositorySystemSession session)
+            throws PluginResolutionException {
+        return delegate.resolve(plugin, repositories, session);
+    }
+
+    @Override
+    public DependencyNode resolve(
+            Plugin plugin,
+            Artifact pluginArtifact,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException {
+        return delegate.resolve(plugin, pluginArtifact, dependencyFilter, repositories, session);
+    }
+
+    @Override
+    public DependencyResult resolvePlugin(
+            Plugin plugin,
+            Artifact pluginArtifact,
+            DependencyFilter dependencyFilter,
+            List<RemoteRepository> repositories,
+            RepositorySystemSession session)
+            throws PluginResolutionException {
+        System.out.println("[gh-13068] resolvePlugin reached for " + plugin.getArtifactId());
+        return delegate.resolvePlugin(plugin, pluginArtifact, dependencyFilter, repositories, session);
+    }
+}


### PR DESCRIPTION
## Summary

Forward port of 349395c0c9, merged into `maven-4.0.x` via #13069.

Closes #13068.

`resolveCoreExtensionAndFlatten` and `resolvePluginAndFlatten` were added to the internal `PluginDependenciesResolver` as **abstract** methods. That happened on both lines — #12329 here, #12335 on `maven-4.0.x` — but the fix so far landed only on `maven-4.0.x`, so 4.1.0 would reintroduce the identical regression.

Implementations that live out of tree are compiled against one Maven and run on another, so the first plugin resolution dies with `AbstractMethodError`. IntelliJ IDEA, Eclipse m2e and NetBeans all override this component; IntelliJ implements the interface directly and therefore breaks. Christofer Dutz confirmed on Apache PLC4X that a build carrying this change imports cleanly where stock rc-6 fails.

## What differs from the maven-4.0.x commit

The production change and the unit test are **byte-identical**. Only the IT needed adjusting, because master has moved on in three ways:

* **No `TestSuiteOrdering` entry.** That class now orders by name pattern (`MavenITgh<number>`) instead of keeping an explicit list, so `MavenITgh13068…` is picked up automatically. The file is untouched here.
* **IT harness.** `AbstractMavenIntegrationTestCase` no longer takes a version range, `extractResources` returns `Path`, and `newVerifier(String)` is deprecated in favour of `newVerifier(Path)`. The IT was rewritten to the current idiom.
* **ITs run under failsafe here**, not surefire.

## Verification

Run locally against this branch:

```
mvn verify -Papache-release -Dgpg.skip=true     BUILD SUCCESS   (0 javadoc findings)
unit  PluginDependenciesResolverDefaultMethodsTest   Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
IT    MavenITgh13068LegacyPluginDependenciesResolverTest
      failsafe:integration-test @ core-it-suite
      Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
      [gh-13068] legacy PluginDependenciesResolver installed
      [gh-13068] resolvePlugin reached for maven-clean-plugin
```

The two marker lines are asserted by the test, so it cannot pass without the extension actually displacing the default component. On `maven-4.0.x` the same IT was verified red without the change, failing with `AbstractMethodError` at `DefaultMavenPluginManager.createPluginRealm`.

## Note

The `resolveCoreExtensionAndFlatten` default is best effort — a dedicated implementation additionally reads the extension's artifact descriptor to apply relocations and run `MavenPluginDependenciesValidator`. Same caveat as on the 4.0.x PR, where @gnodet approved it as is.
