### PR TITLE
Lint GitHub Actions workflows with actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Lints the GitHub Actions workflows themselves with actionlint
+# (https://github.com/rhysd/actionlint): workflow syntax, expression contexts,
+# and embedded shell (via shellcheck). actionlint is run through
+# github/super-linter (restricted to the GitHub Actions validator) because the
+# ASF org allowed-actions policy permits GitHub-owned actions but not the
+# stand-alone actionlint action/image. Only runs when a workflow file changes.
+name: Actionlint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+# cancel superseded runs on the same ref (e.g. rapid pushes to a branch)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout maven
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # super-linter needs full history to resolve the commit range
+          fetch-depth: 0
+
+      # super-linter is GitHub-owned, so it satisfies the ASF allowed-actions
+      # policy (a stand-alone actionlint action/image is not on the allowlist).
+      # VALIDATE_GITHUB_ACTIONS restricts it to actionlint only; other linters
+      # (shellcheck, yaml, ...) can be enabled later via more VALIDATE_* flags.
+      - name: Lint workflows with actionlint (via super-linter)
+        uses: github/super-linter/slim@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # v7
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_GITHUB_ACTIONS: true
+          # DEFAULT_BRANCH is left unset so super-linter auto-detects it,
+          # which keeps this working on forks whose default branch is not master.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -214,8 +214,8 @@ jobs:
           else
             tar xzf maven-dist/apache-maven-*-bin.tar.gz -C maven-local --strip-components 1
           fi
-          echo "MAVEN_HOME=$PWD/maven-local" >> $GITHUB_ENV
-          echo "$PWD/maven-local/bin" >> $GITHUB_PATH
+          echo "MAVEN_HOME=$PWD/maven-local" >> "$GITHUB_ENV"
+          echo "$PWD/maven-local/bin" >> "$GITHUB_PATH"
 
       - name: Build with downloaded Maven
         shell: bash
@@ -315,8 +315,8 @@ jobs:
           else
             tar xzf maven-dist/apache-maven-*-bin.tar.gz -C maven-local --strip-components 1
           fi
-          echo "MAVEN_HOME=$PWD/maven-local" >> $GITHUB_ENV
-          echo "$PWD/maven-local/bin" >> $GITHUB_PATH
+          echo "MAVEN_HOME=$PWD/maven-local" >> "$GITHUB_ENV"
+          echo "$PWD/maven-local/bin" >> "$GITHUB_PATH"
 
       - name: Build Maven and ITs and run them
         shell: bash


### PR DESCRIPTION
This adds a small CI job running [actionlint](https://github.com/rhysd/actionlint) over `.github/workflows/**` — it checks workflow syntax, expression contexts, and embedded shell (via shellcheck). We have no workflow linting today.

It triggers on any branch push and any PR (path-filtered to `.github/workflows/**`), so contributors get early feedback even on their forks, before a PR exists. A `concurrency` group cancels superseded runs on the same ref.

On its first run it flagged 4 real issues — unquoted `$GITHUB_ENV` / `$GITHUB_PATH` (`SC2086`) in `maven.yml`'s two "Extract Maven distribution" steps — fixed in the second commit.

**Opening as a draft to gather opinions before committing to it** — @slawekjaranowski (and others):

- Do we want workflow linting on `apache/maven`?
- If yes, should the reusable logic live in **`apache/maven-gh-actions-shared`** (so every Maven repo adopts it over time via a small caller workflow), rather than a standalone workflow per repo? This PR is the standalone demo; happy to move it to the shared repo if that's preferred.
- Mechanism/pinning: `docker://` image (digest-pinned for a final version) vs `reviewdog/action-actionlint` vs a pinned download — preference?
- Advisory, or a required check?

Note: actionlint does **not** flag the `if: ${{ ... }}` pattern, so that stays as-is.
