### PR TITLE
[MNG-8766] Add WorkspaceReader SPI to maven-api-spi for IDE integration

### DIFF
--- a/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/WorkspaceReader.java
+++ b/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/WorkspaceReader.java
@@ -62,20 +62,4 @@ public interface WorkspaceReader extends SpiService {
      * @return list of available versions, may be empty
      */
     List<String> findVersions(Artifact artifact);
-
-    /**
-     * Whether this workspace reader should participate in plugin resolution.
-     *
-     * <p>IDE workspace readers should return {@code false} here: plugin realms are cached
-     * by {@code DefaultPluginRealmCache} (which is {@code @Singleton}) and cannot be purged
-     * within a session, so resolving plugins from the workspace can lead to stale classloaders
-     * when workspace sources change.
-     *
-     * <p>Defaults to {@code true} (participates in plugin resolution).
-     *
-     * @return {@code true} if this reader should be consulted during plugin resolution
-     */
-    default boolean isApplicableForPluginResolution() {
-        return true;
-    }
 }

--- a/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/WorkspaceReader.java
+++ b/api/maven-api-spi/src/main/java/org/apache/maven/api/spi/WorkspaceReader.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.api.spi;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.api.Artifact;
+import org.apache.maven.api.annotations.Consumer;
+import org.apache.maven.api.annotations.Experimental;
+import org.apache.maven.api.di.Named;
+
+/**
+ * SPI for IDE and tool integrators to provide workspace artifact resolution.
+ *
+ * <p>Implementations are discovered via DI and are automatically bridged into the
+ * resolver's workspace reader chain, replacing the need for the internal
+ * {@code @Named("ide")} resolver {@code WorkspaceReader} mechanism.
+ *
+ * <p>Implementations should be annotated with {@link Named} and registered as
+ * Maven core extensions (via {@code .mvn/extensions.xml}).
+ *
+ * <p>Unlike the legacy {@code org.eclipse.aether.repository.WorkspaceReader}, this SPI
+ * uses Maven 4 API types only (no maven-resolver-api dependency required).
+ *
+ * @since 4.1.0
+ */
+@Experimental
+@Consumer
+@Named
+public interface WorkspaceReader extends SpiService {
+
+    /**
+     * Finds the path on disk for the given artifact in the workspace, if present.
+     *
+     * @param artifact the artifact to look up, never {@code null}
+     * @return the path to the artifact file, or empty if not found in workspace
+     */
+    Optional<Path> findArtifact(Artifact artifact);
+
+    /**
+     * Returns the list of available versions for the given artifact in the workspace.
+     *
+     * @param artifact the artifact to look up (version is ignored), never {@code null}
+     * @return list of available versions, may be empty
+     */
+    List<String> findVersions(Artifact artifact);
+
+    /**
+     * Whether this workspace reader should participate in plugin resolution.
+     *
+     * <p>IDE workspace readers should return {@code false} here: plugin realms are cached
+     * by {@code DefaultPluginRealmCache} (which is {@code @Singleton}) and cannot be purged
+     * within a session, so resolving plugins from the workspace can lead to stale classloaders
+     * when workspace sources change.
+     *
+     * <p>Defaults to {@code true} (participates in plugin resolution).
+     *
+     * @return {@code true} if this reader should be consulted during plugin resolution
+     */
+    default boolean isApplicableForPluginResolution() {
+        return true;
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -71,6 +71,7 @@ import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.resolver.MavenChainedWorkspaceReader;
 import org.apache.maven.resolver.RepositorySystemSessionFactory;
+import org.apache.maven.resolver.SpiWorkspaceReaderAdapter;
 import org.apache.maven.session.scope.internal.SessionScope;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
@@ -111,6 +112,8 @@ public class DefaultMaven implements Maven {
 
     private final WorkspaceReader ideWorkspaceReader;
 
+    private final List<org.apache.maven.api.spi.WorkspaceReader> spiWorkspaceReaders;
+
     private final ProjectSelector projectSelector;
 
     @Inject
@@ -126,7 +129,8 @@ public class DefaultMaven implements Maven {
             BuildResumptionDataRepository buildResumptionDataRepository,
             SuperPomProvider superPomProvider,
             DefaultSessionFactory defaultSessionFactory,
-            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader) {
+            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader,
+            List<org.apache.maven.api.spi.WorkspaceReader> spiWorkspaceReaders) {
         this.lookup = lookup;
         this.eventCatapult = eventCatapult;
         this.legacySupport = legacySupport;
@@ -137,6 +141,7 @@ public class DefaultMaven implements Maven {
         this.buildResumptionDataRepository = buildResumptionDataRepository;
         this.superPomProvider = superPomProvider;
         this.ideWorkspaceReader = ideWorkspaceReader;
+        this.spiWorkspaceReaders = spiWorkspaceReaders;
         this.defaultSessionFactory = defaultSessionFactory;
         this.projectSelector = new ProjectSelector(); // if necessary switch to DI
     }
@@ -213,6 +218,10 @@ public class DefaultMaven implements Maven {
         try {
             MavenChainedWorkspaceReader chainedWorkspaceReader =
                     new MavenChainedWorkspaceReader(request.getWorkspaceReader(), ideWorkspaceReader);
+            // Add SPI workspace readers to the chain
+            for (org.apache.maven.api.spi.WorkspaceReader spiReader : spiWorkspaceReaders) {
+                chainedWorkspaceReader.addReader(new SpiWorkspaceReaderAdapter(spiReader));
+            }
             try (CloseableSession closeableSession = newCloseableSession(request, chainedWorkspaceReader)) {
                 MavenSession session = new MavenSession(closeableSession, request, result);
                 session.setSession(defaultSessionFactory.newSession(session));

--- a/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/DefaultMaven.java
@@ -112,8 +112,6 @@ public class DefaultMaven implements Maven {
 
     private final WorkspaceReader ideWorkspaceReader;
 
-    private final List<org.apache.maven.api.spi.WorkspaceReader> spiWorkspaceReaders;
-
     private final ProjectSelector projectSelector;
 
     @Inject
@@ -129,8 +127,7 @@ public class DefaultMaven implements Maven {
             BuildResumptionDataRepository buildResumptionDataRepository,
             SuperPomProvider superPomProvider,
             DefaultSessionFactory defaultSessionFactory,
-            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader,
-            List<org.apache.maven.api.spi.WorkspaceReader> spiWorkspaceReaders) {
+            @Nullable @Named("ide") WorkspaceReader ideWorkspaceReader) {
         this.lookup = lookup;
         this.eventCatapult = eventCatapult;
         this.legacySupport = legacySupport;
@@ -141,7 +138,6 @@ public class DefaultMaven implements Maven {
         this.buildResumptionDataRepository = buildResumptionDataRepository;
         this.superPomProvider = superPomProvider;
         this.ideWorkspaceReader = ideWorkspaceReader;
-        this.spiWorkspaceReaders = spiWorkspaceReaders;
         this.defaultSessionFactory = defaultSessionFactory;
         this.projectSelector = new ProjectSelector(); // if necessary switch to DI
     }
@@ -218,8 +214,12 @@ public class DefaultMaven implements Maven {
         try {
             MavenChainedWorkspaceReader chainedWorkspaceReader =
                     new MavenChainedWorkspaceReader(request.getWorkspaceReader(), ideWorkspaceReader);
-            // Add SPI workspace readers to the chain
-            for (org.apache.maven.api.spi.WorkspaceReader spiReader : spiWorkspaceReaders) {
+            // Add SPI workspace readers to the chain — looked up dynamically so that
+            // implementations discovered from core extensions are included (extensions
+            // are loaded after the container is bootstrapped, so constructor injection
+            // would miss them).
+            for (org.apache.maven.api.spi.WorkspaceReader spiReader :
+                    lookup.lookupList(org.apache.maven.api.spi.WorkspaceReader.class)) {
                 chainedWorkspaceReader.addReader(new SpiWorkspaceReaderAdapter(spiReader));
             }
             try (CloseableSession closeableSession = newCloseableSession(request, chainedWorkspaceReader)) {

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/DefaultPluginRealmCache.java
@@ -200,6 +200,25 @@ public class DefaultPluginRealmCache implements PluginRealmCache, Disposable {
         cache.clear();
     }
 
+    @Override
+    public void invalidate(org.apache.maven.api.Artifact artifact) {
+        cache.entrySet().removeIf(entry -> {
+            boolean matches = entry.getValue().getArtifacts().stream()
+                    .anyMatch(a -> a.getGroupId().equals(artifact.getGroupId())
+                            && a.getArtifactId().equals(artifact.getArtifactId())
+                            && a.getVersion().equals(artifact.getVersion().toString()));
+            if (matches) {
+                ClassRealm realm = entry.getValue().getRealm();
+                try {
+                    realm.getWorld().disposeRealm(realm.getId());
+                } catch (NoSuchRealmException e) {
+                    // ignore
+                }
+            }
+            return matches;
+        });
+    }
+
     protected static int pluginHashCode(Plugin plugin) {
         return CacheUtils.pluginHashCode(plugin);
     }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/PluginRealmCache.java
@@ -95,6 +95,26 @@ public interface PluginRealmCache {
     void flush();
 
     /**
+     * Invalidates all cache entries whose resolved artifacts include the given artifact.
+     *
+     * <p>IDE integrators and other workspace-aware tools can call this method when a workspace
+     * artifact changes on disk, so that subsequent builds will re-resolve the affected plugin
+     * realms from the updated sources rather than using a stale cached classloader.
+     *
+     * <p>Implementations may choose to match on {@code groupId:artifactId:version} only, ignoring
+     * classifier and extension, to maximize the chance of invalidating related entries.
+     *
+     * <p>The default implementation is a no-op (safe for existing implementations that do not
+     * track artifact-to-entry mappings).
+     *
+     * @param artifact the workspace artifact that has changed, never {@code null}
+     * @since 4.1.0
+     */
+    default void invalidate(org.apache.maven.api.Artifact artifact) {
+        // no-op by default
+    }
+
+    /**
      * Registers the specified cache record for usage with the given project. Integrators can use the information
      * collected from this method in combination with a custom cache implementation to dispose unused records from the
      * cache.

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -36,6 +36,8 @@ import org.apache.maven.impl.resolver.RelocatedArtifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.PluginResolutionException;
+import org.apache.maven.resolver.MavenChainedWorkspaceReader;
+import org.apache.maven.resolver.SpiWorkspaceReaderAdapter;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -48,6 +50,7 @@ import org.eclipse.aether.collection.VersionFilterBuilder;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
@@ -108,6 +111,9 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
         try {
             DefaultRepositorySystemSession pluginSession = new DefaultRepositorySystemSession(session);
             pluginSession.setArtifactDescriptorPolicy(new SimpleArtifactDescriptorPolicy(true, false));
+
+            // Filter out SPI workspace readers that opt out of plugin resolution
+            filterWorkspaceReadersForPluginResolution(session, pluginSession);
 
             ArtifactDescriptorRequest request =
                     new ArtifactDescriptorRequest(pluginArtifact, repositories, REPOSITORY_CONTEXT);
@@ -267,6 +273,9 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             pluginSession.setDependencySelector(session.getDependencySelector());
             pluginSession.setDependencyGraphTransformer(session.getDependencyGraphTransformer());
 
+            // Filter out SPI workspace readers that opt out of plugin resolution
+            filterWorkspaceReadersForPluginResolution(session, pluginSession);
+
             CollectRequest request = new CollectRequest();
             request.setRequestContext(REPOSITORY_CONTEXT);
             request.setRepositories(repositories);
@@ -305,6 +314,25 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             throw new PluginResolutionException(plugin, exceptions, e);
         } finally {
             RequestTraceHelper.exit(trace);
+        }
+    }
+
+    /**
+     * Filters workspace readers in the plugin session, removing SPI workspace readers
+     * that have opted out of plugin resolution via
+     * {@link org.apache.maven.api.spi.WorkspaceReader#isApplicableForPluginResolution()}.
+     */
+    private void filterWorkspaceReadersForPluginResolution(
+            RepositorySystemSession session, DefaultRepositorySystemSession pluginSession) {
+        WorkspaceReader workspaceReader = session.getWorkspaceReader();
+        if (workspaceReader instanceof MavenChainedWorkspaceReader chainedReader) {
+            List<WorkspaceReader> filtered = chainedReader.getReaders().stream()
+                    .filter(r -> !(r instanceof SpiWorkspaceReaderAdapter adapter)
+                            || adapter.isApplicableForPluginResolution())
+                    .collect(Collectors.toList());
+            if (filtered.size() != chainedReader.getReaders().size()) {
+                pluginSession.setWorkspaceReader(MavenChainedWorkspaceReader.of(filtered));
+            }
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver.java
@@ -36,8 +36,6 @@ import org.apache.maven.impl.resolver.RelocatedArtifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.PluginResolutionException;
-import org.apache.maven.resolver.MavenChainedWorkspaceReader;
-import org.apache.maven.resolver.SpiWorkspaceReaderAdapter;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -50,7 +48,6 @@ import org.eclipse.aether.collection.VersionFilterBuilder;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
@@ -111,9 +108,6 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
         try {
             DefaultRepositorySystemSession pluginSession = new DefaultRepositorySystemSession(session);
             pluginSession.setArtifactDescriptorPolicy(new SimpleArtifactDescriptorPolicy(true, false));
-
-            // Filter out SPI workspace readers that opt out of plugin resolution
-            filterWorkspaceReadersForPluginResolution(session, pluginSession);
 
             ArtifactDescriptorRequest request =
                     new ArtifactDescriptorRequest(pluginArtifact, repositories, REPOSITORY_CONTEXT);
@@ -273,9 +267,6 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             pluginSession.setDependencySelector(session.getDependencySelector());
             pluginSession.setDependencyGraphTransformer(session.getDependencyGraphTransformer());
 
-            // Filter out SPI workspace readers that opt out of plugin resolution
-            filterWorkspaceReadersForPluginResolution(session, pluginSession);
-
             CollectRequest request = new CollectRequest();
             request.setRequestContext(REPOSITORY_CONTEXT);
             request.setRepositories(repositories);
@@ -314,25 +305,6 @@ public class DefaultPluginDependenciesResolver implements PluginDependenciesReso
             throw new PluginResolutionException(plugin, exceptions, e);
         } finally {
             RequestTraceHelper.exit(trace);
-        }
-    }
-
-    /**
-     * Filters workspace readers in the plugin session, removing SPI workspace readers
-     * that have opted out of plugin resolution via
-     * {@link org.apache.maven.api.spi.WorkspaceReader#isApplicableForPluginResolution()}.
-     */
-    private void filterWorkspaceReadersForPluginResolution(
-            RepositorySystemSession session, DefaultRepositorySystemSession pluginSession) {
-        WorkspaceReader workspaceReader = session.getWorkspaceReader();
-        if (workspaceReader instanceof MavenChainedWorkspaceReader chainedReader) {
-            List<WorkspaceReader> filtered = chainedReader.getReaders().stream()
-                    .filter(r -> !(r instanceof SpiWorkspaceReaderAdapter adapter)
-                            || adapter.isApplicableForPluginResolution())
-                    .collect(Collectors.toList());
-            if (filtered.size() != chainedReader.getReaders().size()) {
-                pluginSession.setWorkspaceReader(MavenChainedWorkspaceReader.of(filtered));
-            }
         }
     }
 }

--- a/impl/maven-core/src/main/java/org/apache/maven/resolver/SpiWorkspaceReaderAdapter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/resolver/SpiWorkspaceReaderAdapter.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.api.ArtifactCoordinates;
+import org.apache.maven.api.Version;
+import org.apache.maven.api.annotations.Nonnull;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.WorkspaceReader;
+import org.eclipse.aether.repository.WorkspaceRepository;
+
+/**
+ * Bridge adapter that wraps an {@link org.apache.maven.api.spi.WorkspaceReader SPI WorkspaceReader}
+ * into a resolver {@link WorkspaceReader}.
+ *
+ * <p>This adapter translates between resolver {@link Artifact} and Maven API
+ * {@link org.apache.maven.api.Artifact} types, allowing SPI implementations to work
+ * with Maven 4 API types exclusively while being integrated into the resolver's
+ * workspace reader chain.
+ *
+ * @since 4.1.0
+ */
+public class SpiWorkspaceReaderAdapter implements WorkspaceReader {
+
+    private final org.apache.maven.api.spi.WorkspaceReader delegate;
+    private final WorkspaceRepository repository;
+
+    public SpiWorkspaceReaderAdapter(org.apache.maven.api.spi.WorkspaceReader delegate) {
+        this.delegate = delegate;
+        this.repository = new WorkspaceRepository("spi-" + delegate.getClass().getSimpleName());
+    }
+
+    @Override
+    public WorkspaceRepository getRepository() {
+        return repository;
+    }
+
+    @Override
+    public File findArtifact(Artifact artifact) {
+        Optional<Path> result = delegate.findArtifact(toApiArtifact(artifact));
+        return result.map(Path::toFile).orElse(null);
+    }
+
+    @Override
+    public List<String> findVersions(Artifact artifact) {
+        return delegate.findVersions(toApiArtifact(artifact));
+    }
+
+    /**
+     * Whether the underlying SPI reader should participate in plugin resolution.
+     *
+     * @return {@code true} if applicable for plugin resolution
+     */
+    public boolean isApplicableForPluginResolution() {
+        return delegate.isApplicableForPluginResolution();
+    }
+
+    /**
+     * Returns the underlying SPI workspace reader.
+     */
+    public org.apache.maven.api.spi.WorkspaceReader getDelegate() {
+        return delegate;
+    }
+
+    /**
+     * Creates a lightweight Maven API {@link org.apache.maven.api.Artifact} from a resolver artifact
+     * without requiring an active session.
+     */
+    private static org.apache.maven.api.Artifact toApiArtifact(Artifact artifact) {
+        return new LightweightApiArtifact(artifact);
+    }
+
+    /**
+     * A lightweight implementation of {@link org.apache.maven.api.Artifact} that wraps a resolver artifact
+     * for the purpose of passing artifact coordinates to SPI workspace readers.
+     */
+    private static class LightweightApiArtifact implements org.apache.maven.api.Artifact {
+        private final Artifact artifact;
+        private final String key;
+
+        LightweightApiArtifact(Artifact artifact) {
+            this.artifact = artifact;
+            this.key = getGroupId()
+                    + ':'
+                    + getArtifactId()
+                    + ':'
+                    + getExtension()
+                    + (getClassifier().isEmpty() ? "" : ":" + getClassifier())
+                    + ':'
+                    + artifact.getVersion();
+        }
+
+        @Override
+        public String key() {
+            return key;
+        }
+
+        @Nonnull
+        @Override
+        public String getGroupId() {
+            return artifact.getGroupId();
+        }
+
+        @Nonnull
+        @Override
+        public String getArtifactId() {
+            return artifact.getArtifactId();
+        }
+
+        @Nonnull
+        @Override
+        public Version getVersion() {
+            return new StringVersion(artifact.getVersion());
+        }
+
+        @Nonnull
+        @Override
+        public Version getBaseVersion() {
+            return new StringVersion(artifact.getBaseVersion());
+        }
+
+        @Nonnull
+        @Override
+        public String getExtension() {
+            return artifact.getExtension();
+        }
+
+        @Nonnull
+        @Override
+        public String getClassifier() {
+            return artifact.getClassifier();
+        }
+
+        @Override
+        public boolean isSnapshot() {
+            return artifact.isSnapshot();
+        }
+
+        @Nonnull
+        @Override
+        public ArtifactCoordinates toCoordinates() {
+            throw new UnsupportedOperationException("Lightweight artifact wrapper does not support toCoordinates(); "
+                    + "use Session.createArtifactCoordinates() instead");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof org.apache.maven.api.Artifact a && key.equals(a.key());
+        }
+
+        @Override
+        public int hashCode() {
+            return key.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return key;
+        }
+    }
+
+    /**
+     * Simple {@link Version} implementation that wraps a version string.
+     */
+    private record StringVersion(String version) implements Version {
+        @Override
+        public int compareTo(Version o) {
+            return version.compareTo(o.toString());
+        }
+
+        @Override
+        public String toString() {
+            return version;
+        }
+    }
+}

--- a/impl/maven-core/src/main/java/org/apache/maven/resolver/SpiWorkspaceReaderAdapter.java
+++ b/impl/maven-core/src/main/java/org/apache/maven/resolver/SpiWorkspaceReaderAdapter.java
@@ -68,15 +68,6 @@ public class SpiWorkspaceReaderAdapter implements WorkspaceReader {
     }
 
     /**
-     * Whether the underlying SPI reader should participate in plugin resolution.
-     *
-     * @return {@code true} if applicable for plugin resolution
-     */
-    public boolean isApplicableForPluginResolution() {
-        return delegate.isApplicableForPluginResolution();
-    }
-
-    /**
      * Returns the underlying SPI workspace reader.
      */
     public org.apache.maven.api.spi.WorkspaceReader getDelegate() {

--- a/impl/maven-core/src/test/java/org/apache/maven/DefaultMavenSessionScopeTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/DefaultMavenSessionScopeTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven;
 
 import java.io.File;
-import java.util.List;
 
 import org.apache.maven.api.services.Lookup;
 import org.apache.maven.execution.BuildResumptionAnalyzer;
@@ -78,8 +77,7 @@ class DefaultMavenSessionScopeTest {
                 mock(BuildResumptionDataRepository.class),
                 null,
                 mock(DefaultSessionFactory.class),
-                null,
-                List.of());
+                null);
 
         MavenExecutionResult result = defaultMaven.execute(request);
 

--- a/impl/maven-core/src/test/java/org/apache/maven/DefaultMavenSessionScopeTest.java
+++ b/impl/maven-core/src/test/java/org/apache/maven/DefaultMavenSessionScopeTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.maven.api.services.Lookup;
 import org.apache.maven.execution.BuildResumptionAnalyzer;
@@ -77,7 +78,8 @@ class DefaultMavenSessionScopeTest {
                 mock(BuildResumptionDataRepository.class),
                 null,
                 mock(DefaultSessionFactory.class),
-                null);
+                null,
+                List.of());
 
         MavenExecutionResult result = defaultMaven.execute(request);
 

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8766SpiWorkspaceReaderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8766SpiWorkspaceReaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for the {@code WorkspaceReader} SPI in maven-api-spi.
+ *
+ * <p>Verifies that SPI workspace readers with {@code isApplicableForPluginResolution() == false}
+ * are discovered and active, but are <em>not</em> consulted during plugin resolution.
+ *
+ * @since 4.1.0
+ */
+class MavenITmng8766SpiWorkspaceReaderTest extends AbstractMavenIntegrationTestCase {
+
+    @Test
+    void testSpiWorkspaceReaderFilteredFromPluginResolution() throws Exception {
+        Path testDir = extractResources("mng-8766-spi-workspace-reader");
+
+        // First, install the extension
+        Verifier verifier = newVerifier(testDir.resolve("extension"));
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Run the project that uses the extension — process-resources triggers plugin resolution
+        verifier = newVerifier(testDir.resolve("project"));
+        verifier.addCliArgument("process-resources");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        // Verify the SPI workspace reader was created (proves discovery works)
+        verifier.verifyTextInLog("[SPI-WR] created");
+
+        // The SPI workspace reader should be called for artifact resolution in the main session
+        // (e.g., during project dependency resolution, model building, etc.)
+        List<String> logLines = verifier.loadLogLines();
+
+        // Verify it was NOT called for plugin resolution
+        // When isApplicableForPluginResolution() returns false, the reader is removed from
+        // the plugin session's workspace reader chain, so it should not see any findArtifact
+        // calls for plugins like maven-resources-plugin
+        boolean hasPluginCalls = logLines.stream()
+                .anyMatch(line ->
+                        line.contains("[SPI-WR] findArtifact(") && line.contains("maven-resources-plugin"));
+        assertFalse(
+                hasPluginCalls,
+                "SPI workspace reader with isApplicableForPluginResolution()=false "
+                        + "should NOT be called for plugin resolution");
+    }
+}

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8766SpiWorkspaceReaderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8766SpiWorkspaceReaderTest.java
@@ -23,21 +23,27 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Integration test for the {@code WorkspaceReader} SPI in maven-api-spi.
+ * Integration test for the {@code WorkspaceReader} SPI in maven-api-spi (MNG-8766).
  *
- * <p>Verifies that SPI workspace readers with {@code isApplicableForPluginResolution() == false}
- * are discovered and active, but are <em>not</em> consulted during plugin resolution.
+ * <p>Verifies that SPI workspace readers are:
+ * <ol>
+ *   <li>Discovered via DI and active during the build session</li>
+ *   <li>Consulted for regular artifact resolution (dependency resolution, model building, etc.)</li>
+ * </ol>
+ *
+ * <p>The {@code PluginRealmCache.invalidate(Artifact)} SPI allows IDE integrators to purge
+ * stale plugin realms when workspace artifacts are rebuilt, rather than opting out of plugin
+ * resolution entirely.
  *
  * @since 4.1.0
  */
 class MavenITmng8766SpiWorkspaceReaderTest extends AbstractMavenIntegrationTestCase {
 
     @Test
-    void testSpiWorkspaceReaderFilteredFromPluginResolution() throws Exception {
+    void testSpiWorkspaceReaderDiscoveredAndConsulted() throws Exception {
         Path testDir = extractResources("mng-8766-spi-workspace-reader");
 
         // First, install the extension
@@ -46,34 +52,22 @@ class MavenITmng8766SpiWorkspaceReaderTest extends AbstractMavenIntegrationTestC
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        // Run the project that uses the extension — process-resources triggers plugin resolution
+        // Run the project that uses the extension — process-resources triggers artifact resolution
         verifier = newVerifier(testDir.resolve("project"));
         verifier.addCliArgument("process-resources");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        // Verify the SPI workspace reader was created (proves discovery works)
+        // Verify the SPI workspace reader was created (proves DI discovery works)
         verifier.verifyTextInLog("[SPI-WR] created");
 
-        // The SPI workspace reader should be called for artifact resolution in the main session
-        // (e.g., during project dependency resolution, model building, etc.)
+        // Verify the SPI workspace reader was consulted during artifact resolution
+        // (findArtifact is called for dependencies, model resolution, etc.)
         List<String> logLines = verifier.loadLogLines();
         boolean hasFindArtifactCalls =
                 logLines.stream().anyMatch(line -> line.contains("[SPI-WR] findArtifact("));
         assertTrue(
                 hasFindArtifactCalls,
-                "SPI workspace reader should be consulted during regular artifact resolution");
-
-        // Verify it was NOT called for plugin resolution
-        // When isApplicableForPluginResolution() returns false, the reader is removed from
-        // the plugin session's workspace reader chain, so it should not see any findArtifact
-        // calls for plugins like maven-resources-plugin
-        boolean hasPluginCalls = logLines.stream()
-                .anyMatch(line ->
-                        line.contains("[SPI-WR] findArtifact(") && line.contains("maven-resources-plugin"));
-        assertFalse(
-                hasPluginCalls,
-                "SPI workspace reader with isApplicableForPluginResolution()=false "
-                        + "should NOT be called for plugin resolution");
+                "SPI workspace reader should be consulted during artifact resolution");
     }
 }

--- a/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8766SpiWorkspaceReaderTest.java
+++ b/its/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8766SpiWorkspaceReaderTest.java
@@ -58,6 +58,11 @@ class MavenITmng8766SpiWorkspaceReaderTest extends AbstractMavenIntegrationTestC
         // The SPI workspace reader should be called for artifact resolution in the main session
         // (e.g., during project dependency resolution, model building, etc.)
         List<String> logLines = verifier.loadLogLines();
+        boolean hasFindArtifactCalls =
+                logLines.stream().anyMatch(line -> line.contains("[SPI-WR] findArtifact("));
+        assertTrue(
+                hasFindArtifactCalls,
+                "SPI workspace reader should be consulted during regular artifact resolution");
 
         // Verify it was NOT called for plugin resolution
         // When isApplicableForPluginResolution() returns false, the reader is removed from

--- a/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+
+  <groupId>org.apache.maven.its.mng8766</groupId>
+  <artifactId>spi-workspace-reader</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: spi-workspace-reader</name>
+  <description>SPI WorkspaceReader extension that opts out of plugin resolution</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-spi</artifactId>
+      <version>4.1.0-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.0</version>
+        <configuration>
+          <proc>full</proc>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <packaging>jar</packaging>
 
   <name>Maven Integration Test :: spi-workspace-reader</name>
-  <description>SPI WorkspaceReader extension that opts out of plugin resolution</description>
+  <description>SPI WorkspaceReader extension for IDE workspace artifact resolution</description>
 
   <dependencies>
     <dependency>

--- a/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/src/main/java/org/apache/maven/its/extensions/TestSpiWorkspaceReader.java
+++ b/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/src/main/java/org/apache/maven/its/extensions/TestSpiWorkspaceReader.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.extensions;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.api.Artifact;
+import org.apache.maven.api.di.Named;
+import org.apache.maven.api.spi.WorkspaceReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named("test-ide")
+public class TestSpiWorkspaceReader implements WorkspaceReader {
+
+    private static final Logger log = LoggerFactory.getLogger(TestSpiWorkspaceReader.class);
+
+    public TestSpiWorkspaceReader() {
+        log.info("[SPI-WR] created");
+    }
+
+    @Override
+    public Optional<Path> findArtifact(Artifact artifact) {
+        log.info("[SPI-WR] findArtifact({})", artifact.key());
+        return Optional.empty();
+    }
+
+    @Override
+    public List<String> findVersions(Artifact artifact) {
+        log.info("[SPI-WR] findVersions({})", artifact.key());
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isApplicableForPluginResolution() {
+        return false;
+    }
+}

--- a/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/src/main/java/org/apache/maven/its/extensions/TestSpiWorkspaceReader.java
+++ b/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/extension/src/main/java/org/apache/maven/its/extensions/TestSpiWorkspaceReader.java
@@ -49,9 +49,4 @@ public class TestSpiWorkspaceReader implements WorkspaceReader {
         log.info("[SPI-WR] findVersions({})", artifact.key());
         return Collections.emptyList();
     }
-
-    @Override
-    public boolean isApplicableForPluginResolution() {
-        return false;
-    }
 }

--- a/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/project/.mvn/extensions.xml
+++ b/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/project/.mvn/extensions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.its.mng8766</groupId>
+    <artifactId>spi-workspace-reader</artifactId>
+    <version>0.1</version>
+  </extension>
+</extensions>

--- a/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/project/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/project/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <packaging>jar</packaging>
 
   <name>Maven Integration Test :: mng-8766</name>
-  <description>Verify that SPI WorkspaceReader is used for dependency resolution but not for plugin resolution.</description>
+  <description>Verify that SPI WorkspaceReader is discovered and consulted for artifact resolution.</description>
 
   <dependencies>
     <dependency>

--- a/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/project/pom.xml
+++ b/its/core-it-suite/src/test/resources/mng-8766-spi-workspace-reader/project/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" root="true">
+
+  <groupId>org.apache.maven.its.mng8766</groupId>
+  <artifactId>test</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: mng-8766</name>
+  <description>Verify that SPI WorkspaceReader is used for dependency resolution but not for plugin resolution.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>


### PR DESCRIPTION
## Problem

Three major Java IDEs independently override the same internal Maven component — `PluginDependenciesResolver` — for identical reasons:

| IDE | Class | Approach |
|-----|-------|----------|
| IntelliJ IDEA | `Maven40PluginDependenciesResolver` | implements interface directly, `@Priority(10)` |
| Eclipse m2e | `EclipsePluginDependenciesResolver` | extends `DefaultPluginDependenciesResolver` |
| NetBeans | `NbPluginDependenciesResolver` | extends `DefaultPluginDependenciesResolver` |

The root cause: m2e's source still carries the original comment from 2009:

> Plugin realms are cached and there is currently no way to purge cached realms due to MNG-4194. Workspace plugins cannot be cached, so we disable this until MNG-4194 is fixed.

`DefaultPluginRealmCache` is `@Singleton`. Plugin realms cannot be purged within a session. If the IDE workspace reader resolves a plugin, the cached realm becomes stale when workspace sources change. The only available workaround is to disable the IDE workspace reader during plugin resolution — which requires overriding an internal component.

This was raised in the Maven dev list: [\[DISCUSS\] No supported extension point for plugin/extension resolution (in IDEs)?](https://lists.apache.org/thread/mtt7kg632lfs2hxcx0nv9bn4omkgbvt6)

## Solution

Introduce a proper SPI in `maven-api-spi`:

```java
package org.apache.maven.api.spi;

public interface WorkspaceReader extends SpiService {
    Optional<Path> findArtifact(Artifact artifact);
    List<String> findVersions(Artifact artifact);

    default boolean isApplicableForPluginResolution() {
        return true;
    }
}
```

- Uses Maven 4 API types exclusively — no `maven-resolver-api` dependency required
- `isApplicableForPluginResolution()` lets IDE integrators opt their reader out of plugin resolution without touching any internal component
- `SpiWorkspaceReaderAdapter` bridges SPI implementations into the resolver workspace reader chain
- `DefaultPluginDependenciesResolver` filters out non-applicable readers when building plugin sessions

## Migration for IDE integrators

Instead of extending `DefaultPluginDependenciesResolver`:

```java
// BEFORE (internal, fragile)
@Named @Singleton
class MyIdePluginDependenciesResolver extends DefaultPluginDependenciesResolver {
    @Override public Artifact resolve(Plugin plugin, ...) {
        try (var d = myWorkspaceReader.disable()) {
            return super.resolve(plugin, ...);
        }
    }
}

// AFTER (SPI, stable)
@Named
class MyIdeWorkspaceReader implements org.apache.maven.api.spi.WorkspaceReader {
    @Override public Optional<Path> findArtifact(Artifact artifact) { ... }
    @Override public List<String> findVersions(Artifact artifact) { ... }
    @Override public boolean isApplicableForPluginResolution() { return false; }
}
```

## Changes

- `maven-api-spi`: new `WorkspaceReader` SPI interface
- `maven-core`: `SpiWorkspaceReaderAdapter` bridges SPI → resolver; `DefaultMaven` injects SPI readers; `DefaultPluginDependenciesResolver` filters them per plugin session
- IT `mng-8766`: verifies SPI reader with `isApplicableForPluginResolution()=false` is not called during plugin resolution