### PR TITLE
Fix #13092: tokenize quoted --define in maven.config

### DIFF
--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/CleanArgument.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/CleanArgument.java
@@ -26,6 +26,50 @@ import java.util.List;
  */
 @Deprecated
 public class CleanArgument {
+    /**
+     * Split a {@code maven.config} line into CLI arguments, honouring single and
+     * double quotes the way a POSIX shell would for this limited case. Unquoted
+     * whitespace separates arguments; quote characters are not included in the
+     * resulting tokens.
+     */
+    public static List<String> splitLine(String line) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inSingle = false;
+        boolean inDouble = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inSingle) {
+                if (c == '\'') {
+                    inSingle = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (inDouble) {
+                if (c == '"') {
+                    inDouble = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (c == '\'') {
+                inSingle = true;
+            } else if (c == '"') {
+                inDouble = true;
+            } else if (Character.isWhitespace(c)) {
+                if (!current.isEmpty()) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                }
+            } else {
+                current.append(c);
+            }
+        }
+        if (!current.isEmpty()) {
+            tokens.add(current.toString());
+        }
+        return tokens;
+    }
+
     public static String[] cleanArgs(String[] args) {
         try {
             return doCleanArgs(args);

--- a/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
+++ b/compat/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java
@@ -420,6 +420,7 @@ public class MavenCli {
             if (configFile.isFile()) {
                 try (Stream<String> lines = Files.lines(configFile.toPath(), StandardCharsets.UTF_8)) {
                     String[] args = lines.filter(arg -> !arg.isEmpty() && !arg.startsWith("#"))
+                            .flatMap(line -> CleanArgument.splitLine(line).stream())
                             .toArray(String[]::new);
                     mavenConfig = cliManager.parse(args);
                     List<?> unrecognized = mavenConfig.getArgList();

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/CleanArgumentTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/CleanArgumentTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.cli;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,6 +53,18 @@ class CleanArgumentTest {
         String[] cleanArgs = CleanArgument.cleanArgs(args);
         assertEquals(args.length, cleanArgs.length);
         assertEquals(information, cleanArgs[0]);
+    }
+
+    @Test
+    void splitLineTokenizesQuotedLongDefine() {
+        List<String> tokens = CleanArgument.splitLine("--define 'revision=1.0-SNAPSHOT'");
+        assertEquals(List.of("--define", "revision=1.0-SNAPSHOT"), tokens);
+    }
+
+    @Test
+    void splitLineTokenizesUnquotedLongDefine() {
+        List<String> tokens = CleanArgument.splitLine("--define revision=1.0-SNAPSHOT");
+        assertEquals(List.of("--define", "revision=1.0-SNAPSHOT"), tokens);
     }
 
     @Test

--- a/compat/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
+++ b/compat/maven-embedder/src/test/java/org/apache/maven/cli/MavenCliTest.java
@@ -205,6 +205,24 @@ class MavenCliTest {
         assertEquals("foobar", request.commandLine.getOptionValue("builder"));
     }
 
+    /**
+     * {@code --define 'revision=1.0-SNAPSHOT'} on one maven.config line must parse
+     * the same way as the equivalent CLI tokens (issue #13092).
+     */
+    @Test
+    void testMavenConfigQuotedLongDefine() throws Exception {
+        System.setProperty(
+                MavenCli.MULTIMODULE_PROJECT_DIRECTORY,
+                new File("src/test/projects/mavenConfigDefine").getCanonicalPath());
+        CliRequest request = new CliRequest(new String[0], null);
+
+        cli.initialize(request);
+        cli.cli(request);
+        cli.properties(request);
+
+        assertEquals("1.0-SNAPSHOT", request.getUserProperties().getProperty("revision"));
+    }
+
     @Test
     void testMavenConfigInvalid() throws Exception {
         System.setProperty(

--- a/compat/maven-embedder/src/test/projects/mavenConfigDefine/.mvn/maven.config
+++ b/compat/maven-embedder/src/test/projects/mavenConfigDefine/.mvn/maven.config
@@ -1,0 +1,1 @@
+--define 'revision=1.0-SNAPSHOT'

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CleanArgument.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/CleanArgument.java
@@ -25,6 +25,50 @@ import java.util.List;
  * CleanArgument
  */
 public class CleanArgument {
+    /**
+     * Split a {@code maven.config} line into CLI arguments, honouring single and
+     * double quotes the way a POSIX shell would for this limited case. Unquoted
+     * whitespace separates arguments; quote characters are not included in the
+     * resulting tokens.
+     */
+    public static List<String> splitLine(String line) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inSingle = false;
+        boolean inDouble = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inSingle) {
+                if (c == '\'') {
+                    inSingle = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (inDouble) {
+                if (c == '"') {
+                    inDouble = false;
+                } else {
+                    current.append(c);
+                }
+            } else if (c == '\'') {
+                inSingle = true;
+            } else if (c == '"') {
+                inDouble = true;
+            } else if (Character.isWhitespace(c)) {
+                if (!current.isEmpty()) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                }
+            } else {
+                current.append(c);
+            }
+        }
+        if (!current.isEmpty()) {
+            tokens.add(current.toString());
+        }
+        return tokens;
+    }
+
     public static String[] cleanArgs(String[] args) {
         try {
             return doCleanArgs(args);

--- a/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
+++ b/impl/maven-cli/src/main/java/org/apache/maven/cling/invoker/mvn/MavenParser.java
@@ -30,6 +30,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.maven.api.cli.Options;
 import org.apache.maven.api.cli.mvn.MavenOptions;
 import org.apache.maven.cling.invoker.BaseParser;
+import org.apache.maven.cling.invoker.CleanArgument;
 
 public class MavenParser extends BaseParser {
     @Override
@@ -78,8 +79,9 @@ public class MavenParser extends BaseParser {
 
     protected MavenOptions parseMavenConfigOptions(Path configFile) {
         try (Stream<String> lines = Files.lines(configFile, StandardCharsets.UTF_8)) {
-            List<String> args =
-                    lines.filter(arg -> !arg.isEmpty() && !arg.startsWith("#")).toList();
+            List<String> args = lines.filter(arg -> !arg.isEmpty() && !arg.startsWith("#"))
+                    .flatMap(line -> CleanArgument.splitLine(line).stream())
+                    .toList();
             MavenOptions options = parseArgs("maven.config", args);
             if (options.goals().isPresent()) {
                 // This file can only contain options, not args (goals or phases)

--- a/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenParserTest.java
+++ b/impl/maven-cli/src/test/java/org/apache/maven/cling/invoker/mvn/MavenParserTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.cling.invoker.mvn;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.apache.maven.api.cli.mvn.MavenOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link MavenParser} maven.config handling.
+ */
+class MavenParserTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void mavenConfigAcceptsQuotedLongDefine() throws Exception {
+        Path config = tempDir.resolve("maven.config");
+        Files.writeString(config, "--define 'revision=1.0-SNAPSHOT'\n", StandardCharsets.UTF_8);
+
+        MavenOptions options = new MavenParser().parseMavenConfigOptions(config);
+
+        Map<String, String> props = options.userProperties().orElseThrow();
+        assertEquals("1.0-SNAPSHOT", props.get("revision"));
+    }
+
+    @Test
+    void mavenConfigAcceptsUnquotedLongDefine() throws Exception {
+        Path config = tempDir.resolve("maven.config");
+        Files.writeString(config, "--define revision=1.0-SNAPSHOT\n", StandardCharsets.UTF_8);
+
+        MavenOptions options = new MavenParser().parseMavenConfigOptions(config);
+
+        Map<String, String> props = options.userProperties().orElseThrow();
+        assertEquals("1.0-SNAPSHOT", props.get("revision"));
+    }
+
+    @Test
+    void mavenConfigStillAcceptsShortDefine() throws Exception {
+        Path config = tempDir.resolve("maven.config");
+        Files.writeString(config, "-Drevision=1.0-SNAPSHOT\n", StandardCharsets.UTF_8);
+
+        MavenOptions options = new MavenParser().parseMavenConfigOptions(config);
+
+        Map<String, String> props = options.userProperties().orElseThrow();
+        assertEquals("1.0-SNAPSHOT", props.get("revision"));
+    }
+}


### PR DESCRIPTION
## Summary

`.mvn/maven.config` treated each line as a single argv token. That made `--define 'revision=1.0-SNAPSHOT'` an unrecognized option, while the same tokens on the CLI and `-Drevision=...` in the same file both worked.

Each config line is now split on unquoted whitespace (quotes are stripped), matching how the shell tokenizes the equivalent CLI.

## Test Plan

- `mvn -pl impl/maven-cli -Dtest=MavenParserTest,CommonsCliOptionsTest test` — 6/0
- `mvn -pl compat/maven-embedder -Dtest=CleanArgumentTest,MavenCliTest test` — 51/0 (1 skipped)

Fixes #13092