### PR TITLE
[MNG-5527] Honor BOM relocation during dependency management import

### DIFF
--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -1161,9 +1161,9 @@ public class DefaultModelBuilder implements ModelBuilder {
             ModelBuildingRequest request,
             DefaultModelProblemCollector problems,
             Collection<String> importIds) {
-        DependencyManagement depMgmt = model.getDependencyManagement();
+        DependencyManagement dependencyManagement = model.getDependencyManagement();
 
-        if (depMgmt == null) {
+        if (dependencyManagement == null) {
             return;
         }
 
@@ -1171,9 +1171,9 @@ public class DefaultModelBuilder implements ModelBuilder {
 
         importIds.add(importing);
 
-        List<DependencyManagement> importMgmts = null;
+        List<DependencyManagement> importedManagements = null;
 
-        for (Iterator<Dependency> it = depMgmt.getDependencies().iterator(); it.hasNext(); ) {
+        for (Iterator<Dependency> it = dependencyManagement.getDependencies().iterator(); it.hasNext(); ) {
             Dependency dependency = it.next();
 
             if (!"pom".equals(dependency.getType()) || !"import".equals(dependency.getScope())) {
@@ -1182,30 +1182,27 @@ public class DefaultModelBuilder implements ModelBuilder {
 
             it.remove();
 
-            DependencyManagement importMgmt = loadDependencyManagement(dependency, model, request, problems, importIds);
-            if (importMgmt != null) {
-                if (importMgmts == null) {
-                    importMgmts = new ArrayList<>();
+            DependencyManagement importedManagement =
+                    loadDependencyManagement(dependency, model, request, problems, importIds);
+            if (importedManagement != null) {
+                if (importedManagements == null) {
+                    importedManagements = new ArrayList<>();
                 }
-                importMgmts.add(importMgmt);
+                importedManagements.add(importedManagement);
             }
         }
 
         importIds.remove(importing);
 
-        dependencyManagementImporter.importManagement(model, importMgmts, request, problems);
+        dependencyManagementImporter.importManagement(model, importedManagements, request, problems);
     }
 
-    @SuppressWarnings("checkstyle:methodlength")
     private DependencyManagement loadDependencyManagement(
             Dependency dependency,
             Model model,
             ModelBuildingRequest request,
             DefaultModelProblemCollector problems,
             Collection<String> importIds) {
-        final WorkspaceModelResolver workspaceResolver = request.getWorkspaceModelResolver();
-        final ModelResolver modelResolver = request.getModelResolver();
-
         String groupId = dependency.getGroupId();
         String artifactId = dependency.getArtifactId();
         String version = dependency.getVersion();
@@ -1235,8 +1232,7 @@ public class DefaultModelBuilder implements ModelBuilder {
         String imported = groupId + ':' + artifactId + ':' + version;
 
         if (importIds.contains(imported)) {
-            StringBuilder message =
-                    new StringBuilder("The dependencies of type=pom and with scope=import form a cycle: ");
+            StringBuilder message = new StringBuilder("The import POMs form a cycle: ");
             for (String modelId : importIds) {
                 message.append(modelId);
                 message.append(" -> ");
@@ -1247,70 +1243,13 @@ public class DefaultModelBuilder implements ModelBuilder {
             return null;
         }
 
-        DependencyManagement importMgmt =
+        DependencyManagement importedManagement =
                 getCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT);
 
-        if (importMgmt == null) {
-            if (workspaceResolver == null && modelResolver == null) {
-                throw new NullPointerException(String.format(
-                        "request.workspaceModelResolver and request.modelResolver cannot be null"
-                                + " (parent POM %s and POM %s)",
-                        ModelProblemUtils.toId(groupId, artifactId, version), ModelProblemUtils.toSourceHint(model)));
-            }
-
-            Model importModel = null;
-            if (workspaceResolver != null) {
-                try {
-                    importModel = workspaceResolver.resolveEffectiveModel(groupId, artifactId, version);
-                } catch (UnresolvableModelException e) {
-                    problems.add(new ModelProblemCollectorRequest(Severity.FATAL, Version.BASE)
-                            .setMessage(e.getMessage())
-                            .setException(e));
-                    return null;
-                }
-            }
-
-            // no workspace resolver or workspace resolver returned null (i.e. model not in workspace)
+        if (importedManagement == null) {
+            Model importModel = resolveImportModel(dependency, model, request, problems, importIds);
             if (importModel == null) {
-                final ModelSource importSource;
-                try {
-                    importSource = modelResolver.resolveModel(groupId, artifactId, version);
-                } catch (UnresolvableModelException e) {
-                    StringBuilder buffer = new StringBuilder(256);
-                    buffer.append("Non-resolvable import POM");
-                    if (!containsCoordinates(e.getMessage(), groupId, artifactId, version)) {
-                        buffer.append(' ').append(ModelProblemUtils.toId(groupId, artifactId, version));
-                    }
-                    buffer.append(": ").append(e.getMessage());
-
-                    problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
-                            .setMessage(buffer.toString())
-                            .setLocation(dependency.getLocation(""))
-                            .setException(e));
-                    return null;
-                }
-
-                ModelBuildingRequest importRequest = new DefaultModelBuildingRequest();
-                importRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
-                importRequest.setModelCache(request.getModelCache());
-                importRequest.setSystemProperties(request.getSystemProperties());
-                importRequest.setUserProperties(request.getUserProperties());
-                importRequest.setLocationTracking(request.isLocationTracking());
-
-                importRequest.setModelSource(importSource);
-                importRequest.setModelResolver(modelResolver.newCopy());
-
-                final ModelBuildingResult importResult;
-                try {
-                    importResult = build(importRequest, importIds);
-                } catch (ModelBuildingException e) {
-                    problems.addAll(e.getProblems());
-                    return null;
-                }
-
-                problems.addAll(importResult.getProblems());
-
-                importModel = importResult.getEffectiveModel();
+                return null;
             }
 
             Relocation relocation = importModel.getDistributionManagement() != null
@@ -1344,31 +1283,101 @@ public class DefaultModelBuilder implements ModelBuilder {
                 if (groupId.equals(relocated.getGroupId())
                         && artifactId.equals(relocated.getArtifactId())
                         && version.equals(relocated.getVersion())) {
-                    importMgmt = importModel.getDependencyManagement();
+                    importedManagement = importModel.getDependencyManagement();
                 } else {
                     // Keep relocation sources on the same path as imports to detect mixed cycles.
                     importIds.add(imported);
                     try {
-                        importMgmt = loadDependencyManagement(relocated, model, request, problems, importIds);
+                        importedManagement = loadDependencyManagement(relocated, model, request, problems, importIds);
                     } finally {
                         importIds.remove(imported);
                     }
-                    if (importMgmt == null) {
+                    if (importedManagement == null) {
                         return null;
                     }
                 }
             } else {
-                importMgmt = importModel.getDependencyManagement();
+                importedManagement = importModel.getDependencyManagement();
             }
 
-            if (importMgmt == null) {
-                importMgmt = new DependencyManagement();
+            if (importedManagement == null) {
+                importedManagement = new DependencyManagement();
             }
 
-            putCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT, importMgmt);
+            putCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT, importedManagement);
         }
 
-        return importMgmt;
+        return importedManagement;
+    }
+
+    private Model resolveImportModel(
+            Dependency dependency,
+            Model model,
+            ModelBuildingRequest request,
+            DefaultModelProblemCollector problems,
+            Collection<String> importIds) {
+        String groupId = dependency.getGroupId();
+        String artifactId = dependency.getArtifactId();
+        String version = dependency.getVersion();
+        WorkspaceModelResolver workspaceResolver = request.getWorkspaceModelResolver();
+        ModelResolver modelResolver = request.getModelResolver();
+
+        if (workspaceResolver == null && modelResolver == null) {
+            throw new NullPointerException(String.format(
+                    "request.workspaceModelResolver and request.modelResolver cannot be null"
+                            + " (parent POM %s and POM %s)",
+                    ModelProblemUtils.toId(groupId, artifactId, version), ModelProblemUtils.toSourceHint(model)));
+        }
+
+        if (workspaceResolver != null) {
+            try {
+                Model importModel = workspaceResolver.resolveEffectiveModel(groupId, artifactId, version);
+                if (importModel != null) {
+                    return importModel;
+                }
+            } catch (UnresolvableModelException e) {
+                problems.add(new ModelProblemCollectorRequest(Severity.FATAL, Version.BASE)
+                        .setMessage(e.getMessage())
+                        .setException(e));
+                return null;
+            }
+        }
+
+        final ModelSource importSource;
+        try {
+            importSource = modelResolver.resolveModel(groupId, artifactId, version);
+        } catch (UnresolvableModelException e) {
+            StringBuilder buffer = new StringBuilder(256);
+            buffer.append("Non-resolvable import POM");
+            if (!containsCoordinates(e.getMessage(), groupId, artifactId, version)) {
+                buffer.append(' ').append(ModelProblemUtils.toId(groupId, artifactId, version));
+            }
+            buffer.append(": ").append(e.getMessage());
+
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage(buffer.toString())
+                    .setLocation(dependency.getLocation(""))
+                    .setException(e));
+            return null;
+        }
+
+        ModelBuildingRequest importRequest = new DefaultModelBuildingRequest();
+        importRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+        importRequest.setModelCache(request.getModelCache());
+        importRequest.setSystemProperties(request.getSystemProperties());
+        importRequest.setUserProperties(request.getUserProperties());
+        importRequest.setLocationTracking(request.isLocationTracking());
+        importRequest.setModelSource(importSource);
+        importRequest.setModelResolver(modelResolver.newCopy());
+
+        try {
+            final ModelBuildingResult importResult = build(importRequest, importIds);
+            problems.addAll(importResult.getProblems());
+            return importResult.getEffectiveModel();
+        } catch (ModelBuildingException e) {
+            problems.addAll(e.getProblems());
+            return null;
+        }
     }
 
     private boolean validateRelocationCoordinate(

--- a/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
+++ b/compat/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java
@@ -53,6 +53,7 @@ import org.apache.maven.model.Parent;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginManagement;
 import org.apache.maven.model.Profile;
+import org.apache.maven.model.Relocation;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.building.ModelProblem.Severity;
 import org.apache.maven.model.building.ModelProblem.Version;
@@ -1155,7 +1156,6 @@ public class DefaultModelBuilder implements ModelBuilder {
         return superPomProvider.getSuperModel("4.0.0").clone();
     }
 
-    @SuppressWarnings("checkstyle:methodlength")
     private void importDependencyManagement(
             Model model,
             ModelBuildingRequest request,
@@ -1171,11 +1171,6 @@ public class DefaultModelBuilder implements ModelBuilder {
 
         importIds.add(importing);
 
-        final WorkspaceModelResolver workspaceResolver = request.getWorkspaceModelResolver();
-        final ModelResolver modelResolver = request.getModelResolver();
-
-        ModelBuildingRequest importRequest = null;
-
         List<DependencyManagement> importMgmts = null;
 
         for (Iterator<Dependency> it = depMgmt.getDependencies().iterator(); it.hasNext(); ) {
@@ -1187,136 +1182,210 @@ public class DefaultModelBuilder implements ModelBuilder {
 
             it.remove();
 
-            String groupId = dependency.getGroupId();
-            String artifactId = dependency.getArtifactId();
-            String version = dependency.getVersion();
-
-            if (groupId == null || groupId.length() <= 0) {
-                problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
-                        .setMessage("'dependencyManagement.dependencies.dependency.groupId' for "
-                                + dependency.getManagementKey() + " is missing.")
-                        .setLocation(dependency.getLocation("")));
-                continue;
-            }
-            if (artifactId == null || artifactId.length() <= 0) {
-                problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
-                        .setMessage("'dependencyManagement.dependencies.dependency.artifactId' for "
-                                + dependency.getManagementKey() + " is missing.")
-                        .setLocation(dependency.getLocation("")));
-                continue;
-            }
-            if (version == null || version.length() <= 0) {
-                problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
-                        .setMessage("'dependencyManagement.dependencies.dependency.version' for "
-                                + dependency.getManagementKey() + " is missing.")
-                        .setLocation(dependency.getLocation("")));
-                continue;
-            }
-
-            String imported = groupId + ':' + artifactId + ':' + version;
-
-            if (importIds.contains(imported)) {
-                StringBuilder message =
-                        new StringBuilder("The dependencies of type=pom and with scope=import form a cycle: ");
-                for (String modelId : importIds) {
-                    message.append(modelId);
-                    message.append(" -> ");
+            DependencyManagement importMgmt = loadDependencyManagement(dependency, model, request, problems, importIds);
+            if (importMgmt != null) {
+                if (importMgmts == null) {
+                    importMgmts = new ArrayList<>();
                 }
-                message.append(imported);
-                problems.add(
-                        new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE).setMessage(message.toString()));
-
-                continue;
+                importMgmts.add(importMgmt);
             }
-
-            DependencyManagement importMgmt =
-                    getCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT);
-
-            if (importMgmt == null) {
-                if (workspaceResolver == null && modelResolver == null) {
-                    throw new NullPointerException(String.format(
-                            "request.workspaceModelResolver and request.modelResolver cannot be null"
-                                    + " (parent POM %s and POM %s)",
-                            ModelProblemUtils.toId(groupId, artifactId, version),
-                            ModelProblemUtils.toSourceHint(model)));
-                }
-
-                Model importModel = null;
-                if (workspaceResolver != null) {
-                    try {
-                        importModel = workspaceResolver.resolveEffectiveModel(groupId, artifactId, version);
-                    } catch (UnresolvableModelException e) {
-                        problems.add(new ModelProblemCollectorRequest(Severity.FATAL, Version.BASE)
-                                .setMessage(e.getMessage())
-                                .setException(e));
-                        continue;
-                    }
-                }
-
-                // no workspace resolver or workspace resolver returned null (i.e. model not in workspace)
-                if (importModel == null) {
-                    final ModelSource importSource;
-                    try {
-                        importSource = modelResolver.resolveModel(groupId, artifactId, version);
-                    } catch (UnresolvableModelException e) {
-                        StringBuilder buffer = new StringBuilder(256);
-                        buffer.append("Non-resolvable import POM");
-                        if (!containsCoordinates(e.getMessage(), groupId, artifactId, version)) {
-                            buffer.append(' ').append(ModelProblemUtils.toId(groupId, artifactId, version));
-                        }
-                        buffer.append(": ").append(e.getMessage());
-
-                        problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
-                                .setMessage(buffer.toString())
-                                .setLocation(dependency.getLocation(""))
-                                .setException(e));
-                        continue;
-                    }
-
-                    if (importRequest == null) {
-                        importRequest = new DefaultModelBuildingRequest();
-                        importRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
-                        importRequest.setModelCache(request.getModelCache());
-                        importRequest.setSystemProperties(request.getSystemProperties());
-                        importRequest.setUserProperties(request.getUserProperties());
-                        importRequest.setLocationTracking(request.isLocationTracking());
-                    }
-
-                    importRequest.setModelSource(importSource);
-                    importRequest.setModelResolver(modelResolver.newCopy());
-
-                    final ModelBuildingResult importResult;
-                    try {
-                        importResult = build(importRequest, importIds);
-                    } catch (ModelBuildingException e) {
-                        problems.addAll(e.getProblems());
-                        continue;
-                    }
-
-                    problems.addAll(importResult.getProblems());
-
-                    importModel = importResult.getEffectiveModel();
-                }
-
-                importMgmt = importModel.getDependencyManagement();
-
-                if (importMgmt == null) {
-                    importMgmt = new DependencyManagement();
-                }
-
-                putCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT, importMgmt);
-            }
-
-            if (importMgmts == null) {
-                importMgmts = new ArrayList<>();
-            }
-
-            importMgmts.add(importMgmt);
         }
 
         importIds.remove(importing);
 
         dependencyManagementImporter.importManagement(model, importMgmts, request, problems);
+    }
+
+    @SuppressWarnings("checkstyle:methodlength")
+    private DependencyManagement loadDependencyManagement(
+            Dependency dependency,
+            Model model,
+            ModelBuildingRequest request,
+            DefaultModelProblemCollector problems,
+            Collection<String> importIds) {
+        final WorkspaceModelResolver workspaceResolver = request.getWorkspaceModelResolver();
+        final ModelResolver modelResolver = request.getModelResolver();
+
+        String groupId = dependency.getGroupId();
+        String artifactId = dependency.getArtifactId();
+        String version = dependency.getVersion();
+
+        if (groupId == null || groupId.length() <= 0) {
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage("'dependencyManagement.dependencies.dependency.groupId' for "
+                            + dependency.getManagementKey() + " is missing.")
+                    .setLocation(dependency.getLocation("")));
+            return null;
+        }
+        if (artifactId == null || artifactId.length() <= 0) {
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage("'dependencyManagement.dependencies.dependency.artifactId' for "
+                            + dependency.getManagementKey() + " is missing.")
+                    .setLocation(dependency.getLocation("")));
+            return null;
+        }
+        if (version == null || version.length() <= 0) {
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage("'dependencyManagement.dependencies.dependency.version' for "
+                            + dependency.getManagementKey() + " is missing.")
+                    .setLocation(dependency.getLocation("")));
+            return null;
+        }
+
+        String imported = groupId + ':' + artifactId + ':' + version;
+
+        if (importIds.contains(imported)) {
+            StringBuilder message =
+                    new StringBuilder("The dependencies of type=pom and with scope=import form a cycle: ");
+            for (String modelId : importIds) {
+                message.append(modelId);
+                message.append(" -> ");
+            }
+            message.append(imported);
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE).setMessage(message.toString()));
+
+            return null;
+        }
+
+        DependencyManagement importMgmt =
+                getCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT);
+
+        if (importMgmt == null) {
+            if (workspaceResolver == null && modelResolver == null) {
+                throw new NullPointerException(String.format(
+                        "request.workspaceModelResolver and request.modelResolver cannot be null"
+                                + " (parent POM %s and POM %s)",
+                        ModelProblemUtils.toId(groupId, artifactId, version), ModelProblemUtils.toSourceHint(model)));
+            }
+
+            Model importModel = null;
+            if (workspaceResolver != null) {
+                try {
+                    importModel = workspaceResolver.resolveEffectiveModel(groupId, artifactId, version);
+                } catch (UnresolvableModelException e) {
+                    problems.add(new ModelProblemCollectorRequest(Severity.FATAL, Version.BASE)
+                            .setMessage(e.getMessage())
+                            .setException(e));
+                    return null;
+                }
+            }
+
+            // no workspace resolver or workspace resolver returned null (i.e. model not in workspace)
+            if (importModel == null) {
+                final ModelSource importSource;
+                try {
+                    importSource = modelResolver.resolveModel(groupId, artifactId, version);
+                } catch (UnresolvableModelException e) {
+                    StringBuilder buffer = new StringBuilder(256);
+                    buffer.append("Non-resolvable import POM");
+                    if (!containsCoordinates(e.getMessage(), groupId, artifactId, version)) {
+                        buffer.append(' ').append(ModelProblemUtils.toId(groupId, artifactId, version));
+                    }
+                    buffer.append(": ").append(e.getMessage());
+
+                    problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                            .setMessage(buffer.toString())
+                            .setLocation(dependency.getLocation(""))
+                            .setException(e));
+                    return null;
+                }
+
+                ModelBuildingRequest importRequest = new DefaultModelBuildingRequest();
+                importRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+                importRequest.setModelCache(request.getModelCache());
+                importRequest.setSystemProperties(request.getSystemProperties());
+                importRequest.setUserProperties(request.getUserProperties());
+                importRequest.setLocationTracking(request.isLocationTracking());
+
+                importRequest.setModelSource(importSource);
+                importRequest.setModelResolver(modelResolver.newCopy());
+
+                final ModelBuildingResult importResult;
+                try {
+                    importResult = build(importRequest, importIds);
+                } catch (ModelBuildingException e) {
+                    problems.addAll(e.getProblems());
+                    return null;
+                }
+
+                problems.addAll(importResult.getProblems());
+
+                importModel = importResult.getEffectiveModel();
+            }
+
+            Relocation relocation = importModel.getDistributionManagement() != null
+                    ? importModel.getDistributionManagement().getRelocation()
+                    : null;
+            if (relocation != null) {
+                Dependency relocated = dependency.clone();
+                if (!validateRelocationCoordinate(relocation.getGroupId(), "groupId", dependency, problems)
+                        || !validateRelocationCoordinate(relocation.getArtifactId(), "artifactId", dependency, problems)
+                        || !validateRelocationCoordinate(relocation.getVersion(), "version", dependency, problems)) {
+                    return null;
+                }
+                if (relocation.getGroupId() != null && !relocation.getGroupId().isEmpty()) {
+                    relocated.setGroupId(relocation.getGroupId());
+                }
+                if (relocation.getArtifactId() != null
+                        && !relocation.getArtifactId().isEmpty()) {
+                    relocated.setArtifactId(relocation.getArtifactId());
+                }
+                if (relocation.getVersion() != null && !relocation.getVersion().isEmpty()) {
+                    relocated.setVersion(relocation.getVersion());
+                }
+                String message = "The import POM " + imported + " has been relocated to " + relocated.getGroupId() + ':'
+                        + relocated.getArtifactId() + ':' + relocated.getVersion();
+                if (relocation.getMessage() != null) {
+                    message += ": " + relocation.getMessage();
+                }
+                problems.add(new ModelProblemCollectorRequest(Severity.WARNING, Version.BASE)
+                        .setMessage(message)
+                        .setLocation(dependency.getLocation("")));
+                if (groupId.equals(relocated.getGroupId())
+                        && artifactId.equals(relocated.getArtifactId())
+                        && version.equals(relocated.getVersion())) {
+                    importMgmt = importModel.getDependencyManagement();
+                } else {
+                    // Keep relocation sources on the same path as imports to detect mixed cycles.
+                    importIds.add(imported);
+                    try {
+                        importMgmt = loadDependencyManagement(relocated, model, request, problems, importIds);
+                    } finally {
+                        importIds.remove(imported);
+                    }
+                    if (importMgmt == null) {
+                        return null;
+                    }
+                }
+            } else {
+                importMgmt = importModel.getDependencyManagement();
+            }
+
+            if (importMgmt == null) {
+                importMgmt = new DependencyManagement();
+            }
+
+            putCache(request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT, importMgmt);
+        }
+
+        return importMgmt;
+    }
+
+    private boolean validateRelocationCoordinate(
+            String value, String component, Dependency dependency, DefaultModelProblemCollector problems) {
+        if (value != null
+                && ("..".equals(value)
+                        || value.contains("/")
+                        || value.contains("\\")
+                        || value.contains(":")
+                        || value.chars().anyMatch(Character::isISOControl))) {
+            problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+                    .setMessage("Invalid relocation " + component + " '" + value
+                            + "': not a valid artifact coordinate component")
+                    .setLocation(dependency.getLocation("")));
+            return false;
+        }
+        return true;
     }
 
     private <T> void putCache(

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/BomRelocationTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/BomRelocationTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.model.building;
+
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.apache.maven.model.resolution.WorkspaceModelResolver;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Deprecated
+class BomRelocationTest {
+    private final Map<String, Integer> resolutions = new HashMap<>();
+
+    @Test
+    void importsRelocatedBom() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))));
+        Model model = build(poms, management(bom("old")));
+        assertEquals(List.of("library:2"), managedDependencies(model));
+    }
+
+    @Test
+    void followsPartialRelocationChain() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<groupId>relocated</groupId>")),
+                "relocated:old:1", pom("relocated", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "relocated:new:1", pom("relocated", "new", "1", relocation("<version>2</version>")),
+                "relocated:new:2", pom("relocated", "new", "2", management(dependency("library", "2"))));
+        assertEquals(List.of("library:2"), managedDependencies(build(poms, management(bom("old")))));
+    }
+
+    @Test
+    void ignoresManagementFromRelocationSourceAndPreservesPrecedence() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1",
+                        pom(
+                                "test",
+                                "old",
+                                "1",
+                                relocation("<artifactId>new</artifactId>") + management(dependency("obsolete", "1"))),
+                "test:new:1",
+                        pom("test", "new", "1", management(dependency("library", "2") + dependency("other", "2"))),
+                "test:ordinary:1", pom("test", "ordinary", "1", management(dependency("other", "3"))));
+        String content = management(dependency("library", "4") + bom("old") + bom("ordinary"));
+        assertEquals(List.of("library:4", "other:2"), managedDependencies(build(poms, content)));
+    }
+
+    @Test
+    void preservesManagementForUnchangedRelocation() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1",
+                pom(
+                        "test",
+                        "old",
+                        "1",
+                        relocation("<artifactId>old</artifactId>") + management(dependency("library", "2"))));
+        assertEquals(List.of("library:2"), managedDependencies(build(poms, management(bom("old")))));
+    }
+
+    @Test
+    void preservesManagementForMessageOnlyRelocation() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1",
+                pom(
+                        "test",
+                        "old",
+                        "1",
+                        relocation("<message>Use the current release</message>")
+                                + management(dependency("library", "2"))));
+        assertEquals(List.of("library:2"), managedDependencies(build(poms, management(bom("old")))));
+    }
+
+    @Test
+    void detectsRelocationCycle() {
+        assertCycle(
+                Map.of(
+                        "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                        "test:new:1", pom("test", "new", "1", relocation("<artifactId>old</artifactId>"))),
+                "test:consumer:1 -> test:old:1 -> test:new:1 -> test:old:1");
+    }
+
+    @Test
+    void detectsRelocationThenImportCycle() {
+        assertCycle(
+                Map.of(
+                        "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                        "test:new:1", pom("test", "new", "1", management(bom("old")))),
+                "test:consumer:1 -> test:old:1 -> test:new:1 -> test:old:1");
+    }
+
+    @Test
+    void detectsImportThenRelocationCycle() {
+        assertCycle(
+                Map.of(
+                        "test:old:1", pom("test", "old", "1", management(bom("new"))),
+                        "test:new:1", pom("test", "new", "1", relocation("<artifactId>old</artifactId>"))),
+                "test:consumer:1 -> test:old:1 -> test:new:1 -> test:old:1");
+    }
+
+    @Test
+    void reportsUnresolvableRelocationTarget() {
+        Map<String, String> poms =
+                Map.of("test:old:1", pom("test", "old", "1", relocation("<artifactId>missing</artifactId>")));
+        ModelBuildingException exception =
+                assertThrows(ModelBuildingException.class, () -> build(poms, management(bom("old"))));
+        assertTrue(exception.getMessage().contains("Non-resolvable import POM"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("test:missing"), exception.getMessage());
+    }
+
+    @Test
+    void importsRelocatedWorkspaceBom() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))));
+        assertEquals(List.of("library:2"), managedDependencies(build(poms, management(bom("old")), true)));
+    }
+
+    @Test
+    void rejectsInvalidRelocationCoordinates() {
+        for (String component : List.of("groupId", "artifactId", "version")) {
+            for (String value : List.of("..", "bad/name", "bad\\name", "bad:name", "bad&#9;name")) {
+                Map<String, String> poms = Map.of(
+                        "test:old:1",
+                        pom("test", "old", "1", relocation("<" + component + ">" + value + "</" + component + ">")));
+                ModelBuildingException exception =
+                        assertThrows(ModelBuildingException.class, () -> build(poms, management(bom("old"))));
+                assertTrue(exception.getMessage().contains("Invalid relocation " + component), exception.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void repeatedImportsReuseRelocatedManagement() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:alias:1", pom("test", "alias", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))));
+        assertEquals(
+                List.of("library:2"),
+                managedDependencies(build(poms, management(bom("old") + bom("alias") + bom("new")))));
+        assertEquals(1, resolutions.get("test:new:1"));
+    }
+
+    private void assertCycle(Map<String, String> poms, String cycle) {
+        ModelBuildingException exception =
+                assertThrows(ModelBuildingException.class, () -> build(poms, management(bom("old"))));
+        assertTrue(exception.getMessage().contains("form a cycle: " + cycle), exception.getMessage());
+    }
+
+    private Model build(Map<String, String> poms, String content) throws Exception {
+        return build(poms, content, false);
+    }
+
+    private Model build(Map<String, String> poms, String content, boolean workspace) throws Exception {
+        DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
+        request.setModelSource(new StringModelSource(pom("test", "consumer", "1", content)));
+        request.setModelResolver(new DefaultModelBuilderTest.BaseModelResolver() {
+            @Override
+            public ModelSource resolveModel(String groupId, String artifactId, String version)
+                    throws UnresolvableModelException {
+                String id = groupId + ":" + artifactId + ":" + version;
+                resolutions.merge(id, 1, Integer::sum);
+                String source = poms.get(id);
+                if (source == null) {
+                    throw new UnresolvableModelException("Missing " + id, groupId, artifactId, version);
+                }
+                return new StringModelSource(source, id);
+            }
+        });
+        Map<String, Object> cache = new HashMap<>();
+        request.setModelCache(new ModelCache() {
+            @Override
+            public void put(String groupId, String artifactId, String version, String tag, Object data) {
+                cache.put(groupId + ":" + artifactId + ":" + version + ":" + tag, data);
+            }
+
+            @Override
+            public Object get(String groupId, String artifactId, String version, String tag) {
+                return cache.get(groupId + ":" + artifactId + ":" + version + ":" + tag);
+            }
+        });
+        if (workspace) {
+            request.setModelResolver(null);
+            request.setWorkspaceModelResolver(new WorkspaceModelResolver() {
+                @Override
+                public Model resolveRawModel(String groupId, String artifactId, String version) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Model resolveEffectiveModel(String groupId, String artifactId, String version)
+                        throws UnresolvableModelException {
+                    try {
+                        return new MavenXpp3Reader()
+                                .read(new StringReader(poms.get(groupId + ":" + artifactId + ":" + version)));
+                    } catch (Exception e) {
+                        throw new UnresolvableModelException(e.getMessage(), groupId, artifactId, version, e);
+                    }
+                }
+            });
+        }
+        return new DefaultModelBuilderFactory().newInstance().build(request).getEffectiveModel();
+    }
+
+    private List<String> managedDependencies(Model model) {
+        return model.getDependencyManagement().getDependencies().stream()
+                .map(d -> d.getArtifactId() + ":" + d.getVersion())
+                .toList();
+    }
+
+    private static String pom(String groupId, String artifactId, String version, String content) {
+        return "<project><modelVersion>4.0.0</modelVersion><groupId>" + groupId
+                + "</groupId><artifactId>" + artifactId + "</artifactId><version>" + version
+                + "</version><packaging>pom</packaging>" + content + "</project>";
+    }
+
+    private static String relocation(String coordinates) {
+        return "<distributionManagement><relocation>" + coordinates + "</relocation></distributionManagement>";
+    }
+
+    private static String management(String dependencies) {
+        return "<dependencyManagement><dependencies>" + dependencies + "</dependencies></dependencyManagement>";
+    }
+
+    private static String dependency(String artifactId, String version) {
+        return "<dependency><groupId>test</groupId><artifactId>" + artifactId + "</artifactId><version>" + version
+                + "</version></dependency>";
+    }
+
+    private static String bom(String artifactId) {
+        return "<dependency><groupId>test</groupId><artifactId>" + artifactId
+                + "</artifactId><version>1</version><type>pom</type><scope>import</scope></dependency>";
+    }
+}

--- a/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/BomRelocationTest.java
+++ b/compat/maven-model-builder/src/test/java/org/apache/maven/model/building/BomRelocationTest.java
@@ -125,6 +125,15 @@ class BomRelocationTest {
     }
 
     @Test
+    void detectsImportCycle() {
+        assertCycle(
+                Map.of(
+                        "test:old:1", pom("test", "old", "1", management(bom("new"))),
+                        "test:new:1", pom("test", "new", "1", management(bom("old")))),
+                "test:consumer:1 -> test:old:1 -> test:new:1 -> test:old:1");
+    }
+
+    @Test
     void reportsUnresolvableRelocationTarget() {
         Map<String, String> poms =
                 Map.of("test:old:1", pom("test", "old", "1", relocation("<artifactId>missing</artifactId>")));
@@ -171,7 +180,7 @@ class BomRelocationTest {
     private void assertCycle(Map<String, String> poms, String cycle) {
         ModelBuildingException exception =
                 assertThrows(ModelBuildingException.class, () -> build(poms, management(bom("old"))));
-        assertTrue(exception.getMessage().contains("form a cycle: " + cycle), exception.getMessage());
+        assertTrue(exception.getMessage().contains("The import POMs form a cycle: " + cycle), exception.getMessage());
     }
 
     private Model build(Map<String, String> poms, String content) throws Exception {

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -72,6 +73,7 @@ import org.apache.maven.api.model.Mixin;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Parent;
 import org.apache.maven.api.model.Profile;
+import org.apache.maven.api.model.Relocation;
 import org.apache.maven.api.model.Repository;
 import org.apache.maven.api.services.BuilderProblem;
 import org.apache.maven.api.services.BuilderProblem.Severity;
@@ -119,6 +121,7 @@ import org.apache.maven.impl.DefaultRemoteRepository;
 import org.apache.maven.impl.InternalSession;
 import org.apache.maven.impl.RequestTraceHelper;
 import org.apache.maven.impl.cache.Cache;
+import org.apache.maven.impl.resolver.MetadataInputValidator;
 import org.apache.maven.impl.util.PhasingExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1164,6 +1167,10 @@ public class DefaultModelBuilder implements ModelBuilder {
         }
 
         void buildEffectiveModel(Collection<String> importIds) throws ModelBuilderException {
+            buildEffectiveModel(new ImportContext(importIds, Set.of(), false, this, null));
+        }
+
+        private void buildEffectiveModel(ImportContext context) throws ModelBuilderException {
             Model resultModel = readEffectiveModel();
             setSource(resultModel);
             setRootModel(resultModel);
@@ -1185,7 +1192,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             }
 
             // dependency management import
-            resultModel = importDependencyManagement(resultModel, importIds);
+            resultModel = importDependencyManagement(resultModel, context);
 
             // dependency management injection
             resultModel = dependencyManagementInjector.injectManagement(resultModel, request, this);
@@ -2282,7 +2289,8 @@ public class DefaultModelBuilder implements ModelBuilder {
             return new ParentModelWithProfiles(injectedParentModel.withParent(null), parentActivePomProfiles);
         }
 
-        private Model importDependencyManagement(Model model, Collection<String> importIds) {
+        private Model importDependencyManagement(Model model, ImportContext context) {
+            Collection<String> importIds = context.importIds;
             DependencyManagement depMgmt = model.getDependencyManagement();
 
             if (depMgmt == null) {
@@ -2306,7 +2314,7 @@ public class DefaultModelBuilder implements ModelBuilder {
 
                 it.remove();
 
-                DependencyManagement importMgmt = loadDependencyManagement(dependency, importIds);
+                DependencyManagement importMgmt = loadDependencyManagement(dependency, context);
 
                 if (importMgmt != null) {
                     if (importMgmts == null) {
@@ -2430,7 +2438,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             }
         }
 
-        private DependencyManagement loadDependencyManagement(Dependency dependency, Collection<String> importIds) {
+        private DependencyManagement loadDependencyManagement(Dependency dependency, ImportContext context) {
             String groupId = dependency.getGroupId();
             String artifactId = dependency.getArtifactId();
             String version = dependency.getVersion();
@@ -2463,27 +2471,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                 return null;
             }
 
-            String imported = groupId + ':' + artifactId + ':' + version;
-
-            if (importIds.contains(imported)) {
-                StringBuilder message =
-                        new StringBuilder("The dependencies of type=pom and with scope=import form a cycle: ");
-                for (String modelId : importIds) {
-                    message.append(modelId).append(" -> ");
-                }
-                message.append(imported);
-                add(Severity.ERROR, Version.BASE, message.toString());
-                return null;
-            }
-
-            Model importModel = cache(
-                    repositories,
-                    groupId,
-                    artifactId,
-                    version,
-                    null,
-                    IMPORT,
-                    () -> doLoadDependencyManagement(dependency, groupId, artifactId, version, importIds));
+            Model importModel = loadImportModel(dependency, context);
             DependencyManagement importMgmt = importModel != null ? importModel.getDependencyManagement() : null;
             if (importMgmt == null) {
                 importMgmt = DependencyManagement.newInstance();
@@ -2505,21 +2493,116 @@ public class DefaultModelBuilder implements ModelBuilder {
                     .build();
         }
 
+        private Model loadImportModel(Dependency dependency, ImportContext context) {
+            Collection<String> importIds = context.importIds;
+            String groupId = dependency.getGroupId();
+            String artifactId = dependency.getArtifactId();
+            String version = dependency.getVersion();
+            String imported = groupId + ':' + artifactId + ':' + version;
+
+            if (importIds.contains(imported)) {
+                StringBuilder message =
+                        new StringBuilder("The dependencies of type=pom and with scope=import form a cycle: ");
+                for (String modelId : importIds) {
+                    message.append(modelId).append(" -> ");
+                }
+                message.append(imported);
+                if (context.cycleIncludesRelocation(imported)) {
+                    context.reportRelocationProblem(message.toString(), dependency.getLocation(""), null);
+                } else {
+                    add(Severity.ERROR, Version.BASE, message.toString());
+                }
+                return null;
+            }
+
+            ImportModelCacheEntry cached =
+                    cache(repositories, groupId, artifactId, version, null, IMPORT, ImportModelCacheEntry::new);
+            ImportedModel importedModel = cached.model;
+            if (importedModel == null) {
+                boolean locked = cached.lock.tryLock();
+                if (!locked && context.relocationSources.isEmpty()) {
+                    cached.lock.lock();
+                    locked = true;
+                }
+                try {
+                    importedModel = cached.model;
+                    if (importedModel == null) {
+                        // A relocation may lead back to an import being built by another thread.
+                        // Only these paths avoid waiting; ordinary imports still share one in-flight build.
+                        importedModel = doLoadDependencyManagement(dependency, groupId, artifactId, version, context);
+                        if (locked && importedModel != null) {
+                            cached.model = importedModel;
+                        }
+                    }
+                } finally {
+                    if (locked) {
+                        cached.lock.unlock();
+                    }
+                }
+            }
+            if (importedModel == null) {
+                return null;
+            }
+
+            Model importModel = importedModel.model();
+            Relocation relocation = importModel.getDistributionManagement() != null
+                    ? importModel.getDistributionManagement().getRelocation()
+                    : null;
+            if (relocation != null) {
+                if (!validateRelocationCoordinate(relocation.getGroupId(), "groupId", dependency, context)
+                        || !validateRelocationCoordinate(relocation.getArtifactId(), "artifactId", dependency, context)
+                        || !validateRelocationCoordinate(relocation.getVersion(), "version", dependency, context)) {
+                    return null;
+                }
+                Dependency.Builder relocated = Dependency.newBuilder(dependency).version(importedModel.version());
+                if (relocation.getGroupId() != null && !relocation.getGroupId().isEmpty()) {
+                    relocated.groupId(relocation.getGroupId());
+                }
+                if (relocation.getArtifactId() != null
+                        && !relocation.getArtifactId().isEmpty()) {
+                    relocated.artifactId(relocation.getArtifactId());
+                }
+                if (relocation.getVersion() != null && !relocation.getVersion().isEmpty()) {
+                    relocated.version(relocation.getVersion());
+                }
+                Dependency relocatedDependency = relocated.build();
+                String message = "The import POM " + imported + " has been relocated to "
+                        + relocatedDependency.getGroupId() + ':' + relocatedDependency.getArtifactId() + ':'
+                        + relocatedDependency.getVersion();
+                if (relocation.getMessage() != null) {
+                    message += ": " + relocation.getMessage();
+                }
+                add(Severity.WARNING, Version.BASE, message, dependency.getLocation(""));
+                if (!groupId.equals(relocatedDependency.getGroupId())
+                        || !artifactId.equals(relocatedDependency.getArtifactId())
+                        || !importedModel.version().equals(relocatedDependency.getVersion())) {
+                    // Keep relocation sources on the same path as imports to detect mixed cycles.
+                    importIds.add(imported);
+                    try {
+                        return loadImportModel(relocatedDependency, context.withRelocation(imported));
+                    } finally {
+                        importIds.remove(imported);
+                    }
+                }
+            }
+            return importModel;
+        }
+
         @SuppressWarnings("checkstyle:parameternumber")
-        private Model doLoadDependencyManagement(
-                Dependency dependency,
-                String groupId,
-                String artifactId,
-                String version,
-                Collection<String> importIds) {
+        private ImportedModel doLoadDependencyManagement(
+                Dependency dependency, String groupId, String artifactId, String version, ImportContext context) {
             Model importModel;
             ModelSource importSource;
+            String resolvedVersion = version;
             boolean repositoryResolved = false;
             try {
                 importSource = resolveReactorModel(groupId, artifactId, version);
                 if (importSource == null) {
-                    importSource = modelResolver.resolveModel(
-                            request.getSession(), repositories, dependency, new AtomicReference<>());
+                    AtomicReference<Dependency> modified = new AtomicReference<>();
+                    importSource = modelResolver.resolveModel(request.getSession(), repositories, dependency, modified);
+                    if (modified.get() != null) {
+                        resolvedVersion = modified.get().getVersion();
+                    }
                     repositoryResolved = true;
                 }
             } catch (ModelBuilderException | ModelResolverException e) {
@@ -2530,7 +2613,11 @@ public class DefaultModelBuilder implements ModelBuilder {
                 }
                 buffer.append(": ").append(e.getMessage());
 
-                add(Severity.ERROR, Version.BASE, buffer.toString(), dependency.getLocation(""), e);
+                if (context.relocationTarget) {
+                    context.reportRelocationProblem(buffer.toString(), dependency.getLocation(""), e);
+                } else {
+                    add(Severity.ERROR, Version.BASE, buffer.toString(), dependency.getLocation(""), e);
+                }
                 return null;
             }
 
@@ -2563,7 +2650,7 @@ public class DefaultModelBuilder implements ModelBuilder {
                         .build();
                 ModelBuilderSessionState modelBuilderSession = derive(importRequest);
                 // build the effective model
-                modelBuilderSession.buildEffectiveModel(importIds);
+                modelBuilderSession.buildEffectiveModel(context.withProblems(modelBuilderSession));
                 importResult = modelBuilderSession.result;
             } catch (ModelBuilderException e) {
                 return null;
@@ -2575,7 +2662,60 @@ public class DefaultModelBuilder implements ModelBuilder {
                 importModel = rejectSystemScopeFromRepositoryImport(importModel, dependency);
             }
 
-            return importModel;
+            return new ImportedModel(importModel, resolvedVersion);
+        }
+
+        private record ImportedModel(Model model, String version) {}
+
+        private record ImportContext(
+                Collection<String> importIds,
+                Set<String> relocationSources,
+                boolean relocationTarget,
+                ModelProblemCollector problems,
+                ImportContext parent) {
+            ImportContext withRelocation(String source) {
+                return new ImportContext(importIds, concat(relocationSources, source), true, problems, parent);
+            }
+
+            ImportContext withProblems(ModelProblemCollector collector) {
+                return new ImportContext(importIds, relocationSources, false, collector, this);
+            }
+
+            boolean cycleIncludesRelocation(String repeated) {
+                boolean inCycle = false;
+                for (String id : importIds) {
+                    inCycle |= id.equals(repeated);
+                    if (inCycle && relocationSources.contains(id)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            void reportRelocationProblem(String message, InputLocation location, Exception exception) {
+                // Fail every enclosing import without promoting unrelated model validation errors.
+                for (ImportContext context = this; context != null; context = context.parent) {
+                    context.problems.add(Severity.ERROR, Version.BASE, message, location, exception);
+                }
+            }
+        }
+
+        private static final class ImportModelCacheEntry {
+            private final ReentrantLock lock = new ReentrantLock();
+            private volatile ImportedModel model;
+        }
+
+        private boolean validateRelocationCoordinate(
+                String value, String component, Dependency dependency, ImportContext context) {
+            if (MetadataInputValidator.isInvalidCoordinateComponent(value)) {
+                context.reportRelocationProblem(
+                        "Invalid relocation " + component + " '" + value
+                                + "': not a valid artifact coordinate component",
+                        dependency.getLocation(""),
+                        null);
+                return false;
+            }
+            return true;
         }
 
         /**

--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelBuilder.java
@@ -2501,8 +2501,7 @@ public class DefaultModelBuilder implements ModelBuilder {
             String imported = groupId + ':' + artifactId + ':' + version;
 
             if (importIds.contains(imported)) {
-                StringBuilder message =
-                        new StringBuilder("The dependencies of type=pom and with scope=import form a cycle: ");
+                StringBuilder message = new StringBuilder("The import POMs form a cycle: ");
                 for (String modelId : importIds) {
                     message.append(modelId).append(" -> ");
                 }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/BomRelocationConcurrencyTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/BomRelocationConcurrencyTest.java
@@ -1,0 +1,395 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl.model;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.maven.api.RemoteRepository;
+import org.apache.maven.api.Session;
+import org.apache.maven.api.di.Priority;
+import org.apache.maven.api.di.Provides;
+import org.apache.maven.api.model.Dependency;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.model.Parent;
+import org.apache.maven.api.services.ModelBuilder;
+import org.apache.maven.api.services.ModelBuilderException;
+import org.apache.maven.api.services.ModelBuilderRequest;
+import org.apache.maven.api.services.ModelBuilderResult;
+import org.apache.maven.api.services.ModelSource;
+import org.apache.maven.api.services.RequestTrace;
+import org.apache.maven.api.services.Sources;
+import org.apache.maven.api.services.model.ModelResolver;
+import org.apache.maven.api.services.model.ModelResolverException;
+import org.apache.maven.api.spi.ModelTransformer;
+import org.apache.maven.impl.InternalSession;
+import org.apache.maven.impl.standalone.ApiRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class BomRelocationConcurrencyTest {
+    private static final int TIMEOUT_SECONDS = 20;
+
+    @TempDir
+    Path tempDir;
+
+    private ModelResolver resolver;
+    private CountingModelTransformer transformer;
+
+    @Test
+    void detectsConcurrentRelocationCycle() throws Exception {
+        buildConcurrently(Map.of("a", relocation("b"), "b", relocation("a")), true);
+    }
+
+    @Test
+    void detectsConcurrentMixedImportRelocationCycle() throws Exception {
+        // Without relocation, these are two acyclic import graphs, not an existing import-only cycle.
+        buildConcurrently(
+                Map.of(
+                        "a", management(bom("x")),
+                        "x", relocation("b"),
+                        "b", management(bom("y")),
+                        "y", relocation("a")),
+                true);
+    }
+
+    @Test
+    void concurrentAliasesImportSharedTarget() throws Exception {
+        buildConcurrently(
+                Map.of(
+                        "a", relocation("target"),
+                        "b", relocation("target"),
+                        "target",
+                                management("<dependency><groupId>test</groupId><artifactId>library</artifactId>"
+                                        + "<version>2</version></dependency>")),
+                false);
+    }
+
+    @Test
+    void concurrentOrdinaryImportsBuildSharedBomOnce() throws Exception {
+        buildConcurrently(
+                Map.of(
+                        "a", management(bom("target")),
+                        "b", management(bom("target")),
+                        "target",
+                                management("<dependency><groupId>test</groupId><artifactId>library</artifactId>"
+                                        + "<version>2</version></dependency>")),
+                false,
+                true);
+    }
+
+    private void buildConcurrently(Map<String, String> contents, boolean expectCycle) throws Exception {
+        buildConcurrently(contents, expectCycle, false);
+    }
+
+    private void buildConcurrently(Map<String, String> contents, boolean expectCycle, boolean coldOrdinary)
+            throws Exception {
+        Map<String, ModelSource> sources = new HashMap<>();
+        for (var entry : contents.entrySet()) {
+            Path path = tempDir.resolve(entry.getKey() + ".pom");
+            Files.writeString(path, pom(entry.getKey(), entry.getValue()));
+            sources.put("test:" + entry.getKey() + ":1", Sources.resolvedSource(path, "test:" + entry.getKey() + ":1"));
+        }
+        BarrierModelResolver barrierResolver = new BarrierModelResolver(sources, !expectCycle && !coldOrdinary);
+        resolver = barrierResolver;
+        transformer = new CountingModelTransformer(coldOrdinary);
+        Session session = ApiRunner.createSession(
+                injector -> injector.bindInstance(BomRelocationConcurrencyTest.class, this),
+                tempDir.resolve("local-repo"));
+        ModelBuilder builder = session.getService(ModelBuilder.class);
+
+        // Parallel module builds share the outer request, hence the same request-scoped import cache.
+        Path root = tempDir.resolve("root.pom");
+        Files.writeString(root, pom("root", ""));
+        ModelBuilderRequest outerRequest = ModelBuilderRequest.builder()
+                .session(session)
+                .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                .source(Sources.buildSource(root))
+                .build();
+        RequestTrace outerTrace = new RequestTrace(null, outerRequest);
+        List<FutureTask<ModelBuilderResult>> tasks = new ArrayList<>();
+        List<Thread> threads = new ArrayList<>();
+        for (String artifactId : List.of("a", "b")) {
+            Path consumer = tempDir.resolve("consumer-" + artifactId + ".pom");
+            Files.writeString(consumer, pom("consumer-" + artifactId, management(bom(artifactId))));
+            ModelBuilderRequest request = ModelBuilderRequest.builder()
+                    .session(session)
+                    .trace(new RequestTrace(outerTrace, consumer))
+                    // Avoid another executor: only these daemon threads may block on a regression.
+                    .requestType(ModelBuilderRequest.RequestType.BUILD_EFFECTIVE)
+                    .source(Sources.buildSource(consumer))
+                    .build();
+            FutureTask<ModelBuilderResult> task = new FutureTask<>(() -> {
+                try {
+                    return builder.newSession().build(request);
+                } finally {
+                    InternalSession.from(session).setCurrentTrace(null);
+                    if ("a".equals(artifactId)) {
+                        barrierResolver.firstBuildFinished.countDown();
+                    }
+                }
+            });
+            Thread thread = new Thread(task, "bom-relocation-" + artifactId);
+            // Monitor acquisition cannot be interrupted; a deadlock must not keep Surefire alive.
+            thread.setDaemon(true);
+            tasks.add(task);
+            threads.add(thread);
+        }
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        try {
+            threads.forEach(Thread::start);
+            if (coldOrdinary) {
+                transformer.awaitContendingBuild(threads, deadline);
+                transformer.releaseTarget.countDown();
+            }
+            for (FutureTask<ModelBuilderResult> task : tasks) {
+                try {
+                    ModelBuilderResult result =
+                            task.get(Math.max(1, deadline - System.nanoTime()), TimeUnit.NANOSECONDS);
+                    assertFalse(expectCycle, "Build completed without detecting the relocation cycle");
+                    assertEquals(
+                            List.of("library:2"),
+                            result.getEffectiveModel().getDependencyManagement().getDependencies().stream()
+                                    .map(d -> d.getArtifactId() + ":" + d.getVersion())
+                                    .toList());
+                } catch (ExecutionException e) {
+                    if (!expectCycle) {
+                        throw e;
+                    }
+                    ModelBuilderException failure = assertInstanceOf(ModelBuilderException.class, e.getCause());
+                    assertTrue(failure.getMessage().contains("form a cycle"), failure.getMessage());
+                    assertTrue(failure.getMessage().contains("test:a:1"), failure.getMessage());
+                    assertTrue(failure.getMessage().contains("test:b:1"), failure.getMessage());
+                } catch (TimeoutException e) {
+                    fail(
+                            "Concurrent BOM resolution did not terminate; initial resolver barrier remaining: "
+                                    + barrierResolver.firstLoads.getCount() + threadStacks(threads),
+                            e);
+                }
+            }
+            assertEquals(0, barrierResolver.firstLoads.getCount(), "Both source loads must overlap");
+            if (!expectCycle) {
+                assertEquals(
+                        Map.of("test:a:1", 1, "test:b:1", 1, "test:target:1", 1),
+                        barrierResolver.resolveCounts,
+                        "The second model build must reuse the target loaded by the first build");
+                assertEquals(1, transformer.targetBuilds.get(), "The target effective model must be built once");
+            }
+        } finally {
+            transformer.releaseTarget.countDown();
+            tasks.forEach(task -> task.cancel(true));
+            threads.forEach(Thread::interrupt);
+            for (Thread thread : threads) {
+                thread.join(100);
+            }
+        }
+    }
+
+    private static String threadStacks(List<Thread> threads) {
+        StringBuilder message = new StringBuilder();
+        for (Thread thread : threads) {
+            message.append('\n').append(thread.getName()).append(": ").append(thread.getState());
+            for (StackTraceElement frame : thread.getStackTrace()) {
+                message.append("\n    at ").append(frame);
+            }
+        }
+        return message.toString();
+    }
+
+    @Provides
+    @Priority(100)
+    ModelResolver modelResolver() {
+        return resolver;
+    }
+
+    @Provides
+    ModelTransformer modelTransformer() {
+        return transformer;
+    }
+
+    private static String pom(String artifactId, String content) {
+        return "<project><modelVersion>4.0.0</modelVersion><groupId>test</groupId><artifactId>" + artifactId
+                + "</artifactId><version>1</version><packaging>pom</packaging>" + content + "</project>";
+    }
+
+    private static String relocation(String artifactId) {
+        return "<distributionManagement><relocation><artifactId>" + artifactId
+                + "</artifactId></relocation></distributionManagement>";
+    }
+
+    private static String management(String dependencies) {
+        return "<dependencyManagement><dependencies>" + dependencies + "</dependencies></dependencyManagement>";
+    }
+
+    private static String bom(String artifactId) {
+        return "<dependency><groupId>test</groupId><artifactId>" + artifactId
+                + "</artifactId><version>1</version><type>pom</type><scope>import</scope></dependency>";
+    }
+
+    private static final class CountingModelTransformer implements ModelTransformer {
+        private final boolean blockTarget;
+        private final AtomicInteger targetBuilds = new AtomicInteger();
+        private final AtomicReference<Thread> firstBuilder = new AtomicReference<>();
+        private final CountDownLatch targetStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseTarget = new CountDownLatch(1);
+
+        private CountingModelTransformer(boolean blockTarget) {
+            this.blockTarget = blockTarget;
+        }
+
+        @Override
+        public Model transformEffectiveModel(Model model) {
+            if ("test".equals(model.getGroupId()) && "target".equals(model.getArtifactId())) {
+                targetBuilds.incrementAndGet();
+                if (blockTarget && firstBuilder.compareAndSet(null, Thread.currentThread())) {
+                    targetStarted.countDown();
+                    try {
+                        if (!releaseTarget.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                            throw new AssertionError("The shared target build was not released");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError("The shared target build was interrupted", e);
+                    }
+                }
+            }
+            return model;
+        }
+
+        private void awaitContendingBuild(List<Thread> threads, long deadline) throws InterruptedException {
+            assertTrue(
+                    targetStarted.await(Math.max(1, deadline - System.nanoTime()), TimeUnit.NANOSECONDS),
+                    "The first target effective-model build did not start");
+            // Keep the first build cold until another caller waits for it or incorrectly duplicates it.
+            while (System.nanoTime() < deadline) {
+                if (targetBuilds.get() > 1) {
+                    return;
+                }
+                for (Thread thread : threads) {
+                    if (thread != firstBuilder.get() && waitsForImport(thread)) {
+                        return;
+                    }
+                }
+                Thread.sleep(10);
+            }
+            fail("The second caller neither waited nor built the shared BOM" + threadStacks(threads));
+        }
+
+        private static boolean waitsForImport(Thread thread) {
+            if (thread.getState() != Thread.State.WAITING && thread.getState() != Thread.State.BLOCKED) {
+                return false;
+            }
+            boolean importFrame = false;
+            boolean lockFrame = false;
+            for (StackTraceElement frame : thread.getStackTrace()) {
+                importFrame |= frame.getClassName().startsWith(DefaultModelBuilder.class.getName())
+                        && ("loadImportModel".equals(frame.getMethodName())
+                                || "loadDependencyManagement".equals(frame.getMethodName()));
+                lockFrame |= frame.getClassName().startsWith("java.util.concurrent.locks.ReentrantLock")
+                        || frame.getClassName().equals("org.apache.maven.impl.cache.CachingSupplier");
+            }
+            return importFrame && lockFrame;
+        }
+    }
+
+    private static final class BarrierModelResolver implements ModelResolver {
+        private final Map<String, ModelSource> sources;
+        private final boolean orderTargetLoads;
+        private final Set<String> firstCoordinates = ConcurrentHashMap.newKeySet();
+        private final Map<String, Integer> resolveCounts = new ConcurrentHashMap<>();
+        private final CountDownLatch firstLoads = new CountDownLatch(2);
+        private final CountDownLatch firstBuildFinished = new CountDownLatch(1);
+
+        private BarrierModelResolver(Map<String, ModelSource> sources, boolean orderTargetLoads) {
+            this.sources = Map.copyOf(sources);
+            this.orderTargetLoads = orderTargetLoads;
+        }
+
+        @Override
+        public ModelSource resolveModel(
+                Session session, List<RemoteRepository> repositories, Parent parent, AtomicReference<Parent> modified) {
+            return resolve(parent.getGroupId(), parent.getArtifactId(), parent.getVersion());
+        }
+
+        @Override
+        public ModelSource resolveModel(
+                Session session,
+                List<RemoteRepository> repositories,
+                Dependency dependency,
+                AtomicReference<Dependency> modified) {
+            return resolve(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+        }
+
+        @Override
+        public ModelResolverResult resolveModel(ModelResolverRequest request) {
+            return new ModelResolverResult(
+                    request, resolve(request.groupId(), request.artifactId(), request.version()), null);
+        }
+
+        private ModelSource resolve(String groupId, String artifactId, String version) {
+            String coordinates = groupId + ':' + artifactId + ':' + version;
+            ModelSource source = sources.get(coordinates);
+            if (source == null) {
+                throw new ModelResolverException(
+                        "Unexpected model lookup: " + coordinates, groupId, artifactId, version);
+            }
+            resolveCounts.merge(coordinates, 1, Integer::sum);
+            if (("test:a:1".equals(coordinates) || "test:b:1".equals(coordinates))
+                    && firstCoordinates.add(coordinates)) {
+                firstLoads.countDown();
+                try {
+                    if (!firstLoads.await(TIMEOUT_SECONDS / 2, TimeUnit.SECONDS)) {
+                        throw new AssertionError("The two initial BOM loads did not overlap");
+                    }
+                    // Prove cross-request cache reuse without requiring single-flight concurrent loading.
+                    // Cycle fixtures do not use this ordering: both paths must continue together.
+                    if (orderTargetLoads
+                            && "test:b:1".equals(coordinates)
+                            && !firstBuildFinished.await(TIMEOUT_SECONDS / 2, TimeUnit.SECONDS)) {
+                        throw new AssertionError("The first alias build did not complete");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new ModelResolverException(e, groupId, artifactId, version);
+                }
+            }
+            return source;
+        }
+    }
+}

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/BomRelocationTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/BomRelocationTest.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.impl.model;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.api.RemoteRepository;
+import org.apache.maven.api.Session;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.di.Provides;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.api.services.ModelBuilder;
+import org.apache.maven.api.services.ModelBuilderException;
+import org.apache.maven.api.services.ModelBuilderRequest;
+import org.apache.maven.api.services.ModelBuilderResult;
+import org.apache.maven.api.services.Sources;
+import org.apache.maven.impl.standalone.ApiRunner;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BomRelocationTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void importsRelocatedBom() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))));
+        Model model = build(poms, management(bom("old"))).getEffectiveModel();
+        assertEquals(List.of("library:2"), managedDependencies(model));
+    }
+
+    @Test
+    void followsPartialRelocationChain() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<groupId>relocated</groupId>")),
+                "relocated:old:1", pom("relocated", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "relocated:new:1", pom("relocated", "new", "1", relocation("<version>2</version>")),
+                "relocated:new:2", pom("relocated", "new", "2", management(dependency("library", "2"))));
+        assertEquals(
+                List.of("library:2"),
+                managedDependencies(build(poms, management(bom("old"))).getEffectiveModel()));
+    }
+
+    @Test
+    void ignoresManagementFromRelocationSourceAndPreservesPrecedence() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1",
+                        pom(
+                                "test",
+                                "old",
+                                "1",
+                                relocation("<artifactId>new</artifactId>") + management(dependency("obsolete", "1"))),
+                "test:new:1",
+                        pom("test", "new", "1", management(dependency("library", "2") + dependency("other", "2"))),
+                "test:ordinary:1", pom("test", "ordinary", "1", management(dependency("other", "3"))));
+        String content = management(dependency("library", "4") + bom("old") + bom("ordinary"));
+        assertEquals(
+                List.of("library:4", "other:2"),
+                managedDependencies(build(poms, content).getEffectiveModel()));
+    }
+
+    @Test
+    void preservesManagementForUnchangedRelocation() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1",
+                pom(
+                        "test",
+                        "old",
+                        "1",
+                        relocation("<artifactId>old</artifactId>") + management(dependency("library", "2"))));
+        assertEquals(
+                List.of("library:2"),
+                managedDependencies(build(poms, management(bom("old"))).getEffectiveModel()));
+    }
+
+    @Test
+    void preservesManagementForMessageOnlyRelocation() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1",
+                pom(
+                        "test",
+                        "old",
+                        "1",
+                        relocation("<message>Use the current release</message>")
+                                + management(dependency("library", "2"))));
+        assertEquals(
+                List.of("library:2"),
+                managedDependencies(build(poms, management(bom("old"))).getEffectiveModel()));
+    }
+
+    @Test
+    void detectsRelocationCycle() {
+        assertCycle(
+                Map.of(
+                        "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                        "test:new:1", pom("test", "new", "1", relocation("<artifactId>old</artifactId>"))),
+                "test:consumer:1 -> test:old:1 -> test:new:1 -> test:old:1");
+    }
+
+    @Test
+    void detectsRelocationThenImportCycle() {
+        assertCycle(
+                Map.of(
+                        "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                        "test:new:1", pom("test", "new", "1", management(bom("old")))),
+                "test:consumer:1 -> test:old:1 -> test:new:1 -> test:old:1");
+    }
+
+    @Test
+    void detectsImportThenRelocationCycle() {
+        assertCycle(
+                Map.of(
+                        "test:old:1", pom("test", "old", "1", management(bom("new"))),
+                        "test:new:1", pom("test", "new", "1", relocation("<artifactId>old</artifactId>"))),
+                "test:consumer:1 -> test:old:1 -> test:new:1 -> test:old:1");
+    }
+
+    @Test
+    void reportsUnresolvableRelocationTarget() {
+        Map<String, String> poms =
+                Map.of("test:old:1", pom("test", "old", "1", relocation("<artifactId>missing</artifactId>")));
+        ModelBuilderException exception =
+                assertThrows(ModelBuilderException.class, () -> build(poms, management(bom("old"))));
+        assertTrue(exception.getMessage().contains("Non-resolvable import POM"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("test:missing"), exception.getMessage());
+    }
+
+    @Test
+    void partialRelocationKeepsVersionSelectedFromRange() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:2", pom("test", "old", "2", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "1"))),
+                "test:new:2", pom("test", "new", "2", management(dependency("library", "2"))),
+                "test:new:3", pom("test", "new", "3", management(dependency("library", "3"))));
+        String content = management("<dependency><groupId>test</groupId><artifactId>old</artifactId>"
+                + "<version>[1,4)</version><type>pom</type><scope>import</scope></dependency>");
+        assertEquals(
+                List.of("library:2"), managedDependencies(build(poms, content).getEffectiveModel()));
+    }
+
+    @Test
+    void doesNotSubstituteAnotherTargetVersionAfterResolvingRange() {
+        Map<String, String> poms = Map.of(
+                "test:old:2", pom("test", "old", "2", relocation("<artifactId>new</artifactId>")),
+                "test:new:3", pom("test", "new", "3", management(dependency("library", "3"))));
+        String content = management("<dependency><groupId>test</groupId><artifactId>old</artifactId>"
+                + "<version>[1,4)</version><type>pom</type><scope>import</scope></dependency>");
+        ModelBuilderException exception = assertThrows(ModelBuilderException.class, () -> build(poms, content));
+        assertTrue(exception.getMessage().contains("Non-resolvable import POM"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("test:new:2"), exception.getMessage());
+    }
+
+    @Test
+    void importsRelocatedReactorBom() throws Exception {
+        Files.createDirectory(tempDir.resolve(".mvn"));
+        for (String artifact : List.of("old", "new", "consumer")) {
+            Path directory = Files.createDirectory(tempDir.resolve(artifact));
+            String content =
+                    switch (artifact) {
+                        case "old" -> relocation("<artifactId>new</artifactId>");
+                        case "new" -> management(dependency("library", "2"));
+                        default -> management(bom("old"));
+                    };
+            Files.writeString(directory.resolve("pom.xml"), pom("test", artifact, "1", content));
+        }
+        Path root = tempDir.resolve("pom.xml");
+        Files.writeString(
+                root,
+                pom(
+                        "test",
+                        "root",
+                        "1",
+                        "<modules><module>old</module><module>new</module><module>consumer</module></modules>"));
+        Session session = ApiRunner.createSession();
+        ModelBuilderResult result = session.getService(ModelBuilder.class)
+                .newSession()
+                .build(ModelBuilderRequest.builder()
+                        .session(session)
+                        .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                        .recursive(true)
+                        .source(Sources.buildSource(root))
+                        .build());
+        Model consumer = result.getChildren().stream()
+                .map(ModelBuilderResult::getEffectiveModel)
+                .filter(model -> "consumer".equals(model.getArtifactId()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(List.of("library:2"), managedDependencies(consumer));
+    }
+
+    @Test
+    void ordinaryMissingImportHasSameBehaviorThroughRelocation() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(bom("missing"))));
+        assertEquals(
+                List.of(),
+                managedDependencies(build(poms, management(bom("new"))).getEffectiveModel()));
+        assertEquals(
+                List.of(),
+                managedDependencies(build(poms, management(bom("old"))).getEffectiveModel()));
+    }
+
+    @Test
+    void ordinaryImportCycleHasSameBehaviorThroughRelocation() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(bom("nested"))),
+                "test:nested:1", pom("test", "nested", "1", management(bom("new"))));
+        assertEquals(
+                List.of(),
+                managedDependencies(build(poms, management(bom("new"))).getEffectiveModel()));
+        assertEquals(
+                List.of(),
+                managedDependencies(build(poms, management(bom("old"))).getEffectiveModel()));
+    }
+
+    @Test
+    void skipsOrdinaryBomWithUnresolvedSystemPath() throws Exception {
+        Map<String, String> poms = Map.of("test:new:1", pom("test", "new", "1", unresolvedSystemManagement()));
+        assertEquals(
+                List.of(),
+                managedDependencies(build(poms, management(bom("new"))).getEffectiveModel()));
+    }
+
+    @Test
+    void skipsRelocatedBomWithUnresolvedSystemPath() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", unresolvedSystemManagement()));
+        assertEquals(
+                List.of(),
+                managedDependencies(build(poms, management(bom("old"))).getEffectiveModel()));
+    }
+
+    @Test
+    void successfulRelocationDoesNotChangeLaterOrdinaryImportValidation() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))),
+                "test:ordinary:1", pom("test", "ordinary", "1", unresolvedSystemManagement()));
+        assertEquals(
+                List.of("library:2"),
+                managedDependencies(
+                        build(poms, management(bom("old") + bom("ordinary"))).getEffectiveModel()));
+    }
+
+    private static String unresolvedSystemManagement() {
+        return management("<dependency><groupId>test</groupId><artifactId>tool</artifactId>"
+                + "<version>1</version><scope>system</scope>"
+                + "<systemPath>${test.dir}/${test.file}</systemPath></dependency>");
+    }
+
+    @Test
+    void relocatedRepositoryBomStillRejectsSystemScope() throws Exception {
+        Path systemPath = Files.createFile(tempDir.resolve("tool.jar"));
+        String systemDependency = "<dependency><groupId>test</groupId><artifactId>tool</artifactId>"
+                + "<version>1</version><scope>system</scope><systemPath>" + systemPath
+                + "</systemPath></dependency>";
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2") + systemDependency)));
+        assertEquals(
+                List.of("library:2"),
+                managedDependencies(build(poms, management(bom("old"))).getEffectiveModel()));
+    }
+
+    @Test
+    void exclusionsOnRelocatedImportDoNotPolluteCachedTarget() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1",
+                        pom("test", "new", "1", management(dependency("library", "2") + dependency("excluded", "3"))));
+        String exclusions = "<exclusions><exclusion><groupId>test</groupId><artifactId>excluded</artifactId>"
+                + "</exclusion></exclusions>";
+        Model model =
+                build(poms, management(bom("old", exclusions) + bom("new"))).getEffectiveModel();
+        assertEquals(List.of("library:2", "excluded:3"), managedDependencies(model));
+        assertEquals(
+                "excluded",
+                model.getDependencyManagement()
+                        .getDependencies()
+                        .get(0)
+                        .getExclusions()
+                        .get(0)
+                        .getArtifactId());
+        assertTrue(model.getDependencyManagement()
+                .getDependencies()
+                .get(1)
+                .getExclusions()
+                .isEmpty());
+    }
+
+    @Test
+    void importsRelocatedBomTypeWithoutScope() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))));
+        String content = management("<dependency><groupId>test</groupId><artifactId>old</artifactId>"
+                + "<version>1</version><type>bom</type></dependency>");
+        Model model = build(poms, content).getEffectiveModel();
+        assertEquals(List.of("library:2"), managedDependencies(model));
+    }
+
+    @Test
+    void reportsRelocationCoordinatesAndMessage() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1",
+                        pom(
+                                "test",
+                                "old",
+                                "1",
+                                relocation("<artifactId>new</artifactId><message>Please update the import</message>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))));
+        ModelBuilderResult result = build(poms, management(bom("old")));
+        assertTrue(
+                result.getProblemCollector()
+                        .problems()
+                        .anyMatch(
+                                p -> p.getMessage()
+                                        .equals(
+                                                "The import POM test:old:1 has been relocated to test:new:1: Please update the import")));
+    }
+
+    @Test
+    void rejectsInvalidRelocationCoordinates() {
+        for (String component : List.of("groupId", "artifactId", "version")) {
+            for (String value : List.of("..", "bad/name", "bad\\name", "bad:name", "bad&#9;name")) {
+                Map<String, String> poms = Map.of(
+                        "test:old:1",
+                        pom("test", "old", "1", relocation("<" + component + ">" + value + "</" + component + ">")));
+                ModelBuilderException exception =
+                        assertThrows(ModelBuilderException.class, () -> build(poms, management(bom("old"))));
+                assertTrue(exception.getMessage().contains("Invalid relocation " + component), exception.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void repeatedImportsReuseRelocatedManagement() throws Exception {
+        Map<String, String> poms = Map.of(
+                "test:old:1", pom("test", "old", "1", relocation("<artifactId>new</artifactId>")),
+                "test:alias:1", pom("test", "alias", "1", relocation("<artifactId>new</artifactId>")),
+                "test:new:1", pom("test", "new", "1", management(dependency("library", "2"))));
+        assertEquals(
+                List.of("library:2"),
+                managedDependencies(build(poms, management(bom("old") + bom("alias") + bom("new")))
+                        .getEffectiveModel()));
+    }
+
+    private void assertCycle(Map<String, String> poms, String cycle) {
+        ModelBuilderException exception =
+                assertThrows(ModelBuilderException.class, () -> build(poms, management(bom("old"))));
+        assertTrue(exception.getMessage().contains("form a cycle: " + cycle), exception.getMessage());
+    }
+
+    private ModelBuilderResult build(Map<String, String> poms, String content) throws Exception {
+        Path projectDir = Files.createTempDirectory(tempDir, "project-");
+        Files.createDirectory(projectDir.resolve(".mvn"));
+        Path remoteRepo = projectDir.resolve("remote-repo");
+        Map<Path, List<String>> versions = new HashMap<>();
+        for (Map.Entry<String, String> entry : poms.entrySet()) {
+            String[] coordinates = entry.getKey().split(":");
+            Path path = remoteRepo.resolve(coordinates[0].replace('.', '/') + "/" + coordinates[1] + "/"
+                    + coordinates[2] + "/" + coordinates[1] + "-" + coordinates[2] + ".pom");
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, entry.getValue());
+            versions.computeIfAbsent(path.getParent().getParent(), key -> new ArrayList<>())
+                    .add(coordinates[2]);
+        }
+        for (Map.Entry<Path, List<String>> entry : versions.entrySet()) {
+            String metadataVersions = entry.getValue().stream()
+                    .map(version -> "<version>" + version + "</version>")
+                    .collect(java.util.stream.Collectors.joining());
+            Files.writeString(
+                    entry.getKey().resolve("maven-metadata.xml"),
+                    "<metadata><versioning><versions>" + metadataVersions + "</versions></versioning></metadata>");
+        }
+        Path consumer = projectDir.resolve("pom.xml");
+        Files.writeString(consumer, pom("test", "consumer", "1", content));
+        Session session = ApiRunner.createSession(
+                injector -> injector.bindInstance(BomRelocationTest.class, this), projectDir.resolve("local-repo"));
+        session = session.withRemoteRepositories(List.of(session.createRemoteRepository(
+                RemoteRepository.CENTRAL_ID, remoteRepo.toUri().toString())));
+        return session.getService(ModelBuilder.class)
+                .newSession()
+                .build(ModelBuilderRequest.builder()
+                        .session(session)
+                        .requestType(ModelBuilderRequest.RequestType.BUILD_PROJECT)
+                        .source(Sources.buildSource(consumer))
+                        .build());
+    }
+
+    private List<String> managedDependencies(Model model) {
+        return model.getDependencyManagement().getDependencies().stream()
+                .map(d -> d.getArtifactId() + ":" + d.getVersion())
+                .toList();
+    }
+
+    private static String pom(String groupId, String artifactId, String version, String content) {
+        return "<project><modelVersion>4.0.0</modelVersion><groupId>" + groupId
+                + "</groupId><artifactId>" + artifactId + "</artifactId><version>" + version
+                + "</version><packaging>pom</packaging>" + content + "</project>";
+    }
+
+    private static String relocation(String coordinates) {
+        return "<distributionManagement><relocation>" + coordinates + "</relocation></distributionManagement>";
+    }
+
+    private static String management(String dependencies) {
+        return "<dependencyManagement><dependencies>" + dependencies + "</dependencies></dependencyManagement>";
+    }
+
+    private static String dependency(String artifactId, String version) {
+        return "<dependency><groupId>test</groupId><artifactId>" + artifactId + "</artifactId><version>" + version
+                + "</version></dependency>";
+    }
+
+    private static String bom(String artifactId) {
+        return bom(artifactId, "");
+    }
+
+    private static String bom(String artifactId, String extra) {
+        return "<dependency><groupId>test</groupId><artifactId>" + artifactId
+                + "</artifactId><version>1</version><type>pom</type><scope>import</scope>" + extra + "</dependency>";
+    }
+
+    @Provides
+    @Named(FileTransporterFactory.NAME)
+    static FileTransporterFactory newFileTransporterFactory() {
+        return new FileTransporterFactory();
+    }
+}

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/BomRelocationTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/BomRelocationTest.java
@@ -144,6 +144,15 @@ class BomRelocationTest {
     }
 
     @Test
+    void detectsDirectImportCycle() {
+        ModelBuilderException exception =
+                assertThrows(ModelBuilderException.class, () -> build(Map.of(), management(bom("consumer"))));
+        assertTrue(
+                exception.getMessage().contains("The import POMs form a cycle: test:consumer:1 -> test:consumer:1"),
+                exception.getMessage());
+    }
+
+    @Test
     void reportsUnresolvableRelocationTarget() {
         Map<String, String> poms =
                 Map.of("test:old:1", pom("test", "old", "1", relocation("<artifactId>missing</artifactId>")));
@@ -379,7 +388,7 @@ class BomRelocationTest {
     private void assertCycle(Map<String, String> poms, String cycle) {
         ModelBuilderException exception =
                 assertThrows(ModelBuilderException.class, () -> build(poms, management(bom("old"))));
-        assertTrue(exception.getMessage().contains("form a cycle: " + cycle), exception.getMessage());
+        assertTrue(exception.getMessage().contains("The import POMs form a cycle: " + cycle), exception.getMessage());
     }
 
     private ModelBuilderResult build(Map<String, String> poms, String content) throws Exception {

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5527BomRelocationTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5527BomRelocationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MavenITmng5527BomRelocationTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void followsRelocationChainAndPreservesImportExclusions() throws Exception {
+        Path testDir = extractResources("mng-5527-bom-relocation/project");
+        Verifier verifier = newVerifier(testDir);
+        verifier.setAutoclean(false);
+        verifier.filterFile("../settings-template.xml", "settings.xml", verifier.newDefaultFilterMap());
+        verifier.addCliArguments("-s", "settings.xml", "verify");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog("has been relocated");
+
+        Properties properties = verifier.loadProperties("target/project.properties");
+        assertEquals("1", properties.getProperty("project.dependencyManagement.dependencies"));
+        assertEquals(
+                "org.apache.commons:commons-lang3:jar",
+                properties.getProperty("project.dependencyManagement.dependencies.0.managementKey"));
+        assertEquals("3.18.0", properties.getProperty("project.dependencyManagement.dependencies.0.version"));
+        assertEquals("1", properties.getProperty("project.dependencyManagement.dependencies.0.exclusions"));
+        assertEquals(
+                "commons-io", properties.getProperty("project.dependencyManagement.dependencies.0.exclusions.0.groupId"));
+        assertEquals(
+                "commons-io", properties.getProperty("project.dependencyManagement.dependencies.0.exclusions.0.artifactId"));
+        assertEquals("3.18.0", properties.getProperty("project.dependencies.0.version"));
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/project/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/project/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.mng5527</groupId>
+  <artifactId>project</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.mng5527</groupId>
+        <artifactId>old-bom</artifactId>
+        <version>1</version>
+        <type>pom</type>
+        <scope>import</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-expression</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eval</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <expressions>
+                <expression>project/dependencyManagement</expression>
+                <expression>project/dependencies</expression>
+              </expressions>
+              <outputFile>${project.build.directory}/project.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/repo/org/apache/maven/its/mng5527/old-bom/1/old-bom-1.pom
+++ b/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/repo/org/apache/maven/its/mng5527/old-bom/1/old-bom-1.pom
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.mng5527</groupId>
+  <artifactId>old-bom</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+  <distributionManagement>
+    <relocation>
+      <groupId>org.apache.maven.its.mng5527.relocated</groupId>
+      <artifactId>new-bom</artifactId>
+      <version>2</version>
+    </relocation>
+  </distributionManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/repo/org/apache/maven/its/mng5527/relocated/new-bom/2/new-bom-2.pom
+++ b/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/repo/org/apache/maven/its/mng5527/relocated/new-bom/2/new-bom-2.pom
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.mng5527.relocated</groupId>
+  <artifactId>new-bom</artifactId>
+  <version>2</version>
+  <packaging>pom</packaging>
+  <distributionManagement>
+    <relocation>
+      <version>3</version>
+    </relocation>
+  </distributionManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/repo/org/apache/maven/its/mng5527/relocated/new-bom/3/new-bom-3.pom
+++ b/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/repo/org/apache/maven/its/mng5527/relocated/new-bom/3/new-bom-3.pom
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.mng5527.relocated</groupId>
+  <artifactId>new-bom</artifactId>
+  <version>3</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.18.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/settings-template.xml
+++ b/its/core-it-suite/src/test/resources/mng-5527-bom-relocation/settings-template.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <profiles>
+    <profile>
+      <id>maven-core-it-repo</id>
+      <repositories>
+        <repository>
+          <id>maven-core-it</id>
+          <url>@baseurl@/../repo</url>
+          <releases>
+            <checksumPolicy>ignore</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>maven-core-it-repo</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Fixes #6804.

Follow BOM relocation chains in both model builders, including partial relocations. Preserve dependency-management precedence, import exclusions, and the modern resolver's selected version when resolving a range.

Report invalid relocation coordinates, missing relocation targets, and relocation/import cycles without changing ordinary imported-model validation behavior. Preserve sharing of ordinary in-flight imports while avoiding cyclic waits introduced by relocation traversal.

Validation:
- The reported failure reproduces on untouched master and passes with the fix through both the CLI and the new Core IT.
- All 39 focused relocation, compatibility, and concurrency tests pass.
- `mvn verify` passes: 3,152 unit tests, zero failures/errors, 16 skips, plus one reactor integration test.
- Full forked Core IT: 1,074 tests, three failing tests, 43 skips. MNG3955 and MNG4411 fail identically on untouched master. MavenITMvnupToolchainPluginStrategyTest passes after refreshing its previously modified generated fixture. MNG4590 and the new MNG5527 test pass in the full run.

- [x] This pull request addresses one issue without unrelated changes.
- [x] The description explains what changes, how, and why.
- [x] Commits have meaningful subjects and bodies.
- [x] Regression tests cover the behavioral changes; the reported case fails without the fix.
- [x] `mvn verify` passes.
- [ ] The [Core IT suite](https://maven.apache.org/core-its/core-it-suite/) passes.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).