### PR TITLE
Skip flaky consolidate-caches on PRs; never fail the run

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -353,6 +353,14 @@ jobs:
             ~/.mimir/*.log
 
   consolidate-caches:
+    # This job downloads the per-job cache artifacts to publish a single consolidated
+    # cache. The "Publish cache" step below is already gated to non-PR events, so on a
+    # pull_request the job has nothing to publish and only risks a flaky ~2 GB artifact
+    # download (actions/download-artifact "failed after 5 retries"). Skip it on PRs, and
+    # keep it non-fatal elsewhere: the consolidated cache is best-effort (the next run
+    # rebuilds it), so a transient download flake must never fail the whole run.
+    if: ${{ github.event_name != 'pull_request' }}
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
The `consolidate-caches` job reds the whole CI run when a transient GitHub artifact-download flake hits its `Download Caches` step (`actions/download-artifact`, ~2 GB of `cache-<os>*` per OS), even though the entire build + IT matrix is green:

```
##[error]Unable to download artifact(s): … Artifact download failed after 5 retries.
```

The job's only real output — `Publish cache` — is already gated `if: github.event_name != 'pull_request'`, so on a PR it downloads ~2 GB just to discard it, and its sole failure mode is this flake.

This:
- **skips the job on `pull_request`** (`if: ${{ github.event_name != 'pull_request' }}`) — no payoff there + saves the ~2 GB download per PR run;
- **`continue-on-error: true`** so on non-PR runs the flake never reds the run — the consolidated cache is best-effort (the next run rebuilds it).

Discussed on Slack with @sjaranowski and @cstamas (both OK with the approach). Example failing run: https://github.com/apache/maven/actions/runs/34209185905
