### PR TITLE
Bump default plugin versions to latest stable 3.x

### DIFF
--- a/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java
@@ -416,7 +416,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
 
     static class CleanLifecycle implements Lifecycle {
 
-        private static final String MAVEN_CLEAN_PLUGIN_VERSION = "3.4.0";
+        private static final String MAVEN_CLEAN_PLUGIN_VERSION = "3.5.0";
 
         @Override
         public String id() {
@@ -529,7 +529,7 @@ public class DefaultLifecycleRegistry implements LifecycleRegistry {
 
     static class SiteLifecycle implements Lifecycle {
 
-        private static final String MAVEN_SITE_PLUGIN_VERSION = "3.21.0";
+        private static final String MAVEN_SITE_PLUGIN_VERSION = "3.22.0";
         private static final String MAVEN_SITE_PLUGIN =
                 MAVEN_PLUGINS + "maven-site-plugin:" + MAVEN_SITE_PLUGIN_VERSION + ":";
         private static final String PHASE_SITE = "site";

--- a/impl/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java
@@ -35,29 +35,29 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class AbstractLifecycleMappingProvider implements Provider<LifecycleMapping> {
     // START SNIPPET: versions
-    protected static final String RESOURCES_PLUGIN_VERSION = "3.3.1";
+    protected static final String RESOURCES_PLUGIN_VERSION = "3.5.0";
 
-    protected static final String COMPILER_PLUGIN_VERSION = "3.13.0";
+    protected static final String COMPILER_PLUGIN_VERSION = "3.16.0";
 
-    protected static final String SUREFIRE_PLUGIN_VERSION = "3.5.2";
+    protected static final String SUREFIRE_PLUGIN_VERSION = "3.6.0";
 
-    protected static final String INSTALL_PLUGIN_VERSION = "3.1.3";
+    protected static final String INSTALL_PLUGIN_VERSION = "3.1.4";
 
-    protected static final String DEPLOY_PLUGIN_VERSION = "3.1.3";
+    protected static final String DEPLOY_PLUGIN_VERSION = "3.1.4";
 
     // packaging
 
-    protected static final String JAR_PLUGIN_VERSION = "3.4.2";
+    protected static final String JAR_PLUGIN_VERSION = "3.5.1";
 
-    protected static final String EAR_PLUGIN_VERSION = "3.3.0";
+    protected static final String EAR_PLUGIN_VERSION = "3.4.0";
 
-    protected static final String EJB_PLUGIN_VERSION = "3.2.1";
+    protected static final String EJB_PLUGIN_VERSION = "3.3.0";
 
-    protected static final String PLUGIN_PLUGIN_VERSION = "3.15.1";
+    protected static final String PLUGIN_PLUGIN_VERSION = "3.15.2";
 
-    protected static final String RAR_PLUGIN_VERSION = "3.0.0";
+    protected static final String RAR_PLUGIN_VERSION = "3.1.0";
 
-    protected static final String WAR_PLUGIN_VERSION = "3.4.0";
+    protected static final String WAR_PLUGIN_VERSION = "3.5.1";
     // END SNIPPET: versions
 
     private final LifecycleMapping lifecycleMapping;


### PR DESCRIPTION
> **Draft — held intentionally.** Waiting on Slawek's in-flight plugin releases (notably install/deploy) and the master update; the targets will be refreshed and this marked ready once those land. Opened as a draft now to signal intent and track the change.

The 4.x lines bind a fixed version to every plugin of the `default`, `clean` and `site` lifecycles, hardcoded as Java constants in two files:

- `impl/maven-core/src/main/java/org/apache/maven/lifecycle/providers/packaging/AbstractLifecycleMappingProvider.java` (11 plugins)
- `impl/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultLifecycleRegistry.java` (clean, site)

Unlike the 3.10 line (which inherits `version.maven-*` from the ASF parent), these constants have no refresh mechanism and had drifted to ~mid-2024 values. This bumps all 13 to the latest stable 3.x:

| Plugin | before | after |
|---|---|---|
| clean | 3.4.0 | 3.5.0 |
| resources | 3.3.1 | 3.5.0 |
| compiler | 3.13.0 | 3.16.0 |
| surefire | 3.5.2 | 3.6.0 |
| install | 3.1.3 | 3.1.4 |
| deploy | 3.1.3 | 3.1.4 |
| jar | 3.4.2 | 3.5.1 |
| ear | 3.3.0 | 3.4.0 |
| ejb | 3.2.1 | 3.3.0 |
| plugin | 3.15.1 | 3.15.2 |
| rar | 3.0.0 | 3.1.0 |
| war | 3.4.0 | 3.5.1 |
| site | 3.21.0 | 3.22.0 |

All targets are the latest `< 4.0.0` release on Central, each requiring Maven >= 3.6.3 and Java >= 8, so they are safe as defaults on this line; the 3.x plugin lines keep the Maven 3+4 compatibility layer, delivering accumulated fixes without breaking changes.

Notably `maven-compiler-plugin` moves off 3.13.0, which carries MCOMPILER-592 (empty `project.build.outputTimestamp` -> `IndexOutOfBoundsException`, fixed in 3.14.0) — reachable with default settings.

Follow-up (separate): these constants live in two files with no bot-visible coordinate, so nothing keeps them current. Converging them onto the 3.10 filtered-`plugin-versions.properties` mechanism would let Dependabot propose future bumps.
