### PR TITLE
Fix NPE on a recursive property reference in a list field

### DIFF
--- a/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
+++ b/impl/maven-impl/src/main/java/org/apache/maven/impl/model/DefaultModelInterpolator.java
@@ -134,7 +134,11 @@ public class DefaultModelInterpolator implements ModelInterpolator {
                 return di.interpolate(value, null, cycleMap, cb, postprocessor, false);
             } catch (InterpolatorException e) {
                 problems.add(BuilderProblem.Severity.ERROR, ModelProblem.Version.BASE, e.getMessage(), e);
-                return null;
+                // Keep the original text rather than handing null back to the transformer. A null
+                // ends up as an element of a List<String> model field such as build/filters, and
+                // the immutable model constructor copies that list with List.copyOf, which fails
+                // with a bare NullPointerException that hides the problem just collected above.
+                return value;
             }
         };
     }

--- a/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelInterpolatorTest.java
+++ b/impl/maven-impl/src/test/java/org/apache/maven/impl/model/DefaultModelInterpolatorTest.java
@@ -632,6 +632,26 @@ class DefaultModelInterpolatorTest {
         assertTrue(collector.getErrors().get(0).contains("recursive variable reference"));
     }
 
+    @Test
+    public void testRecursiveExpressionCycleInListField() throws Exception {
+        Map<String, String> props = new HashMap<>();
+        props.put("aa", "${bb}");
+        props.put("bb", "${aa}");
+
+        Model model = Model.newBuilder()
+                .properties(props)
+                .build(Build.newBuilder().filters(List.of("${aa}")).build())
+                .build();
+
+        SimpleProblemCollector collector = new SimpleProblemCollector();
+
+        ModelBuilderRequest request = createModelBuildingRequest(Map.of()).build();
+        Model out = interpolator.interpolateModel(model, null, request, collector);
+
+        assertEquals(List.of("${aa}"), out.getBuild().getFilters());
+        assertTrue(collector.getErrors().get(0).contains("recursive variable reference"));
+    }
+
     @Disabled("per def cannot be recursive: ${basedir} is immediately going for project.basedir")
     @Test
     public void testRecursiveExpressionCycleBaseDir() throws Exception {


### PR DESCRIPTION
On a recursive reference `DefaultModelInterpolator` records an ERROR and returns `null`. The transformer writes it into `List<String>` fields such as `build/filters` (its `Properties` branch already guards), and the immutable constructor calls `List.copyOf`, so the build dies with a bare NPE that hides the collected error:

```
java.lang.NullPointerException
 at java.util.List.copyOf(List.java:1193)
 at o.a.m.model.v4.MavenTransformer.transformBuild(:514)
 at o.a.m.impl.model.DefaultModelInterpolator.interpolateModel(:111)
```

Returning the original text fixes it at the source instead of in the generated template, and matches `DecryptingSettingsTransformer` and MNG-8174 (#12932), which covered Maven 3 only.

The new test fails on master with that NPE. Full `mvn test`: 3136 tests, 0 failures. Can open a `maven-4.0.x` backport.
