### PR TITLE
Implement getOutputPath() in the site IT plugin

### DIFF
--- a/its/core-it-support/core-it-plugins/maven-it-plugin-site/src/main/java/org/apache/maven/plugin/coreit/InfoReport.java
+++ b/its/core-it-support/core-it-plugins/maven-it-plugin-site/src/main/java/org/apache/maven/plugin/coreit/InfoReport.java
@@ -130,7 +130,15 @@ public class InfoReport extends AbstractMojo implements MavenReport {
         }
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    public String getOutputPath() {
         return "info";
     }
 


### PR DESCRIPTION
`InfoReport` in `maven-it-plugin-site` implements only `getOutputName()`, which Maven Reporting API 4.0.0 deprecated in favour of `getOutputPath()`. The IT plugin already compiles against 4.0.0, so it can use the current method; `getOutputName()` stays as a deprecated delegate because the interface still declares it abstract.

No behaviour change — `info` either way. Last of a sweep that has moved the estate's report implementations onto `getOutputPath()`.

Verified: `mvn -f its/core-it-support/core-it-plugins/maven-it-plugin-site/pom.xml compile` → BUILD SUCCESS. I did not run the core ITs.

Targets `maven-4.0.x` first; the same change for `master` follows once this lands.

*This change was created with AI assistance.*
